### PR TITLE
Readability convert member functions to static

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -118,7 +118,6 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-avoid-unconditional-preprocessor-if,
   -readability-container-contains,
-  -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-enum-initial-value,
   -readability-function-size,

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.hpp
@@ -50,7 +50,7 @@ private:
     tt::tt_metal::distributed::SocketConfig convert_to_socket_config(
         const TestSocketConfig& socket_config, const ParsedMemoryConfig& memory_config);
 
-    tt::tt_metal::distributed::SocketConnection convert_to_socket_connection(
+    static tt::tt_metal::distributed::SocketConnection convert_to_socket_connection(
         const SocketConnectionConfig& connection_config);
 
     void run_test(const ParsedTestConfig& test);

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
@@ -113,7 +113,7 @@ public:
 
     std::optional<std::string> get_yaml_config_path();
     bool has_help_option();
-    void print_help();
+    static void print_help();
     bool print_configs();
 
 private:

--- a/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/multihost_fabric_fixtures.hpp
@@ -277,7 +277,7 @@ public:
 
     // The derived fixture must infer if the current system is suitable for the requested
     // topology in the Mesh Graph, when implementing this function.
-    bool system_supported() {
+    static bool system_supported() {
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
         return *(tt::tt_metal::MetalContext::instance().global_distributed_context().size()) ==
@@ -302,7 +302,7 @@ public:
         }
     }
 
-    bool system_supported() {
+    static bool system_supported() {
         const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
         return *(tt::tt_metal::MetalContext::instance().global_distributed_context().size()) ==

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -51,8 +51,8 @@ public:
     inline static std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devices_;
     inline static bool slow_dispatch_;
 
-    const std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>>& get_devices() const { return devices_; }
-    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& get_device(ChipId id) const {
+    static const std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>>& get_devices() { return devices_; }
+    static const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& get_device(ChipId id) {
         return devices_map_.at(id);
     }
 
@@ -262,7 +262,7 @@ public:
     static void SetUpTestSuite() {}
     static void TearDownTestSuite() {}
 
-    void SetUp(
+    static void SetUp(
         const std::string& mesh_graph_desc_file,
         const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
         tt::tt_metal::MetalContext::instance().set_custom_fabric_topology(

--- a/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_fabric_builder_local_connections.cpp
@@ -65,7 +65,7 @@ protected:
         RouterConnectionMapping connection_mapping;
     };
 
-    MockRouter create_mock_mesh_router(RoutingDirection dir, uint32_t router_id, bool has_z) {
+    static MockRouter create_mock_mesh_router(RoutingDirection dir, uint32_t router_id, bool has_z) {
         return MockRouter{
             .node_id = FabricNodeId(MeshId{0}, router_id),
             .direction = dir,
@@ -81,7 +81,7 @@ protected:
         };
     }
 
-    MockRouter create_mock_z_router(uint32_t router_id) {
+    static MockRouter create_mock_z_router(uint32_t router_id) {
         static auto intermesh_config = IntermeshVCConfig::full_mesh();
         return MockRouter{
             .node_id = FabricNodeId(MeshId{0}, router_id),

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_archetypes.cpp
@@ -85,7 +85,7 @@ protected:
     /**
      * @brief Create a mesh router archetype
      */
-    RouterArchetype create_mesh_router_archetype(
+    static RouterArchetype create_mesh_router_archetype(
         Topology topology, RoutingDirection direction, bool has_z, FabricNodeId node_id, uint8_t eth_chan = 0) {
         // Channel mapping
         FabricRouterChannelMapping channel_mapping(
@@ -108,9 +108,7 @@ protected:
     /**
      * @brief Create a Z router archetype
      */
-    RouterArchetype create_z_router_archetype(
-        FabricNodeId node_id,
-        uint8_t eth_chan = 0) {
+    static RouterArchetype create_z_router_archetype(FabricNodeId node_id, uint8_t eth_chan = 0) {
         static auto intermesh_config = IntermeshVCConfig::full_mesh();
 
         // Channel mapping

--- a/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_router_connection_mapping.cpp
@@ -65,7 +65,7 @@ protected:
     void TearDown() override {}
 
     // Helper to verify a single target
-    void verify_target(
+    static void verify_target(
         const ConnectionTarget& target,
         ConnectionType expected_type,
         uint32_t expected_vc,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -36,7 +36,7 @@ protected:
     static tt::tt_metal::AsicID make_asic(uint64_t id) { return tt::tt_metal::AsicID{id}; }
 
     // Create N nodes for the default mesh
-    std::vector<FabricNodeId> make_nodes(size_t count) const {
+    static std::vector<FabricNodeId> make_nodes(size_t count) {
         std::vector<FabricNodeId> nodes;
         nodes.reserve(count);
         for (uint32_t i = 0; i < count; ++i) {
@@ -121,8 +121,8 @@ protected:
     // -------------------------------------------------------------------------
 
     // Assign all nodes to the same rank
-    std::map<FabricNodeId, MeshHostRankId> make_uniform_node_ranks(
-        const std::vector<FabricNodeId>& nodes, MeshHostRankId rank = MeshHostRankId{0}) const {
+    static std::map<FabricNodeId, MeshHostRankId> make_uniform_node_ranks(
+        const std::vector<FabricNodeId>& nodes, MeshHostRankId rank = MeshHostRankId{0}) {
         std::map<FabricNodeId, MeshHostRankId> result;
         for (const auto& node : nodes) {
             result[node] = rank;

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -42,7 +42,7 @@ protected:
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_1, .noc = tt::tt_metal::NOC::RISCV_1_default});
     }
 
-    void setup_kernel_dir(const std::string& orig_kernel_file, const std::string& new_kernel_file) {
+    static void setup_kernel_dir(const std::string& orig_kernel_file, const std::string& new_kernel_file) {
         const std::string& kernel_dir = tt::tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         const std::filesystem::path& kernel_file_path_under_kernel_dir(kernel_dir + new_kernel_file);
         const std::filesystem::path& dirs_under_kernel_dir = kernel_file_path_under_kernel_dir.parent_path();
@@ -53,7 +53,7 @@ protected:
         std::filesystem::copy(kernel_file_path_under_metal_root, kernel_file_path_under_kernel_dir);
     }
 
-    void cleanup_kernel_dir() {
+    static void cleanup_kernel_dir() {
         const std::string& kernel_dir = tt::tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(kernel_dir)) {
             std::filesystem::remove_all(entry);
@@ -66,7 +66,7 @@ protected:
 private:
     bool are_preconditions_satisfied() { return this->are_env_vars_set() && this->is_kernel_dir_valid(); }
 
-    bool are_env_vars_set() {
+    static bool are_env_vars_set() {
         bool are_set = true;
         if (!tt::tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
             log_info(tt::LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be set");
@@ -86,7 +86,7 @@ private:
         return is_valid;
     }
 
-    bool does_path_exist(const std::string& path) {
+    static bool does_path_exist(const std::string& path) {
         const std::filesystem::path& file_path(path);
         return std::filesystem::exists(file_path);
     }

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -28,7 +28,7 @@ private:
 
 public:
     // A function to run a program, according to which dispatch mode is set.
-    void RunProgram(
+    static void RunProgram(
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         distributed::MeshWorkload& workload,
         const bool skip_finish = false) {
@@ -37,17 +37,17 @@ public:
             distributed::Finish(mesh_device->mesh_command_queue());
         }
     }
-    void FinishCommands(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    static void FinishCommands(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
         distributed::Finish(mesh_device->mesh_command_queue());
     }
-    void WriteBuffer(
+    static void WriteBuffer(
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         const std::shared_ptr<distributed::MeshBuffer>& in_buffer,
         std::vector<uint32_t>& src_vec) {
         distributed::WriteShard(
             mesh_device->mesh_command_queue(), in_buffer, src_vec, distributed::MeshCoordinate(0, 0));
     }
-    void ReadBuffer(
+    static void ReadBuffer(
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         const std::shared_ptr<distributed::MeshBuffer>& out_buffer,
         std::vector<uint32_t>& dst_vec) {
@@ -100,7 +100,7 @@ protected:
         }
     }
 
-    void RunTestOnDevice(
+    static void RunTestOnDevice(
         const std::function<void()>& run_function, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
         auto* device = mesh_device->get_devices()[0];
         log_info(tt::LogTest, "Running test on device {}.", device->id());

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -470,7 +470,7 @@ protected:
             this->devices_[0]);
     }
 
-    DestPrintTestConfig CreateTestConfig(const TestParams& params) {
+    static DestPrintTestConfig CreateTestConfig(const TestParams& params) {
         return DestPrintTestConfigBuilder()
             .set_num_tiles(params.num_tiles)
             .set_data_format(params.data_format)

--- a/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/inspector/test_rpc_startup.cpp
@@ -14,28 +14,28 @@
 class InspectorFixture : public ::testing::Test {
   protected:
     // Helper to find a free port
-    int find_free_port() {
-        int sock = socket(AF_INET, SOCK_STREAM, 0);
-        if (sock < 0) {
-            return 0;
-        }
-        sockaddr_in addr{};
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = INADDR_ANY;
-        addr.sin_port = 0; // Let OS pick
-        if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-            close(sock);
-            return 0;
-        }
-        socklen_t len = sizeof(addr);
-        if (getsockname(sock, (struct sockaddr*)&addr, &len) == -1) {
-            close(sock);
-            return 0;
-        }
-        int port = ntohs(addr.sin_port);
-        close(sock);
-        return port;
-    }
+      static int find_free_port() {
+          int sock = socket(AF_INET, SOCK_STREAM, 0);
+          if (sock < 0) {
+              return 0;
+          }
+          sockaddr_in addr{};
+          addr.sin_family = AF_INET;
+          addr.sin_addr.s_addr = INADDR_ANY;
+          addr.sin_port = 0;  // Let OS pick
+          if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+              close(sock);
+              return 0;
+          }
+          socklen_t len = sizeof(addr);
+          if (getsockname(sock, (struct sockaddr*)&addr, &len) == -1) {
+              close(sock);
+              return 0;
+          }
+          int port = ntohs(addr.sin_port);
+          close(sock);
+          return port;
+      }
 
     std::string find_free_port_address() {
         int port = find_free_port();
@@ -45,7 +45,7 @@ class InspectorFixture : public ::testing::Test {
         return "localhost:" + std::to_string(port);
     }
 
-    void try_connect(const std::string& address) {
+    static void try_connect(const std::string& address) {
         auto io = ::kj::setupAsyncIo();
         auto& waitScope = io.waitScope;
         kj::Network& network = io.provider->getNetwork();
@@ -57,7 +57,7 @@ class InspectorFixture : public ::testing::Test {
         auto response = request.send().wait(waitScope);
     }
 
-    void start(tt::tt_metal::inspector::RpcServerController& controller, const std::string& address) {
+    static void start(tt::tt_metal::inspector::RpcServerController& controller, const std::string& address) {
         controller.get_rpc_server().setGetProgramsCallback([](auto result) {
             result.initPrograms(0);
         });

--- a/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
+++ b/tests/tt_metal/tt_metal/device/galaxy_fixture.hpp
@@ -33,7 +33,7 @@ private:
 };
 
 class TGFixture : public MeshDispatchFixture {
-    void SkipTestSuiteIfNotTG() {
+    static void SkipTestSuiteIfNotTG() {
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "This test can only run on Wormhole B0";
         }

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -81,7 +81,7 @@ protected:
         }
     }
 
-    void initialize_seed() {
+    static void initialize_seed() {
         const uint32_t seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(time(nullptr)));
         log_info(tt::LogTest, "Using seed: {}", seed);
         srand(seed);
@@ -191,7 +191,7 @@ protected:
         return {unique_rt_args, common_rt_args};
     }
 
-    KernelProperties get_small_kernel_properties() {
+    static KernelProperties get_small_kernel_properties() {
         KernelProperties small_kernel_properties;
         small_kernel_properties.min_kernel_size_bytes = MIN_KERNEL_SIZE_BYTES;
         small_kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES * (2.0 / 10);
@@ -207,7 +207,7 @@ protected:
         return small_kernel_properties;
     }
 
-    KernelProperties get_large_kernel_properties() {
+    static KernelProperties get_large_kernel_properties() {
         KernelProperties large_kernel_properties;
         large_kernel_properties.min_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES * (9.0 / 10);
         large_kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES;
@@ -282,7 +282,7 @@ private:
     }
 
     // Generates a random number within the given bounds (inclusive) that is divisible by divisible_by
-    uint32_t generate_random_num(const uint32_t min, const uint32_t max, const uint32_t divisible_by = 1) {
+    static uint32_t generate_random_num(const uint32_t min, const uint32_t max, const uint32_t divisible_by = 1) {
         TT_FATAL(max >= min, "max: {}, min: {} - max must be >= min", max, min);
 
         const uint32_t adjusted_min = ((min + divisible_by - 1) / divisible_by) * divisible_by;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -56,7 +56,7 @@ private:
     CoreCoord host_core;
 
     // Validate a single core's worth of results vs expected
-    bool validate_one_core(
+    static bool validate_one_core(
         IDevice* device,
         std::unordered_set<CoreCoord>& validated_cores,
         const one_core_data_t& one_core_data,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -524,7 +524,7 @@ protected:
     }
 
     // Helper function to report performance
-    void report_performance(
+    static void report_performance(
         DeviceData& device_data,
         size_t num_cores_to_log,
         std::chrono::duration<double> elapsed,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_allocator.hpp
@@ -254,9 +254,9 @@ public:
 
 private:
     void reserve_core_internal(const CoreCoord& core, CoreType core_type, uint32_t partition_id = 0);
-    void assign_core_to_partition(CorePool& pool, const CoreCoord& core, uint32_t partition_id);
+    static void assign_core_to_partition(CorePool& pool, const CoreCoord& core, uint32_t partition_id);
     CoreCoord find_next_available_core(CorePool& pool, uint32_t partition_id = 0);
-    CoreCoord find_next_available_sync_core(CorePool& pool);
+    static CoreCoord find_next_available_sync_core(CorePool& pool);
     void refill_pool(CorePool& pool);
 };
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -403,8 +403,8 @@ public:
     }
 
     // Process results after barrier_reads() has been called
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> complete_read_buffer_from_cores(
-        const ReadBufferOperation& op) const {
+    static std::unordered_map<CoreCoord, std::vector<uint32_t>> complete_read_buffer_from_cores(
+        const ReadBufferOperation& op) {
         // Process results (existing splice logic)
         std::unordered_map<CoreCoord, std::vector<uint32_t>> results;
         auto num_words_per_core = op.size_bytes / sizeof(uint32_t);
@@ -1437,7 +1437,7 @@ public:
         return true;
     }
 
-    uint32_t get_max_routing_planes_for_device(const FabricNodeId& node_id) const {
+    static uint32_t get_max_routing_planes_for_device(const FabricNodeId& node_id) {
         // Find the minimum number of routing planes across all directions for this device
         uint32_t min_routing_planes = std::numeric_limits<uint32_t>::max();
 
@@ -1626,7 +1626,7 @@ private:
         are_devices_open_ = true;
     }
 
-    MeshCoordinate get_displacement(const MeshCoordinate& src_coords, const MeshCoordinate& dst_coords) const {
+    static MeshCoordinate get_displacement(const MeshCoordinate& src_coords, const MeshCoordinate& dst_coords) {
         TT_FATAL(
             src_coords.dims() == dst_coords.dims(),
             "Cannot find distance from coords with different dimensions: {} != {}",
@@ -1640,8 +1640,8 @@ private:
         return MeshCoordinate(coords);
     }
 
-    MeshCoordinateRange get_coords_from_range(
-        const MeshCoordinate& src_coords, const MeshCoordinate& dst_coords) const {
+    static MeshCoordinateRange get_coords_from_range(
+        const MeshCoordinate& src_coords, const MeshCoordinate& dst_coords) {
         const auto start = std::min(src_coords, dst_coords);
         const auto end = std::max(src_coords, dst_coords);
         return MeshCoordinateRange(start, end);
@@ -1863,7 +1863,7 @@ private:
         return visited;
     }
 
-    int32_t get_step_for_direction(RoutingDirection dir) const {
+    static int32_t get_step_for_direction(RoutingDirection dir) {
         switch (dir) {
             case RoutingDirection::N: return -1;
             case RoutingDirection::S: return 1;
@@ -1873,7 +1873,7 @@ private:
         }
     }
 
-    int32_t get_dim_for_direction(RoutingDirection dir) const {
+    static int32_t get_dim_for_direction(RoutingDirection dir) {
         switch (dir) {
             case RoutingDirection::N:
             case RoutingDirection::S: return NS_DIM;
@@ -1898,7 +1898,7 @@ private:
         return MeshCoordinate::BoundaryMode::NONE;
     }
 
-    RoutingDirection get_trunk_direction(const std::unordered_map<RoutingDirection, uint32_t>& split_hops) const {
+    static RoutingDirection get_trunk_direction(const std::unordered_map<RoutingDirection, uint32_t>& split_hops) {
         if (split_hops.count(RoutingDirection::N) > 0 && split_hops.at(RoutingDirection::N) > 0) {
             return RoutingDirection::N;
         } else if (split_hops.count(RoutingDirection::S) > 0 && split_hops.at(RoutingDirection::S) > 0) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -259,7 +259,7 @@ private:
     // Parsing helpers
     CoreCoord parse_core_coord(const YAML::Node& node);
     MeshCoordinate parse_mesh_coord(const YAML::Node& node);
-    MeshId parse_mesh_id(const YAML::Node& yaml_node);
+    static MeshId parse_mesh_id(const YAML::Node& yaml_node);
     template <typename T>
     T parse_scalar(const YAML::Node& yaml_node);
     template <typename T>
@@ -287,7 +287,7 @@ public:
     bool dump_built_tests();
     std::string get_built_tests_dump_file_name(const std::string& default_file_name);
     bool has_help_option();
-    void print_help();
+    static void print_help();
 
     // Progress monitoring options
     bool show_progress();
@@ -406,7 +406,7 @@ public:
         return built_tests;
     }
     // Helper function to check if a test should be skipped based on architecture or cluster type.
-    bool should_skip_test_on_platform(const ParsedTestConfig& test_config) const {
+    static bool should_skip_test_on_platform(const ParsedTestConfig& test_config) {
         // Skip if the test declares platforms to skip and this platform matches
         if (test_config.skip.has_value()) {
             // Determine current platform identifiers
@@ -632,7 +632,7 @@ private:
         return expanded_tests;
     }
 
-    std::vector<ParsedTestConfig> expand_parametrizations(const ParsedTestConfig& raw_config) {
+    static std::vector<ParsedTestConfig> expand_parametrizations(const ParsedTestConfig& raw_config) {
         std::vector<ParsedTestConfig> parametrized_configs;
         parametrized_configs.push_back(raw_config);
 
@@ -754,8 +754,8 @@ private:
         }
     }
 
-    void validate_chip_unicast(
-        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) const {
+    static void validate_chip_unicast(
+        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) {
         TT_FATAL(
             pattern.destination.has_value() &&
                 (pattern.destination->device.has_value() || pattern.destination->hops.has_value()),
@@ -777,8 +777,8 @@ private:
             test.name);
     }
 
-    void validate_chip_multicast(
-        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) const {
+    static void validate_chip_multicast(
+        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) {
         TT_FATAL(
             pattern.destination.has_value() && pattern.destination->hops.has_value(),
             "Test '{}': Multicast pattern for sender on device {} must have a destination specified by 'hops'.",
@@ -790,8 +790,8 @@ private:
             test.name);
     }
 
-    void validate_sync_pattern(
-        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) const {
+    static void validate_sync_pattern(
+        const TrafficPatternConfig& pattern, const SenderConfig& sender, const TestConfig& test) {
         // The NeighborExchange topology uses unicast sync patterns, so we perform a different check
         if (test.fabric_setup.topology == tt::tt_fabric::Topology::NeighborExchange) {
             TT_FATAL(
@@ -1223,7 +1223,7 @@ private:
         return {sync_patterns, sync_val};
     }
 
-    void add_senders_from_pairs(
+    static void add_senders_from_pairs(
         ParsedTestConfig& test,
         const std::vector<std::pair<FabricNodeId, FabricNodeId>>& pairs,
         const ParsedTrafficPatternConfig& base_pattern) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -860,7 +860,7 @@ private:
         }
     }
 
-    void validate_packet_sizes_for_policy(const TestConfig& config, uint32_t payload_chunk_size) {
+    static void validate_packet_sizes_for_policy(const TestConfig& config, uint32_t payload_chunk_size) {
         uint32_t max_packet_size = 0;
         for (const auto& sender : config.senders) {
             for (const auto& pattern : sender.patterns) {
@@ -1527,7 +1527,7 @@ private:
         write_bandwidth_summary_csv_to_file(csv_summary_upload_file_path_, true);
     }
 
-    std::string get_golden_csv_filename() {
+    static std::string get_golden_csv_filename() {
         auto arch_name = tt::tt_metal::hal::get_arch_name();
         auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
 
@@ -1618,7 +1618,7 @@ private:
         return true;
     }
 
-    std::string get_golden_latency_csv_filename();
+    static std::string get_golden_latency_csv_filename();
 
     bool load_golden_latency_csv();
 
@@ -1644,7 +1644,8 @@ private:
     }
 
     // Common CSV diff file initialization
-    std::ofstream init_diff_csv_file(std::filesystem::path& diff_csv_path, const std::string& csv_header, const std::string& test_type) {
+    static std::ofstream init_diff_csv_file(
+        std::filesystem::path& diff_csv_path, const std::string& csv_header, const std::string& test_type) {
         std::filesystem::path output_path =
             std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / output_dir;
         std::ostringstream diff_oss;
@@ -1679,7 +1680,7 @@ private:
 
     ComparisonResult create_comparison_result(const BandwidthResultSummary& test_result);
 
-    std::string convert_num_devices_to_string(const std::vector<uint32_t>& num_devices);
+    static std::string convert_num_devices_to_string(const std::vector<uint32_t>& num_devices);
 
     void compare_summary_results_with_golden() {
         if (golden_csv_entries_.empty()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -184,7 +184,7 @@ private:
     static constexpr uint32_t BUFFERS_PER_CHANNEL = 8;
 
     // Helper method to assign and validate mux channels for a connection
-    void assign_and_validate_channels(Connection& conn, const ConnectionKey& key);
+    static void assign_and_validate_channels(Connection& conn, const ConnectionKey& key);
 };
 
 struct TestWorker {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -197,7 +197,7 @@ void TestProgressMonitor::display_progress(
     std::cout << ss.str() << std::flush;
 }
 
-std::string TestProgressMonitor::format_count(uint64_t count) const {
+std::string TestProgressMonitor::format_count(uint64_t count) {
     if (count >= 1000000) {
         return std::to_string(count / 1000000) + "M";
     } else if (count >= 1000) {
@@ -206,7 +206,7 @@ std::string TestProgressMonitor::format_count(uint64_t count) const {
     return std::to_string(count);
 }
 
-std::string TestProgressMonitor::format_throughput(double packets_per_second) const {
+std::string TestProgressMonitor::format_throughput(double packets_per_second) {
     std::stringstream ss;
     if (packets_per_second >= 1000000) {
         ss << std::fixed << std::setprecision(1) << (packets_per_second / 1000000.0) << "M/s";
@@ -218,7 +218,7 @@ std::string TestProgressMonitor::format_throughput(double packets_per_second) co
     return ss.str();
 }
 
-std::string TestProgressMonitor::format_duration(double seconds) const {
+std::string TestProgressMonitor::format_duration(double seconds) {
     if (seconds >= 3600) {
         uint32_t hours = static_cast<uint32_t>(seconds / 3600);
         uint32_t minutes = static_cast<uint32_t>((seconds - (hours * 3600)) / 60);
@@ -233,7 +233,7 @@ std::string TestProgressMonitor::format_duration(double seconds) const {
 }
 
 std::optional<double> TestProgressMonitor::estimate_eta(
-    uint64_t current_total, uint64_t target_total, double throughput) const {
+    uint64_t current_total, uint64_t target_total, double throughput) {
     if (throughput <= 0 || current_total >= target_total) {
         return std::nullopt;
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.hpp
@@ -77,15 +77,15 @@ private:
         std::chrono::duration<double> elapsed_since_last_poll);
 
     // Formatting helpers
-    std::string format_count(uint64_t count) const;
-    std::string format_throughput(double packets_per_second) const;
-    std::string format_duration(double seconds) const;
+    static std::string format_count(uint64_t count);
+    static std::string format_throughput(double packets_per_second);
+    static std::string format_duration(double seconds);
 
     // Hung detection
     bool is_device_hung(tt::tt_fabric::FabricNodeId device_id, uint64_t current_packets);
 
     // ETA calculation
-    std::optional<double> estimate_eta(uint64_t current_total, uint64_t target_total, double throughput) const;
+    static std::optional<double> estimate_eta(uint64_t current_total, uint64_t target_total, double throughput);
 
     // Context and configuration
     ::TestContext* ctx_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.hpp
@@ -183,11 +183,11 @@ public:
 private:
     void organize_speedups_by_topology();
 
-    double calculate_geomean_speedup(const std::vector<double>& speedups);
+    static double calculate_geomean_speedup(const std::vector<double>& speedups);
 
     void calculate_overall_geomean_speedup();
 
-    std::vector<double> concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups);
+    static std::vector<double> concatenate_topology_speedups(const SpeedupsByTopology& topology_speedups);
 
     void calculate_geomean_speedup_by_topology();
 

--- a/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
+++ b/tests/ttnn/tracy/cpp/test_get_programs_perf_data.cpp
@@ -109,7 +109,7 @@ protected:
         distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
     }
 
-    void WriteProgramsPerfDataToJson(
+    static void WriteProgramsPerfDataToJson(
         const std::vector<std::map<tt::ChipId, std::set<experimental::ProgramAnalysisData>>>& programs_perf_data_list,
         const std::string& file_name) {
         nlohmann::json json_programs_perf_data_list;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -140,7 +140,7 @@ public:
     std::shared_ptr<MeshDevice> mesh_device_;
 
     // Gets the appropriate mesh shape based on device configuration
-    MeshShape GetDeterminedMeshShape() const { return SystemMesh::instance().shape(); }
+    static MeshShape GetDeterminedMeshShape() { return SystemMesh::instance().shape(); }
 
     // Validates environment and hardware for tests
     void ValidateEnvironment() {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators.cpp
@@ -22,12 +22,12 @@ struct UnharvestedWormholeWorkerToNocLookup
     static constexpr std::array<noc_grid_index_t, 8> worker_to_routing_x = {1, 2, 3, 4, 6, 7, 8, 9};
     static constexpr std::array<noc_grid_index_t, 10> worker_to_routing_y = {1, 2, 3, 4, 5, 7, 8, 9, 10, 11};
 
-    noc_grid_index_t get_noc_x_from_worker_x(noc_grid_index_t worker_x) const {
+    static noc_grid_index_t get_noc_x_from_worker_x(noc_grid_index_t worker_x) {
         // ASSERT worker_x < worker_to_routing_x_wormhole.size()
         return worker_to_routing_x[worker_x];
     }
 
-    noc_grid_index_t get_noc_y_from_worker_y(noc_grid_index_t worker_y) const {
+    static noc_grid_index_t get_noc_y_from_worker_y(noc_grid_index_t worker_y) {
         // ASSERT worker_y < worker_to_routing_y_wormhole.size()
         return worker_to_routing_y[worker_y];
     }

--- a/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
@@ -20,7 +20,7 @@ protected:
     void TearDown() override {}
 
     // Helper to create core coordinate vectors
-    std::vector<CoreCoord> make_cores(uint32_t num_cores) {
+    static std::vector<CoreCoord> make_cores(uint32_t num_cores) {
         std::vector<CoreCoord> cores;
         cores.reserve(num_cores);
         for (uint32_t i = 0; i < num_cores; i++) {
@@ -30,7 +30,7 @@ protected:
     }
 
     // Verify transfer correctness by checking that all elements are accounted for
-    bool verify_transfers(const std::vector<GatherTransfer>& transfers, uint32_t B, uint32_t C, uint32_t HW) {
+    static bool verify_transfers(const std::vector<GatherTransfer>& transfers, uint32_t B, uint32_t C, uint32_t HW) {
         // Track which elements have been transferred
         std::set<std::tuple<uint32_t, uint32_t, uint32_t>> transferred_elements;
 
@@ -63,7 +63,7 @@ protected:
     }
 
     // Check if transfers are properly coalesced
-    bool check_coalescing(const std::vector<GatherTransfer>& transfers) {
+    static bool check_coalescing(const std::vector<GatherTransfer>& transfers) {
         for (size_t i = 1; i < transfers.size(); i++) {
             const auto& prev = transfers[i - 1];
             const auto& curr = transfers[i];
@@ -79,7 +79,7 @@ protected:
     }
 
     // Validate blocked transfer groups
-    bool verify_blocked_groups(
+    static bool verify_blocked_groups(
         const std::vector<BlockedTransferGroup>& groups, uint32_t output_width, uint32_t block_size) {
         // Check that groups are properly organized
         std::set<std::pair<uint32_t, uint32_t>> seen_blocks;
@@ -102,7 +102,7 @@ protected:
     }
 
     // Helper to create test input shards
-    std::vector<std::vector<float>> create_test_input(uint32_t B, uint32_t C, uint32_t HW, uint32_t num_cores) {
+    static std::vector<std::vector<float>> create_test_input(uint32_t B, uint32_t C, uint32_t HW, uint32_t num_cores) {
         std::vector<std::vector<float>> shards(num_cores);
         uint32_t shard_width = HW / num_cores;
         uint32_t shard_height = B * C;
@@ -124,7 +124,7 @@ protected:
     // Helper to compute expected output value for a given position
     // Output layout: [C, B*HW/num_output_cores] per shard
     // For output shard idx, position [c, pos] corresponds to input [b, c, hw]
-    float compute_expected_output_value(
+    static float compute_expected_output_value(
         uint32_t output_shard_idx,
         uint32_t c,
         uint32_t pos,

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -114,10 +114,10 @@ static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFacto
 // Old infrastructure device operation that uses the "create_program" method
 struct OldInfraDeviceOpWithCreateProgram {
     void validate(const std::vector<Tensor>& input_tensors) const {}
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+    static std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) { return {}; }
+    static std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) { return {}; }
 
-    auto create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    static auto create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) {
         return tt::tt_metal::operation::ProgramWithCallbacks();
     }
 };
@@ -125,13 +125,13 @@ struct OldInfraDeviceOpWithCreateProgram {
 // Old infrastructure device operation that uses the "create_program_at" method
 struct OldInfraDeviceOpWithCreateMeshWorkload {
     void validate(const std::vector<Tensor>& input_tensors) const {}
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+    static std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) { return {}; }
+    static std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) { return {}; }
 
-    auto create_mesh_workload(
+    static auto create_mesh_workload(
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const std::vector<Tensor>& input_tensors,
-        std::vector<Tensor>& output_tensors) const {
+        std::vector<Tensor>& output_tensors) {
         return tt::tt_metal::operation::MeshWorkloadWithCallbacks();
     }
 };

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -34,7 +34,7 @@ protected:
     size_t num_devices_ = 0;
 
 public:
-    bool check_dispatch_mode() {
+    static bool check_dispatch_mode() {
         auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         return slow_dispatch == nullptr;
     }

--- a/tools/tests/scaleout/test_link_retraining.cpp
+++ b/tools/tests/scaleout/test_link_retraining.cpp
@@ -79,7 +79,9 @@ public:
         return *physical_system_descriptor_;
     }
     const std::unordered_map<uint64_t, ChipId>& get_asic_id_to_chip_id() const { return asic_id_to_chip_id_; }
-    std::string get_cabling_descriptor_path() const { return "tools/tests/scaleout/cabling_descriptors/t3k.textproto"; }
+    static std::string get_cabling_descriptor_path() {
+        return "tools/tests/scaleout/cabling_descriptors/t3k.textproto";
+    }
 };
 
 [[nodiscard]] uint32_t get_link_training_status(const tt::Cluster& cluster, ChipId chip_id, const tt_xy_pair& coord) {

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -56,7 +56,7 @@ public:
     bfloat16 operator/(bfloat16 rhs) const;
 
 private:
-    uint16_t from_float(float val);
+    static uint16_t from_float(float val);
 };
 
 std::ostream& operator<<(std::ostream& os, const bfloat16& bfp16);

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -261,24 +261,24 @@ template <bool _compiler_deprioritize_this = true>
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRangeSet> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::tt_metal::CoreRangeSet& core_range_set, format_context& ctx) const
+    static auto format(const tt::tt_metal::CoreRangeSet& core_range_set, format_context& ctx)
         -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRange> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) const -> format_context::iterator;
+    static auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreCoord> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const -> format_context::iterator;
+    static auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) -> format_context::iterator;
 };
 
 namespace std {

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -261,24 +261,26 @@ template <bool _compiler_deprioritize_this = true>
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRangeSet> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const tt::tt_metal::CoreRangeSet& core_range_set, format_context& ctx)
-        -> format_context::iterator;
+    auto format(const tt::tt_metal::CoreRangeSet& core_range_set, format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreRange> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) -> format_context::iterator;
+    auto format(const tt::tt_metal::CoreRange& core_range, format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<tt::tt_metal::CoreCoord> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) -> format_context::iterator;
+    auto format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 namespace std {

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -174,7 +174,7 @@ public:
 
     eth_chan_directions get_eth_chan_direction(FabricNodeId fabric_node_id, int chan) const;
     // TODO: remove this converter, we should consolidate the directions here
-    eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction) const;
+    static eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction);
 
     // Return ethernet channels on a chip that face external meshes (inter-mesh exit nodes)
     std::vector<chan_id_t> get_intermesh_facing_eth_chans(FabricNodeId fabric_node_id) const;
@@ -202,7 +202,7 @@ public:
     // intended for users to grab available eth cores for testing
     // `skip_reserved_cores` is ignored on BH because there are no ethernet cores used for Fast Dispatch
     // tunneling
-    std::unordered_set<CoreCoord> get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores = false) const;
+    static std::unordered_set<CoreCoord> get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores = false);
     std::unordered_set<CoreCoord> get_inactive_ethernet_cores(ChipId chip_id) const;
 
     // Collect router port directions map from all hosts via MPI and merge into local map
@@ -268,8 +268,8 @@ private:
     // custom logic to order eth channels
     void order_ethernet_channels();
 
-    routing_plane_id_t get_routing_plane_id(
-        chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const;
+    static routing_plane_id_t get_routing_plane_id(
+        chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction);
 
     // Tries to get a valid downstream channel from the candidate_target_chans
     // First along same routing plane, but if not available, take round robin from candidates
@@ -403,7 +403,7 @@ private:
 
     // This method performs validation through assertions and exceptions.
     void validate_torus_setup(tt::tt_fabric::FabricConfig fabric_config) const;
-    std::string get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const;
+    static std::string get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config);
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
@@ -113,9 +113,9 @@ public:
     }
 
     // Instance type checks
-    bool is_graph(const InstanceData& instance) const { return instance.kind == NodeKind::Graph; }
-    bool is_mesh(const InstanceData& instance) const { return instance.kind == NodeKind::Mesh; }
-    bool is_switch(const InstanceData& instance) const { return instance.kind == NodeKind::Switch; }
+    static bool is_graph(const InstanceData& instance) { return instance.kind == NodeKind::Graph; }
+    static bool is_mesh(const InstanceData& instance) { return instance.kind == NodeKind::Mesh; }
+    static bool is_switch(const InstanceData& instance) { return instance.kind == NodeKind::Switch; }
 
     // Typed enumeration
     const std::vector<GlobalNodeId>& all_meshes() const { return mesh_instances_; }

--- a/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
@@ -70,8 +70,8 @@ private:
     // Direct lookup table: [src_mesh][src_chip][dst_mesh] -> exit chip_id in src_mesh
     std::vector<std::vector<std::vector<ChipId>>> exit_node_lut_;
 
-    std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> get_paths_to_all_meshes(
-        MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const;
+    static std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> get_paths_to_all_meshes(
+        MeshId src, const InterMeshConnectivity& inter_mesh_connectivity);
     void generate_intramesh_routing_table(const IntraMeshConnectivity& intra_mesh_connectivity);
     // when generating intermesh routing table, we use the intramesh connectivity table to find the shortest path to
     // the exit chip
@@ -92,7 +92,7 @@ struct hash<tt::tt_fabric::FabricNodeId> {
 
 template <>
 struct fmt::formatter<tt::tt_fabric::FabricNodeId> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator;
+    static auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) -> format_context::iterator;
 };

--- a/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
@@ -92,7 +92,8 @@ struct hash<tt::tt_fabric::FabricNodeId> {
 
 template <>
 struct fmt::formatter<tt::tt_fabric::FabricNodeId> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) -> format_context::iterator;
+    auto format(const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
@@ -401,7 +401,7 @@ private:
     void rebuild_host_rank_structs_from_mapping(
         const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 
-    void print_logical_adjacency_map(const std::map<MeshId, LogicalAdjacencyMap>& adj_map) const;
+    static void print_logical_adjacency_map(const std::map<MeshId, LogicalAdjacencyMap>& adj_map);
 
     void print_physical_adjacency_map(const std::map<MeshId, PhysicalAdjacencyMap>& adj_map) const;
 };

--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -112,9 +112,9 @@ public:
 
     void flush_program_memory_usage(uint64_t program_id, const IDevice* device);
 
-    void dump_memory_usage_state(const IDevice* device, const std::string& prefix = "") const;
+    static void dump_memory_usage_state(const IDevice* device, const std::string& prefix = "");
 
-    MemoryView get_memory_view(const IDevice* device, const BufferType& buffer_type) const;
+    static MemoryView get_memory_view(const IDevice* device, const BufferType& buffer_type);
 
     static void toggle(bool state);
     static MemoryReporter& inst();

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -156,9 +156,10 @@ struct hash<tt::tt_metal::TileDescriptor> {
 // Formatter support for TileDescriptor (needed for reflection/logging)
 template <>
 struct fmt::formatter<tt::tt_metal::TileDescriptor> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const tt::tt_metal::TileDescriptor& tile_desc, format_context& ctx) -> format_context::iterator {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto format(const tt::tt_metal::TileDescriptor& tile_desc, format_context& ctx) const -> format_context::iterator {
         return fmt::format_to(
             ctx.out(), "TileDescriptor({}x{}{})", tile_desc.height, tile_desc.width, tile_desc.transpose ? ",T" : "");
     }

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -156,9 +156,9 @@ struct hash<tt::tt_metal::TileDescriptor> {
 // Formatter support for TileDescriptor (needed for reflection/logging)
 template <>
 struct fmt::formatter<tt::tt_metal::TileDescriptor> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const tt::tt_metal::TileDescriptor& tile_desc, format_context& ctx) const -> format_context::iterator {
+    static auto format(const tt::tt_metal::TileDescriptor& tile_desc, format_context& ctx) -> format_context::iterator {
         return fmt::format_to(
             ctx.out(), "TileDescriptor({}x{}{})", tile_desc.height, tile_desc.width, tile_desc.transpose ? ",T" : "");
     }

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -645,19 +645,21 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b)
 
 }  // namespace tt::tt_metal
 
-auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) -> format_context::iterator {
+auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
+    -> format_context::iterator {
     std::stringstream ss;
     ss << core_coord.str();
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
-auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) -> format_context::iterator {
+auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) const
+    -> format_context::iterator {
     std::stringstream ss;
     ss << core_range.str();
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
-auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx)
+auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx) const
     -> format_context::iterator {
     std::stringstream ss;
     ss << core_range_set.str();

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -645,21 +645,19 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b)
 
 }  // namespace tt::tt_metal
 
-auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
-    -> format_context::iterator {
+auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) -> format_context::iterator {
     std::stringstream ss;
     ss << core_coord.str();
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
-auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) const
-    -> format_context::iterator {
+auto fmt::formatter<CoreRange>::format(const CoreRange& core_range, format_context& ctx) -> format_context::iterator {
     std::stringstream ss;
     ss << core_range.str();
     return fmt::format_to(ctx.out(), "{}", ss.str());
 }
 
-auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx) const
+auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx)
     -> format_context::iterator {
     std::stringstream ss;
     ss << core_range_set.str();

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -129,7 +129,7 @@ void MemoryReporter::flush_program_memory_usage(uint64_t program_id, const IDevi
         this->program_l1_usage_summary_report_);
 }
 
-void MemoryReporter::dump_memory_usage_state(const IDevice* device, const std::string& prefix) const {
+void MemoryReporter::dump_memory_usage_state(const IDevice* device, const std::string& prefix) {
     std::ofstream memory_usage_summary_report, l1_usage_summary_report, detailed_memory_usage_report;
 
     fs::create_directories(metal_reports_dir());
@@ -157,7 +157,7 @@ void DumpDeviceMemoryState(const IDevice* device, const std::string& prefix) {
     MemoryReporter::inst().dump_memory_usage_state(device, prefix);
 }
 
-MemoryView MemoryReporter::get_memory_view(const IDevice* device, const BufferType& buffer_type) const {
+MemoryView MemoryReporter::get_memory_view(const IDevice* device, const BufferType& buffer_type) {
     auto stats = device->allocator()->get_statistics(buffer_type);
     auto num_banks_ = device->allocator()->get_num_banks(buffer_type);
 

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -101,7 +101,7 @@ private:
     // launch message must be unique across physical devices to accurately capture program execution time on host and
     // device. This API is responsible for updating the launch message before writing it to each device (see
     // tt_metal/api/tt-metalium/dev_msgs.h for a description of how the host_assigned_id field is generated).
-    void update_launch_messages_for_device_profiler(
+    static void update_launch_messages_for_device_profiler(
         ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device);
     // Clear the num_workers_completed counter on the dispatcher cores corresponding to this CQ.
     void clear_expected_num_workers_completed();

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -43,7 +43,7 @@ private:
     ProgramBinaryStatus get_program_binary_status(std::size_t mesh_id) const;
     void set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status);
     ProgramConfig& get_program_config(uint32_t index, bool using_fast_dispatch);
-    ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
+    static ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
     void compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device);
     void finalize_offsets(MeshDevice* mesh_device);
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -618,7 +618,7 @@ void ControlPlane::validate_mesh_connections() const {
 }
 
 routing_plane_id_t ControlPlane::get_routing_plane_id(
-    chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const {
+    chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) {
     auto it = std::find(eth_chans_in_direction.begin(), eth_chans_in_direction.end(), eth_chan_id);
     return std::distance(eth_chans_in_direction.begin(), it);
 }
@@ -1192,7 +1192,7 @@ std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
     return valid_eth_chans;
 }
 
-eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDirection direction) const {
+eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDirection direction) {
     eth_chan_directions dir;
     switch (direction) {
         case RoutingDirection::N: dir = eth_chan_directions::NORTH; break;
@@ -1980,7 +1980,7 @@ bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) con
     return this->physical_system_descriptor_->is_cross_host_eth_link(tt::tt_metal::AsicID{asic_id}, chan_id);
 }
 
-std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
+std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
     std::unordered_set<CoreCoord> active_ethernet_cores;
@@ -2943,7 +2943,7 @@ void ControlPlane::validate_torus_setup(tt::tt_fabric::FabricConfig fabric_confi
     log_debug(tt::LogFabric, "Torus validation passed for configuration: {}", enchantum::to_string(fabric_config));
 }
 
-std::string ControlPlane::get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const {
+std::string ControlPlane::get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) {
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     TT_FATAL(
         cluster_type == tt::tt_metal::ClusterType::GALAXY,

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -102,7 +102,7 @@ private:
      *
      * Called by connect_routers() after inter-device connections are established.
      */
-    void configure_local_connections(
+    static void configure_local_connections(
         const std::map<FabricRouterBuilder*, std::map<RoutingDirection, FabricRouterBuilder*>>&
             routers_by_direction_map);
 

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -186,7 +186,7 @@ void FabricBuilderContext::initialize_tensix_config() {
     }
 }
 
-IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
+IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& mesh_graph = control_plane.get_mesh_graph();
 
@@ -237,6 +237,5 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
 
     return config;
 }
-
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -161,8 +161,7 @@ public:
     bool requires_intermesh_vc_mesh_pass_through() const { return intermesh_vc_config_.requires_vc1_mesh_pass_through; }
 
 private:
-
-    IntermeshVCConfig compute_intermesh_vc_config() const;
+    static IntermeshVCConfig compute_intermesh_vc_config();
 
     friend class FabricContext;
 

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -20,7 +20,7 @@
 
 namespace tt::tt_fabric {
 
-std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() const {
+std::unordered_map<MeshId, bool> FabricContext::check_for_wrap_around_mesh() {
     std::unordered_map<MeshId, bool> wrap_around_mesh;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -122,14 +122,14 @@ bool FabricContext::is_wrap_around_mesh(MeshId mesh_id) const {
     return it->second;
 }
 
-bool FabricContext::is_switch_mesh(MeshId mesh_id) const {
+bool FabricContext::is_switch_mesh(MeshId mesh_id) {
     // Stub: returns false for now (all meshes are compute meshes)
     // TODO: Implement when switch mesh support lands - delegate to ControlPlane
     (void)mesh_id;  // Unused for now
     return false;
 }
 
-bool FabricContext::has_z_router_on_device(ChipId device_id) const {
+bool FabricContext::has_z_router_on_device(ChipId device_id) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& mesh_graph = control_plane.get_mesh_graph();
     const auto& inter_mesh_connectivity = mesh_graph.get_inter_mesh_connectivity();

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -55,13 +55,13 @@ public:
     // ============ Mesh Type Queries ============
     // Stub: returns false for now (all meshes are compute meshes)
     // TODO: Implement when switch mesh support lands
-    bool is_switch_mesh(MeshId mesh_id) const;
+    static bool is_switch_mesh(MeshId mesh_id);
 
     // ============ Z Router Queries ============
     // Check if a device has a Z router
     // Stub for Phase 3: returns false (will be implemented in Phase 5)
     // TODO(Phase 5): Implement proper Z router detection
-    bool has_z_router_on_device(ChipId device_id) const;
+    static bool has_z_router_on_device(ChipId device_id);
 
     // ============ Tensix Config Query ============
     // Returns true if tensix is enabled (MUX or UDM mode)
@@ -84,7 +84,7 @@ public:
     static tt::tt_fabric::Topology get_topology_from_config(tt::tt_fabric::FabricConfig fabric_config);
 
 private:
-    std::unordered_map<MeshId, bool> check_for_wrap_around_mesh() const;
+    static std::unordered_map<MeshId, bool> check_for_wrap_around_mesh();
     size_t compute_packet_header_size_bytes() const;
     size_t compute_max_payload_size_bytes() const;
 

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -362,7 +362,7 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
 }
 
 // UDM mode helper: builds list of workers sorted by column (x first, then y within each column)
-std::vector<CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt_metal::IDevice* device) const {
+std::vector<CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt_metal::IDevice* device) {
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t total_workers = compute_grid.x * compute_grid.y;
 

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -276,7 +276,7 @@ private:
         const std::vector<tt_metal::IDevice*>& all_active_devices);
 
     // UDM mode helper: builds list of workers sorted by column (y first, then x)
-    std::vector<CoreCoord> build_workers_by_column(tt::tt_metal::IDevice* device) const;
+    static std::vector<CoreCoord> build_workers_by_column(tt::tt_metal::IDevice* device);
 
     // UDM mode helper: gets unique tensix cores for worker assignment (excludes dispatch routing plane)
     std::vector<CoreCoord> get_tensix_cores_for_workers(tt::tt_metal::IDevice* device) const;

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -876,7 +876,7 @@ FabricTensixDatamoverMuxBuilder::FabricTensixDatamoverMuxBuilder(
     TT_FATAL(config_ != nullptr, "Config cannot be null");
 }
 
-const char* FabricTensixDatamoverMuxBuilder::get_kernel_file_path() const {
+const char* FabricTensixDatamoverMuxBuilder::get_kernel_file_path() {
     const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
     if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
         return "tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp";

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -446,7 +446,7 @@ public:
     void append_upstream_routers_noc_xy(uint32_t noc_x, uint32_t noc_y);
 
 private:
-    const char* get_kernel_file_path() const;
+    static const char* get_kernel_file_path();
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_runtime_args(tt::tt_metal::Program& program) const;
 

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -188,10 +188,10 @@ public:
         const std::string& src_host, const std::string& dst_host) const;
     const HostTopology& get_host_topology() const;
     std::string get_host_name_for_asic(AsicID asic_id) const;
-    UID get_u_id(const std::string& hostname);
-    RackID get_rack_id(const std::string& hostname);
-    AisleID get_aisle_id(const std::string& hostname);
-    HallID get_hall_id(const std::string& hostname);
+    static UID get_u_id(const std::string& hostname);
+    static RackID get_rack_id(const std::string& hostname);
+    static AisleID get_aisle_id(const std::string& hostname);
+    static HallID get_hall_id(const std::string& hostname);
     std::vector<std::string> get_all_hostnames() const;
     std::string my_host_name() const;
     uint32_t get_rank_for_hostname(const std::string& host_name) const;

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -18,7 +18,7 @@
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 
 auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
-    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) -> format_context::iterator {
+    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
     return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
 }
 

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -18,7 +18,7 @@
 #include <tt-metalium/experimental/fabric/topology_mapper.hpp>
 
 auto fmt::formatter<tt::tt_fabric::FabricNodeId>::format(
-    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) const -> format_context::iterator {
+    const tt::tt_fabric::FabricNodeId& node_id, format_context& ctx) -> format_context::iterator {
     return fmt::format_to(ctx.out(), "(M{}, D{})", *node_id.mesh_id, node_id.chip_id);
 }
 
@@ -161,7 +161,7 @@ void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConn
 // Shortest Path
 // TODO: Put into mesh algorithms?
 std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> RoutingTableGenerator::get_paths_to_all_meshes(
-    MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const {
+    MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) {
     // TODO: add more tests for this
     std::uint32_t num_meshes = inter_mesh_connectivity.size();
     // avoid vector<bool> specialization

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -1294,7 +1294,7 @@ int TopologyMapper::get_mpi_rank_for_mesh_host_rank(MeshId mesh_id, MeshHostRank
     return -1;  // Unreachable
 }
 
-void TopologyMapper::print_logical_adjacency_map(const std::map<MeshId, LogicalAdjacencyMap>& adj_map) const {
+void TopologyMapper::print_logical_adjacency_map(const std::map<MeshId, LogicalAdjacencyMap>& adj_map) {
     log_debug(tt::LogFabric, "TopologyMapper: Logical Adjacency Map:");
     for (const auto& [mesh_id, node_map] : adj_map) {
         log_debug(tt::LogFabric, "  Mesh ID: {}", *mesh_id);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1568,7 +1568,7 @@ thread_local MetalContext::CommandQueueIdStack MetalContext::command_queue_id_st
 MetalContext::CommandQueueIdStack& MetalContext::get_command_queue_id_stack_for_thread() {
     return MetalContext::command_queue_id_stack_for_thread_;
 }
-const MetalContext::CommandQueueIdStack& MetalContext::get_command_queue_id_stack_for_thread() const {
+const MetalContext::CommandQueueIdStack& MetalContext::get_command_queue_id_stack_for_thread() {
     return MetalContext::command_queue_id_stack_for_thread_;
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -120,8 +120,8 @@ public:
 
     // This is used to track the current thread's command queue id stack
     using CommandQueueIdStack = std::vector<uint8_t>;
-    CommandQueueIdStack& get_command_queue_id_stack_for_thread();
-    const CommandQueueIdStack& get_command_queue_id_stack_for_thread() const;
+    static CommandQueueIdStack& get_command_queue_id_stack_for_thread();
+    static const CommandQueueIdStack& get_command_queue_id_stack_for_thread();
 
     // Utilities
     bool is_coord_in_range(CoreCoord coord, CoreType core_type);

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -457,14 +457,14 @@ private:
     void transfer_stream_to_output(const RiscKey& risc_key, ostringstream* intermediate_stream);
 
     // Returns the formatted output data from a dprint stream
-    string get_formatted_output_data(const RiscKey& risc_key, const ostringstream* stream);
+    static string get_formatted_output_data(const RiscKey& risc_key, const ostringstream* stream);
 
     // Returns the stream that the dprint data should be output to. Can be auto-generated files, the user-selected file,
     // stdout, or nothing.
     ostream* get_output_stream(const RiscKey& risc_key);
 
     // Helper functions to init/attach/detach a single device
-    void init_device(ChipId device_id);
+    static void init_device(ChipId device_id);
     void attach_device(ChipId device_id);
     void detach_device(ChipId device_id);
 

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -22,12 +22,12 @@ private:
     void rpc_get_programs(rpc::Inspector::GetProgramsResults::Builder& results);
     void rpc_get_mesh_devices(rpc::Inspector::GetMeshDevicesResults::Builder& results);
     void rpc_get_mesh_workloads(rpc::Inspector::GetMeshWorkloadsResults::Builder& results);
-    void rpc_get_devices_in_use(rpc::Inspector::GetDevicesInUseResults::Builder& results);
+    static void rpc_get_devices_in_use(rpc::Inspector::GetDevicesInUseResults::Builder& results);
     void rpc_get_kernel(
         rpc::Inspector::GetKernelParams::Reader params, rpc::Inspector::GetKernelResults::Builder results);
     void rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builder results);
     void rpc_get_all_dispatch_core_infos(rpc::Inspector::GetAllDispatchCoreInfosResults::Builder results);
-    void rpc_get_metal_device_id_mappings(rpc::Inspector::GetMetalDeviceIdMappingsResults::Builder results);
+    static void rpc_get_metal_device_id_mappings(rpc::Inspector::GetMetalDeviceIdMappingsResults::Builder results);
 
     static rpc::BinaryStatus convert_binary_status(ProgramBinaryStatus status);
     static void populate_core_info(rpc::CoreInfo::Builder& out, const CoreInfo& info, uint32_t event_id);

--- a/tt_metal/impl/debug/inspector/logger.hpp
+++ b/tt_metal/impl/debug/inspector/logger.hpp
@@ -34,7 +34,7 @@ private:
     bool initialized{false};
     std::filesystem::path logging_path;
 
-    int64_t convert_timestamp(const time_point& tp) const {
+    static int64_t convert_timestamp(const time_point& tp) {
         return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
     }
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -51,7 +51,7 @@ public:
         const std::lock_guard<std::mutex> lock(watch_mutex_);
         create_log_file();
     }
-    std::string log_file_name();
+    static std::string log_file_name();
     int register_kernel(const std::string& name);
     void register_kernel_elf_paths(int id, std::vector<std::string>& paths);
     void read_kernel_ids_from_file();
@@ -63,7 +63,7 @@ public:
     std::unique_lock<std::mutex> get_lock() { return std::unique_lock<std::mutex>(watch_mutex_); }
 
 private:
-    double get_elapsed_secs();
+    static double get_elapsed_secs();
     void create_log_file();
     void create_kernel_file();
     void create_kernel_elf_file();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -360,7 +360,7 @@ void DeviceManager::initialize_host(IDevice* dev) const {
     }
 }
 
-void DeviceManager::init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const {
+void DeviceManager::init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) {
     std::vector<std::shared_future<tt_metal::IDevice*>> events;
     for (uint32_t i = 0; i < active_devices.size(); i++) {
         const auto& dev = active_devices[i];

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -77,7 +77,7 @@ private:
     void initialize_host(IDevice* dev) const;
 
     // Initialize state for activated devices
-    void init_fabric(const std::vector<IDevice*>& active_devices) const;
+    static void init_fabric(const std::vector<IDevice*>& active_devices);
     void initialize_active_devices();
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
     void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -60,12 +60,12 @@ uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceA
     return device_cq_addrs_[index];
 }
 
-uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const {
+uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) {
     return ttsl::as_underlying_type<CommandQueueHostAddrType>(host_addr) *
            tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
 }
 
-uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
+uint32_t DispatchMemMap::get_sync_offset(uint32_t index) {
     TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
     uint32_t offset = index * MetalContext::instance().hal().get_alignment(HalMemType::L1);
     return offset;
@@ -95,7 +95,7 @@ uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const {
     }
 }
 
-uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) const {
+uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) {
     TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET);
     return index;
 }
@@ -178,7 +178,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
     TT_ASSERT(dispatch_cb_end < l1_size);
 }
 
-std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType& core_type) const {
+std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType& core_type) {
     uint32_t l1_base;
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -64,16 +64,16 @@ public:
 
     uint32_t get_device_command_queue_addr(const CommandQueueDeviceAddrType& device_addr_type) const;
 
-    uint32_t get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const;
+    static uint32_t get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr);
 
-    uint32_t get_sync_offset(uint32_t index) const;
+    static uint32_t get_sync_offset(uint32_t index);
 
     uint32_t get_dispatch_message_addr_start() const;
 
     uint32_t get_dispatch_stream_index(uint32_t index) const;
 
     // Offset to be passed in the go message.
-    uint8_t get_dispatch_message_update_offset(uint32_t index) const;
+    static uint8_t get_dispatch_message_update_offset(uint32_t index);
 
     uint32_t get_prefetcher_l1_size() const;
 
@@ -81,7 +81,7 @@ private:
     // Reset the instance using the settings for the core_type and num_hw_cqs.
     void reset(const CoreType& core_type, uint32_t num_hw_cqs);
 
-    std::pair<uint32_t, uint32_t> get_device_l1_info(const CoreType& core_type) const;
+    static std::pair<uint32_t, uint32_t> get_device_l1_info(const CoreType& core_type);
 
     uint32_t cmddat_q_base_ = 0;
     uint32_t scratch_db_base_ = 0;

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -156,7 +156,7 @@ private:
 
     std::condition_variable reads_processed_cv_;
     std::mutex reads_processed_cv_mutex_;
-    CoreType get_dispatch_core_type();
+    static CoreType get_dispatch_core_type();
 
     CoreCoord virtual_enqueue_program_dispatch_core_;
     CoreCoord completion_queue_writer_core_;

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -56,7 +56,7 @@ public:
 
     EnqueueCommandType type() override { return EnqueueCommandType::TERMINATE; }
 
-    constexpr bool has_side_effects() { return false; }
+    static constexpr bool has_side_effects() { return false; }
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -167,7 +167,7 @@ protected:
         bool send_to_brisc,
         bool force_watcher_no_inline,
         tt::tt_metal::KernelBuildOptLevel opt_level = tt::tt_metal::KernelBuildOptLevel::Os);
-    int GetPort(const FDKernel* other, const std::vector<FDKernel*>& kernels) const {
+    static int GetPort(const FDKernel* other, const std::vector<FDKernel*>& kernels) {
         for (int idx = 0; idx < kernels.size(); idx++) {
             if (kernels[idx] == other) {
                 return idx;

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -571,7 +571,7 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     this->prefetch_q_dev_ptrs[cq_id] += sizeof(DispatchSettings::prefetch_q_entry_type);
 }
 
-void SystemMemoryManager::on_timeout_detected() const {
+void SystemMemoryManager::on_timeout_detected() {
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
 
     // Serialize Inspector RPC data if enabled

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -93,7 +93,7 @@ public:
         uint8_t cq_id, uint32_t current_event_id, uint32_t last_completed_event_id);
 
 private:
-    void on_timeout_detected() const;
+    static void on_timeout_detected();
 
     ChipId device_id = 0;
     std::vector<uint32_t> completion_byte_addrs;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -63,16 +63,16 @@ public:
     // Executor functions for all traced host API calls (commands)
     // Trace APIs are no longer supported due to trace API deprecation. See Issue #24955
     void execute(const tt::tt_metal::flatbuffer::Command* command);
-    void execute(const tt::tt_metal::flatbuffer::EnqueueTraceCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::ReplayTraceCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::LoadTraceCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::ReleaseTraceCommand* command);
+    static void execute(const tt::tt_metal::flatbuffer::EnqueueTraceCommand* command);
+    static void execute(const tt::tt_metal::flatbuffer::ReplayTraceCommand* command);
+    static void execute(const tt::tt_metal::flatbuffer::LoadTraceCommand* command);
+    static void execute(const tt::tt_metal::flatbuffer::ReleaseTraceCommand* command);
     void execute(const tt::tt_metal::flatbuffer::BufferCreateCommand* cmd);
     void execute(const tt::tt_metal::flatbuffer::BufferDeallocateCommand* command);
     void execute(const tt::tt_metal::flatbuffer::BufferDeleteCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueWriteBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueReadBufferCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::FinishCommand* command);
+    static void execute(const tt::tt_metal::flatbuffer::FinishCommand* command);
     void execute(const tt::tt_metal::flatbuffer::ProgramConstructorCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueProgramCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* command);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1642,7 +1642,7 @@ private:
 class GoSignalGenerator {
 public:
     // Determine the size of the go signal commands.
-    void size_commands(
+    static void size_commands(
         DeviceCommandCalculator& calculator,
         IDevice* /*device*/,
         SubDeviceId /*sub_device_id*/,
@@ -1663,7 +1663,7 @@ public:
     }
 
     // Assemble the go signal commands into the device command sequence.
-    void assemble_commands(
+    static void assemble_commands(
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
         const CommandConstants& constants,

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -472,7 +472,7 @@ void JitBuildState::compile_one(
     jit_build::write_dependency_hashes(out_dir, obj);
 }
 
-bool JitBuildState::need_compile(const string& out_dir, const string& obj) const {
+bool JitBuildState::need_compile(const string& out_dir, const string& obj) {
     return MetalContext::instance().rtoptions().get_force_jit_compile() || !fs::exists(out_dir + obj) ||
            !jit_build::dependencies_up_to_date(out_dir, obj);
 }
@@ -576,7 +576,7 @@ std::string JitBuildState::weakened_firmware_name() const {
     return fmt::format("{}{}/{}_{}", this->env_.out_firmware_root_, this->target_name_, this->target_name_, name);
 }
 
-void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const {
+void JitBuildState::extract_zone_src_locations(const std::string& out_dir) {
     // ZoneScoped;
     static std::atomic<bool> new_log = true;
     if (tt::tt_metal::getDeviceProfilerState()) {

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -119,7 +119,7 @@ protected:
     // Used when JitBuildSettings is not provided
     std::string default_linker_opt_level_;
 
-    bool need_compile(const std::string& out_dir, const std::string& obj) const;
+    static bool need_compile(const std::string& out_dir, const std::string& obj);
     size_t compile(const std::string& out_path, const JitBuildSettings* settings) const;
     void compile_one(
         const std::string& out_path,
@@ -130,7 +130,7 @@ protected:
     void link(const std::string& out_path, const JitBuildSettings* settings) const;
     void weaken(const std::string& out_path) const;
     std::string weakened_firmware_name() const;
-    void extract_zone_src_locations(const std::string& out_dir) const;
+    static void extract_zone_src_locations(const std::string& out_dir);
 
 public:
     JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& build_config);

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -139,7 +139,7 @@ uint32_t generate_risc_startup_addr(uint32_t firmware_base) {
     return jal_offset | opcode;
 }
 
-HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) const {
+HalProcessorSet Hal::parse_processor_set_spec(std::string_view spec) {
     HalProcessorSet set;
 
     // TODO: might need a new syntax for new architectures.

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -457,7 +457,7 @@ public:
     std::pair<HalProcessorClassType, uint32_t> get_processor_class_and_type_from_index(
         HalProgrammableCoreType programmable_core_type, uint32_t processor_index) const;
     // Parses a string representation of a set of processor names (used by env vars).
-    HalProcessorSet parse_processor_set_spec(std::string_view spec) const;
+    static HalProcessorSet parse_processor_set_spec(std::string_view spec);
 
     uint32_t get_total_num_risc_processors() const;
     uint32_t get_max_processors_per_core() const { return max_processors_per_core_; }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -880,8 +880,7 @@ std::unique_ptr<tt::umd::SysmemBuffer> Cluster::map_sysmem_buffer(
     return sysmem_manager->map_sysmem_buffer(buffer, sysmem_buffer_size, map_to_noc);
 }
 
-void Cluster::verify_sw_fw_versions(
-    int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const {
+void Cluster::verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) {
     umd::tt_version sw(sw_version), fw_first_eth_core(fw_versions.at(0));
     log_info(
         tt::LogDevice,

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -129,7 +129,7 @@ public:
     std::optional<int> get_physical_slot(ChipId chip) const;
 
     //! device driver and misc apis
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
+    static void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions);
     bool verify_eth_fw_capability() const;
 
     void deassert_risc_reset_at_core(

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -957,9 +957,10 @@ struct fmt::formatter<T, char, std::enable_if_t<std::is_enum<T>::value>> {
 
 template <>
 struct fmt::formatter<std::filesystem::path> {
-    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    static auto format(const std::filesystem::path& path, format_context& ctx) -> format_context::iterator {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto format(const std::filesystem::path& path, format_context& ctx) const -> format_context::iterator {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << path;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -957,9 +957,9 @@ struct fmt::formatter<T, char, std::enable_if_t<std::is_enum<T>::value>> {
 
 template <>
 struct fmt::formatter<std::filesystem::path> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
 
-    auto format(const std::filesystem::path& path, format_context& ctx) const -> format_context::iterator {
+    static auto format(const std::filesystem::path& path, format_context& ctx) -> format_context::iterator {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << path;

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -198,9 +198,10 @@ using core::Config;
 
 template <>
 struct fmt::formatter<ttnn::Config> {
-    static constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
 
-    static auto format(const ttnn::Config& config, format_context& ctx) -> format_context::iterator {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto format(const ttnn::Config& config, format_context& ctx) const -> format_context::iterator {
         std::stringstream ss;
         ss << config;
         return fmt::format_to(ctx.out(), "{}", ss.str());

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -198,9 +198,9 @@ using core::Config;
 
 template <>
 struct fmt::formatter<ttnn::Config> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    static constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
 
-    auto format(const ttnn::Config& config, format_context& ctx) const -> format_context::iterator {
+    static auto format(const ttnn::Config& config, format_context& ctx) -> format_context::iterator {
         std::stringstream ss;
         ss << config;
         return fmt::format_to(ctx.out(), "{}", ss.str());

--- a/ttnn/api/ttnn/tensor/layout/page_config.hpp
+++ b/ttnn/api/ttnn/tensor/layout/page_config.hpp
@@ -20,20 +20,20 @@ class RowMajorPageConfig {
 public:
     RowMajorPageConfig(const Tile& tile = Tile());
 
-    Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const;
-    void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const;
+    static Alignment create_default_alignment(DataType dtype, const MemoryConfig& memory_config);
+    static void validate_alignment(const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config);
 
-    Shape2D get_page_shape(
+    static Shape2D get_page_shape(
         const Shape2D& physical_size,
         DataType dtype,
         const MemoryConfig& memory_config,
-        const std::optional<Shape2D>& physical_shard_size) const;
-    size_t get_page_size_bytes(const Shape2D& page_size, DataType dtype) const;
+        const std::optional<Shape2D>& physical_shard_size);
+    static size_t get_page_size_bytes(const Shape2D& page_size, DataType dtype);
 
     const Tile& get_tile() const;
 
-    Alignment get_required_shard_shape_alignment() const;
-    Alignment get_recommended_shard_shape_alignment(DataType dtype) const;
+    static Alignment get_required_shard_shape_alignment();
+    static Alignment get_recommended_shard_shape_alignment(DataType dtype);
 
     bool operator==(const RowMajorPageConfig&) const = default;
     bool operator!=(const RowMajorPageConfig&) const = default;

--- a/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/tensor_layout.hpp
@@ -64,7 +64,7 @@ public:
     // Flattens input shape into height and width
     // - Height is accumulated over all dims except last
     // - Width is equal to the last dim
-    Shape2D compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const;
+    static Shape2D compute_logical_2d_shape(const tt::tt_metal::Shape& shape);
 
     // Returns number of elements laid out in physically memory across H:W dimensions
     //  W is row width aligned to page width and shard width, depends on data type

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -30,7 +30,7 @@ public:
     HostStorage transform(const std::function<HostBuffer(const HostBuffer&)>& callable) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
-    auto attribute_values() const { return std::forward_as_tuple(); }
+    static auto attribute_values() { return std::forward_as_tuple(); }
 
 private:
     DistributedHostBuffer distributed_buffer_;
@@ -48,7 +48,7 @@ struct DeviceStorage {
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple();
-    auto attribute_values() const { return std::forward_as_tuple(); }
+    static auto attribute_values() { return std::forward_as_tuple(); }
 
     bool is_allocated() const;
 

--- a/ttnn/core/tensor/layout/page_config.cpp
+++ b/ttnn/core/tensor/layout/page_config.cpp
@@ -145,7 +145,7 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
 
 RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {}
 
-Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const MemoryConfig& memory_config) const {
+Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const MemoryConfig& memory_config) {
     if (memory_config.shard_spec().has_value()) {
         const auto& shard_spec = memory_config.shard_spec().value();
         return Alignment({shard_spec.shape[1]});
@@ -157,7 +157,7 @@ Alignment RowMajorPageConfig::create_default_alignment(DataType dtype, const Mem
 }
 
 void RowMajorPageConfig::validate_alignment(
-    const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) const {
+    const Alignment& alignment, DataType dtype, const MemoryConfig& memory_config) {
     TT_FATAL(!alignment.empty(), "Alignment must contain at least one dimension for Row Major layout.");
     const uint32_t width_alignment = alignment[-1];
 
@@ -179,7 +179,7 @@ Shape2D RowMajorPageConfig::get_page_shape(
     const Shape2D& physical_size,
     DataType dtype,
     const MemoryConfig& memory_config,
-    const std::optional<Shape2D>& physical_shard_size) const {
+    const std::optional<Shape2D>& physical_shard_size) {
     if (physical_size.height() == 0 || physical_size.width() == 0) {
         return Shape2D(1, sizeof(uint32_t) / CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype));
     }
@@ -201,16 +201,16 @@ Shape2D RowMajorPageConfig::get_page_shape(
     return Shape2D(1, physical_size.width());
 }
 
-size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) const {
+size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataType dtype) {
     const auto size = page_shape.height() * page_shape.width() * CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype);
     return size;
 }
 
 const Tile& RowMajorPageConfig::get_tile() const { return tile_; }
 
-Alignment RowMajorPageConfig::get_required_shard_shape_alignment() const { return Alignment({1}); }
+Alignment RowMajorPageConfig::get_required_shard_shape_alignment() { return Alignment({1}); }
 
-Alignment RowMajorPageConfig::get_recommended_shard_shape_alignment(DataType dtype) const {
+Alignment RowMajorPageConfig::get_recommended_shard_shape_alignment(DataType dtype) {
     auto element_size_bytes = CMAKE_UNIQUE_NAMESPACE::rm_element_size_bytes(dtype);
     auto alignment_bytes = std::lcm(CMAKE_UNIQUE_NAMESPACE::RECOMMENDED_MEMORY_ALIGNMENT_BYTES, element_size_bytes);
     return Alignment({alignment_bytes / element_size_bytes});

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -298,7 +298,7 @@ Shape2D TensorLayout::get_physical_shard_shape() const {
     return shard_spec.shape;
 }
 
-Shape2D TensorLayout::compute_logical_2d_shape(const tt::tt_metal::Shape& shape) const {
+Shape2D TensorLayout::compute_logical_2d_shape(const tt::tt_metal::Shape& shape) {
     if (shape.rank() < 2) {
         return Shape2D{1, shape[-1]};
     }

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -254,7 +254,7 @@ size_t LineTopology::get_distance_to_end_of_line(ttnn::ccl::LineDirection direct
     }
 }
 
-ttnn::ccl::Topology LineTopology::topology() const { return ttnn::ccl::Topology::Linear; }
+ttnn::ccl::Topology LineTopology::topology() { return ttnn::ccl::Topology::Linear; }
 
 tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
     const ttnn::MeshCoordinateRangeSet& tensor_coords,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -118,7 +118,7 @@ class LineTopology {
 
     size_t get_distance_to_end_of_line(ttnn::ccl::LineDirection direction) const;
 
-    ttnn::ccl::Topology topology() const;
+    static ttnn::ccl::Topology topology() ;
 
    private:
     size_t _line_size;
@@ -654,12 +654,12 @@ public:
     ttnn::ccl::v2::TensorSlice get_worker_slice_v2(std::size_t global_worker_index);
 
     // method to compute offsets in a wrapped layout
-    std::vector<tt_xy_pair> compute_worker_slice_offsets(
+    static std::vector<tt_xy_pair> compute_worker_slice_offsets(
         const std::vector<tt_xy_pair>& worker_slice_shapes,
         tt_xy_pair const& tensor_slice_shape);
 
     // method to create worker slice shapes in a tile layout
-    std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
+    static std::vector<tt_xy_pair> create_worker_slice_shapes_for_tile_layout(
         const ttnn::Shape& tensor_shape,
         tt_xy_pair const& tensor_slice_shape_in_tiles,
         uint32_t num_workers,
@@ -677,7 +677,7 @@ private:
         uint32_t max_slice_size_in_bytes,
         uint32_t half_cb_n_pages);
 
-    tt_xy_pair calculate_tensor_slice_shape(const Tensor& input_tensor, int slice_dim, uint32_t partition_size);
+    static tt_xy_pair calculate_tensor_slice_shape(const Tensor& input_tensor, int slice_dim, uint32_t partition_size);
     Shape4D<uint32_t> calculate_tensor_slice_offset(const Tensor& input_tensor, int slice_dim, uint32_t partition_index);
 
     // Class member variables
@@ -705,10 +705,10 @@ public:
     ttnn::ccl::v2::TensorSlice get_worker_slice_v2(std::size_t global_worker_index);
 
     // method to compute offsets in a wrapped layout
-    std::vector<Shape4D<uint32_t>> compute_worker_slice_offsets(std::vector<Shape4D<uint32_t>> const& worker_slice_shapes);
+    static std::vector<Shape4D<uint32_t>> compute_worker_slice_offsets(std::vector<Shape4D<uint32_t>> const& worker_slice_shapes);
 
     // method to create worker slice shapes in a tile layout
-    std::vector<Shape4D<uint32_t>> create_worker_slice_shapes_for_tile_layout(
+    static std::vector<Shape4D<uint32_t>> create_worker_slice_shapes_for_tile_layout(
         Shape4D<uint32_t> const& tensor_slice_shape_in_tiles,
         uint32_t num_workers);
 
@@ -720,7 +720,7 @@ private:
         uint32_t partition_size,
         uint32_t total_num_workers);
 
-    Shape4D<uint32_t> calculate_tensor_slice_shape(Shape4D<uint32_t> const& tensor_shape, int slice_dim, uint32_t partition_size);
+    static Shape4D<uint32_t> calculate_tensor_slice_shape(Shape4D<uint32_t> const& tensor_shape, int slice_dim, uint32_t partition_size);
     Shape4D<uint32_t> calculate_tensor_slice_offset(Shape4D<uint32_t> const& tensor_shape, int slice_dim, uint32_t partition_index);
 
     // Class member variables

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp
@@ -47,7 +47,7 @@ public:
 struct VirtualCoordWormholeWorkerToNocLookup
     : address_generators::WorkerToNocCoordLookup<VirtualCoordWormholeWorkerToNocLookup> {
     VirtualCoordWormholeWorkerToNocLookup() : address_generators::WorkerToNocCoordLookup<VirtualCoordWormholeWorkerToNocLookup>() {}
-    noc_grid_index_t get_noc_x_from_worker_x(noc_grid_index_t worker_x) const {
+    static noc_grid_index_t get_noc_x_from_worker_x(noc_grid_index_t worker_x) {
         #if defined(KERNEL_BUILD)
         return worker_x + VIRTUAL_TENSIX_START_X;
         #else
@@ -56,7 +56,7 @@ struct VirtualCoordWormholeWorkerToNocLookup
         #endif
     }
 
-    noc_grid_index_t get_noc_y_from_worker_y(noc_grid_index_t worker_y) const {
+    static noc_grid_index_t get_noc_y_from_worker_y(noc_grid_index_t worker_y) {
         #if defined(KERNEL_BUILD)
         return worker_y + VIRTUAL_TENSIX_START_Y
         #else

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -213,7 +213,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<ReshardDeviceOperation::tenso
 ReshardDeviceOperation::create_op_performance_model(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) const {
+    tensor_return_value_t& output_tensor) {
     int ideal_dev_clock_cycles = common_tm_bw_model(tensor_args.input, output_tensor);
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         {tensor_args.input}, {output_tensor}, ideal_dev_clock_cycles);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
@@ -41,10 +41,10 @@ struct ReshardDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor) const;
+        tensor_return_value_t& output_tensor);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -88,7 +88,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<ShardedToInterleavedDeviceOpe
 ShardedToInterleavedDeviceOperation::create_op_performance_model(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) const {
+    tensor_return_value_t& output_tensor) {
     int ideal_dev_clock_cycles = common_tm_bw_model(tensor_args.input_tensor, output_tensor);
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         {tensor_args.input_tensor}, {output_tensor}, ideal_dev_clock_cycles);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
@@ -26,10 +26,10 @@ struct ShardedToInterleavedDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor) const;
+        tensor_return_value_t& output_tensor);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
@@ -76,7 +76,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<ShardedToInterleavedPartialDe
 ShardedToInterleavedPartialDeviceOperation::create_op_performance_model(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) const {
+    tensor_return_value_t& output_tensor) {
     int ideal_dev_clock_cycles = common_tm_bw_model(tensor_args.input_tensor, output_tensor);
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         {tensor_args.input_tensor}, {output_tensor}, ideal_dev_clock_cycles);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
@@ -28,10 +28,10 @@ struct ShardedToInterleavedPartialDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor) const;
+        tensor_return_value_t& output_tensor);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -89,7 +89,7 @@ std::vector<ttnn::TensorSpec> Tilize::compute_output_specs(const std::vector<Ten
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> Tilize::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
     uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
@@ -24,10 +24,10 @@ struct Tilize {
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+        std::vector<Tensor>& output_tensors);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -105,7 +105,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 TilizeWithValPadding::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.hpp
@@ -25,10 +25,10 @@ struct TilizeWithValPadding {
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+        std::vector<Tensor>& output_tensors);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -190,7 +190,7 @@ std::vector<ttnn::TensorSpec> Untilize::compute_output_specs(const std::vector<T
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> Untilize::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
     uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.hpp
@@ -33,10 +33,10 @@ struct Untilize {
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+        std::vector<Tensor>& output_tensors);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -148,7 +148,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 UntilizeWithUnpadding::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor>& output_tensors) const {
+    std::vector<Tensor>& output_tensors) {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_tensor = output_tensors.at(0);
     uint32_t tile_width = input_tensor.tensor_spec().tile().get_width();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.hpp
@@ -25,10 +25,10 @@ struct UntilizeWithUnpadding {
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const;
+        std::vector<Tensor>& output_tensors);
 };
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -21,7 +21,7 @@ struct Lowercase {
 
 template <>
 struct fmt::formatter<ttnn::operations::binary_ng::Lowercase> : fmt::formatter<std::string_view> {
-    auto format(const ttnn::operations::binary_ng::Lowercase& value, fmt::format_context& ctx) const {
+    static auto format(const ttnn::operations::binary_ng::Lowercase& value, fmt::format_context& ctx) {
         auto out = ctx.out();
         for (char c : value.view) {
             *out++ = std::tolower(static_cast<unsigned char>(c));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -21,7 +21,8 @@ struct Lowercase {
 
 template <>
 struct fmt::formatter<ttnn::operations::binary_ng::Lowercase> : fmt::formatter<std::string_view> {
-    static auto format(const ttnn::operations::binary_ng::Lowercase& value, fmt::format_context& ctx) {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto format(const ttnn::operations::binary_ng::Lowercase& value, fmt::format_context& ctx) const {
         auto out = ctx.out();
         for (char c : value.view) {
             *out++ = std::tolower(static_cast<unsigned char>(c));

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.cpp
@@ -9,7 +9,8 @@
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::broadcast_to::Lowercase> : fmt::formatter<std::string_view> {
-    static auto format(const ttnn::operations::experimental::broadcast_to::Lowercase& value, fmt::format_context& ctx) {
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    auto format(const ttnn::operations::experimental::broadcast_to::Lowercase& value, fmt::format_context& ctx) const {
         auto out = ctx.out();
         for (char c : value.view) {
             *out++ = std::tolower(static_cast<unsigned char>(c));

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.cpp
@@ -9,7 +9,7 @@
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::broadcast_to::Lowercase> : fmt::formatter<std::string_view> {
-    auto format(const ttnn::operations::experimental::broadcast_to::Lowercase& value, fmt::format_context& ctx) const {
+    static auto format(const ttnn::operations::experimental::broadcast_to::Lowercase& value, fmt::format_context& ctx) {
         auto out = ctx.out();
         for (char c : value.view) {
             *out++ = std::tolower(static_cast<unsigned char>(c));

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -500,7 +500,7 @@ std::vector<std::vector<BlockedTransferGroup>> split_by_destination_core(
 namespace fmt {
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, format_context& ctx)
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, format_context& ctx) const
     -> format_context::iterator {
     std::string str = fmt::format(
         "GatherTransfer(B={}, C={}: Core{}[{},{}][row={}·C+{}, cols={}:{}] → Core{}[{},{}][row={}, cols={}:{}], "
@@ -525,8 +525,8 @@ auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::Gath
 }
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t, format_context& ctx)
-    -> format_context::iterator {
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
+    format_context& ctx) const -> format_context::iterator {
     std::string str = fmt::format(
         "LowLevelGatherTransfer(src_shard{}[{}:{}] (offset={} B) @ NOC({},{}) => dst_shard{}[{}:{}] (offset={} B), "
         "len={}, size={} B)",
@@ -546,8 +546,8 @@ auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowL
 }
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t, format_context& ctx)
-    -> format_context::iterator {
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
+    format_context& ctx) const -> format_context::iterator {
     uint32_t col_start = t.dst_block_idx * t.block_size;
     uint32_t col_end = col_start + t.block_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -500,7 +500,7 @@ std::vector<std::vector<BlockedTransferGroup>> split_by_destination_core(
 namespace fmt {
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, format_context& ctx) const
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, format_context& ctx)
     -> format_context::iterator {
     std::string str = fmt::format(
         "GatherTransfer(B={}, C={}: Core{}[{},{}][row={}·C+{}, cols={}:{}] → Core{}[{},{}][row={}, cols={}:{}], "
@@ -525,8 +525,8 @@ auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::Gath
 }
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
-    format_context& ctx) const -> format_context::iterator {
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t, format_context& ctx)
+    -> format_context::iterator {
     std::string str = fmt::format(
         "LowLevelGatherTransfer(src_shard{}[{}:{}] (offset={} B) @ NOC({},{}) => dst_shard{}[{}:{}] (offset={} B), "
         "len={}, size={} B)",
@@ -546,8 +546,8 @@ auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowL
 }
 
 auto formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>::format(
-    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
-    format_context& ctx) const -> format_context::iterator {
+    const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t, format_context& ctx)
+    -> format_context::iterator {
     uint32_t col_start = t.dst_block_idx * t.block_size;
     uint32_t col_end = col_start + t.block_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
@@ -340,23 +340,23 @@ inline std::vector<uint32_t> serialize_blocked_transfer_groups(
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>
     : formatter<string_view> {
-    auto format(
-        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t,
-        fmt::format_context& ctx) const -> format_context::iterator;
+    static auto format(
+        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, fmt::format_context& ctx)
+        -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>
     : formatter<string_view> {
-    auto format(
+    static auto format(
         const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
-        fmt::format_context& ctx) const -> format_context::iterator;
+        fmt::format_context& ctx) -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>
     : formatter<string_view> {
-    auto format(
+    static auto format(
         const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
-        fmt::format_context& ctx) const -> format_context::iterator;
+        fmt::format_context& ctx) -> format_context::iterator;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
@@ -340,23 +340,26 @@ inline std::vector<uint32_t> serialize_blocked_transfer_groups(
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer>
     : formatter<string_view> {
-    static auto format(
-        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t, fmt::format_context& ctx)
-        -> format_context::iterator;
+    auto format(
+        const ttnn::operations::experimental::cnn::convert_to_hwc::detail::GatherTransfer& t,
+        fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer>
     : formatter<string_view> {
-    static auto format(
+    auto format(
         const ttnn::operations::experimental::cnn::convert_to_hwc::detail::LowLevelGatherTransfer& t,
-        fmt::format_context& ctx) -> format_context::iterator;
+        fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup>
     : formatter<string_view> {
-    static auto format(
+    auto format(
         const ttnn::operations::experimental::cnn::convert_to_hwc::detail::BlockedTransferGroup& t,
-        fmt::format_context& ctx) -> format_context::iterator;
+        fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/rmsnorm_pre_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/rmsnorm_pre_all_gather_op.cpp
@@ -13,7 +13,7 @@
 
 namespace ttnn::operations::experimental::transformer {
 
-void FusedRMSNormPreAllGather::validate(const std::vector<Tensor>& input_tensors) const {
+void FusedRMSNormPreAllGather::validate(const std::vector<Tensor>& input_tensors) {
     using namespace tt::constants;
 
     TT_FATAL(input_tensors.size() == 1, "Must have 1 input tensor");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/rmsnorm_pre_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/rmsnorm_pre_all_gather_op.hpp
@@ -21,7 +21,7 @@ struct FusedRMSNormPreAllGather {
     const DataType dtype;
     const DeviceComputeKernelConfig compute_kernel_config;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
+    static void validate(const std::vector<Tensor>& input_tensors);
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.cpp
@@ -17,7 +17,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::normalization {
 
-void LayerNormPreAllGather::validate(const std::vector<Tensor>& input_tensors) const {
+void LayerNormPreAllGather::validate(const std::vector<Tensor>& input_tensors) {
     TT_FATAL(input_tensors.size() == 1, "Must have 1 input tensor");
     const auto& tensor = input_tensors.at(0);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp
@@ -38,7 +38,7 @@ struct LayerNormPreAllGather {
     LayerNormProgramConfig program_config;
     std::optional<bool> use_2d_core_grid;
 
-    void validate(const std::vector<Tensor>& input_tensors) const;
+    static void validate(const std::vector<Tensor>& input_tensors);
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1131,7 +1131,7 @@ std::string SlidingWindowConfig::to_string() const {
 }  // namespace ttnn::operations::sliding_window
 
 auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(
-    const ttnn::operations::sliding_window::ParallelConfig& t, format_context& ctx) -> format_context::iterator {
+    const ttnn::operations::sliding_window::ParallelConfig& t, format_context& ctx) const -> format_context::iterator {
     std::string shard_scheme_str;
     if (t.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
         shard_scheme_str = "HEIGHT_SHARDED";
@@ -1187,7 +1187,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::form
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::ShardBoundary>::format(
-    const ttnn::operations::sliding_window::ShardBoundary& t, format_context& ctx) -> format_context::iterator {
+    const ttnn::operations::sliding_window::ShardBoundary& t, format_context& ctx) const -> format_context::iterator {
     return fmt::format_to(
         ctx.out(),
         "[output_shard=({}, {}), input_shard=({}, {})]",

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1131,7 +1131,7 @@ std::string SlidingWindowConfig::to_string() const {
 }  // namespace ttnn::operations::sliding_window
 
 auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(
-    const ttnn::operations::sliding_window::ParallelConfig& t, format_context& ctx) const -> format_context::iterator {
+    const ttnn::operations::sliding_window::ParallelConfig& t, format_context& ctx) -> format_context::iterator {
     std::string shard_scheme_str;
     if (t.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
         shard_scheme_str = "HEIGHT_SHARDED";
@@ -1159,8 +1159,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::format(
-    const ttnn::operations::sliding_window::SlidingWindowConfig& t, format_context& ctx) const
-    -> format_context::iterator {
+    const ttnn::operations::sliding_window::SlidingWindowConfig& t, format_context& ctx) -> format_context::iterator {
     std::string str = fmt::format(
         "SlidingWindowConfig(batch_size={}, input_hw=({},{}), window_hw=({},{}), stride_hw=({},{}), padding=(({}, {}), "
         "({}, {})), output_padding = ({}, {}), "
@@ -1188,7 +1187,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::form
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::ShardBoundary>::format(
-    const ttnn::operations::sliding_window::ShardBoundary& t, format_context& ctx) const -> format_context::iterator {
+    const ttnn::operations::sliding_window::ShardBoundary& t, format_context& ctx) -> format_context::iterator {
     return fmt::format_to(
         ctx.out(),
         "[output_shard=({}, {}), input_shard=({}, {})]",

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -195,18 +195,18 @@ struct std::hash<ttnn::operations::sliding_window::ParallelConfig> {
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig> : formatter<string_view> {
-    auto format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, fmt::format_context& ctx) const
+    static auto format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, fmt::format_context& ctx)
         -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::ParallelConfig> : formatter<string_view> {
-    auto format(const ttnn::operations::sliding_window::ParallelConfig& t, fmt::format_context& ctx) const
+    static auto format(const ttnn::operations::sliding_window::ParallelConfig& t, fmt::format_context& ctx)
         -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::ShardBoundary> : formatter<string_view> {
-    auto format(const ttnn::operations::sliding_window::ShardBoundary& t, fmt::format_context& ctx) const
+    static auto format(const ttnn::operations::sliding_window::ShardBoundary& t, fmt::format_context& ctx)
         -> format_context::iterator;
 };

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -195,18 +195,18 @@ struct std::hash<ttnn::operations::sliding_window::ParallelConfig> {
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig> : formatter<string_view> {
-    static auto format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, fmt::format_context& ctx)
-        -> format_context::iterator;
+    auto format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::ParallelConfig> : formatter<string_view> {
-    static auto format(const ttnn::operations::sliding_window::ParallelConfig& t, fmt::format_context& ctx)
-        -> format_context::iterator;
+    auto format(const ttnn::operations::sliding_window::ParallelConfig& t, fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };
 
 template <>
 struct fmt::formatter<ttnn::operations::sliding_window::ShardBoundary> : formatter<string_view> {
-    static auto format(const ttnn::operations::sliding_window::ShardBoundary& t, fmt::format_context& ctx)
-        -> format_context::iterator;
+    auto format(const ttnn::operations::sliding_window::ShardBoundary& t, fmt::format_context& ctx) const
+        -> format_context::iterator;  // NOLINT(readability-convert-member-functions-to-static)
 };


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:

https://clang.llvm.org/extra/clang-tidy/checks/readability/convert-member-functions-to-static.html

It is typically c++ best practice to declare class methods as static if they do not require any members or state from the class instance.

### What's changed
- Enable check
- Apply automatic FIXIT

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] New/Existing tests provide coverage for changes