### PR TITLE
#34211: Change the mailbox api usage for `ttnn.manual_seed`

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_receive_all_data.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_receive_all_data.cpp
@@ -12,15 +12,28 @@
 
 namespace NAMESPACE {
 void MAIN {
-    // Read core ID from mailbox
-    bool is_core_id = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);
+    // Compile time args
+    constexpr uint32_t kernel_communication_cb_index = get_compile_time_arg_val(0);
+
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Get message from reader
+    cb_wait_front(kernel_communication_cb_index, one_tile);
+
+    // Read core ID from message
+    const uint32_t message_core_id = read_tile_value(kernel_communication_cb_index, 0, 0);
+    const bool is_core_id = (message_core_id != 0) ? true : false;
 
     if (is_core_id) {
-        // Read seed from mailbox
-        uint32_t seed = (uint32_t)mailbox_read(ckernel::ThreadId::BriscThreadId);
+        // Read seed from message
+        const uint32_t seed = read_tile_value(kernel_communication_cb_index, 0, 1);
 
         // Set random generator with seed
         rand_tile_init(seed);
     }
+
+    // Pop the communication entry
+    cb_pop_front(kernel_communication_cb_index, one_tile);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_receive_all_data.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_receive_all_data.cpp
@@ -22,12 +22,13 @@ void MAIN {
     cb_wait_front(kernel_communication_cb_index, one_tile);
 
     // Read core ID from message
-    const uint32_t message_core_id = read_tile_value(kernel_communication_cb_index, 0, 0);
+    const uint32_t message_core_id =
+        read_tile_value(kernel_communication_cb_index, /*tile_index=*/0, /*element_offset=*/0);
     const bool is_core_id = (message_core_id != 0) ? true : false;
 
     if (is_core_id) {
         // Read seed from message
-        const uint32_t seed = read_tile_value(kernel_communication_cb_index, 0, 1);
+        const uint32_t seed = read_tile_value(kernel_communication_cb_index, /*tile_index=*/0, /*element_offset=*/1);
 
         // Set random generator with seed
         rand_tile_init(seed);

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
@@ -5,7 +5,6 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_unary/rand.h"
-#include "compute_kernel_api/tile_move_copy.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
@@ -24,7 +24,7 @@ void MAIN {
     cb_wait_front(kernel_communication_cb_index, one_tile);
 
     // Get communication entry
-    const uint32_t message = read_tile_value(kernel_communication_cb_index, 0, 0);
+    const uint32_t message = read_tile_value(kernel_communication_cb_index, /*tile_index=*/0, /*element_offset=*/0);
     const bool is_core_id = (message != 0) ? true : false;
 
     // Initialize random generator if core_id matched

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/compute/manual_seed_single_seed_receive_user_id.cpp
@@ -5,6 +5,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/eltwise_unary/rand.h"
+#include "compute_kernel_api/tile_move_copy.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 
@@ -13,14 +14,25 @@
 namespace NAMESPACE {
 void MAIN {
     // Compile time args
-    constexpr uint32_t seed = get_compile_time_arg_val(0);
+    constexpr uint32_t kernel_communication_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t seed = get_compile_time_arg_val(1);
 
-    // Read core ID from mailbox
-    bool is_core_id = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);
+    // Constants
+    constexpr uint32_t one_tile = 1;
+
+    // Get message from reader
+    cb_wait_front(kernel_communication_cb_index, one_tile);
+
+    // Get communication entry
+    const uint32_t message = read_tile_value(kernel_communication_cb_index, 0, 0);
+    const bool is_core_id = (message != 0) ? true : false;
 
     // Initialize random generator if core_id matched
     if (is_core_id) {
         rand_tile_init(seed);
     }
+
+    // Pop the communication entry
+    cb_pop_front(kernel_communication_cb_index, one_tile);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/dataflow/reader_manual_seed_read_all_data.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/dataflow/reader_manual_seed_read_all_data.cpp
@@ -16,8 +16,9 @@ void kernel_main() {
     // Compile time args
     constexpr uint32_t user_ids_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t seeds_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t number_of_ids = get_compile_time_arg_val(2);
-    constexpr auto user_ids_tensor_accessor_args = TensorAccessorArgs<3>();
+    constexpr uint32_t kernel_communication_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t number_of_ids = get_compile_time_arg_val(3);
+    constexpr auto user_ids_tensor_accessor_args = TensorAccessorArgs<4>();
     constexpr auto seeds_tensor_accessor_args =
         TensorAccessorArgs<user_ids_tensor_accessor_args.next_compile_time_args_offset()>();
 
@@ -60,15 +61,14 @@ void kernel_main() {
         }
     }
 
-    // Send result to compute kernel via mailbox
-    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_user_id);
-    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_user_id);
-    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_user_id);
+    // Prepare message for compute kernel
+    cb_reserve_back(kernel_communication_cb_index, one_tile);
+    const uint32_t kernel_communication_l1_write_addr_index = get_write_ptr(kernel_communication_cb_index);
+    volatile tt_l1_ptr uint32_t* communication_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_communication_l1_write_addr_index);
+    communication_ptr[0] = is_user_id ? 1 : 0;
+    communication_ptr[1] = is_user_id ? seed : 0;
 
-    // Send seed to compute kernel via mailbox
-    if (is_user_id) {
-        ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, seed);
-        ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, seed);
-        ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, seed);
-    }
+    // Send to compute kernel
+    cb_push_back(kernel_communication_cb_index, one_tile);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/dataflow/reader_manual_seed_read_user_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/kernels/dataflow/reader_manual_seed_read_user_id.cpp
@@ -14,8 +14,9 @@ void kernel_main() {
 
     // Compile time args
     constexpr uint32_t user_ids_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t number_of_ids = get_compile_time_arg_val(1);
-    constexpr auto user_ids_tensor_accessor_args = TensorAccessorArgs<2>();
+    constexpr uint32_t kernel_communication_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t number_of_ids = get_compile_time_arg_val(2);
+    constexpr auto user_ids_tensor_accessor_args = TensorAccessorArgs<3>();
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -42,8 +43,13 @@ void kernel_main() {
         }
     }
 
-    // Send result to compute kernel via mailbox
-    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_user_id);
-    ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, is_user_id);
-    ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, is_user_id);
+    // Prepare message for compute kernel
+    cb_reserve_back(kernel_communication_cb_index, one_tile);
+    const uint32_t kernel_communication_l1_write_addr_index = get_write_ptr(kernel_communication_cb_index);
+    volatile tt_l1_ptr uint32_t* communication_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_communication_l1_write_addr_index);
+    communication_ptr[0] = is_user_id ? 1 : 0;
+
+    // Send to compute kernel
+    cb_push_back(kernel_communication_cb_index, one_tile);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
@@ -151,6 +151,9 @@ ManualSeedSingleSeedSetCoresProgramFactory::cached_program_t ManualSeedSingleSee
     constexpr uint32_t user_ids_cb_index = tt::CBIndex::c_0;
     create_tensor_circular_buffer(program, core_grid, user_ids_tensor, user_ids_cb_index);
 
+    constexpr uint32_t kernel_communication_cb_index = tt::CBIndex::c_1;
+    create_tensor_circular_buffer(program, core_grid, user_ids_tensor, kernel_communication_cb_index);
+
     // Create core kernels
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(cores.size());
@@ -162,20 +165,14 @@ ManualSeedSingleSeedSetCoresProgramFactory::cached_program_t ManualSeedSingleSee
         "manual_seed_single_seed_receive_user_id.cpp";
 
     // Create reader kernel
-    tt::tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(operation_attributes.device->arch());
-    std::vector<uint32_t> reader_compile_time_args = {user_ids_cb_index, number_of_ids};
+    std::vector<uint32_t> reader_compile_time_args = {user_ids_cb_index, kernel_communication_cb_index, number_of_ids};
     TensorAccessorArgs(*user_ids_tensor_buffer).append_to(reader_compile_time_args);
     const tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        reader_kernel_path,
-        core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = in0_noc,
-            .compile_args = reader_compile_time_args});
+        program, reader_kernel_path, core_grid, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
 
     // Create compute kernel
-    std::vector<uint32_t> compute_compile_time_args = {operation_attributes.seeds.value_or(0)};
+    std::vector<uint32_t> compute_compile_time_args = {
+        kernel_communication_cb_index, operation_attributes.seeds.value_or(0)};
     tt::tt_metal::CreateKernel(
         program,
         compute_kernel_path,
@@ -238,6 +235,9 @@ ManualSeedSetSeedsSetCoresProgramFactory::cached_program_t ManualSeedSetSeedsSet
     constexpr uint32_t seeds_cb_index = tt::CBIndex::c_1;
     create_tensor_circular_buffer(program, core_grid, seeds_tensor, seeds_cb_index);
 
+    constexpr uint32_t kernel_communication_cb_index = tt::CBIndex::c_2;
+    create_tensor_circular_buffer(program, core_grid, seeds_tensor, kernel_communication_cb_index);
+
     // Create core kernels
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(cores.size());
@@ -249,21 +249,19 @@ ManualSeedSetSeedsSetCoresProgramFactory::cached_program_t ManualSeedSetSeedsSet
         "manual_seed_receive_all_data.cpp";
 
     // Create reader kernel
-    tt::tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(operation_attributes.device->arch());
-    std::vector<uint32_t> reader_compile_time_args = {user_ids_cb_index, seeds_cb_index, number_of_ids};
+    std::vector<uint32_t> reader_compile_time_args = {
+        user_ids_cb_index, seeds_cb_index, kernel_communication_cb_index, number_of_ids};
     TensorAccessorArgs(*user_ids_tensor_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*seeds_tensor_buffer).append_to(reader_compile_time_args);
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        reader_kernel_path,
-        core_grid,
-        tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = in0_noc,
-            .compile_args = reader_compile_time_args});
+        program, reader_kernel_path, core_grid, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
 
     // Create compute kernel
-    tt::tt_metal::CreateKernel(program, compute_kernel_path, core_grid, tt::tt_metal::ComputeConfig{});
+    tt::tt_metal::CreateKernel(
+        program,
+        compute_kernel_path,
+        core_grid,
+        tt::tt_metal::ComputeConfig{.compile_args = {kernel_communication_cb_index}});
 
     for (uint32_t core_id = 0; core_id < cores.size(); ++core_id) {
         // Get core

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/docs/Manual_seed.md
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/docs/Manual_seed.md
@@ -151,7 +151,7 @@ This strategy sets the same seed value to multiple cores specified by a tensor o
    * The match result is communicated to the compute kernel via circular buffer
 
 4. **Seed Initialization**:
-   * The compute kernel reads the match result from the mailbox
+   * The compute kernel reads the match result from the CB message
    * If matched, it calls `rand_tile_init(seed)` to initialize RNG
    * Non-matching cores skip initialization and remain unmodified
 
@@ -206,8 +206,8 @@ This strategy provides maximum flexibility by allowing different seeds to be ass
    * Tensors must have identical shapes and volumes (1-dimensional)
 
 4. **Seed Initialization**:
-   * The compute kernel reads the match result from the mailbox
-   * If matched, it reads the seed value from the mailbox
+   * The compute kernel reads the match result from the CB message
+   * If matched, it reads the seed value from the CB message
    * Calls `rand_tile_init(seed)` with the matched seed value
    * Cores not listed in user_ids remain unmodified
 

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/docs/Manual_seed.md
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/docs/Manual_seed.md
@@ -148,7 +148,7 @@ This strategy sets the same seed value to multiple cores specified by a tensor o
 3. **Data Movement and Processing**:
    * Each core's reader kernel loads the user_ids tensor from DRAM to L1
    * The reader kernel checks if its core_id (passed at runtime) matches any ID in the tensor
-   * The match result is communicated to the compute kernel via mailbox
+   * The match result is communicated to the compute kernel via circular buffer
 
 4. **Seed Initialization**:
    * The compute kernel reads the match result from the mailbox
@@ -170,13 +170,14 @@ The program factory creates a single reader kernel and a single compute kernel t
 Each core's reader kernel performs the following operations:
 1. Reads the user_ids tensor from DRAM into L1 memory using NoC operations
 2. Iterates through the user_ids array to check if its core ID (received as runtime argument) matches any entry
-3. Communicates the match result (boolean) to the compute kernel via mailbox writes to all compute threads
+3. Writes the match result (boolean) to a dedicated circular buffer for kernel communication
+4. Pushes the communication entry to make it available to the compute kernel
 
-The mailbox communication mechanism allows the reader kernel (running on the data movement processor) to pass information to the compute kernel threads without using circular buffers.
+The circular buffer communication mechanism provides a structured way for the reader kernel (running on the data movement processor) to pass information to the compute kernel.
 
 **Compute Kernel (`manual_seed_single_seed_receive_user_id.cpp`):**
 
-The compute kernel waits for the match result from the reader kernel via `mailbox_read()`. If the match is positive, it initializes the RNG by calling `rand_tile_init(seed)` with the seed value received as a compile-time argument. Non-matching cores skip initialization entirely.
+The compute kernel waits for data from the reader kernel via `cb_wait_front()` on the kernel communication circular buffer. It then reads the match result using `read_tile_value()`. If the match is positive, it initializes the RNG by calling `rand_tile_init(seed)` with the seed value received as a compile-time argument. After processing, it pops the communication entry with `cb_pop_front()`. Non-matching cores skip initialization entirely.
 
 ---
 
@@ -201,7 +202,7 @@ This strategy provides maximum flexibility by allowing different seeds to be ass
    * Each core's reader kernel loads both user_ids and seeds tensors from DRAM to L1
    * The reader kernel checks if its core_id (passed at runtime) matches any ID in user_ids
    * If matched, it retrieves the corresponding seed from the seeds tensor at the same index
-   * Both the match result and the seed value are communicated to the compute kernel via mailbox
+   * Both the match result and the seed value are communicated to the compute kernel via circular buffer
    * Tensors must have identical shapes and volumes (1-dimensional)
 
 4. **Seed Initialization**:
@@ -227,13 +228,14 @@ Each core's reader kernel executes a more complex workflow:
 1. Reads both the user_ids tensor and seeds tensor from DRAM into separate L1 memory regions using NoC operations
 2. Iterates through the user_ids array to find if its core ID matches any entry
 3. If a match is found, retrieves the corresponding seed value from the seeds tensor at the same index
-4. Sends both the match result (boolean) and the seed value (if matched) to the compute kernel via mailbox writes
+4. Writes both the match result (boolean at index 0) and the seed value (at index 1) to the kernel communication circular buffer
+5. Pushes the communication entry to make it available to the compute kernel
 
-The dual-mailbox communication pattern allows passing both control information (whether to initialize) and data (the seed value) from the reader to the compute kernel.
+The circular buffer communication pattern allows passing both control information (whether to initialize) and data (the seed value) from the reader to the compute kernel in a single structured message.
 
 **Compute Kernel (`manual_seed_receive_all_data.cpp`):**
 
-The compute kernel reads the match result from the mailbox via `mailbox_read()`. If positive, it reads the seed value from a second mailbox message and calls `rand_tile_init(seed)` to initialize the RNG with the core-specific seed. This allows each core to receive a unique seed value while using the same kernel code.
+The compute kernel waits for data from the reader kernel via `cb_wait_front()` on the kernel communication circular buffer. It reads the match result from index 0 using `read_tile_value()`. If positive, it reads the seed value from index 1 and calls `rand_tile_init(seed)` to initialize the RNG with the core-specific seed. After processing, it pops the communication entry with `cb_pop_front()`. This allows each core to receive a unique seed value while using the same kernel code.
 
 ---
 


### PR DESCRIPTION
### Ticket

#34211 

### Problem description
The current implementation of ttnn.manual_seed relies on the Mailbox mechanism for transferring data between the reader and compute kernels. As noted in the discussion here: https://github.com/tenstorrent/tt-metal/issues/31490, this mechanism is scheduled for deprecation.

### What's changed
- Removed mailbox usage,
- Added communication through CB and `read_tile_value` API,
- Updated docs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20232625036