### PR TITLE
test: disable constantly failing layernorm test

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_distributed_layernorm_post_allgather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_distributed_layernorm_post_allgather.py
@@ -178,6 +178,7 @@ def test_layernorm_part_2_with_program_cache(
     [True, False],
     ids=["rmsnorm", "layernorm"],
 )
+@pytest.mark.skip(reason="#34410")
 def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, dtype, device):
     dummy_tensors = []
 


### PR DESCRIPTION
### Ticket
#34410

### Problem description
Test has been failing for some time now, and it simply blocks automation.

### What's changed
Disabled test