### PR TITLE
test: turn off test_move_op on BH P100

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 
 import ttnn
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_blackhole
 import torch
 import ttnn
 
@@ -18,6 +18,11 @@ shapes = [
 
 @pytest.mark.parametrize("shape", shapes)
 def test_move_op(shape, device):
+    is_p100 = (
+        is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
+    )
+    if is_p100:
+        pytest.skip(reason="see #34415")
     run_move_op(shape, device)
 
 


### PR DESCRIPTION
### Ticket
#34415

### Problem description
Test is constantly failing, see https://github.com/tenstorrent/tt-metal/issues/34415 for more details.

### What's changed
Turning off test.