### PR TITLE
[Reduce APC] Move n150 tt-train-cpp-unit-tests from APC to L2Nightly

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -155,7 +155,6 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
           { arch: wormhole_b0, runner-label: N300 },
         ]
     if: ${{ needs.find-changed-files.outputs.test-tt-train == 'true' }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -242,3 +242,20 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  tt-train-cpp-unit-tests:
+    if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
+    needs: build-artifact
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 },
+        ]
+    uses: ./.github/workflows/tt-train-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      gtest_filter: "*"


### PR DESCRIPTION
### What's changed
Move n150 tt-train-cpp-unit-tests from APC to L2Nightly

### Checklist
All post commit CI runs as expected: https://github.com/tenstorrent/tt-metal/actions/runs/20237064509
L2Nightly CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/20235868677