### PR TITLE
Disable move_sharded test for blackhole

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 
 import ttnn
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_blackhole
 import torch
 import ttnn
 
@@ -16,6 +16,7 @@ shapes = [
 ]
 
 
+@pytest.mark.skipif(is_blackhole(), reason="disabled due to illegal kernel placement, see issue #5863")
 @pytest.mark.parametrize("shape", shapes)
 def test_move_op(shape, device):
     run_move_op(shape, device)


### PR DESCRIPTION
### Ticket

[#5863](https://github.com/tenstorrent/tt-metal/issues/5863)

### Problem description
Test is failing for blackhole.
Initially test was disabled for WH and BH.
In https://github.com/tenstorrent/tt-metal/pull/33173 I enabled it after checking that referenced task is closed and after local verification on WH.

### What's changed
Disable test again, this time for BH only.

### Checklist
- [ ] [Blackhole Post commit #20238268892](https://github.com/tenstorrent/tt-metal/actions/runs/20238268892) CI with demo tests passes