### PR TITLE
SDXL TP=2 prompt batch hotfix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import ttnn
 import torch
 from diffusers import StableDiffusionXLImg2ImgPipeline, DiffusionPipeline
 from loguru import logger
@@ -14,6 +13,8 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
     MAX_SEQUENCE_LENGTH,
     TEXT_ENCODER_2_PROJECTION_DIM,
+    determinate_min_batch_size,
+    prepare_device,
 )
 import os
 from models.common.utility_functions import profiler
@@ -49,7 +50,7 @@ def run_demo_inference(
     timesteps=None,
     sigmas=None,
 ):
-    batch_size = list(ttnn_device.shape)[1] if use_cfg_parallel else ttnn_device.get_num_devices()
+    batch_size = determinate_min_batch_size(ttnn_device, use_cfg_parallel)
 
     start_from, _ = evaluation_range
 
@@ -225,12 +226,6 @@ def run_demo_inference(
                 logger.info(f"Image saved to output/output{len(out_images) + start_from}_tt_img2img.png")
 
     return out_images
-
-
-def prepare_device(mesh_device, use_cfg_parallel):
-    if use_cfg_parallel:
-        assert mesh_device.get_num_devices() % 2 == 0, "Mesh device must have even number of devices"
-        mesh_device.reshape(ttnn.MeshShape(2, mesh_device.get_num_devices() // 2))
 
 
 # Note: The 'fabric_config' parameter is only required when running with cfg_parallel enabled,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -25,6 +25,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     batch_encode_prompt_on_device,
     retrieve_timesteps,
     run_tt_image_gen,
+    determinate_min_batch_size,
 )
 from models.common.utility_functions import profiler
 
@@ -74,9 +75,7 @@ class TtSDXLPipeline(LightweightModule):
 
         self.ttnn_device = ttnn_device
         self.cpu_device = "cpu"
-        self.batch_size = (
-            list(self.ttnn_device.shape)[1] if pipeline_config.use_cfg_parallel else ttnn_device.get_num_devices()
-        )
+        self.batch_size = determinate_min_batch_size(ttnn_device, pipeline_config.use_cfg_parallel)
         self.torch_pipeline = torch_pipeline
         self.pipeline_config = pipeline_config
         self._reset_num_inference_steps()


### PR DESCRIPTION
### Problem description
`warmup_tt_text_encoders` failed when TP=2 and has a negative prompt set - as a list. And list is how inference server uses the pipeline. 

If negative prompt was string; then it's padded to 2 (same as prompt) and pipeline works; but really runs TP=2 batch=2. 

```
models/experimental/stable_diffusion_xl_base/demo/demo.py:308: in test_demo
    return run_demo_inference(
python_env/lib/python3.10/site-packages/torch/utils/_contextlib.py:116: in decorate_context
    return func(*args, **kwargs)
models/experimental/stable_diffusion_xl_base/demo/demo.py:152: in run_demo_inference
    ) = tt_sdxl.encode_prompts(prompts_batch, negative_prompts_batch, prompts_2_batch, negative_prompts_2_batch)
models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py:379: in encode_prompts
    batch_embeds = batch_encode_prompt_on_device(
models/experimental/stable_diffusion_xl_base/tests/test_common.py:333: in batch_encode_prompt_on_device
    raise ValueError(
E   ValueError: `negative_prompt`: ['disturbing'] has batch size 1, but `prompt`: ['An astronaut riding a green horse', ''] has batch size 2. Please make sure that passed `negative_prompt` matches the batch size of `prompt`.
```

### What's changed
def common function to determinate min batch size and use it as appropriate. additionally pulled out few things into test_common, to avoid similar pitfalls.

in order to catch his issue in the future; added negative prompt ("disturbing"); looked for the one that doesnt influence original image that much; because of emotional attachments people might have. 

<img width="1140" height="511" alt="image" src="https://github.com/user-attachments/assets/f09d2863-65e0-454b-af6a-2f4fb25e5800" />


### Checklist
- [x] [Freq model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20238577851)
- [x] [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20343323165)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20238550482)
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20367823027)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20238541956)

Accuracy tests
- [X] TP=1 https://github.com/tenstorrent/tt-shield/actions/runs/20342991501
- [x] TP=1 https://github.com/tenstorrent/tt-shield/actions/runs/20365645484
- [x] TP=2 https://github.com/tenstorrent/tt-shield/actions/runs/20365656365

Models CI with Inference server 
- [x] https://github.com/tenstorrent/tt-shield/actions/runs/20368394679/job/58532206071
