### PR TITLE
[tt-train] Add Linear Regression TP+DP Example 

### DIFF
--- a/tt-train/sources/examples/CMakeLists.txt
+++ b/tt-train/sources/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(linear_regression)
 add_subdirectory(linear_regression_ddp)
+add_subdirectory(linear_regression_tp_dp)
 add_subdirectory(nano_gpt)
 add_subdirectory(sample_app)
 add_subdirectory(mnist_mlp)

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
             const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
             auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
                 data, ttnn::Shape{batch_size, 1, 1, num_features}, device, ttnn::Layout::TILE, mapper.get()));
-                
+
             auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
                 targets, ttnn::Shape{batch_size, 1, 1, num_targets}, device, ttnn::Layout::TILE, mapper.get()));
 

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -70,7 +70,6 @@ int main(int argc, char** argv) {
             const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, 0);
             auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
                 data, ttnn::Shape{batch_size, 1, 1, num_features}, device, ttnn::Layout::TILE, mapper.get()));
-
             auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
                 targets, ttnn::Shape{batch_size, 1, 1, num_targets}, device, ttnn::Layout::TILE, mapper.get()));
 
@@ -81,12 +80,12 @@ int main(int argc, char** argv) {
 
     auto model = ttml::models::linear_regression::create(num_features, num_targets);
 
-    float learning_rate = 0.05F * num_targets * (batch_size / 128.F);
+    float learning_rate = 0.1F * num_targets * (batch_size / 128.F);
     auto sgd_config = ttml::optimizers::SGDConfig{.lr = learning_rate, .momentum = 0.0F};
     auto optimizer = ttml::optimizers::SGD(model->parameters(), sgd_config);
 
     int training_step = 0;
-    const int num_epochs = 100;
+    const int num_epochs = 10;
     for (int epoch = 0; epoch < num_epochs; ++epoch) {
         for (const auto& [data, targets] : train_dataloader) {
             optimizer.zero_grad();
@@ -95,7 +94,6 @@ int main(int argc, char** argv) {
 
             auto loss = ttml::ops::mse_loss(output, targets);
             auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});
-            std::cout << "loss_xtensors size: " << loss_xtensors.size() << std::endl;
             float mean_loss = 0.0F;
             for (const auto& loss_xtensor : loss_xtensors) {
                 mean_loss += loss_xtensor(0);

--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -124,7 +124,6 @@ int main(int argc, char** argv) {
         for (const auto& [data, targets] : train_dataloader) {
             optimizer.zero_grad();
             auto output = (*model)(data);
-            auto output_values = ttml::core::to_xtensor(output->get_value(), ttml::core::IdentityComposer{});
 
             auto loss = ttml::ops::mse_loss(output, targets);
             auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});

--- a/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
+++ b/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(linear_regression_ddp)
+
+set(SOURCES main.cpp)
+add_executable(linear_regression_tp_dp ${SOURCES})
+target_link_libraries(linear_regression_tp_dp PRIVATE ttml)

--- a/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
+++ b/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(linear_regression_ddp)
+project(linear_regression_tp_dp)
 
 set(SOURCES main.cpp)
 add_executable(linear_regression_tp_dp ${SOURCES})

--- a/tt-train/sources/examples/linear_regression_tp_dp/linear_regression_tp_dp.py
+++ b/tt-train/sources/examples/linear_regression_tp_dp/linear_regression_tp_dp.py
@@ -293,6 +293,12 @@ def main():
     # - TP devices per group (tensor parallelism) along mesh dimension 1
     logical_mesh_shape = ttnn.MeshShape(mesh_rows, mesh_cols)
     num_devices = mesh_rows * mesh_cols
+    # In these examples, I assume dp is always the first mesh axis and tp is the second one, which will be
+    # preserved later on when adding tp+dp llm training support. A user will set if they want to use data
+    # parallel or not and which mesh device shape they want to use, the axis will be
+    # decided automatically: data parallel will always be the first one if
+    # present, the second will be cp (if present, if dp is disabled --- cp will be the first one), then pp,
+    # tp and ep.
     dp_size = mesh_rows
     tp_size = mesh_cols
 

--- a/tt-train/sources/examples/linear_regression_tp_dp/linear_regression_tp_dp.py
+++ b/tt-train/sources/examples/linear_regression_tp_dp/linear_regression_tp_dp.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Linear Regression with Tensor Parallelism (TP) and Data Parallelism (DP).
+
+This is a Python port of the C++ linear_regression_tp_dp example, demonstrating
+combined TP+DP training using Python bindings.
+
+The mesh is organized as:
+- DP dimension (mesh dim 0): Groups for data parallelism
+- TP dimension (mesh dim 1): Devices per group for tensor parallelism
+
+Example: 8x4 mesh = 32 devices total (8 DP groups × 4 TP devices each)
+
+Supported parallelism strategies:
+- ColumnParallelLinear (default): Shards output features across TP devices.
+  Input is broadcast, output remains sharded.
+- RowParallelLinear (--row flag): Shards input features across TP devices.
+  Output is all-reduced to produce full result.
+
+Usage:
+    python linear_regression_tp_dp.py [--row] [-b BATCH_SIZE] [--mesh_shape RxC]
+
+Requirements:
+    - TT-Metal with fabric enabled
+    - Sufficient devices for the mesh (dp_size × tp_size)
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import numpy as np
+from typing import Optional
+
+import ttnn
+import ttml
+
+
+# ---------------------------------------------------------------------------
+# Distributed Linear Modules (Python implementations matching C++)
+# ---------------------------------------------------------------------------
+
+
+class RowParallelLinear(ttml.modules.ModuleBase):
+    """Row-parallel linear layer.
+
+    Shards input features across TP devices.
+    Each device computes partial output, then all-reduces to get final output.
+
+    For row-parallel: Y = XW^T + b, where X is sharded along feature dim.
+    Each device has W[in_features/tp_size, out_features].
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        has_bias: bool = True,
+        input_is_parallel: bool = False,
+        shard_dim: Optional[int] = None,
+        weight_seed: int = 12345,
+    ):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.input_is_parallel = input_is_parallel
+        self.shard_dim = shard_dim
+
+        # Get device and TP size
+        device = ttml.autograd.AutoContext.get_instance().get_device()
+        if shard_dim is not None:
+            self.tp_size = device.shape[shard_dim]
+        else:
+            self.tp_size = device.num_devices()
+
+        # Each device has a shard of the weight matrix
+        # TTML weight shape convention: [1, 1, out_features, in_features]
+        # For RowParallel: shard along in_features (dim 3)
+        # Per-device weight shape: [1, 1, out_features, in_features/tp_size]
+
+        # Initialize weight with uniform distribution matching C++ (with fixed seed for reproducibility)
+        rng = np.random.default_rng(weight_seed)
+        init_k = math.sqrt(1.0 / in_features)
+        weight_data = rng.uniform(
+            -init_k, init_k, (1, 1, out_features, in_features)
+        ).astype(np.float32)
+
+        # Create sharded weight tensor - shard along last dim (in_features)
+        mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(device, 3, shard_dim)
+        self.weight = ttml.autograd.Tensor.from_numpy(
+            weight_data, ttnn.Layout.TILE, None, mapper
+        )
+
+        self.bias = None
+        if has_bias:
+            # Bias is replicated across TP devices, uniform init like C++ (using same rng for reproducibility)
+            bias_data = rng.uniform(-init_k, init_k, (1, 1, 1, out_features)).astype(
+                np.float32
+            )
+            self.bias = ttml.autograd.Tensor.from_numpy(bias_data, ttnn.Layout.TILE)
+
+        self.create_name("row_parallel_linear")
+        self.register_tensor(self.weight, "weight")
+        if self.bias is not None:
+            self.register_tensor(self.bias, "bias")
+
+    def __call__(self, tensor):
+        x = tensor
+
+        if not self.input_is_parallel:
+            # Scatter input along TP dimension
+            x = ttml.ops.distributed.scatter(x, tensor.get_rank() - 1, self.shard_dim)
+
+        # Linear operation (no bias here)
+        x = ttml.ops.linear.linear(x, self.weight, None)
+
+        # All-reduce with noop_backward=input_is_parallel to avoid double all-reduce in backward
+        # (broadcast does all-reduce in backward, so if input_is_parallel we skip that)
+        x = ttml.ops.distributed.all_reduce(x, self.input_is_parallel, self.shard_dim)
+
+        # Add bias after all-reduce
+        if self.bias is not None:
+            x = ttml.ops.binary.add(x, self.bias)
+
+        return x
+
+
+class ColumnParallelLinear(ttml.modules.ModuleBase):
+    """Column-parallel linear layer.
+
+    Broadcasts input to all TP devices.
+    Each device computes a shard of output features.
+    Optionally gathers output.
+
+    For column-parallel: Y = XW^T + b, where W is sharded along output dim.
+    Each device has W[in_features, out_features/tp_size].
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        has_bias: bool = True,
+        gather_output: bool = False,
+        shard_dim: Optional[int] = None,
+        weight_seed: int = 12345,
+    ):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.gather_output = gather_output
+        self.shard_dim = shard_dim
+
+        # Get device and TP size
+        device = ttml.autograd.AutoContext.get_instance().get_device()
+        if shard_dim is not None:
+            self.tp_size = device.shape[shard_dim]
+        else:
+            self.tp_size = device.num_devices()
+
+        # Each device has a shard of the weight matrix
+        # TTML weight shape convention: [1, 1, out_features, in_features]
+        # For ColumnParallel: shard along out_features (dim 2)
+        # Per-device weight shape: [1, 1, out_features/tp_size, in_features]
+
+        # Initialize weight with uniform distribution matching C++ (with fixed seed for reproducibility)
+        rng = np.random.default_rng(weight_seed)
+        init_k = math.sqrt(1.0 / in_features)
+        weight_data = rng.uniform(
+            -init_k, init_k, (1, 1, out_features, in_features)
+        ).astype(np.float32)
+
+        # Create sharded weight tensor - shard along out_features (dim 2)
+        weight_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(
+            device, 2, shard_dim
+        )
+        self.weight = ttml.autograd.Tensor.from_numpy(
+            weight_data, ttnn.Layout.TILE, None, weight_mapper
+        )
+
+        self.bias = None
+        if has_bias:
+            # Bias shape: [1, 1, 1, out_features] - shard along last dim, uniform init like C++ (using same rng)
+            bias_data = rng.uniform(-init_k, init_k, (1, 1, 1, out_features)).astype(
+                np.float32
+            )
+            bias_mapper = ttml.core.distributed.shard_tensor_to_mesh_mapper(
+                device, 3, shard_dim
+            )
+            self.bias = ttml.autograd.Tensor.from_numpy(
+                bias_data, ttnn.Layout.TILE, None, bias_mapper
+            )
+
+        self.create_name("column_parallel_linear")
+        self.register_tensor(self.weight, "weight")
+        if self.bias is not None:
+            self.register_tensor(self.bias, "bias")
+
+    def __call__(self, tensor):
+        # Broadcast input along TP dimension
+        x = ttml.ops.distributed.broadcast(tensor, self.shard_dim)
+
+        # Linear operation with sharded weight and bias
+        x = ttml.ops.linear.linear(x, self.weight, self.bias)
+
+        if self.gather_output:
+            # All-gather output along TP dimension
+            x = ttml.ops.distributed.all_gather(
+                x, tensor.get_rank() - 1, self.shard_dim
+            )
+
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Data generation (matching C++ make_regression)
+# ---------------------------------------------------------------------------
+
+
+def make_regression(
+    n_samples: int,
+    n_features: int,
+    n_targets: int,
+    noise: float = 0.0,
+    bias: bool = True,
+    seed: int = 42,
+):
+    """Generate synthetic regression data."""
+    rng = np.random.default_rng(seed)
+
+    # Generate random weight matrix
+    W = rng.standard_normal((n_features, n_targets)).astype(np.float32)
+
+    # Generate random features
+    X = rng.standard_normal((n_samples, n_features)).astype(np.float32)
+
+    # Compute targets: Y = X @ W
+    Y = X @ W
+
+    if bias:
+        b = rng.standard_normal(n_targets).astype(np.float32)
+        Y += b
+
+    if noise > 0:
+        Y += noise * rng.standard_normal(Y.shape).astype(np.float32)
+
+    return X, Y
+
+
+# ---------------------------------------------------------------------------
+# Main training script
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Linear Regression TP+DP Example")
+    parser.add_argument(
+        "--row",
+        action="store_true",
+        help="Use RowParallelLinear (shards input features), default is ColumnParallelLinear",
+    )
+    parser.add_argument("-b", "--batch_size", type=int, default=8192, help="Batch size")
+    parser.add_argument(
+        "--mesh_shape",
+        type=str,
+        default="8x4",
+        help="Logical mesh shape RxC (e.g. 8x4) where R=DP size, C=TP size",
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=10, help="Number of training epochs"
+    )
+    args = parser.parse_args()
+
+    # Parse mesh shape
+    try:
+        mesh_parts = args.mesh_shape.lower().split("x")
+        if len(mesh_parts) != 2:
+            raise ValueError()
+        mesh_rows = int(mesh_parts[0])
+        mesh_cols = int(mesh_parts[1])
+        if mesh_rows <= 0 or mesh_cols <= 0:
+            raise ValueError()
+    except (ValueError, IndexError):
+        print(f"Error: invalid --mesh_shape '{args.mesh_shape}', expected RxC like 8x4")
+        return 1
+
+    # Mesh configuration
+    # - DP groups (data parallelism) along mesh dimension 0
+    # - TP devices per group (tensor parallelism) along mesh dimension 1
+    logical_mesh_shape = ttnn.MeshShape(mesh_rows, mesh_cols)
+    num_devices = mesh_rows * mesh_cols
+    dp_size = mesh_rows
+    tp_size = mesh_cols
+
+    # Training hyperparameters
+    training_samples_count = 100000
+    num_features = 64
+    num_targets = 64
+    noise = 0.0
+    has_bias = True
+    batch_size = args.batch_size
+    use_row_parallel = args.row
+
+    # Validate dimensions
+    if num_features % tp_size != 0:
+        print(
+            f"Error: num_features ({num_features}) must be divisible by tp_size ({tp_size})"
+        )
+        return 1
+    if num_targets % tp_size != 0:
+        print(
+            f"Error: num_targets ({num_targets}) must be divisible by tp_size ({tp_size})"
+        )
+        return 1
+    if batch_size == 0:
+        print("Error: batch_size must be > 0")
+        return 1
+    if batch_size % dp_size != 0:
+        print(
+            f"Error: batch_size ({batch_size}) must be divisible by dp_size ({dp_size})"
+        )
+        return 1
+
+    # Enable fabric BEFORE opening the device
+    ttml.core.distributed.enable_fabric(num_devices)
+
+    # Open device with mesh shape
+    autograd_ctx = ttml.autograd.AutoContext.get_instance()
+    autograd_ctx.open_device([mesh_rows, mesh_cols])
+    device = autograd_ctx.get_device()
+
+    # Generate training dataset
+    print(f"Generating {training_samples_count} training samples...")
+    X_train, Y_train = make_regression(
+        n_samples=training_samples_count,
+        n_features=num_features,
+        n_targets=num_targets,
+        noise=noise,
+        bias=has_bias,
+    )
+
+    # Create model based on parallelism type
+    # shard_dim=1 specifies weights should be sharded along mesh dimension 1 (TP dimension)
+    # Use fixed weight_seed so Row and Column parallel have identical initial weights
+    weight_seed = 12345
+    if use_row_parallel:
+        print("Using RowParallelLinear: shards input features, all_reduces output")
+        model = RowParallelLinear(
+            num_features,
+            num_targets,
+            has_bias=has_bias,
+            input_is_parallel=True,  # Input already sharded from data distribution
+            shard_dim=1,
+            weight_seed=weight_seed,
+        )
+    else:
+        print("Using ColumnParallelLinear: shards output features, sharded output")
+        model = ColumnParallelLinear(
+            num_features,
+            num_targets,
+            has_bias=has_bias,
+            gather_output=False,  # Keep output sharded
+            shard_dim=1,
+            weight_seed=weight_seed,
+        )
+
+    print(f"Batch size: {batch_size}, DP groups: {dp_size}, TP size: {tp_size}")
+
+    # Configure optimizer - use same formula as C++
+    learning_rate = 0.1 * num_targets * (batch_size / 128.0)
+    if not use_row_parallel:
+        # Loss is calculated for each TP partition, so it's averaged over 1/tp_size
+        # times fewer samples, making gradient tp_size times greater
+        learning_rate /= tp_size
+
+    sgd_config = ttml.optimizers.SGDConfig.make(learning_rate, 0.0, 0.0, 0.0, False)
+    optimizer = ttml.optimizers.SGD(model.parameters(), sgd_config)
+
+    def create_batch_tensors(x_batch: np.ndarray, y_batch: np.ndarray):
+        """Create distributed tensors for a batch using proper 2D mesh mapping.
+
+        For ColumnParallel (default):
+        - Data: Shard{0} on DP (batch dim), Replicate on TP (broadcast to all TP devices)
+        - Targets: Shard{0} on DP (batch dim), Shard{3} on TP (shard output features)
+
+        For RowParallel:
+        - Data: Shard{0} on DP (batch dim), Shard{3} on TP (shard input features)
+        - Targets: Shard{0} on DP (batch dim), Replicate on TP (matches all-reduced output)
+        """
+        actual_batch_size = x_batch.shape[0]
+
+        # Reshape to [batch, 1, 1, features] to match C++ convention
+        x_batch = x_batch.reshape(actual_batch_size, 1, 1, num_features).astype(
+            np.float32
+        )
+        y_batch = y_batch.reshape(actual_batch_size, 1, 1, num_targets).astype(
+            np.float32
+        )
+
+        # Configure data mapper based on parallelism type
+        # Placements list: [DP placement, TP placement]
+        if use_row_parallel:
+            # RowParallelLinear: input is sharded across TP, so data should be sharded
+            data_config = ttnn.MeshMapperConfig(
+                [
+                    ttnn.PlacementShard(0),
+                    ttnn.PlacementShard(3),
+                ],  # DP: shard batch, TP: shard features
+                logical_mesh_shape,
+            )
+        else:
+            # ColumnParallelLinear: input is broadcast, so data should be replicated on TP
+            data_config = ttnn.MeshMapperConfig(
+                [
+                    ttnn.PlacementShard(0),
+                    ttnn.PlacementReplicate(),
+                ],  # DP: shard batch, TP: replicate
+                logical_mesh_shape,
+            )
+
+        data_mapper = ttnn.create_mesh_mapper(device, data_config)
+
+        # Create data tensor using ttml.autograd.Tensor.from_numpy with mapper
+        data_tensor = ttml.autograd.Tensor.from_numpy(
+            x_batch, ttnn.Layout.TILE, None, data_mapper
+        )
+
+        # Configure targets mapper based on parallelism type
+        if use_row_parallel:
+            # RowParallelLinear: output is all-reduced (replicated), so targets should be replicated on TP
+            targets_config = ttnn.MeshMapperConfig(
+                [
+                    ttnn.PlacementShard(0),
+                    ttnn.PlacementReplicate(),
+                ],  # DP: shard batch, TP: replicate
+                logical_mesh_shape,
+            )
+        else:
+            # ColumnParallelLinear with gather_output=false: output is sharded, so targets should be sharded
+            targets_config = ttnn.MeshMapperConfig(
+                [
+                    ttnn.PlacementShard(0),
+                    ttnn.PlacementShard(3),
+                ],  # DP: shard batch, TP: shard features
+                logical_mesh_shape,
+            )
+
+        targets_mapper = ttnn.create_mesh_mapper(device, targets_config)
+
+        # Create targets tensor (no gradient needed for targets)
+        targets_tensor = ttml.autograd.Tensor.from_numpy(
+            y_batch, ttnn.Layout.TILE, None, targets_mapper
+        )
+        targets_tensor.set_requires_grad(False)
+
+        return data_tensor, targets_tensor
+
+    def get_loss_value(loss):
+        """Aggregate loss over all devices and return mean."""
+        composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+        loss_numpy = loss.to_numpy(composer=composer)
+        return float(loss_numpy.mean())
+
+    # Training loop
+    training_step = 0
+    num_epochs = args.epochs
+    num_batches = training_samples_count // batch_size
+
+    print(f"\nStarting training for {num_epochs} epochs...")
+
+    for epoch in range(num_epochs):
+        # Shuffle data each epoch
+        indices = np.random.permutation(training_samples_count)
+        X_shuffled = X_train[indices]
+        Y_shuffled = Y_train[indices]
+
+        for batch_idx in range(num_batches):
+            start_idx = batch_idx * batch_size
+            end_idx = start_idx + batch_size
+
+            x_batch = X_shuffled[start_idx:end_idx]
+            y_batch = Y_shuffled[start_idx:end_idx]
+
+            # Create distributed tensors with proper 2D mesh mapping
+            data, targets = create_batch_tensors(x_batch, y_batch)
+
+            # Zero gradients
+            optimizer.zero_grad()
+
+            # Forward pass
+            output = model(data)
+
+            # Compute loss
+            loss = ttml.ops.loss.mse_loss(output, targets, ttml.ops.ReduceType.MEAN)
+
+            # Log loss
+            loss_val = get_loss_value(loss)
+            print(f"Step: {training_step} Loss: {loss_val:.6f}")
+            training_step += 1
+
+            # Backward pass (retain_graph=False to free graph after backward)
+            loss.backward(False)
+
+            # Synchronize gradients across DP groups (dimension 0)
+            ttml.core.distributed.synchronize_gradients(model.parameters(), 0)
+
+            # Optimizer step
+            optimizer.step()
+
+            # Reset autograd graph
+            autograd_ctx.reset_graph()
+
+    print("\nTraining complete!")
+
+    # Cleanup
+    autograd_ctx.close_device()
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -86,9 +86,9 @@ int main(int argc, char** argv) {
     const uint32_t dp_size = logical_mesh_shape[0];
     const uint32_t tp_size = logical_mesh_shape[1];
 
-    assert(num_features % tp_size == 0);
-    assert(num_targets % tp_size == 0);
-    assert(batch_size % dp_size == 0);
+    TT_FATAL(num_features % tp_size == 0, "num_features must be divisible by tp_size (going to be sharded)");
+    TT_FATAL(num_targets % tp_size == 0, "num_targets must be divisible by tp_size (going to be sharded)");
+    TT_FATAL(batch_size % dp_size == 0, "batch_size must be divisible by dp_size (going to be sharded)");
 
     // Validate that batch_size is divisible by dp_size
     if (batch_size == 0) {

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -103,7 +103,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // Enable fabric BEFORE opening the device - fabric config must be set before device initialization
     ttml::ttnn_fixed::distributed::enable_fabric(num_devices);
     ttml::autograd::ctx().open_device(logical_mesh_shape);
     auto* device = &ttml::autograd::ctx().get_device();
@@ -119,64 +118,63 @@ int main(int argc, char** argv) {
     auto training_dataset = ttml::datasets::make_regression(training_params);
 
     // Collate function: prepare batch data for TP+DP training
-    std::function<BatchType(std::vector<DatasetSample>&& samples)> collate_fn =
-        [device, logical_mesh_shape, use_row_parallel](std::vector<DatasetSample>&& samples) {
-            const uint32_t actual_batch_size = samples.size();
+    std::function<BatchType(std::vector<DatasetSample> && samples)> collate_fn =
+        [device, logical_mesh_shape, use_row_parallel](std::vector<DatasetSample>&& samples) -> BatchType {
+        const uint32_t actual_batch_size = samples.size();
 
-            // Flatten samples into contiguous vectors
-            std::vector<float> data;
-            std::vector<float> targets;
-            data.reserve(actual_batch_size * num_features);
-            targets.reserve(actual_batch_size * num_targets);
-            for (auto& [features, target] : samples) {
-                std::move(features.begin(), features.end(), std::back_inserter(data));
-                std::move(target.begin(), target.end(), std::back_inserter(targets));
-            }
+        // Flatten samples into contiguous vectors
+        std::vector<float> data;
+        std::vector<float> targets;
+        data.reserve(actual_batch_size * num_features);
+        targets.reserve(actual_batch_size * num_targets);
+        for (auto& [features, target] : samples) {
+            std::move(features.begin(), features.end(), std::back_inserter(data));
+            std::move(target.begin(), target.end(), std::back_inserter(targets));
+        }
 
-            // Configure data mapper based on parallelism type
-            tt::tt_metal::distributed::MeshMapperConfig data_config;
-            data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
-            if (use_row_parallel) {
-                // RowParallelLinear: input is sharded, so data should be sharded
-                data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard
-            } else {
-                // ColumnParallelLinear: input is broadcast, so data should be broadcast
-                data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: broadcast
-            }
-            data_config.mesh_shape_override = logical_mesh_shape;
-            const auto data_mapper = ttnn::distributed::create_mesh_mapper(*device, data_config);
+        // Configure data mapper based on parallelism type
+        tt::tt_metal::distributed::MeshMapperConfig data_config;
+        data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
+        if (use_row_parallel) {
+            // RowParallelLinear: input is sharded, so data should be sharded
+            data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard
+        } else {
+            // ColumnParallelLinear: input is broadcast, so data should be broadcast
+            data_config.placements.push_back(
+                tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: broadcast
+        }
+        data_config.mesh_shape_override = logical_mesh_shape;
+        const auto data_mapper = ttnn::distributed::create_mesh_mapper(*device, data_config);
 
-            // Create data tensor with proper sharding
-            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
-                data,
-                ttnn::Shape{actual_batch_size, 1, 1, num_features},
-                device,
-                ttnn::Layout::TILE,
-                data_mapper.get()));
+        // Create data tensor with proper sharding
+        auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+            data, ttnn::Shape{actual_batch_size, 1, 1, num_features}, device, ttnn::Layout::TILE, data_mapper.get()));
 
-            // Configure targets mapper based on parallelism type
-            tt::tt_metal::distributed::MeshMapperConfig targets_config;
-            targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
-            if (use_row_parallel) {
-                // RowParallelLinear: output is always replicated (via all_reduce), so targets should be replicated
-                targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: replicate
-            } else {
-                // ColumnParallelLinear with gather_output=false: output is sharded, so targets should be sharded
-                targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard output features
-            }
-            targets_config.mesh_shape_override = logical_mesh_shape;
-            const auto targets_mapper = ttnn::distributed::create_mesh_mapper(*device, targets_config);
+        // Configure targets mapper based on parallelism type
+        tt::tt_metal::distributed::MeshMapperConfig targets_config;
+        targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
+        if (use_row_parallel) {
+            // RowParallelLinear: output is always replicated (via all_reduce), so targets should be replicated
+            targets_config.placements.push_back(
+                tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: replicate
+        } else {
+            // ColumnParallelLinear with gather_output=false: output is sharded, so targets should be sharded
+            targets_config.placements.push_back(
+                tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard output features
+        }
+        targets_config.mesh_shape_override = logical_mesh_shape;
+        const auto targets_mapper = ttnn::distributed::create_mesh_mapper(*device, targets_config);
 
-            // Create targets tensor
-            auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
-                targets,
-                ttnn::Shape{actual_batch_size, 1, 1, num_targets},
-                device,
-                ttnn::Layout::TILE,
-                targets_mapper.get()));
+        // Create targets tensor
+        auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+            targets,
+            ttnn::Shape{actual_batch_size, 1, 1, num_targets},
+            device,
+            ttnn::Layout::TILE,
+            targets_mapper.get()));
 
-            return std::make_pair(data_tensor, targets_tensor);
-        };
+        return {data_tensor, targets_tensor};
+    };
 
     auto train_dataloader = DataLoader(training_dataset, batch_size, /* shuffle */ true, collate_fn);
 

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -83,6 +83,12 @@ int main(int argc, char** argv) {
     // config file)
     const auto logical_mesh_shape = tt::tt_metal::distributed::MeshShape(mesh_rows, mesh_cols);
     const uint32_t num_devices = logical_mesh_shape[0] * logical_mesh_shape[1];
+    // In these examples, I assume dp is always the first mesh axis and tp is the second one, which will be
+    // preserved later on when adding tp+dp llm training support. A user will set if they want to use data
+    // parallel or not and which mesh device shape they want to use, the axis will be
+    // decided automatically: data parallel will always be the first one if
+    // present, the second will be cp (if present, if dp is disabled --- cp will be the first one), then pp,
+    // tp and ep.
     const uint32_t dp_size = logical_mesh_shape[0];
     const uint32_t tp_size = logical_mesh_shape[1];
 

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -35,8 +35,9 @@ int main(int argc, char** argv) {
     argv = app.ensure_utf8(argv);
 
     // - 8 DP groups (data parallelism) along mesh dimension 0
-    // - 4 TP devices per group (tensor parallelism) along mesh dimension 
-    // you need a right mgd config file for this (default mesh shape is 1x32, look at enable_fabric function for the mgd config file)
+    // - 4 TP devices per group (tensor parallelism) along mesh dimension
+    // you need a right mgd config file for this (default mesh shape is 1x32, look at enable_fabric function for the mgd
+    // config file)
     const auto logical_mesh_shape = tt::tt_metal::distributed::MeshShape(8, 4);  // 8 DP groups × 4 TP devices
     const uint32_t num_devices = logical_mesh_shape[0] * logical_mesh_shape[1];
     const uint32_t dp_size = logical_mesh_shape[0];
@@ -85,7 +86,6 @@ int main(int argc, char** argv) {
         .bias = bias,
     };
     auto training_dataset = ttml::datasets::make_regression(training_params);
-    
 
     // Collate function: prepare batch data for TP+DP training
     std::function<BatchType(std::vector<DatasetSample>&& samples)> collate_fn =
@@ -196,8 +196,8 @@ int main(int argc, char** argv) {
 
             // Forward pass
             auto output = (*model)(data);
-            auto loss = ttml::ops::mse_loss(output, targets);            
-            
+            auto loss = ttml::ops::mse_loss(output, targets);
+
             // Log loss
             fmt::print("Step: {} Loss: {}\n", training_step++, get_loss_value(loss));
 

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -171,6 +171,7 @@ int main(int argc, char** argv) {
         /* loss is caclulated for each tp partition, so its averaged over 1/tp_size times less samples making gradient tp_size times greater*/
         learning_rate /= tp_size;
     }
+    // std::cout << "Learning rate: " << learning_rate << std::endl;
 
     auto sgd_config = ttml::optimizers::SGDConfig{.lr = learning_rate, .momentum = 0.0F};
     auto optimizer = ttml::optimizers::SGD(model->parameters(), sgd_config);
@@ -204,7 +205,7 @@ int main(int argc, char** argv) {
             loss->backward();
 
             // Synchronize gradients across DP groups (average gradients for data parallelism)
-            ttml::core::distributed::synchronize_parameters(model->parameters());
+            ttml::core::distributed::synchronize_parameters(model->parameters(), 0U);
 
             // Optimizer step
             optimizer.step();

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -86,6 +86,10 @@ int main(int argc, char** argv) {
     const uint32_t dp_size = logical_mesh_shape[0];
     const uint32_t tp_size = logical_mesh_shape[1];
 
+    assert(num_features % tp_size == 0);
+    assert(num_targets % tp_size == 0);
+    assert(batch_size % dp_size == 0);
+
     // Validate that batch_size is divisible by dp_size
     if (batch_size == 0) {
         fmt::print(stderr, "Error: batch_size must be > 0\n");
@@ -195,7 +199,8 @@ int main(int argc, char** argv) {
     // Configure optimizer
     float learning_rate = 0.1F * num_targets * (batch_size / 128.F); /* Denys's lr*/
     if (!use_row_parallel) {
-        /* loss is caclulated for each tp partition, so its averaged over 1/tp_size times less samples making gradient tp_size times greater*/
+        /* loss is calculated for each tp partition, so it is averaged over 1/tp_size times less samples making gradient
+         * tp_size times greater*/
         learning_rate /= tp_size;
     }
 

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
             loss->backward();
 
             // Synchronize gradients across DP groups (average gradients for data parallelism)
-            ttml::core::distributed::synchronize_parameters(model->parameters(), 0U);
+            ttml::core::distributed::synchronize_gradients(model->parameters(), 0U);
 
             // Optimizer step
             optimizer.step();

--- a/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_tp_dp/main.cpp
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CLI/CLI.hpp>
+#include <fmt/format.h>
+
+#include <core/ttnn_all_includes.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "autograd/tensor.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "core/xtensor_utils.hpp"
+#include "datasets/dataloader.hpp"
+#include "datasets/generators.hpp"
+#include "models/linear_regression.hpp"
+#include "modules/distributed/linear.hpp"
+#include "ops/losses.hpp"
+#include "optimizers/sgd.hpp"
+#include "ttnn_fixed/distributed/tt_metal.hpp"
+#include "core/distributed/distributed.hpp"
+
+
+using ttml::autograd::TensorPtr;
+
+using DatasetSample = std::pair<std::vector<float>, std::vector<float>>;
+using BatchType = std::pair<TensorPtr, TensorPtr>;
+using DataLoader = ttml::datasets::DataLoader<
+    ttml::datasets::InMemoryFloatVecDataset,
+    std::function<BatchType(std::vector<DatasetSample>&& samples)>,
+    BatchType>;
+
+int main(int argc, char** argv) {
+    CLI::App app{"Linear Regression TP+DP Example"};
+    argv = app.ensure_utf8(argv);
+
+    // - 8 DP groups (data parallelism) along mesh dimension 0
+    // - 4 TP devices per group (tensor parallelism) along mesh dimension 
+    // you need a right mgd config file for this (default mesh shape is 1x32, look at enable_fabric function for the mgd config file)
+    const auto logical_mesh_shape = tt::tt_metal::distributed::MeshShape(8, 4);  // 8 DP groups × 4 TP devices
+    const auto num_devices = logical_mesh_shape[0] * logical_mesh_shape[1];
+    const auto num_dp_groups = logical_mesh_shape[0];
+    const auto tp_size = logical_mesh_shape[1];
+
+    // Training hyperparameters
+    const size_t training_samples_count = 100000;
+    const size_t num_features = 64;
+    const size_t num_targets = 64;
+    const float noise = 0.0F;
+    const bool bias = true;
+    // Parse command line arguments
+    // Default to column parallelism, use row if --row flag is passed
+    bool use_row_parallel = false;
+    uint32_t batch_size = 8192;
+
+    app.add_flag("--row", use_row_parallel, "Use RowParallelLinear (shards input features), default is ColumnParallelLinear");
+    app.add_option("-b,--batch_size", batch_size, "Batch size")->default_val(batch_size);
+
+    CLI11_PARSE(app, argc, argv);
+
+    // Validate that batch_size is divisible by num_dp_groups
+    if (batch_size == 0) {
+        fmt::print(stderr, "Error: batch_size must be > 0\n");
+        return 1;
+    }
+    if (batch_size % num_dp_groups != 0) {
+        fmt::print(stderr,
+                   "Error: batch_size ({}) must be divisible by num_dp_groups ({})\n",
+                   batch_size,
+                   num_dp_groups);
+        return 1;
+    }
+
+    // Enable fabric BEFORE opening the device - fabric config must be set before device initialization
+    ttml::ttnn_fixed::distributed::enable_fabric(num_devices);
+    ttml::autograd::ctx().open_device(logical_mesh_shape);
+    auto* device = &ttml::autograd::ctx().get_device();
+
+    // Generate training dataset
+    auto training_params = ttml::datasets::MakeRegressionParams{
+        .n_samples = training_samples_count,
+        .n_features = num_features,
+        .n_targets = num_targets,
+        .noise = noise,
+        .bias = bias,
+    };
+    auto training_dataset = ttml::datasets::make_regression(training_params);
+    
+
+    // Collate function: prepare batch data for TP+DP training
+    std::function<BatchType(std::vector<DatasetSample>&& samples)> collate_fn =
+        [device, logical_mesh_shape, use_row_parallel](std::vector<DatasetSample>&& samples) {
+            const uint32_t actual_batch_size = samples.size();
+
+            // Flatten samples into contiguous vectors
+            std::vector<float> data;
+            std::vector<float> targets;
+            data.reserve(actual_batch_size * num_features);
+            targets.reserve(actual_batch_size * num_targets);
+            for (auto& [features, target] : samples) {
+                std::move(features.begin(), features.end(), std::back_inserter(data));
+                std::move(target.begin(), target.end(), std::back_inserter(targets));
+            }
+
+            // Configure data mapper based on parallelism type
+            tt::tt_metal::distributed::MeshMapperConfig data_config;
+            data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
+            if (use_row_parallel) {
+                // RowParallelLinear: input is sharded, so data should be sharded
+                data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard
+            } else {
+                // ColumnParallelLinear: input is broadcast, so data should be broadcast
+                data_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: broadcast
+            }
+            data_config.mesh_shape_override = logical_mesh_shape;
+            const auto data_mapper = ttnn::distributed::create_mesh_mapper(*device, data_config);
+
+            // Create data tensor with proper sharding
+            auto data_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+                data,
+                ttnn::Shape{actual_batch_size, 1, 1, num_features},
+                device,
+                ttnn::Layout::TILE,
+                data_mapper.get()));
+
+            // Configure targets mapper based on parallelism type
+            tt::tt_metal::distributed::MeshMapperConfig targets_config;
+            targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{0});  // DP: shard batch
+            if (use_row_parallel) {
+                // RowParallelLinear: output is always replicated (via all_reduce), so targets should be replicated
+                targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Replicate{});  // TP: replicate
+            } else {
+                // ColumnParallelLinear with gather_output=true: output is replicated, so targets should be replicated
+                // ColumnParallelLinear with gather_output=false: output is sharded, so targets should be sharded
+                // For now, we'll use gather_output=false, so shard targets
+                targets_config.placements.push_back(tt::tt_metal::distributed::MeshMapperConfig::Shard{3});  // TP: shard
+            }
+            targets_config.mesh_shape_override = logical_mesh_shape;
+            const auto targets_mapper = ttnn::distributed::create_mesh_mapper(*device, targets_config);
+
+            // Create targets tensor
+            auto targets_tensor = ttml::autograd::create_tensor(ttml::core::from_vector(
+                targets,
+                ttnn::Shape{actual_batch_size, 1, 1, num_targets},
+                device,
+                ttnn::Layout::TILE,
+                targets_mapper.get()));
+
+            return std::make_pair(data_tensor, targets_tensor);
+        };
+
+    auto train_dataloader = DataLoader(training_dataset, batch_size, /* shuffle */ true, collate_fn);
+
+    // Initialize model based on parallelism type
+    // shard_dim=1 specifies that weights should be sharded along mesh dimension 1 (TP dimension)
+    std::shared_ptr<ttml::modules::ModuleBase> model;
+    if (use_row_parallel) {
+        fmt::print("Using RowParallelLinear: shards input features, all_reduces output\n");
+        // RowParallelLinear: shards input features, all_reduces output
+        model = std::make_shared<ttml::modules::distributed::RowParallelLinear>(
+            num_features, num_targets, /* has_bias */ bias, /* input_is_parallel */ true, /* shard_dim */ 1U);
+    } else {
+        fmt::print("Using ColumnParallelLinear: shards output features, broadcasts input\n");
+        // ColumnParallelLinear: shards output features, broadcasts input
+        model = std::make_shared<ttml::modules::distributed::ColumnParallelLinear>(
+            num_features, num_targets, /* has_bias */ bias, /* gather_output */ false, /* shard_dim */ 1U);
+    }
+    fmt::print("Batch size: {}, DP groups: {}, TP size: {}\n", batch_size, num_dp_groups, tp_size);
+
+    // Configure optimizer
+    float learning_rate = 0.1F * num_targets * (batch_size / 128.F); /* Denys's lr*/
+    if (!use_row_parallel) {
+        //Danik TODO: find out why this is needed
+        learning_rate *= 0.1F;
+    }
+    auto sgd_config = ttml::optimizers::SGDConfig{.lr = learning_rate, .momentum = 0.0F};
+    auto optimizer = ttml::optimizers::SGD(model->parameters(), sgd_config);
+
+    auto get_loss_value = [](const TensorPtr& loss) {
+        auto loss_xtensors = ttml::core::to_xtensor(loss->get_value(), ttml::core::IdentityComposer{});
+        float loss_float = std::accumulate(
+            loss_xtensors.begin(), loss_xtensors.end(), 0.0F, [](float acc, auto& xtensor) {
+                return acc + xtensor(0);
+            });
+        float mean_loss = loss_float / static_cast<float>(loss_xtensors.size());
+        return mean_loss;
+    };
+
+    // Training loop
+    int training_step = 0;
+    const int num_epochs = 10;
+    for (int epoch = 0; epoch < num_epochs; ++epoch) {
+        for (const auto& [data, targets] : train_dataloader) {
+            optimizer.zero_grad();
+
+            // Forward pass
+            auto output = (*model)(data);
+            auto loss = ttml::ops::mse_loss(output, targets);            
+            
+            // Log loss
+            fmt::print("Step: {} Loss: {}\n", training_step++, get_loss_value(loss));
+
+            // Backward pass
+            loss->backward();
+
+            // Synchronize gradients across DP groups (average gradients for data parallelism)
+            ttml::core::distributed::synchronize_parameters(model->parameters());
+
+            // Optimizer step
+            optimizer.step();
+            ttml::autograd::ctx().reset_graph();
+        }
+    }
+}

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -14,7 +14,7 @@
 
 namespace ttml::core::distributed {
 
-ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
+ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, std::optional<uint32_t> dp_dim) {
     auto* device = &autograd::ctx().get_device();
     auto devices_count = device->get_devices().size();
     assert(devices_count >= 1U);
@@ -24,21 +24,14 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
     }
 
     auto mesh_shape = device->shape();
-    
-    // For TP+DP (2D mesh): only synchronize across DP dimension (mesh dim 0), not TP dimension (mesh dim 1)
-    // For 1D mesh: synchronize across all devices
-    if (mesh_shape.dims() == 2 && mesh_shape[0] > 1) {
-        // 2D mesh with multiple DP groups: only reduce along DP dimension (cluster_axis=0)
-        // This averages gradients across DP groups while preserving TP sharding
-        auto num_dp_groups = mesh_shape[0];
-        auto result = ttnn::all_reduce(tensor, /* cluster_axis */ 0U);
-        // Average by number of DP groups
-        result = ttnn::multiply(result, 1.0F / static_cast<float>(num_dp_groups));
+    if (dp_dim.has_value()) {
+        TT_FATAL(dp_dim.value() >= 0 && dp_dim.value() < mesh_shape.dims(), "Cluster axis must be within mesh shape");
+        auto result = ttnn::all_reduce(tensor, dp_dim.value());
+        const auto dp_size = mesh_shape[dp_dim.value()];
+        result = ttnn::multiply(result, 1.0F / static_cast<float>(dp_size));
         return result;
     } else {
-        // 1D mesh or single DP group: reduce across all devices
-        auto result = ttnn::all_reduce(tensor, /* cluster_axis */ std::nullopt);
-        // Average by total number of devices
+        auto result = ttnn::all_reduce(tensor);
         result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
         return result;
     }
@@ -47,7 +40,7 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
 void synchronize_gradients(const serialization::NamedParameters& parameters) {
     for (auto& [name, tensor] : parameters) {
         if (tensor->is_grad_initialized()) {
-            tensor->set_grad(synchronize_tensor(tensor->get_grad()));
+            tensor->set_grad(synchronize_tensor(tensor->get_grad(), dp_dim));
         }
     }
 }

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -23,10 +23,25 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor) {
         return tensor;
     }
 
-    // all_reduce Mean is not supported, use sum and divide by #devices
-    auto result = ttnn_fixed::distributed::all_reduce(tensor);
-    result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
-    return result;
+    auto mesh_shape = device->shape();
+    
+    // For TP+DP (2D mesh): only synchronize across DP dimension (mesh dim 0), not TP dimension (mesh dim 1)
+    // For 1D mesh: synchronize across all devices
+    if (mesh_shape.dims() == 2 && mesh_shape[0] > 1) {
+        // 2D mesh with multiple DP groups: only reduce along DP dimension (cluster_axis=0)
+        // This averages gradients across DP groups while preserving TP sharding
+        auto num_dp_groups = mesh_shape[0];
+        auto result = ttnn::all_reduce(tensor, /* cluster_axis */ 0U);
+        // Average by number of DP groups
+        result = ttnn::multiply(result, 1.0F / static_cast<float>(num_dp_groups));
+        return result;
+    } else {
+        // 1D mesh or single DP group: reduce across all devices
+        auto result = ttnn::all_reduce(tensor, /* cluster_axis */ std::nullopt);
+        // Average by total number of devices
+        result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
+        return result;
+    }
 }
 
 void synchronize_gradients(const serialization::NamedParameters& parameters) {

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -16,25 +16,17 @@ namespace ttml::core::distributed {
 
 ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, std::optional<uint32_t> dp_dim) {
     auto* device = &autograd::ctx().get_device();
-    auto devices_count = device->get_devices().size();
-    assert(devices_count >= 1U);
+    TT_FATAL(!dp_dim.has_value() || dp_dim.value() < device->shape().dims(), "Cluster axis must be within mesh shape");
+    const auto dp_size = dp_dim.has_value() ? device->shape()[dp_dim.value()] : device->get_devices().size();
+    assert(dp_size >= 1U);
     // no need to synchronize if there is only one device
-    if (devices_count == 1U) {
+    if (dp_size == 1U) {
         return tensor;
     }
 
-    auto mesh_shape = device->shape();
-    if (dp_dim.has_value()) {
-        TT_FATAL(dp_dim.value() >= 0 && dp_dim.value() < mesh_shape.dims(), "Cluster axis must be within mesh shape");
-        auto result = ttnn::all_reduce(tensor, dp_dim.value());
-        const auto dp_size = mesh_shape[dp_dim.value()];
-        result = ttnn::multiply(result, 1.0F / static_cast<float>(dp_size));
-        return result;
-    } else {
-        auto result = ttnn::all_reduce(tensor);
-        result = ttnn::multiply(result, 1.0F / static_cast<float>(devices_count));
-        return result;
-    }
+    auto result = ttnn::all_reduce(tensor, dp_dim);
+    result = ttnn::multiply(result, 1.0F / static_cast<float>(dp_size));
+    return result;
 }
 
 void synchronize_gradients(const serialization::NamedParameters& parameters, std::optional<uint32_t> dp_dim) {

--- a/tt-train/sources/ttml/core/distributed/distributed.cpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.cpp
@@ -37,7 +37,7 @@ ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, std::optional<uint32
     }
 }
 
-void synchronize_gradients(const serialization::NamedParameters& parameters) {
+void synchronize_gradients(const serialization::NamedParameters& parameters, std::optional<uint32_t> dp_dim) {
     for (auto& [name, tensor] : parameters) {
         if (tensor->is_grad_initialized()) {
             tensor->set_grad(synchronize_tensor(tensor->get_grad(), dp_dim));

--- a/tt-train/sources/ttml/core/distributed/distributed.hpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.hpp
@@ -14,7 +14,7 @@ using Rank = tt::tt_metal::distributed::multihost::Rank;
 using Tag = tt::tt_metal::distributed::multihost::Tag;
 using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;
 
-ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor);
+ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, std::optional<uint32_t> dp_dim = std::nullopt);
 
 void synchronize_gradients(const serialization::NamedParameters& parameters);
 

--- a/tt-train/sources/ttml/core/distributed/distributed.hpp
+++ b/tt-train/sources/ttml/core/distributed/distributed.hpp
@@ -16,6 +16,7 @@ using DistributedContext = tt::tt_metal::distributed::multihost::DistributedCont
 
 ttnn::Tensor synchronize_tensor(const ttnn::Tensor& tensor, std::optional<uint32_t> dp_dim = std::nullopt);
 
-void synchronize_gradients(const serialization::NamedParameters& parameters);
+void synchronize_gradients(
+    const serialization::NamedParameters& parameters, std::optional<uint32_t> dp_dim = std::nullopt);
 
 }  // namespace ttml::core::distributed

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -18,8 +18,13 @@
 namespace ttml::modules::distributed {
 
 RowParallelLinear::RowParallelLinear(
-    uint32_t in_features, uint32_t out_features, bool has_bias, bool input_is_parallel) :
-    m_input_is_parallel(input_is_parallel) {
+    uint32_t in_features,
+    uint32_t out_features,
+    bool has_bias,
+    bool input_is_parallel,
+    std::optional<uint32_t> shard_dim) :
+    m_input_is_parallel(input_is_parallel),
+    m_shard_dim(shard_dim) {
     initialize_tensors(in_features, out_features, has_bias);
 
     create_name("row_parallel_linear");
@@ -33,7 +38,7 @@ autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& ten
     auto x = tensor;
     if (!m_input_is_parallel) {
         // reduce scatter with mean
-        x = ops::distributed::reduce_scatter(x, tensor->get_rank() - 1U);
+        x = ops::distributed::reduce_scatter(x, tensor->get_rank() - 1U, m_shard_dim);
         x = ops::mul(x, 1.F / static_cast<float>(autograd::ctx().get_device().num_devices()));
     }
     // do not pass bias
@@ -44,7 +49,7 @@ autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& ten
         does all reduce in backward pass. See similar implementation in fairscale for more details.
         https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/model_parallel/mappings.py#L102
     */
-    x = ops::distributed::all_reduce(x, /* noop_backward */ true);
+    x = ops::distributed::all_reduce(x, /* noop_backward */ true, m_shard_dim);
     if (m_bias != nullptr) {
         x = ops::add(x, m_bias);
     }
@@ -53,22 +58,31 @@ autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& ten
 
 void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias) {
     auto* device = &autograd::ctx().get_device();
-    auto num_devices = static_cast<uint32_t>(device->num_devices());
-    if (in_features % num_devices != 0) {
+    auto mesh_shape = device->shape();
+
+    // Determine TP size based on mesh shape and shard_dim
+    uint32_t tp_size = 1U;
+    if (m_shard_dim.has_value() && mesh_shape.dims() == 2) {
+        // For 2D mesh with explicit shard_dim: TP size is mesh dimension specified by shard_dim
+        tp_size = mesh_shape[m_shard_dim.value()];
+    } else {
+        tp_size = static_cast<uint32_t>(device->num_devices());
+    }
+
+    if (in_features % tp_size != 0) {
         throw std::runtime_error(fmt::format(
-            "Input features must be divisible by the number of devices. Input features = {}, devices = {}",
+            "Input features must be divisible by the TP size. Input features = {}, TP size = {}",
             in_features,
-            num_devices));
+            tp_size));
     }
 
     auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
-
     uint32_t rank = 4U;
-    auto mesh_shape = device->shape();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
 
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
-    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U);
+
+    std::unique_ptr<ttnn::distributed::TensorToMesh> mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
     m_weight = autograd::create_tensor(
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
@@ -80,8 +94,13 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
 }
 
 ColumnParallelLinear::ColumnParallelLinear(
-    uint32_t in_features, uint32_t out_features, bool has_bias, bool gather_output) :
-    m_gather_output(gather_output) {
+    uint32_t in_features,
+    uint32_t out_features,
+    bool has_bias,
+    bool gather_output,
+    std::optional<uint32_t> shard_dim) :
+    m_gather_output(gather_output),
+    m_shard_dim(shard_dim) {
     initialize_tensors(in_features, out_features, has_bias);
 
     create_name("column_parallel_linear");
@@ -93,41 +112,53 @@ ColumnParallelLinear::ColumnParallelLinear(
 
 autograd::TensorPtr ColumnParallelLinear::operator()(const autograd::TensorPtr& tensor) {
     auto x = tensor;
-    x = ops::distributed::broadcast(x);
+    // Broadcast data along TP dimension to ensure all TP devices in each DP group have the same data
+    x = ops::distributed::broadcast(x, m_shard_dim);
     x = ops::linear_op(x, m_weight, m_bias);
     if (m_gather_output) {
-        x = ops::distributed::all_gather(x, tensor->get_rank() - 1U);
+        // All-gather output along TP dimension to gather sharded outputs within each DP group
+        x = ops::distributed::all_gather(x, tensor->get_rank() - 1U, m_shard_dim);
     }
     return x;
 }
 
 void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_features, bool has_bias) {
     auto* device = &autograd::ctx().get_device();
-    auto num_devices = static_cast<uint32_t>(device->num_devices());
-    if (out_features % num_devices != 0) {
+    auto mesh_shape = device->shape();
+
+    // Determine TP size based on mesh shape and shard_dim
+    uint32_t tp_size = 1U;
+    if (m_shard_dim.has_value() && mesh_shape.dims() == 2) {
+        // For 2D mesh with explicit shard_dim: TP size is mesh dimension specified by shard_dim
+        tp_size = mesh_shape[m_shard_dim.value()];
+    } else {
+        // 1D mesh: use all devices
+        tp_size = static_cast<uint32_t>(device->num_devices());
+    }
+
+    if (out_features % tp_size != 0) {
         throw std::runtime_error(fmt::format(
-            "Output features must be divisible by the number of devices. Output features = {}, devices = {}",
+            "Output features must be divisible by the TP size. Output features = {}, TP size = {}",
             out_features,
-            num_devices));
+            tp_size));
     }
 
     auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
-
     uint32_t rank = 4U;
-    auto mesh_shape = device->shape();
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
 
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
-    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 2U);
+
+    auto weight_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 2U, m_shard_dim);
     m_weight = autograd::create_tensor(
-        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
+        ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, weight_mapper.get()));
 
     if (has_bias) {
         auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
         auto bias = init::uniform_init(bias_shape, init::UniformRange{-init_k, init_k});
-        mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U);
+        auto bias_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
         m_bias = autograd::create_tensor(
-            ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(bias, device, ttnn::Layout::TILE, mapper.get()));
+            ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(bias, device, ttnn::Layout::TILE, bias_mapper.get()));
     }
 }
 

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -47,7 +47,7 @@ autograd::TensorPtr RowParallelLinear::operator()(const autograd::TensorPtr& ten
         does all reduce in backward pass. See similar implementation in fairscale for more details.
         https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/model_parallel/mappings.py#L102
     */
-    x = ops::distributed::all_reduce(x, /* noop_backward */ true, m_shard_dim);
+    x = ops::distributed::all_reduce(x, /* noop_backward */ m_input_is_parallel, m_shard_dim);
     if (m_bias != nullptr) {
         x = ops::add(x, m_bias);
     }

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -76,13 +76,13 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
             tp_size));
     }
 
-    auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
+    const auto weight_shape = ttnn::Shape({1, 1, out_features, in_features});
     uint32_t rank = 4U;
     const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
 
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
 
-    std::unique_ptr<ttnn::distributed::TensorToMesh> mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
+    const auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
     m_weight = autograd::create_tensor(
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, mapper.get()));
 
@@ -149,14 +149,14 @@ void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out
 
     auto weight = init::uniform_init(weight_shape, init::UniformRange{-init_k, init_k});
 
-    auto weight_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 2U, m_shard_dim);
+    const auto weight_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 2U, m_shard_dim);
     m_weight = autograd::create_tensor(
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight, device, ttnn::Layout::TILE, weight_mapper.get()));
 
     if (has_bias) {
-        auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
-        auto bias = init::uniform_init(bias_shape, init::UniformRange{-init_k, init_k});
-        auto bias_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
+        const auto bias_shape = ttnn::Shape({1, 1, 1, out_features});
+        const auto bias = init::uniform_init(bias_shape, init::UniformRange{-init_k, init_k});
+        const auto bias_mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*device, rank - 1U, m_shard_dim);
         m_bias = autograd::create_tensor(
             ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(bias, device, ttnn::Layout::TILE, bias_mapper.get()));
     }

--- a/tt-train/sources/ttml/modules/distributed/linear.hpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "autograd/tensor.hpp"
 #include "modules/module_base.hpp"
 
@@ -12,7 +14,11 @@ namespace ttml::modules::distributed {
 class RowParallelLinear : public ModuleBase {
 public:
     RowParallelLinear(
-        uint32_t in_features, uint32_t out_features, bool has_bias = true, bool input_is_parallel = false);
+        uint32_t in_features,
+        uint32_t out_features,
+        bool has_bias = true,
+        bool input_is_parallel = false,
+        std::optional<uint32_t> shard_dim = std::nullopt);
     autograd::TensorPtr operator()(const autograd::TensorPtr& tensor) override;
 
 private:
@@ -21,11 +27,17 @@ private:
     autograd::TensorPtr m_weight;
     autograd::TensorPtr m_bias;
     bool m_input_is_parallel{false};
+    std::optional<uint32_t> m_shard_dim{std::nullopt};
 };
 
 class ColumnParallelLinear : public ModuleBase {
 public:
-    ColumnParallelLinear(uint32_t in_features, uint32_t out_features, bool has_bias = true, bool gather_output = false);
+    ColumnParallelLinear(
+        uint32_t in_features,
+        uint32_t out_features,
+        bool has_bias = true,
+        bool gather_output = false,
+        std::optional<uint32_t> shard_dim = std::nullopt);
     autograd::TensorPtr operator()(const autograd::TensorPtr& tensor) override;
 
 private:
@@ -34,6 +46,7 @@ private:
     autograd::TensorPtr m_weight;
     autograd::TensorPtr m_bias;
     bool m_gather_output{false};
+    std::optional<uint32_t> m_shard_dim{std::nullopt};
 };
 
 }  // namespace ttml::modules::distributed

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -5,6 +5,7 @@
 #include "nb_core.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
@@ -127,19 +128,12 @@ void py_module(nb::module_& m) {
         // Returns std::unique_ptr<TensorToMesh>
         py_distributed.def(
             "shard_tensor_to_mesh_mapper",
-            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(ttnn::distributed::MeshDevice&, int)>(
-                &ttnn::distributed::shard_tensor_to_mesh_mapper),
-            nb::arg("device"),
-            nb::arg("dim"));
-
-        // Returns std::unique_ptr<TensorToMesh>
-        py_distributed.def(
-            "shard_tensor_to_mesh_mapper",
-            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(ttnn::distributed::MeshDevice&, int, std::optional<int>)>(
+            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(
+                ttnn::distributed::MeshDevice&, int, std::optional<int>)>(
                 &ttnn::distributed::shard_tensor_to_mesh_mapper),
             nb::arg("device"),
             nb::arg("dim"),
-            nb::arg("cluster_axis") = std::nullopt);
+            nb::arg("cluster_axis") = nb::none());
 
         // Returns std::unique_ptr<MeshToTensor> - composer for combining distributed tensors
         py_distributed.def(
@@ -169,7 +163,7 @@ void py_module(nb::module_& m) {
             "synchronize_gradients",
             &ttml::core::distributed::synchronize_gradients,
             nb::arg("parameters"),
-            nb::arg("dp_dim") = std::nullopt);
+            nb::arg("dp_dim") = nb::none());
 
         // Bind DistributedContext methods
         using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -166,7 +166,7 @@ void py_module(nb::module_& m) {
             nb::arg("mesh_shape_override"));
         // Synchronize gradients across devices for DDP
         py_distributed.def(
-            "synchronize_gradients", &ttml::core::distributed::synchronize_gradients, nb::arg("parameters"));
+            "synchronize_gradients", &ttml::core::distributed::synchronize_parameters, nb::arg("parameters"), nb::arg("dp_dim") = std::nullopt);
 
         // Bind DistributedContext methods
         using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -166,7 +166,10 @@ void py_module(nb::module_& m) {
             nb::arg("mesh_shape_override"));
         // Synchronize gradients across devices for DDP
         py_distributed.def(
-            "synchronize_gradients", &ttml::core::distributed::synchronize_parameters, nb::arg("parameters"), nb::arg("dp_dim") = std::nullopt);
+            "synchronize_gradients",
+            &ttml::core::distributed::synchronize_gradients,
+            nb::arg("parameters"),
+            nb::arg("dp_dim") = std::nullopt);
 
         // Bind DistributedContext methods
         using DistributedContext = tt::tt_metal::distributed::multihost::DistributedContext;

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -131,7 +131,7 @@ void py_module(nb::module_& m) {
                 &ttnn::distributed::shard_tensor_to_mesh_mapper),
             nb::arg("device"),
             nb::arg("dim"));
-        
+
         // Returns std::unique_ptr<TensorToMesh>
         py_distributed.def(
             "shard_tensor_to_mesh_mapper",
@@ -140,7 +140,7 @@ void py_module(nb::module_& m) {
             nb::arg("device"),
             nb::arg("dim"),
             nb::arg("cluster_axis") = std::nullopt);
-    
+
         // Returns std::unique_ptr<MeshToTensor> - composer for combining distributed tensors
         py_distributed.def(
             "concat_mesh_to_tensor_composer",

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -131,6 +131,15 @@ void py_module(nb::module_& m) {
                 &ttnn::distributed::shard_tensor_to_mesh_mapper),
             nb::arg("device"),
             nb::arg("dim"));
+        
+        // Returns std::unique_ptr<TensorToMesh>
+        py_distributed.def(
+            "shard_tensor_to_mesh_mapper",
+            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(ttnn::distributed::MeshDevice&, int, std::optional<int>)>(
+                &ttnn::distributed::shard_tensor_to_mesh_mapper),
+            nb::arg("device"),
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = std::nullopt);
     
         // Returns std::unique_ptr<MeshToTensor> - composer for combining distributed tensors
         py_distributed.def(

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -127,10 +127,11 @@ void py_module(nb::module_& m) {
         // Returns std::unique_ptr<TensorToMesh>
         py_distributed.def(
             "shard_tensor_to_mesh_mapper",
-            &ttnn::distributed::shard_tensor_to_mesh_mapper,
+            static_cast<std::unique_ptr<ttnn::distributed::TensorToMesh> (*)(ttnn::distributed::MeshDevice&, int)>(
+                &ttnn::distributed::shard_tensor_to_mesh_mapper),
             nb::arg("device"),
-            nb::arg("rank"));
-
+            nb::arg("dim"));
+    
         // Returns std::unique_ptr<MeshToTensor> - composer for combining distributed tensors
         py_distributed.def(
             "concat_mesh_to_tensor_composer",

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
@@ -101,33 +100,15 @@ void py_module(nb::module_& m) {
 
     {
         auto py_distributed = static_cast<nb::module_>(m.attr("distributed"));
-        // All reduce with optional cluster_axis
         py_distributed.def(
             "all_reduce",
             &ttml::ops::distributed::all_reduce,
             nb::arg("tensor"),
-            nb::arg("noop_backward") = false,
-            nb::arg("cluster_axis") = std::nullopt);
-        // Reduce scatter with optional cluster_axis
+            nb::arg("noop_backward") = false);
         py_distributed.def(
-            "reduce_scatter",
-            &ttml::ops::distributed::reduce_scatter,
-            nb::arg("tensor"),
-            nb::arg("dim"),
-            nb::arg("cluster_axis") = std::nullopt);
-        // All gather with optional cluster_axis
-        py_distributed.def(
-            "all_gather",
-            &ttml::ops::distributed::all_gather,
-            nb::arg("tensor"),
-            nb::arg("dim"),
-            nb::arg("cluster_axis") = std::nullopt);
-        // Broadcast with optional cluster_axis
-        py_distributed.def(
-            "broadcast",
-            &ttml::ops::distributed::broadcast,
-            nb::arg("tensor"),
-            nb::arg("cluster_axis") = std::nullopt);
+            "reduce_scatter", &ttml::ops::distributed::reduce_scatter, nb::arg("tensor"), nb::arg("dim"));
+        py_distributed.def("all_gather", &ttml::ops::distributed::all_gather, nb::arg("tensor"), nb::arg("dim"));
+        py_distributed.def("broadcast", &ttml::ops::distributed::broadcast, nb::arg("tensor"));
     }
 
     {

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -107,20 +107,19 @@ void py_module(nb::module_& m) {
             nb::arg("noop_backward") = false,
             nb::arg("cluster_axis") = nb::none());
         py_distributed.def(
-            "reduce_scatter", 
-            &ttml::ops::distributed::reduce_scatter, 
-            nb::arg("tensor"), 
-            nb::arg("dim"),
-            nb::arg("cluster_axis") = nb::none());
-        py_distributed.def("all_gather", 
-            &ttml::ops::distributed::all_gather, 
-            nb::arg("tensor"), 
-            nb::arg("dim"),
-            nb::arg("cluster_axis") = nb::none());
-        py_distributed.def("broadcast", 
-            &ttml::ops::distributed::broadcast, 
+            "reduce_scatter",
+            &ttml::ops::distributed::reduce_scatter,
             nb::arg("tensor"),
+            nb::arg("dim"),
             nb::arg("cluster_axis") = nb::none());
+        py_distributed.def(
+            "all_gather",
+            &ttml::ops::distributed::all_gather,
+            nb::arg("tensor"),
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = nb::none());
+        py_distributed.def(
+            "broadcast", &ttml::ops::distributed::broadcast, nb::arg("tensor"), nb::arg("cluster_axis") = nb::none());
     }
 
     {

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -104,11 +104,23 @@ void py_module(nb::module_& m) {
             "all_reduce",
             &ttml::ops::distributed::all_reduce,
             nb::arg("tensor"),
-            nb::arg("noop_backward") = false);
+            nb::arg("noop_backward") = false,
+            nb::arg("cluster_axis") = nb::none());
         py_distributed.def(
-            "reduce_scatter", &ttml::ops::distributed::reduce_scatter, nb::arg("tensor"), nb::arg("dim"));
-        py_distributed.def("all_gather", &ttml::ops::distributed::all_gather, nb::arg("tensor"), nb::arg("dim"));
-        py_distributed.def("broadcast", &ttml::ops::distributed::broadcast, nb::arg("tensor"));
+            "reduce_scatter", 
+            &ttml::ops::distributed::reduce_scatter, 
+            nb::arg("tensor"), 
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = nb::none());
+        py_distributed.def("all_gather", 
+            &ttml::ops::distributed::all_gather, 
+            nb::arg("tensor"), 
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = nb::none());
+        py_distributed.def("broadcast", 
+            &ttml::ops::distributed::broadcast, 
+            nb::arg("tensor"),
+            nb::arg("cluster_axis") = nb::none());
     }
 
     {

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -113,6 +113,12 @@ void py_module(nb::module_& m) {
             nb::arg("dim"),
             nb::arg("cluster_axis") = nb::none());
         py_distributed.def(
+            "scatter",
+            &ttml::ops::distributed::scatter,
+            nb::arg("tensor"),
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = nb::none());
+        py_distributed.def(
             "all_gather",
             &ttml::ops::distributed::all_gather,
             nb::arg("tensor"),

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -101,15 +101,33 @@ void py_module(nb::module_& m) {
 
     {
         auto py_distributed = static_cast<nb::module_>(m.attr("distributed"));
+        // All reduce with optional cluster_axis
         py_distributed.def(
             "all_reduce",
             &ttml::ops::distributed::all_reduce,
             nb::arg("tensor"),
-            nb::arg("noop_backward") = false);
+            nb::arg("noop_backward") = false,
+            nb::arg("cluster_axis") = std::nullopt);
+        // Reduce scatter with optional cluster_axis
         py_distributed.def(
-            "reduce_scatter", &ttml::ops::distributed::reduce_scatter, nb::arg("tensor"), nb::arg("dim"));
-        py_distributed.def("all_gather", &ttml::ops::distributed::all_gather, nb::arg("tensor"), nb::arg("dim"));
-        py_distributed.def("broadcast", &ttml::ops::distributed::broadcast, nb::arg("tensor"));
+            "reduce_scatter",
+            &ttml::ops::distributed::reduce_scatter,
+            nb::arg("tensor"),
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = std::nullopt);
+        // All gather with optional cluster_axis
+        py_distributed.def(
+            "all_gather",
+            &ttml::ops::distributed::all_gather,
+            nb::arg("tensor"),
+            nb::arg("dim"),
+            nb::arg("cluster_axis") = std::nullopt);
+        // Broadcast with optional cluster_axis
+        py_distributed.def(
+            "broadcast",
+            &ttml::ops::distributed::broadcast,
+            nb::arg("tensor"),
+            nb::arg("cluster_axis") = std::nullopt);
     }
 
     {

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -13,33 +13,33 @@
 
 namespace ttml::ops::distributed {
 
-autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim) {
-    auto out = autograd::create_tensor(ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim));
-    autograd::GradFunction grad = [tensor, out, dim]() {
-        tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim));
+autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
+    auto out = autograd::create_tensor(ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim, cluster_axis));
+    autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
+        tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim, cluster_axis));
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
     return out;
 }
 
-autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim) {
-    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_gather(tensor->get_value(), dim));
-    autograd::GradFunction grad = [tensor, out, dim]() {
-        tensor->add_grad(ttnn_fixed::distributed::reduce_scatter(out->get_grad(), dim));
+autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
+    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_gather(tensor->get_value(), dim, cluster_axis));
+    autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
+        tensor->add_grad(ttnn_fixed::distributed::reduce_scatter(out->get_grad(), dim, cluster_axis));
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
     return out;
 }
 
-autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward) {
-    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_reduce(tensor->get_value()));
-    autograd::GradFunction grad = [tensor, out, noop_backward]() {
+autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward, std::optional<uint32_t> cluster_axis) {
+    auto out = autograd::create_tensor(ttnn_fixed::distributed::all_reduce(tensor->get_value(), cluster_axis));
+    autograd::GradFunction grad = [tensor, out, noop_backward, cluster_axis]() {
         if (noop_backward) {
             tensor->add_grad(out->get_grad());
         } else {
-            tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad()));
+            tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad(), cluster_axis));
         }
     };
     auto links = autograd::get_links(tensor);
@@ -47,10 +47,10 @@ autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_back
     return out;
 }
 
-autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor) {
+autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(tensor->get_value());
-    autograd::GradFunction grad = [tensor, out]() {
-        tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad()));
+    autograd::GradFunction grad = [tensor, out, cluster_axis]() {
+        tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad(), cluster_axis));
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -73,8 +73,6 @@ autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_back
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(tensor->get_value());
     autograd::GradFunction grad = [tensor, out, cluster_axis]() {
-        // auto* device = &autograd::ctx().get_device();
-        // const uint32_t tp_size = cluster_axis.has_value() ? device->shape()[cluster_axis.value()] : device->num_devices();
         tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad(), cluster_axis));
     };
     auto links = autograd::get_links(tensor);

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -27,14 +27,13 @@ autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, s
 autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
     auto* device = &autograd::ctx().get_device();
     auto mesh_shape = device->shape();
-    uint32_t tp_size = cluster_axis.has_value() ? mesh_shape[cluster_axis.value()] 
-                                                 : static_cast<uint32_t>(device->num_devices());
-    
+    uint32_t tp_size =
+        cluster_axis.has_value() ? mesh_shape[cluster_axis.value()] : static_cast<uint32_t>(device->num_devices());
 
     auto scattered = ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim, cluster_axis);
     /* average across TP as input is assumed to be replicated across TP axis*/
     auto out = autograd::create_tensor(ttnn::multiply(scattered, 1.F / static_cast<float>(tp_size)));
-    
+
     /* input is replicated across TP axis, so d(nx/n) / dx = dx / dx = 1 for i=0,1,...,n and 0 otherwise */
     autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
         tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim, cluster_axis));
@@ -46,7 +45,7 @@ autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim, std::opt
 
 autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(ttnn_fixed::distributed::all_gather(tensor->get_value(), dim, cluster_axis));
-        
+
     autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
         if (out->is_grad_initialized()) {
             tensor->add_grad(ttnn_fixed::distributed::reduce_scatter(out->get_grad(), dim, cluster_axis));

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -15,6 +15,27 @@ namespace ttml::ops::distributed {
 
 autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim, cluster_axis));
+    /* d(x_0 + x_1 + ... + x_n) / dx_i = 1 for i=0,1,...,n and 0 otherwise */
+    autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
+        tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim, cluster_axis));
+    };
+    auto links = autograd::get_links(tensor);
+    out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
+    return out;
+}
+
+autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
+    auto* device = &autograd::ctx().get_device();
+    auto mesh_shape = device->shape();
+    uint32_t tp_size = cluster_axis.has_value() ? mesh_shape[cluster_axis.value()] 
+                                                 : static_cast<uint32_t>(device->num_devices());
+    
+
+    auto scattered = ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim, cluster_axis);
+    /* average across TP as input is assumed to be replicated across TP axis*/
+    auto out = autograd::create_tensor(ttnn::multiply(scattered, 1.F / static_cast<float>(tp_size)));
+    
+    /* input is replicated across TP axis, so d(nx/n) / dx = dx / dx = 1 for i=0,1,...,n and 0 otherwise */
     autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
         tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim, cluster_axis));
     };
@@ -25,8 +46,11 @@ autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, s
 
 autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(ttnn_fixed::distributed::all_gather(tensor->get_value(), dim, cluster_axis));
+        
     autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
-        tensor->add_grad(ttnn_fixed::distributed::reduce_scatter(out->get_grad(), dim, cluster_axis));
+        if (out->is_grad_initialized()) {
+            tensor->add_grad(ttnn_fixed::distributed::reduce_scatter(out->get_grad(), dim, cluster_axis));
+        }
     };
     auto links = autograd::get_links(tensor);
     out->set_node(autograd::ctx().add_backward_node(std::move(grad), links));
@@ -50,6 +74,8 @@ autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_back
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor, std::optional<uint32_t> cluster_axis) {
     auto out = autograd::create_tensor(tensor->get_value());
     autograd::GradFunction grad = [tensor, out, cluster_axis]() {
+        // auto* device = &autograd::ctx().get_device();
+        // const uint32_t tp_size = cluster_axis.has_value() ? device->shape()[cluster_axis.value()] : device->num_devices();
         tensor->add_grad(ttnn_fixed::distributed::all_reduce(out->get_grad(), cluster_axis));
     };
     auto links = autograd::get_links(tensor);

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
@@ -8,9 +8,9 @@
 
 namespace ttml::ops::distributed {
 
-autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim);
-autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward = false);
-autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim);
-autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor);
+autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward = false, std::optional<uint32_t> cluster_axis = std::nullopt);
+autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor, std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttml::ops::distributed

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
@@ -8,6 +8,9 @@
 
 namespace ttml::ops::distributed {
 
+// dim: tensor dimension to scatter/gather/reduce across (which tensor dimension will change after the operation)
+// cluster_axis: mesh device shape axis to scatter/gather/reduce across (which parts of the tensor participate in the
+// operation), default is none (all axes)
 autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward = false, std::optional<uint32_t> cluster_axis = std::nullopt);

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.hpp
@@ -9,6 +9,7 @@
 namespace ttml::ops::distributed {
 
 autograd::TensorPtr reduce_scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+autograd::TensorPtr scatter(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 autograd::TensorPtr all_reduce(const autograd::TensorPtr& tensor, bool noop_backward = false, std::optional<uint32_t> cluster_axis = std::nullopt);
 autograd::TensorPtr all_gather(const autograd::TensorPtr& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 autograd::TensorPtr broadcast(const autograd::TensorPtr& tensor, std::optional<uint32_t> cluster_axis = std::nullopt);

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -22,36 +22,19 @@ tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim, std
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
         *mesh_device, /* cluster_axis */ cluster_axis);
 
-    if (cluster_axis.has_value()) {
-        // Use cluster_axis overload for 2D mesh
-        return ttnn::experimental::all_gather_async(
-            tensor,
-            dim,
-            cluster_axis.value(),
-            *mesh_device,
-            ttnn::ccl::Topology::Linear,
-            ccl_resources.get_all_gather_semaphore(),
-            /* persistent_output_tensor */ std::nullopt,
-            /* memory_config */ std::nullopt,
-            std::optional<size_t>(num_links),
-            /* subdevice_id */ std::nullopt,
-            /* use_optimal_ccl_for_llama */ false,
-            /* barrier_semaphore */ ccl_resources.get_barrier_semaphore(),
-            /* reverse_order */ false,
-            /* sub_core_grid */ std::nullopt);
-    } else {
-        // Use original overload for 1D mesh or when cluster_axis is not specified
-        return ttnn::experimental::all_gather_async(
-            tensor,
-            dim,
-            ccl_resources.get_all_gather_semaphore(),
-            num_links,
-            /* memory_config */ std::nullopt,
-            ttnn::ccl::Topology::Linear,
-            /* subdevice_id */ std::nullopt,
-            /* use_optimal_ccl_for_llama */ false,
-            /* barrier_semaphore */ ccl_resources.get_barrier_semaphore());
-    }
+    // Use cluster_axis overload for 2D mesh
+    return ttnn::experimental::all_gather_async(
+        tensor,
+        /* persistent_output_buffer */ std::nullopt,
+        dim,
+        ccl_resources.get_all_gather_semaphore(),
+        num_links,
+        /* memory_config */ std::nullopt,
+        ttnn::ccl::Topology::Linear,
+        /* subdevice_id */ std::nullopt,
+        cluster_axis,
+        /* use_optimal_ccl_for_llama */ false,
+        /* barrier_semaphore */ ccl_resources.get_barrier_semaphore());
 }
 
 tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optional<uint32_t> cluster_axis) {
@@ -74,33 +57,19 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optiona
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
         *mesh_device, /* cluster_axis */ cluster_axis);
 
-    if (cluster_axis.has_value()) {
-        // Use cluster_axis overload for 2D mesh
-        return ttnn::experimental::all_reduce_async(
-            tensor,
-            cluster_axis,
-            *mesh_device,
-            /* barrier_semaphores */ std::nullopt,
-            /* rs_global_semaphores */ std::nullopt,
-            /* ag_global_semaphores */ std::nullopt,
-            ttnn::operations::reduction::ReduceType::Sum,
-            /* memory_config */ std::nullopt,
-            ttnn::ccl::Topology::Linear,
-            std::optional<size_t>(num_links),
-            /* worker_subdevice_id_opt */ std::nullopt);
-    } else {
-        // Use original overload for 1D mesh
-        return ttnn::experimental::all_reduce_async(
-            tensor,
-            num_devices,
-            all_reduce_barrier_semaphores,
-            reduce_scatter_semaphores,
-            all_gather_semaphores,
-            ttnn::operations::reduction::ReduceType::Sum,
-            /* memory_config */ std::nullopt,
-            /* topology */ ttnn::ccl::Topology::Linear,
-            /* num_preferred_links */ num_links);
-    }
+    // Use cluster_axis overload for 2D mesh
+    return ttnn::experimental::all_reduce_async(
+        tensor,
+        cluster_axis,
+        *mesh_device,
+        /* barrier_semaphores */ std::nullopt,
+        /* rs_global_semaphores */ std::nullopt,
+        /* ag_global_semaphores */ std::nullopt,
+        ttnn::operations::reduction::ReduceType::Sum,
+        /* memory_config */ std::nullopt,
+        ttnn::ccl::Topology::Linear,
+        std::optional<size_t>(num_links),
+        /* worker_subdevice_id_opt */ std::nullopt);
 }
 
 tt::tt_metal::Tensor reduce_scatter(const tt::tt_metal::Tensor& tensor, int dim, std::optional<uint32_t> cluster_axis) {

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -21,7 +21,7 @@ tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim, std
     auto& ccl_resources = ttml::autograd::ctx().get_ccl_resources();
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
         *mesh_device, /* cluster_axis */ cluster_axis);
-    
+
     if (cluster_axis.has_value()) {
         // Use cluster_axis overload for 2D mesh
         return ttnn::experimental::all_gather_async(
@@ -41,16 +41,16 @@ tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim, std
             /* sub_core_grid */ std::nullopt);
     } else {
         // Use original overload for 1D mesh or when cluster_axis is not specified
-    return ttnn::experimental::all_gather_async(
-        tensor,
-        dim,
-        ccl_resources.get_all_gather_semaphore(),
-        num_links,
-        /* memory_config */ std::nullopt,
-        ttnn::ccl::Topology::Linear,
-        /* subdevice_id */ std::nullopt,
-        /* use_optimal_ccl_for_llama */ false,
-        /* barrier_semaphore */ ccl_resources.get_barrier_semaphore());
+        return ttnn::experimental::all_gather_async(
+            tensor,
+            dim,
+            ccl_resources.get_all_gather_semaphore(),
+            num_links,
+            /* memory_config */ std::nullopt,
+            ttnn::ccl::Topology::Linear,
+            /* subdevice_id */ std::nullopt,
+            /* use_optimal_ccl_for_llama */ false,
+            /* barrier_semaphore */ ccl_resources.get_barrier_semaphore());
     }
 }
 
@@ -73,7 +73,7 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optiona
 
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
         *mesh_device, /* cluster_axis */ cluster_axis);
-    
+
     if (cluster_axis.has_value()) {
         // Use cluster_axis overload for 2D mesh
         return ttnn::experimental::all_reduce_async(
@@ -90,16 +90,16 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optiona
             /* worker_subdevice_id_opt */ std::nullopt);
     } else {
         // Use original overload for 1D mesh
-    return ttnn::experimental::all_reduce_async(
-        tensor,
-        num_devices,
-        all_reduce_barrier_semaphores,
-        reduce_scatter_semaphores,
-        all_gather_semaphores,
-        ttnn::operations::reduction::ReduceType::Sum,
-        /* memory_config */ std::nullopt,
-        /* topology */ ttnn::ccl::Topology::Linear,
-        /* num_preferred_links */ num_links);
+        return ttnn::experimental::all_reduce_async(
+            tensor,
+            num_devices,
+            all_reduce_barrier_semaphores,
+            reduce_scatter_semaphores,
+            all_gather_semaphores,
+            ttnn::operations::reduction::ReduceType::Sum,
+            /* memory_config */ std::nullopt,
+            /* topology */ ttnn::ccl::Topology::Linear,
+            /* num_preferred_links */ num_links);
     }
 }
 

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -20,7 +20,7 @@ tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim, std
     }
     auto& ccl_resources = ttml::autograd::ctx().get_ccl_resources();
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
-        *mesh_device, cluster_axis ? std::optional<size_t>(cluster_axis.value()) : std::nullopt);
+        *mesh_device, /* cluster_axis */ cluster_axis);
     
     if (cluster_axis.has_value()) {
         // Use cluster_axis overload for 2D mesh
@@ -72,7 +72,7 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optiona
     auto reduce_scatter_semaphores = ccl_resources.get_reduce_scatter_semaphores();
 
     uint32_t num_links = ttnn::operations::ccl::common::get_num_links(
-        *mesh_device, cluster_axis ? std::optional<size_t>(cluster_axis.value()) : std::nullopt);
+        *mesh_device, /* cluster_axis */ cluster_axis);
     
     if (cluster_axis.has_value()) {
         // Use cluster_axis overload for 2D mesh

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.hpp
@@ -7,8 +7,8 @@
 
 namespace ttml::ttnn_fixed::distributed {
 
-tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim);
-tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor);
-tt::tt_metal::Tensor reduce_scatter(const tt::tt_metal::Tensor& tensor, int dim);
+tt::tt_metal::Tensor all_gather(const tt::tt_metal::Tensor& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
+tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor, std::optional<uint32_t> cluster_axis = std::nullopt);
+tt::tt_metal::Tensor reduce_scatter(const tt::tt_metal::Tensor& tensor, int dim, std::optional<uint32_t> cluster_axis = std::nullopt);
 
 }  // namespace ttml::ttnn_fixed::distributed

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -64,6 +64,8 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
 // the tensor.
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim);
 
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> shard_dim);
+
 // Composer interface used for aggregating a tensor distributed over a mesh.
 class MeshToTensor {
 public:

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -62,9 +62,9 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
 // Creates a mapper that shards a tensor along a single dimension.
 // Shorthand for specifying a MeshMapperConfig with 1D mesh shape, and sharding the tensor along a single dimension of
 // the tensor.
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim);
 
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis);
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
+    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis = std::nullopt);
 
 // Composer interface used for aggregating a tensor distributed over a mesh.
 class MeshToTensor {

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -64,7 +64,7 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
 // the tensor.
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim);
 
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> shard_dim);
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis);
 
 // Composer interface used for aggregating a tensor distributed over a mesh.
 class MeshToTensor {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -504,6 +504,7 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_devic
             .mesh_shape_override = MeshShape(mesh_device.num_devices())}));
 }
 
+// Shard a tensor across one mesh dimension, and replicate the tensor along the other dimensions.
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> shard_dim) {
     if (!shard_dim.has_value()) {
         return shard_tensor_to_mesh_mapper(mesh_device, dim);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -505,20 +505,21 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_devic
 }
 
 // Shard a tensor across one mesh dimension, and replicate the tensor along the other dimensions.
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis) {
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
+    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis) {
     if (!cluster_axis.has_value()) {
         return shard_tensor_to_mesh_mapper(mesh_device, dim);
     }
-    TT_FATAL(mesh_device.shape().dims()==2, "Mesh device shape must be 2D");
-    TT_FATAL(dim >= 0 && cluster_axis >= 0 && cluster_axis < mesh_device.shape().dims(), "Dimension {} or {} is out of range", dim, cluster_axis);
-    tt::stl::SmallVector<MeshMapperConfig::Placement> placements(2);
-    placements[0] = MeshMapperConfig::Replicate{};
-    placements[1] = MeshMapperConfig::Replicate{};
+    TT_FATAL(
+        cluster_axis.value() >= 0 && cluster_axis.value() < mesh_device.shape().dims(),
+        "Cluster axis {} is out of range for mesh device with {} dimensions",
+        cluster_axis.value(),
+        mesh_device.shape().dims());
+    tt::stl::SmallVector<MeshMapperConfig::Placement> placements(
+        mesh_device.shape().dims(), MeshMapperConfig::Replicate{});
     placements[cluster_axis.value()] = MeshMapperConfig::Shard{dim};
-    return std::make_unique<TensorToMesh>(TensorToMesh::create(
-        mesh_device,
-        MeshMapperConfig{
-            .placements = placements}));
+    return std::make_unique<TensorToMesh>(
+        TensorToMesh::create(mesh_device, MeshMapperConfig{.placements = placements}));
 }
 
 std::unique_ptr<TensorToMesh> create_mesh_mapper(MeshDevice& mesh_device, const MeshMapperConfig& config) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -505,16 +505,16 @@ std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_devic
 }
 
 // Shard a tensor across one mesh dimension, and replicate the tensor along the other dimensions.
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> shard_dim) {
-    if (!shard_dim.has_value()) {
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis) {
+    if (!cluster_axis.has_value()) {
         return shard_tensor_to_mesh_mapper(mesh_device, dim);
     }
     TT_FATAL(mesh_device.shape().dims()==2, "Mesh device shape must be 2D");
-    TT_FATAL(dim >= 0 && shard_dim >= 0 && shard_dim < mesh_device.shape().dims(), "Dimension {} or {} is out of range", dim, shard_dim);
+    TT_FATAL(dim >= 0 && cluster_axis >= 0 && cluster_axis < mesh_device.shape().dims(), "Dimension {} or {} is out of range", dim, cluster_axis);
     tt::stl::SmallVector<MeshMapperConfig::Placement> placements(2);
     placements[0] = MeshMapperConfig::Replicate{};
     placements[1] = MeshMapperConfig::Replicate{};
-    placements[shard_dim.value()] = MeshMapperConfig::Shard{dim};
+    placements[cluster_axis.value()] = MeshMapperConfig::Shard{dim};
     return std::make_unique<TensorToMesh>(TensorToMesh::create(
         mesh_device,
         MeshMapperConfig{

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -496,19 +496,15 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
             .mesh_shape_override = MeshShape(mesh_device.num_devices())}));
 }
 
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim) {
-    return std::make_unique<TensorToMesh>(TensorToMesh::create(
-        mesh_device,
-        MeshMapperConfig{
-            .placements = {MeshMapperConfig::Shard{dim}},
-            .mesh_shape_override = MeshShape(mesh_device.num_devices())}));
-}
-
 // Shard a tensor across one mesh dimension, and replicate the tensor along the other dimensions.
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
-    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis) {
+    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis = std::nullopt) {
     if (!cluster_axis.has_value()) {
-        return shard_tensor_to_mesh_mapper(mesh_device, dim);
+        return std::make_unique<TensorToMesh>(TensorToMesh::create(
+            mesh_device,
+            MeshMapperConfig{
+                .placements = {MeshMapperConfig::Shard{dim}},
+                .mesh_shape_override = MeshShape(mesh_device.num_devices())}));
     }
     TT_FATAL(
         cluster_axis.value() >= 0 && cluster_axis.value() < mesh_device.shape().dims(),

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -498,7 +498,7 @@ std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_d
 
 // Shard a tensor across one mesh dimension, and replicate the tensor along the other dimensions.
 std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
-    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis = std::nullopt) {
+    MeshDevice& mesh_device, int dim, std::optional<int> cluster_axis) {
     if (!cluster_axis.has_value()) {
         return std::make_unique<TensorToMesh>(TensorToMesh::create(
             mesh_device,


### PR DESCRIPTION
## Summary

This PR adds new examples demonstrating combined Tensor Parallelism (TP) and Data Parallelism (DP) for linear regression training in both python and C++ (./tt-train/sources/examples/linear_regression_tp_dp/*). 

## Changes

### New Features

- **New TP+DP Linear Regression Example** (`tt-train/sources/examples/linear_regression_tp_dp/`)
  - NEED TO CHANGE device_topology in the MGD config you are using (./tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto is the default one) to { dims: [ 4, 8 ] } or { dims: [ 8, 4 ] } or use an existing mesh descriptor like this 
`TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.textproto` before  running the script.

  - Demonstrates training with combined tensor parallelism and data parallelism
  - Supports both `RowParallelLinear` and `ColumnParallelLinear` modes via `--row` flag
  - Mesh shape: x DP groups × y TP devices (is passed via --mesh_shape parameter like this `4x8` or 8x4 is used by default,  need to also be changed in the mgd config accordingly).

 **Limitation**: You have to initialize the fabric with all devices, you can't use a proper submesh. In these examples, I assume dp is always the first mesh axis and tp is the second, which will be preserved later on when adding tp+dp llm training support. A user will set if they want to use data parallel or not and the axis will decided automatically: data parallel will always be the first one if present, the second will be cp (if present, if there is not dp --- cp will be the first one), then pp, tp and ep.

### Parallelism Modes

1. **ColumnParallelLinear** (default):
   - Shards output features across TP dimension
   - Broadcasts input to all TP devices
   - Supports `gather_output` option

2. **RowParallelLinear** (`--row` flag):
   - Shards input features across TP dimension
   - All-reduces output across TP devices
   - Input can be parallel or sequential

3. In case our mesh topology is linear (like {1,32}) we fall back to the previous ccls and LinearParallel implementations.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes