### PR TITLE
Make expm1 accurate on float32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -17,11 +17,16 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 /*
- * Both _float_to_int32_ and _float_to_int32_positive_ use branch to handle special cases
- * With exp21f function, some of these cases never happen (e.g. negative exponent, overflow)
+ * Convert an float value to a 32-bit integer value (specialized function for exp21f and exp61f)
+
+ * exp21f and exp61f rely on a float -> int conversion to compute the exponent of the integer part of the input.
+ * Two functions are available: _float_to_int32_ and _float_to_int32_positive_, which use branch to handle special cases
+ * With exp21f/exp61f function, some of these cases never happen (e.g. negative exponent, overflow)
  * This allow for a branch free (and much smaller algorithm) to compute integer value
+ *
+ * The constraint on `val` is: 0 <= val < 128.0f
  */
-sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
+sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
     sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     sfpi::vInt shift = exp - 23;
@@ -63,7 +68,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // Fundamentally, this computes exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
-    sfpi::vInt z = _float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+    sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
@@ -83,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat p2 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + fractional_part, 0);
 
     // Compute 2**(adjusted fractional part) through float -> int conversion
-    fractional_part = _float_to_int32_exp21f_(p1 * p2);
+    fractional_part = _float_to_int32_for_exp21f_(p1 * p2);
 
     // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
     exponential_part = sfpi::reinterpret<sfpi::vInt>(
@@ -109,7 +114,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
         // z = (bias + x * factor * N_m; where:
         // factor = 0x00b8aa3b (computed through log(e))
         // bias = 0x3f800000
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -19,7 +19,7 @@ template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
         sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
-        zif = sfpu::_float_to_int32_exp21f_(d2 * d3);
+        zif = _float_to_int32_for_exp21f_(d2 * d3);
 
         zii = sfpi::reinterpret<sfpi::vInt>(
             sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,23 +4,25 @@
 
 #pragma once
 
-namespace ckernel {
-namespace sfpu {
+#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
+
+namespace ckernel::sfpu {
 
 /*
- * This function implements the exponential function using a polynomial approximation algorithm
+ * This function implements expm1(x) = exp(x) - 1 using a polynomial approximation algorithm
  * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
  * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
  * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
  *
  * @param val The input value (sfpi::vFloat vector), can be any floating point number
  *
- * @return sfpi::vFloat Result of exp(val)
+ * @return sfpi::vFloat Result of expm1(val)
  *
  * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
-template <bool is_fp32_dest_acc_en = false>
+template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
     v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
@@ -30,11 +32,15 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
     }
     v_elseif(val > sfpi::vFloat(-88.0f)) {
+        // Clamp to prevent overflow if x > 89
+        sfpi::vFloat threshold_high = sfpi::vFloat(89.f);
+        sfpi::vec_min_max(val, threshold_high);
+
         // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
         // z = (bias + x * factor * N_m; where:
         // factor = 0x00b8aa3b (computed through log(e))
         // bias = 0x3f800000
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
 
@@ -42,7 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
         sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
-        zif = sfpu::_float_to_int32_exp21f_(d2 * d3);
+        zif = _float_to_int32_for_exp21f_(d2 * d3);
 
         // Restore exponent
         zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
@@ -60,22 +66,98 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     return y;
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+/*
+ * This function implements expm1(x) = exp(x) - 1 with high accuracy for float32.
+ * Target accuracy: < 2 ULP for float32.
+ *
+ * Uses hybrid approach optimized for maximum ULP error:
+ * - Taylor series (order 8) for |x| < 0.5 to avoid catastrophic cancellation
+ * - exp(x) - 1 for |x| >= 0.5 (calls _sfpu_exp_f32_accurate_)
+ *
+ * This avoids catastrophic cancellation when x is near 0.
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ * @return sfpi::vFloat Result of expm1(val)
+ */
+sfpi_inline sfpi::vFloat _sfpu_expm1_f32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    // For small |x| < 0.5: use Taylor series to avoid cancellation
+    v_if(abs_val < sfpi::vConstFloatPrgm0) {
+        // Use a polynomial approximation around 0 to avoid catastrophic cancellation
+        // Polynomial coefficients found using Sollya with the following commands:
+        // > fpminimax(exp(x)-1, [|1,2,3,4,5,6,7|], [|single...|], [-0.5; -2^(-40)] + [2^(-40); 0.5], relative);
+        result = PolynomialEvaluator::eval(
+            val,
+            sfpi::vConst0,
+            sfpi::vConst1,
+            sfpi::vConstFloatPrgm1,
+            0.16666667163372039794921875f,
+            4.16650883853435516357421875e-2f,
+            8.333188481628894805908203125e-3f,
+            1.400390756316483020782470703125e-3f,
+            sfpi::vConstFloatPrgm2);
+    }
+    v_else {
+        // For moderate values: use exp(x) - 1
+        // This is accurate because exp(x) is not close to 1
+        // Call the accurate exp implementation and subtract 1
+        sfpi::vFloat exp_result = _sfpu_exp_f32_accurate_(val);
+        result = exp_result - sfpi::vConst1;
+    }
+    v_endif;
+
+    return result;
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_(sfpi::vFloat val);
+
+// is_fp32_dest_acc_en == false: use bfloat16-optimized version
+template <>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<false>(sfpi::vFloat val) {
+    return _sfpu_expm1_<false>(val);
+}
+
+// is_fp32_dest_acc_en == true: use float32-accurate version
+template <>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
+    return _sfpu_expm1_f32_accurate_(val);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_expm1() {
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
-        sfpi::dst_reg++;
+    if constexpr (APPROXIMATION_MODE) {
+        // Use original approximation mode
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg++;
+        }
+    } else {
+        // Use improved version based on destination precision
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg++;
+        }
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void expm1_init() {
-    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
-    sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560e;
+    if constexpr (APPROXIMATION_MODE || !is_fp32_dest_acc_en) {
+        // Polynomial coefficients for approximation of exp on [1; 2]
+        // Used by the approximation mode and bfloat16 mode
+        sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+        sfpi::vConstIntPrgm1 = 0xf94ee7;
+        sfpi::vConstIntPrgm2 = 0x560e;
+    } else {
+        sfpi::vConstFloatPrgm0 = 0.5f;
+        sfpi::vConstFloatPrgm1 = 0.500000059604644775390625f;
+        sfpi::vConstFloatPrgm2 = 1.99588379473425447940826416015625e-4f;
+    }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -10,15 +10,15 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -17,11 +17,16 @@ namespace sfpu {
 sfpi_inline sfpi::vFloat sfpu_exp(sfpi::vFloat val) { return _sfpu_exp_(val); }
 
 /*
- * Both _float_to_int32_ and _float_to_int32_positive_ use branch to handle special cases
- * With exp21f function, some of these cases never happen (e.g. negative exponent, overflow)
+ * Convert an float value to a 32-bit integer value (specialized function for exp21f and exp61f)
+
+ * exp21f and exp61f rely on a float -> int conversion to compute the exponent of the integer part of the input.
+ * Two functions are available: _float_to_int32_ and _float_to_int32_positive_, which use branch to handle special cases
+ * With exp21f/exp61f function, some of these cases never happen (e.g. negative exponent, overflow)
  * This allow for a branch free (and much smaller algorithm) to compute integer value
+ *
+ * The constraint on `val` is: 0 <= val < 128.0f
  */
-sfpi_inline sfpi::vInt _float_to_int32_exp21f_(sfpi::vFloat val) {
+sfpi_inline sfpi::vInt _float_to_int32_for_exp21f_(sfpi::vFloat val) {
     sfpi::vInt exp = exexp(val);
     sfpi::vInt man = exman8(val);  // get mantissa with implicit bit (man in [1; 2])
     sfpi::vInt shift = exp - 23;
@@ -63,7 +68,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     // Fundamentally, this computes exp(x) = 2**(x / ln2) = 2**(x_i) * 2**(x_f) where
     // - z_i = trunc(x / ln2) (integer part)
     // - z_f = x/ln2 - trunc(x/ln2) (fractional part)
-    sfpi::vInt z = _float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+    sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
     sfpi::vInt exponential_part =
         exexp_nodebias(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract exponent ( = 2**(integer part of val/ln2))
     sfpi::vInt fractional_part =
@@ -83,7 +88,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_(sfpi::vFloat val) {
     sfpi::vFloat p2 = sfpi::int32_to_float(sfpi::vInt(POLY_D3) + fractional_part, 0);
 
     // Compute 2**(adjusted fractional part) through float -> int conversion
-    fractional_part = _float_to_int32_exp21f_(p1 * p2);
+    fractional_part = _float_to_int32_for_exp21f_(p1 * p2);
 
     // Recombined exponent and mantissa: this is equivalent to 2**(x_i) * 2**(x_f)
     exponential_part = sfpi::reinterpret<sfpi::vInt>(
@@ -109,7 +114,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_61f_(sfpi::vFloat val) {
         // z = (bias + x * factor * N_m); where:
         // factor = 0x00b8aa3b (computed through log(e))
         // bias = 0x3f800000
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = sfpi::exexp(sfpi::reinterpret<sfpi::vFloat>(z));   // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -19,7 +19,7 @@ template <bool is_fp32_dest_acc_en = false>
 sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
     sfpi::vFloat y = 0.0f;
     v_if(val > -127.f) {
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00800000) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Extract exponent
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Extract mantissa
 
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_21f_(sfpi::vFloat val) {
         sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
         sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
-        zif = sfpu::_float_to_int32_exp21f_(d2 * d3);
+        zif = _float_to_int32_for_exp21f_(d2 * d3);
 
         zii = sfpi::reinterpret<sfpi::vInt>(
             sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));  // restore exponent

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -4,23 +4,25 @@
 
 #pragma once
 
-namespace ckernel {
-namespace sfpu {
+#include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
+
+namespace ckernel::sfpu {
 
 /*
- * This function implements the exponential function using a polynomial approximation algorithm
+ * This function implements expm1(x) = exp(x) - 1 using a polynomial approximation algorithm
  * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
  * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
  * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
  *
  * @param val The input value (sfpi::vFloat vector), can be any floating point number
  *
- * @return sfpi::vFloat Result of exp(val)
+ * @return sfpi::vFloat Result of expm1(val)
  *
  * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
  *      ( https://doi.org/10.1109/MSP.2022.3157460 )
  */
-template <bool is_fp32_dest_acc_en = false>
+template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     sfpi::vFloat y = sfpi::vConstNeg1;
     v_if(sfpi::abs(val) < sfpi::s2vFloat16b(0.4f)) {
@@ -30,11 +32,16 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         y = val * (sfpi::vConst1 + val * (sfpi::vFloat(0.5f) + val * sfpi::vFloat(0.166f)));
     }
     v_elseif(val > sfpi::vFloat(-88.0f)) {
+        // Clamp to prevent overflow if x > 89
+        sfpi::vFloat threshold_high = sfpi::vFloat(89.f);
+        sfpi::vec_min_max(val, threshold_high);
+
         // The paper relies on the following formula (c.f. Section 2 and 3 of paper):
         // z = (bias + x * factor * N_m; where:
         // factor = 0x00b8aa3b (computed through log(e))
         // bias = 0x3f800000
-        sfpi::vInt z = sfpu::_float_to_int32_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
+
+        sfpi::vInt z = _float_to_int32_for_exp21f_(val * sfpi::vFloat(0x00b8aa3b) + sfpi::vFloat(0x3f800000));
         sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));
         sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));
 
@@ -42,7 +49,7 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
         sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vConstIntPrgm1 + zif, 0);
         sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vConstIntPrgm2 + zif, 0);
         d2 = d1 * d2;
-        zif = sfpu::_float_to_int32_exp21f_(d2 * d3);
+        zif = _float_to_int32_for_exp21f_(d2 * d3);
 
         // Restore exponent
         zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
@@ -60,23 +67,98 @@ sfpi_inline sfpi::vFloat _sfpu_expm1_(sfpi::vFloat val) {
     return y;
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+/*
+ * This function implements expm1(x) = exp(x) - 1 with high accuracy for float32.
+ * Target accuracy: < 2 ULP for float32.
+ *
+ * Uses hybrid approach optimized for maximum ULP error:
+ * - Taylor series (order 8) for |x| < 0.5 to avoid catastrophic cancellation
+ * - exp(x) - 1 for |x| >= 0.5 (calls _sfpu_exp_f32_accurate_)
+ *
+ * This avoids catastrophic cancellation when x is near 0.
+ *
+ * @param val The input value (sfpi::vFloat vector), can be any floating point number
+ * @return sfpi::vFloat Result of expm1(val)
+ */
+sfpi_inline sfpi::vFloat _sfpu_expm1_f32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result;
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    // For small |x| < 0.5: use Taylor series to avoid cancellation
+    v_if(abs_val < sfpi::vConstFloatPrgm0) {
+        // Use a polynomial approximation around 0 to avoid catastrophic cancellation
+        // Polynomial coefficients found using Sollya with the following commands:
+        // > fpminimax(exp(x)-1, [|1,2,3,4,5,6,7|], [|single...|], [-0.5; -2^(-40)] + [2^(-40); 0.5], relative);
+        result = PolynomialEvaluator::eval(
+            val,
+            sfpi::vConst0,
+            sfpi::vConst1,
+            sfpi::vConstFloatPrgm1,
+            0.16666667163372039794921875f,
+            4.16650883853435516357421875e-2f,
+            8.333188481628894805908203125e-3f,
+            1.400390756316483020782470703125e-3f,
+            sfpi::vConstFloatPrgm2);
+    }
+    v_else {
+        // For moderate values: use exp(x) - 1
+        // This is accurate because exp(x) is not close to 1
+        // Call the accurate exp implementation and subtract 1
+        sfpi::vFloat exp_result = _sfpu_exp_f32_accurate_(val);
+        result = exp_result - sfpi::vConst1;
+    }
+    v_endif;
+
+    return result;
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_(sfpi::vFloat val);
+
+// is_fp32_dest_acc_en == false: use bfloat16-optimized version
+template <>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<false>(sfpi::vFloat val) {
+    return _sfpu_expm1_<false>(val);
+}
+
+// is_fp32_dest_acc_en == true: use float32-accurate version
+template <>
+sfpi_inline sfpi::vFloat _sfpu_expm1_improved_<true>(sfpi::vFloat val) {
+    return _sfpu_expm1_f32_accurate_(val);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_expm1() {
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
-        sfpi::dst_reg++;
+    if constexpr (APPROXIMATION_MODE) {
+        // Use original approximation mode
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_expm1_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg++;
+        }
+    } else {
+        // Use improved version based on destination precision
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat v = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_expm1_improved_<is_fp32_dest_acc_en>(v);
+            sfpi::dst_reg++;
+        }
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void expm1_init() {
-    // Polynomial coefficients for approximation of exp on [1; 2]
-    sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
-    sfpi::vConstIntPrgm1 = 0xf94ee7;
-    sfpi::vConstIntPrgm2 = 0x560e;
+    if constexpr (APPROXIMATION_MODE || !is_fp32_dest_acc_en) {
+        // Polynomial coefficients for approximation of exp on [1; 2]
+        // Used by the approximation mode and bfloat16 mode
+        sfpi::vConstFloatPrgm0 = 0.40196114e-7f;
+        sfpi::vConstIntPrgm1 = 0xf94ee7;
+        sfpi::vConstIntPrgm2 = 0x560e;
+    } else {
+        sfpi::vConstFloatPrgm0 = 0.5f;
+        sfpi::vConstFloatPrgm1 = 0.500000059604644775390625f;
+        sfpi::vConstFloatPrgm2 = 1.99588379473425447940826416015625e-4f;
+    }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_expm1.h
@@ -10,15 +10,15 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::expm1, APPROXIMATE>(sfpu::expm1_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_expm1(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_expm1<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -432,12 +432,18 @@ ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_in
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
  // clang-format on
-ALWI void expm1_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_expm1<true, DST_ACCUM_MODE>(idst))); }
+template <bool approx = false>
+ALWI void expm1_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_expm1<approx, DST_ACCUM_MODE>(idst)));
+}
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void expm1_tile_init() { MATH((llk_math_eltwise_unary_sfpu_expm1_init<true>())); }
+template <bool approx = false>
+ALWI void expm1_tile_init() {
+    MATH((llk_math_eltwise_unary_sfpu_expm1_init<approx, DST_ACCUM_MODE>()));
+}
 
 // clang-format off
 /**


### PR DESCRIPTION
### Ticket
#28187

### Problem description
`ttnn.expm1(x)` is not accurate because it uses an exp_21f implementation instead of the new exp approximation for float32.  

### What's changed
- Make expm1 accurate within 2 ULP on float32 (note: `approx = true` will switch to the same algorithm as bfloat16)
- Update tests to ensure this accuracy
- Fix bug where bfloat16 expm1 would become -1 on large values (instead of infinity). 
- Rename `_float_to_int32_exp21f_` ->  `_float_to_int32_for_exp21f_ ` ( #34327 ) 

#### Accuracy evaluation

Type | Branch | Max ULP error |
-- | -- | --
float32 | main | ~64'000
float32 | new | 2


<img width="744" height="378" alt="expm1-accurate-float32" src="https://github.com/user-attachments/assets/29e98e1f-7a92-4b93-bd62-cbd84408db34" />

Zoomed-in version:

<img width="563" height="378" alt="expm1-accurate-zoom-float32" src="https://github.com/user-attachments/assets/bb432635-8b10-4908-bb81-e969a06c8ccb" />


#### Performance evaluation 

Switching to a higher accuracy exp function increases the execution time by a factor of 1.8.
(handling > 88 values in bfloat16 also increase execution time of bfloat16 expm1) 

On Wormhole:

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
bfloat16 | main | 1.79 | 1834
float16 | new | 1.79 | 1930
float32 | main | 1.88 | 1922
float32 | new | 3.38 | 3459


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20249035046)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK, failures also on main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20249664675)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20250195328)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20250198227)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) [OK, failures on main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20250200260)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [x] New/Existing tests provide coverage for changes