### PR TITLE
[skip ci] Address false positives from `validate_deprecation.py`

### DIFF
--- a/scripts/validate_api/git_utils.py
+++ b/scripts/validate_api/git_utils.py
@@ -87,6 +87,12 @@ def parse_diff_for_removed_lines(diff_output: str, pattern_matcher) -> List[Tupl
     return results
 
 
+def get_merge_base(ref1: str, ref2: str = "HEAD") -> str:
+    """Get the merge-base (common ancestor) between two refs."""
+    output = run_git(["git", "merge-base", ref1, ref2])
+    return output.strip()
+
+
 def get_changed_file_paths(base_ref: str, head_ref: str = "HEAD") -> List[str]:
     """List of changed files (paths) (includes deleted ones and staged changes)."""
     committed = run_git(["git", "diff", "--name-only", base_ref, head_ref])

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -56,7 +56,10 @@ def find_removed_deprecations(files: List[str], base_ref: str = "origin/main") -
     try:
         merge_base = git_utils.get_merge_base(base_ref)
     except RuntimeError as e:
-        print(f"Warning: Could not find merge-base with {base_ref}: {e}. Falling back to direct comparison with {base_ref}.", file=sys.stderr)
+        print(
+            f"Warning: Could not find merge-base with {base_ref}: {e}. Falling back to direct comparison with {base_ref}.",
+            file=sys.stderr,
+        )
         merge_base = base_ref
 
     # Get all C++ files that changed (including deleted ones) since merge-base

--- a/scripts/validate_api/validate_deprecation.py
+++ b/scripts/validate_api/validate_deprecation.py
@@ -56,7 +56,7 @@ def find_removed_deprecations(files: List[str], base_ref: str = "origin/main") -
     try:
         merge_base = git_utils.get_merge_base(base_ref)
     except RuntimeError as e:
-        print(f"Warning: Could not find merge-base with {base_ref}: {e}", file=sys.stderr)
+        print(f"Warning: Could not find merge-base with {base_ref}: {e}. Falling back to direct comparison with {base_ref}.", file=sys.stderr)
         merge_base = base_ref
 
     # Get all C++ files that changed (including deleted ones) since merge-base


### PR DESCRIPTION
### Ticket
NA

### Problem description
Across December, several users have reported being inexplicably blocked by this pre-commit hook `validate-metalium-deprecation`. After rebasing their branch on main, the issue goes away. This indicates that some kind of false positive was getting detected by the pre-commit hook.

The script was comparing the current branch directly against `origin/main`. If new deprecations were added to `origin/main` *after* a developer created their branch, those deprecations appeared as "removed" in the diff (they exist in main but not in the branch). This caused false positives - the script complained about deprecations being removed too early, even though the developer never touched those files.

### What's changed

The fix is to compare against the **merge-base** (the common ancestor commit) instead of directly against `origin/main`. This way, we only detect deprecations that the developer actually removed, not deprecations that were added to main after their branch was created.

Use `git merge-base` to find the common ancestor commit between the branch and `origin/main`, then compare against that instead.

### Changes Made

1. **`git_utils.py`** - Added new function:

```90:93:/workspace/scripts/validate_api/git_utils.py
def get_merge_base(ref1: str, ref2: str = "HEAD") -> str:
    """Get the merge-base (common ancestor) between two refs."""
    output = run_git(["git", "merge-base", ref1, ref2])
    return output.strip()
```

2. **`validate_deprecation.py`** - Updated `find_removed_deprecations()` to use merge-base:

```52:85:/workspace/scripts/validate_api/validate_deprecation.py
def find_removed_deprecations(files: List[str], base_ref: str = "origin/main") -> List[DeprecatedItem]:
    # Use merge-base to find the common ancestor between base_ref and HEAD.
    # This ensures we only detect deprecations that the developer actually removed,
    # not deprecations that were added to base_ref after their branch was created.
    try:
        merge_base = git_utils.get_merge_base(base_ref)
    except RuntimeError as e:
        print(f"Warning: Could not find merge-base with {base_ref}: {e}", file=sys.stderr)
        merge_base = base_ref
    # ... rest uses merge_base instead of base_ref
```

Now the script will only flag violations when the developer actually removes a deprecation that existed in the codebase when they branched off - not when new deprecations are added to main after they branched.