### PR TITLE
Clarify N*H*W limitation for groupnorm

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -857,3 +857,25 @@ def test_group_norm_no_input_mask(device, N, C, H, W, num_groups):
 
     # Verify that the higher-accuracy config is closer to torch
     assert pcc_high > pcc_low, "High-accuracy config should have higher PCC than low-accuracy config"
+
+
+@pytest.mark.parametrize(
+    "input_shape, num_groups, msg_pattern",
+    [
+        ((2, 1, 16, 32), 8, "must be a multiple of the tile size"),
+    ],
+)
+def test_group_norm_negative_tests(
+    input_shape,
+    num_groups,
+    msg_pattern,
+    device,
+):
+    input_tensor = ttnn.empty(input_shape, device=device)
+    with pytest.raises(RuntimeError, match=msg_pattern):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=num_groups,
+            core_grid=ttnn.CoreGrid(y=1, x=1),
+            inplace=False,
+        )

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -60,6 +60,12 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(a.buffer() != nullptr, "Operands to groupnorm need to be allocated in buffers on device!");
     TT_FATAL(a.padded_shape()[3] % args.num_groups == 0, "channel must be divisible by num_groups!");
     TT_FATAL(a.padded_shape()[1] == 1, "input tensor shape[1] must be 1!");
+    TT_FATAL(
+        (a.padded_shape()[1] * a.padded_shape()[2]) % TILE_SIZE == 0,
+        "H*W ({}*{}) must be a multiple of the tile size ({})",
+        a.padded_shape()[1],
+        a.padded_shape()[2],
+        TILE_SIZE);
 
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -61,11 +61,11 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(a.padded_shape()[3] % args.num_groups == 0, "channel must be divisible by num_groups!");
     TT_FATAL(a.padded_shape()[1] == 1, "input tensor shape[1] must be 1!");
     TT_FATAL(
-        (a.padded_shape()[1] * a.padded_shape()[2]) % TILE_SIZE == 0,
+        (a.padded_shape()[1] * a.padded_shape()[2]) % TILE_HEIGHT == 0,
         "H*W ({}*{}) must be a multiple of the tile size ({})",
         a.padded_shape()[1],
         a.padded_shape()[2],
-        TILE_SIZE);
+        TILE_HEIGHT);
 
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -101,7 +101,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
 
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
-              - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
+              - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
               - :attr:`gamma` and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -99,7 +99,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
 
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
-              - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
+              - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
               - :attr:`gamma` and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_pybind.cpp
@@ -99,7 +99,7 @@ void bind_normalization_group_norm_operation(pybind11::module& module) {
 
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
-              - For the :attr:`input_tensor`, N*H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
+              - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
               - :attr:`gamma` and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.


### PR DESCRIPTION
### Ticket
#33988


### Problem description
GroupNorm works on H*W*C/num_groups elements at a time. When H*W is not a multiple of TILE_HEIGHT, there are elements in height dimension that are not part of the group, yet are included in the computation of mean, var and also the final normalization step. This leads to incorrect output.

The existing check says N*H*W should be a multiple of TILE_HEIGHT.

### What's changed
Since N is batch dimension, and groups belonging to different batches are processed separately, we should tighten the constraints to have H*W be a multiple of 32. This PR corrects the language in the docs and adds a validation for the same.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20285715752
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20285718620/job/58351513522
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20314134253
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/20316649947
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
- [x] L2 Nightly https://github.com/tenstorrent/tt-metal/actions/runs/20454905590