### PR TITLE
#0: Enable ttsim tests fully on PRs and forks

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -272,7 +272,6 @@ jobs:
 
   ttsim-integration-tests:
     needs: [ build ]
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ttsim.yaml
@@ -282,7 +281,7 @@ jobs:
       package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       run-ttsim-integration-tests: true
-      run-metal-cpp-unit-tests: false
+      run-metal-cpp-unit-tests: true
 
   docker-image:
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft


### PR DESCRIPTION
### Ticket

@mcraigheadTT said we should enable these.
@afuller-TT said it's good to go.

### Problem description

Let's re-enable these tests so everyone can run them, as we have public assets for ttsim now https://github.com/tenstorrent/ttsim

### What's changed

Enable ttsim fully on PRs!!

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes