### PR TITLE
[skip ci] Add publish-package input to build-artifact workflow

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -53,6 +53,8 @@ on:
         default: true
         description: "Make resulting debian packages available in the workflow"
       skip-tt-train:
+        # FIXME: TT-Train needs to get fixed to not assume a specific toolchain.
+        #        Fow now enabling an opt-out. But this should get removed.
         required: false
         type: boolean
         default: true

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -47,9 +47,12 @@ on:
         type: boolean
         default: true
         description: "Make resulting artifact available in the workflow"
+      publish-package:
+        required: false
+        type: boolean
+        default: true
+        description: "Make resulting debian packages available in the workflow"
       skip-tt-train:
-        # FIXME: TT-Train needs to get fixed to not assume a specific toolchain.
-        #        Fow now enabling an opt-out. But this should get removed.
         required: false
         type: boolean
         default: true
@@ -347,6 +350,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: ☁️ Upload packages
+        if: ${{ inputs.publish-package }}
         uses: actions/upload-artifact@v4
         timeout-minutes: 10
         with:

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -37,5 +37,6 @@ jobs:
       toolchain: ${{ matrix.config.toolchain }}
       build-type: ${{ matrix.config.build-type }}
       publish-artifact: false
+      publish-package: false
       skip-tt-train: true
       tracy: false


### PR DESCRIPTION
### Ticket
NA

### Problem description
- We don't need to upload packages in build-wrapper.yaml .... no one consumes them.
- Lets not waste CI time
- Lets avoid any potential conflict with multiple builds in the same job uploading packages with the same name

### What's changed
- Add another boolean input to control package upload.

### Checklist
- [x] [Build Sweep](https://github.com/tenstorrent/tt-metal/actions/runs/20252474091) CI passes
- [x] New/Existing tests provide coverage for changes