### PR TITLE
fix: unused var for log_debug

### DIFF
--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -58,6 +58,8 @@ void log_external_operation(const operation::ExternalOperation& operation, const
     if (not attributes.empty()) {
         log_debug(tt::LogOp, "Attributes:");
         for (auto&& [name, value] : attributes) {
+            (void)name;
+            (void)value;
             log_debug(tt::LogOp, "\t{} = {}", name, value);
         }
     }
@@ -65,6 +67,7 @@ void log_external_operation(const operation::ExternalOperation& operation, const
     log_debug(tt::LogOp, "Input std::vector<Tensor>:");
     for (auto index = 0; index < input_tensors.size(); index++) {
         const auto& tensor = input_tensors[index];
+        (void)tensor;
         log_debug(tt::LogOp, "\t{}: {}", index, tensor);
     }
 


### PR DESCRIPTION
### Ticket
This PR resloves https://github.com/tenstorrent/tt-mlir/issues/6322

### Problem description
tt-milr debug build will report unused var warning-error.