### PR TITLE
Copy from device after every trace execution in tt-transformers prefill

### DIFF
--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -175,7 +175,9 @@ class Generator:
                 )
 
                 if chunk_start == last_chunk_start:
-                    logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx_in_chunk % 32))
+                    logits = self.model.process_output_prefill(
+                        tt_logits.cpu(), last_token_idx=(last_token_idx_in_chunk % 32)
+                    )
                     return logits
                 else:
                     del tt_logits
@@ -195,7 +197,7 @@ class Generator:
                 kv_cache=kv_cache,
             )
 
-            logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx % 32))
+            logits = self.model.process_output_prefill(tt_logits.cpu(), last_token_idx=(last_token_idx % 32))
 
             # deallocate device tensors that are not needed by decode
             # [INFO] logits is a torch tensor

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -363,7 +363,7 @@ class Generator:
             # if data parallel is greater than 1, we need to add logits to out_list and do the processing after all the prefill are done
             # otherwise, we can process the logits after prefill immediately
             if self.data_parallel > 1:
-                out_list.append(logits)
+                out_list.append(logits.cpu(blocking=False))
             else:
                 output_logits[idx] = self.model[model_id].process_output_prefill(
                     logits, last_token_idx=(last_token_idx % 32)
@@ -377,6 +377,7 @@ class Generator:
                 last_token_idx = seq_len - 1
                 user_id = empty_slots[idx]
                 model_id = user_id // max_batch_size_per_model if model_id_warmup is None else model_id_warmup
+                ttnn.synchronize_device(self.model[model_id].mesh_device)
 
                 # Since we give unpadded_seq_len, only the tile containing the last token is returned
                 output_logits[idx] = self.model[model_id].process_output_prefill(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -183,7 +183,6 @@ class Generator:
             chunk_page_table=transformed_inputs[2],
             kv_cache=kv_cache,
         )
-        ttnn.synchronize_device(self.model_args[model_id].mesh_device)
         logger.info("Done Compiling Model")
 
         device_inputs = copy_host_to_device(host_inputs, mesh_device=self.model_args[model_id].mesh_device)
@@ -198,7 +197,6 @@ class Generator:
             kv_cache=kv_cache,
         )
         ttnn.end_trace_capture(self.model_args[model_id].mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(self.model_args[model_id].mesh_device)
         logger.info("Done Capturing Prefill Trace")
         return trace_id, tt_out_trace, *device_inputs
 

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -353,7 +353,7 @@ class Transformer(LightweightModule):
 
     def process_output_prefill(self, tt_out, last_token_idx):
         """
-        Input is ttnn device tensor of logits. Output is torch logits tensor.
+        Input is ttnn host tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
         return self.concat_host_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -356,7 +356,7 @@ class Transformer(LightweightModule):
         Input is ttnn device tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
-        return self.concat_host_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
+        return self.concat_host_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -356,6 +356,7 @@ class Transformer(LightweightModule):
         Input is ttnn host tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
+        assert tt_out.storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
         return self.concat_host_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):


### PR DESCRIPTION
We have an issue where the model fails determinism test even though seed is fixed. The culprit was logits corruption during prefill. Logits tensor was sometimes corrupted by the execution of trace by the following user, so the resolution was to copy the tensor to host before executing the next trace.

https://github.com/tenstorrent/tt-metal/issues/34346

- [x] [vllm nightly llama](https://github.com/tenstorrent/tt-metal/actions/runs/20260232100)
- [x] [vllm nightly qwen](https://github.com/tenstorrent/tt-metal/actions/runs/20297140813)
- [x] [llama 8B model ci, seed test passing](https://github.com/tenstorrent/tt-shield/actions/runs/20260818556/job/58174961837#step:9:3370) 
- [x] [t3k llama demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20273268045)