### PR TITLE
#34013: ttnn.add for different memory_config produces inf output

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_mismatched_shard_config.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_binary_mismatched_shard_config.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for binary operations with tensors that have identical shapes but different
+sharded memory configurations.
+
+This test validates the fix for a bug where tensors with identical shapes but different
+sharded memory configurations would incorrectly trigger the native L1 sharding path,
+producing incorrect (inf) output. The fix ensures proper memory configuration comparison
+before enabling the optimized sharding path.
+"""
+
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+
+
+def test_add_with_mismatched_width_shard_configs(device):
+    torch.manual_seed(0)
+
+    tensor_shape = (1, 1, 32, 2048)
+
+    mem_config_a = ttnn.create_sharded_memory_config(
+        shape=(32, 64),
+        core_grid=ttnn.CoreGrid(x=8, y=4),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    mem_config_b = ttnn.create_sharded_memory_config(
+        shape=(32, 128),
+        core_grid=ttnn.CoreGrid(x=8, y=2),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Create torch tensors with values in range [-0.5, 0.5] to avoid overflow
+    a_torch = torch.rand(tensor_shape, dtype=torch.bfloat16) - 0.5
+    b_torch = torch.rand(tensor_shape, dtype=torch.bfloat16) - 0.5
+
+    # Create ttnn tensors with different memory configs
+    a = ttnn.from_torch(a_torch, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config_a)
+    b = ttnn.from_torch(b_torch, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config_b)
+
+    c_torch = torch.add(a_torch, b_torch)
+    c = ttnn.add(a, b, memory_config=mem_config_a)
+    c_result = ttnn.to_torch(c)
+
+    assert not torch.isinf(c_result).any(), "Output contains inf values - mismatched shard config bug detected"
+
+    # Verify correctness with PCC and ULP
+    assert_with_pcc(c_torch, c_result, 0.9999)
+    assert_with_ulp(c_torch, c_result, ulp_threshold=1)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -118,8 +118,7 @@ bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>&
     }
 
     // a and b identical shape, no broadcast on any dimension
-    if (b.has_value() && (a.logical_shape() == b->logical_shape()) &&
-        (a.memory_config().memory_layout() == b->memory_config().memory_layout())) {
+    if (b.has_value() && (a.logical_shape() == b->logical_shape()) && (a.memory_config() == b->memory_config())) {
         if (is_uneven(a) || is_uneven(*b) || is_uneven(c)) {
             return false;
         }


### PR DESCRIPTION
### Ticket
#34013 

### Problem description
 ttnn.add operation on tensors with different sharded memory_config, produces inf output.

### What's changed
The bug is due to handling of sharding in non-bcast case. The condition for native L1 sharding now checks full `memory_config()` equality instead of just `memory_layout()`, preventing mismatches in shard specifications from being overlooked.

For detailed analysis kindly refer to the issue.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20259961676) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/20259981646) CI failed same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/20254590619/job/58154039113)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20259988643) CI passes 
- [x] [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20259996377) TLB related failures
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/runs/20260007526) CI failed same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/20257890933)
- [x] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/runs/20260012947/job/58170152293) CI failed same as [main](https://github.com/tenstorrent/tt-metal/actions/runs/20069541000)
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20260017709/job/58170189446) only falcon40b failed due to TLB issue.
- [ ] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [x] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/runs/20260029977) job passes