### PR TITLE
misc-header-include-cycle

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -83,7 +83,6 @@ Checks: >
   -google-readability-todo,
   -google-runtime-int,
   -misc-const-correctness,
-  -misc-header-include-cycle,
   -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
@@ -19,7 +19,6 @@ Tensor global_avg_pool2d(
 
 }  // namespace tt::tt_metal
 
-#include "ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/core/core.hpp"
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/misc/header-include-cycle.html

### What's changed
- Enable check
- Fix the one violation. Header file includes its self.