### PR TITLE
[skpi ci] Fix Package and release naming

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -1,4 +1,4 @@
-name: Package and release
+name: "Package and release"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Problem description
Currently auto retry system can't catch failures in Package and release as naming is not the same (parentheses are missing)

### What's changed
Add parentheses