### PR TITLE
#34500: use output tensor mem config in bound_matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2552,3 +2552,36 @@ def test_matmul_block_sharded_input_with_padding(device):
 
     output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_output, output, pcc=0.99)
+
+
+def test_matmul_activation_with_sharded_input(device):
+    # Create input tensors
+    torch_input_a = torch.randn(32, 1024, dtype=torch.bfloat16)
+    torch_input_b = torch.randn(1024, 1024, dtype=torch.bfloat16)
+
+    # Convert to TTNN tensors with DRAM interleaved layout
+    input_a = ttnn.from_torch(
+        torch_input_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    input_b = ttnn.from_torch(
+        torch_input_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    # Width sharded output config
+    # When we specify only the sharding type without full shard spec,
+    # and pass it to matmul with activation, unary op needs to have full shard spec
+    output_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, buffer_type=ttnn.BufferType.L1
+    )
+
+    # This should not crash with "validate_shard_spec" error because:
+    # 1. matmul gets called with activation="silu" and partial memory config
+    # 2. matmul internally calls unary (silu) with the output tensor's memory config
+    # 3. unary's compute_output_specs creates TensorLayout with the output tensor's full config
+    try:
+        output = ttnn.matmul(
+            input_a, input_b, memory_config=output_mem_config, activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU)
+        )
+    except Exception as e:
+        pytest.fail(f"Got unexpected exception {e}")

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -211,7 +211,7 @@ ttnn::Tensor bound_matmul(
             output_tensor,
             bias.value(),
             /*output_dtype=*/std::nullopt,
-            parameters.output_mem_config,
+            output_tensor.memory_config(),
             optional_output_tensor);
     }
 
@@ -219,7 +219,7 @@ ttnn::Tensor bound_matmul(
         const UnaryWithParam& activation = parameters.user_fused_activation.value();
 
         output_tensor = ttnn::operations::unary::Unary_chain::invoke(
-            output_tensor, {activation}, parameters.output_mem_config, optional_output_tensor);
+            output_tensor, {activation}, output_tensor.memory_config(), optional_output_tensor);
     }
 
     return output_tensor;


### PR DESCRIPTION
### Ticket
Link to Github Issue #34500

### Problem description
bound_matmul was using the input output_mem_config which can be partial instead of the output tensor's mem config for calls after matmul.

### What's changed
Use the output tensor's mem config.

Without changes to bound_matmul test fails:
```
>           pytest.fail(f"Got unexpected exception {e}")
E           Failed: Got unexpected exception bad optional access
```
With changes test passes:
```
PASSED tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_matmul_activation_with_sharded_input
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20272865413
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes