### PR TITLE
#0: Fix reduce_scatter_minimal_async failure

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -4,6 +4,7 @@
 
 #include "reduce_scatter_minimal_async.hpp"
 #include "device/reduce_scatter_minimal_async_op_device_operation.hpp"
+#include "ttnn/operations/experimental/ccl/composite_common.hpp"
 
 namespace ttnn::operations::experimental::ccl {
 
@@ -31,6 +32,13 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
         num_devices > 1, "reduce_scatter_minimal_async op will only work for num_devices > 1, but has {}", num_devices);
 
     log_debug(tt::LogOp, "reduce_scatter_minimal_async: num_devices = {}", num_devices);
+
+    // Use composite reduce scatter for edge cases (e.g., tile dimensions not evenly divisible)
+    if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
+        log_debug(tt::LogOp, "reduce_scatter_minimal_async: using composite_reduce_scatter");
+        return composite_common::composite_reduce_scatter(
+            input_tensor, dim, num_links, topology, memory_config, sub_device_id, cluster_axis);
+    }
 
     bool using_persistent_buffers = persistent_output_buffers.has_value();
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[T3K CCL tests](https://github.com/tenstorrent/tt-metal/actions/runs/20214129802/job/58024611957) and others failing with `Number of tiles at dimension 3 must be divisible by ring_size`

### What's changed

- Added composite implementation routing that was missing when the op was migrated to TMP device op infra

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20273527310))
- [x] BH CCL nightly ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20273907052/job/58217710078))
- [x] T3K CCL nightly ([link to run](https://github.com/tenstorrent/tt-metal/actions/runs/20273563681/job/58216465430))