### PR TITLE
test: disable constantly failing distributed tests on N300

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -118,6 +118,10 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
     if (mesh_device_->num_devices() == 1) {
         GTEST_SKIP() << "Skipping test for a unit-size mesh device";
     }
+    const tt::BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    if (board_type == tt::BoardType::N300) {
+        GTEST_SKIP() << "Skipping test for N300 board due to #34420";
+    }
     uint32_t num_iters = 5;
     std::vector<std::shared_ptr<MeshBuffer>> src0_bufs = {};
     std::vector<std::shared_ptr<MeshBuffer>> src1_bufs = {};

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -27,6 +27,7 @@
 #include "tests/tt_metal/distributed/utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal::distributed::test {
 namespace {
@@ -212,6 +213,10 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
 TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
     if (mesh_device_->num_devices() == 1) {
         GTEST_SKIP() << "Skipping test for a unit-size mesh device";
+    }
+    const tt::BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    if (board_type == tt::BoardType::N300) {
+        GTEST_SKIP() << "Skipping test for N300 board due to #34420";
     }
     uint32_t NUM_TILES = 1000;
     uint32_t num_iterations = 20;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -578,6 +578,10 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
     if (mesh_device_->num_devices() == 1) {
         GTEST_SKIP() << "Skipping test for a unit-size mesh device";
     }
+    const tt::BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
+    if (board_type == tt::BoardType::N300) {
+        GTEST_SKIP() << "Skipping test for N300 board due to #34420";
+    }
     CoreCoord worker_grid_size = mesh_device_->compute_with_storage_grid_size();
     uint32_t single_tile_size = ::tt::tile_size(DataFormat::Float16_b);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34420

### Problem description
Disabling the test on N300 due to failures. This failure was masked by #34422. They probably share the root cause.
Failure is observable on main. See [here](https://github.com/tenstorrent/tt-metal/actions/runs/20258211467/job/58204710236) for more details.

### What's changed
Disabled tests:
- MeshWorkloadTestSuite.MeshWorkloadSanity
- MeshEventsTestSuite.CustomDeviceRanges
- MeshEventsTestSuite.AsyncWorkloadAndIO

### Checklist
- [ ] [L2 tt-metal nightly test](https://github.com/tenstorrent/tt-metal/actions/runs/20274908177) CI passes