### PR TITLE
Enable DeepSeekV3 unit/module tests on 4X CI pipeline

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -173,7 +173,7 @@ jobs:
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run tests on multiple hosts
         uses: ./.github/actions/docker-run
-        timeout-minutes: 30
+        timeout-minutes: 130
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
@@ -185,8 +185,12 @@ jobs:
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_ENABLE_ERISC_IRAM="1"
             -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+            -e DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache
             -v /etc/mpirun:/etc/mpirun:ro
             -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            -v /mnt/MLPerf/tt_dnn-models/deepseek-ai:/mnt/MLPerf/tt_dnn-models/deepseek-ai:rw
+            -v /mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface:rw
             --device /dev/tenstorrent
             --pid=host
             --hostname=mpirun-host

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -7,12 +7,12 @@ if [ -z "${ARCH_NAME}" ]; then
   exit 1
 fi
 
-run_quad_galaxy_unit_tests() {
+run_quad_galaxy_fabric_sanity_tests() {
   # Record the start time
   fail=0
   start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_quad_galaxy_unit_tests"
+  echo "LOG_METAL: Running run_quad_galaxy_fabric_sanity_tests"
 
   source python_env/bin/activate
 
@@ -24,47 +24,74 @@ run_quad_galaxy_unit_tests() {
   # TODO: Currently failing
   #mpirun-ulfm $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/test/tt_metal/tt_fabric/test_physical_discovery ; fail+=$?
 
+  # Cluster validation and connectivity tests
+  echo "LOG_METAL: Running cluster validation tests"
   mpirun-ulfm $mpi_args -x TT_METAL_HOME=$(pwd) -x LD_LIBRARY_PATH=$(pwd)/build/lib ./build/tools/scaleout/run_cluster_validation --print-connectivity --send-traffic --hard-fail ; fail+=$?
+
+  # System health tests
+  echo "LOG_METAL: Running system health tests"
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" ./build/test/tt_metal/tt_fabric/test_system_health --gtest_filter="Cluster.ReportIntermeshLinks" ; fail+=$?
 
+  # Multi-host cluster mesh device tests
+  echo "LOG_METAL: Running multi-host cluster mesh device tests"
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/ttnn/unit_tests/base_functionality/test_multi_host_clusters.py::test_quad_galaxy_mesh_device_trace\"" ; fail+=$?
 
   # TODO: Currently failing on 1D/2D tests
   #tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter=\"MultiHost.TestQuadGalaxy*\"" ; fail+=$?
 
+  # CCL all-to-all dispatch tests
+  echo "LOG_METAL: Running CCL all-to-all dispatch tests"
   tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "source python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x16_quad_galaxy\"" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
-  echo "LOG_METAL: run_quad_galaxy_unit_tests $duration seconds to complete"
+  echo "LOG_METAL: run_quad_galaxy_fabric_sanity_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi
 }
 
-run_quad_galaxy_resnet50_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
+run_dual_galaxy_deepseek_tests() {
+  echo "LOG_METAL: Running run_dual_galaxy_deepseek_tests"
 
-  echo "LOG_METAL: Running run_quad_galaxy_resnet50_tests"
+  export MESH_DEVICE=DUAL
+  source python_env/bin/activate
 
-  pytest models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py ; fail+=$?
+  local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile_01_02 --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
+  local mpi_args="--host g05glx02,g05glx01 $mpi_args_base"
+  local rank_binding="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
 
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_quad_galaxy_resnet50_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
+  # Install DeepSeek requirements
+  echo "LOG_METAL: Installing DeepSeek requirements"
+  pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt ; fail+=$?
+
+  # Run DeepSeek module tests with tt-run wrapper (excluding unit tests as per existing workflow pattern)
+  echo "LOG_METAL: Running DeepSeek module tests"
+  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "source python_env/bin/activate && pytest models/demos/deepseek_v3/tests"
+}
+
+run_quad_galaxy_deepseek_tests() {
+  echo "LOG_METAL: Running run_quad_galaxy_deepseek_tests"
+
+  export MESH_DEVICE=QUAD
+  source python_env/bin/activate
+
+  local mpi_args_base="--map-by rankfile:file=/etc/mpirun/rankfile --mca btl self,tcp --mca btl_tcp_if_include cnx1 --tag-output"
+  local mpi_args="--host g05glx04,g05glx03,g05glx02,g05glx01 $mpi_args_base"
+  local rank_binding="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+
+  echo "LOG_METAL: Installing DeepSeek requirements"
+  pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt ; fail+=$?
+
+  echo "LOG_METAL: Running DeepSeek module tests"
+  tt-run --rank-binding "$rank_binding" --mpi-args "$mpi_args" bash -c "source python_env/bin/activate && pytest models/demos/deepseek_v3/tests"
 }
 
 run_quad_galaxy_tests() {
-  run_quad_galaxy_unit_tests
-  # TODO: #30155 - Enable the test when hardware hang is addressed.
-  # run_quad_galaxy_resnet50_tests
+  run_quad_galaxy_fabric_sanity_tests
+  run_dual_galaxy_deepseek_tests
+  run_quad_galaxy_deepseek_tests
 }
 
 fail=0


### PR DESCRIPTION
### Summary

This change updates the multi-host CI pipeline to run the DeepSeekV3 module tests on 2 and 4 hosts.