### PR TITLE
Resolve N300 Distributed test failures

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -127,18 +127,20 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
 
     auto programs = tt::tt_metal::distributed::test::utils::create_eltwise_bin_programs(
         mesh_device_, src0_bufs, src1_bufs, output_bufs);
-    uint32_t num_cols_in_workload = mesh_device_->num_cols() / 2;
+    uint32_t num_rows = mesh_device_->num_rows();
+    uint32_t num_rows_in_workload = num_rows / 2;
+    TT_FATAL(num_rows_in_workload > 0, "The MeshWorkload must be enqueued on at least one row.");
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices_0(
         MeshCoordinate{0, 0},
         MeshCoordinate{
-            mesh_device_->num_rows() - 1,
-            num_cols_in_workload - 1,
+            num_rows_in_workload - 1,
+            mesh_device_->num_cols() - 1,
         });
     MeshCoordinateRange devices_1(
-        MeshCoordinate{0, num_cols_in_workload},
+        MeshCoordinate{num_rows_in_workload, 0},
         MeshCoordinate{
-            mesh_device_->num_rows() - 1,
+            num_rows - 1,
             mesh_device_->num_cols() - 1,
         });
 
@@ -190,7 +192,7 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
                         dst_vec,
                         output_bufs[(col_idx * worker_grid_size.y) + row_idx],
                         device_coord);
-                    if (device_coord[1] <= num_cols_in_workload - 1) {
+                    if (device_coord[0] <= (num_rows_in_workload - 1)) {
                         for (int i = 0; i < dst_vec.size(); i++) {
                             EXPECT_EQ(static_cast<float>(dst_vec[i]), (2 * iter + 5));
                         }
@@ -225,8 +227,8 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
     for (std::size_t i = 0; i < num_iterations; i++) {
         std::vector<uint32_t> src_vec(NUM_TILES * single_tile_size / sizeof(uint32_t), i);
         std::iota(src_vec.begin(), src_vec.end(), i);
-        MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{mesh_device_->num_rows() - 1, 0});
-        MeshCoordinateRange devices_1(MeshCoordinate{0, 1}, MeshCoordinate{mesh_device_->num_rows() - 1, 1});
+        MeshCoordinateRange devices_0(MeshCoordinate{0, 0}, MeshCoordinate{0, mesh_device_->num_cols() - 1});
+        MeshCoordinateRange devices_1(MeshCoordinate{1, 0}, MeshCoordinate{1, mesh_device_->num_cols() - 1});
 
         std::vector<std::vector<uint32_t>> readback_vecs = {};
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34420)

### Problem description
- OOB device accesses were being done on N300 systems, since the shape changed from 1x2 to 2x1
- This was causing multiple failures on pipelines

### What's changed
- Modify tests to work with new shapes and add better error reporting for OOB accesses

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes