### PR TITLE
Enable all DeepSeekV3 unit and module tests in multihost CI pipeline

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -176,7 +176,7 @@ jobs:
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run tests on multiple hosts
         uses: ./.github/actions/docker-run
-        timeout-minutes: 30
+        timeout-minutes: 120
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -176,7 +176,7 @@ jobs:
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run tests on multiple hosts
         uses: ./.github/actions/docker-run
-        timeout-minutes: 120
+        timeout-minutes: 140
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -34,7 +34,7 @@ run_quad_galaxy_unit_tests() {
   fi
 }
 
-run_quad_galaxy_deepseekv3_tests() {
+run_dual_galaxy_deepseekv3_tests_on_quad_galaxy() {
     fail=0
 
     # Run dual galaxy tests on quad galaxy since this is the only available machine
@@ -55,8 +55,7 @@ run_quad_galaxy_deepseekv3_tests() {
     local DEEPSEEK_V3_CACHE="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache"
     local MESH_DEVICE="DUAL"
 
-    # TODO: For now we just test a single module, we should add all of them here eventually
-    local TEST_CASE="pytest -svvv models/demos/deepseek_v3/tests/test_mla.py::test_forward_pass[run_test_forward_pass_mla2d-model.layers.0.self_attn-device_params0-decode-1-32]"
+    local TEST_CASE="pytest -svvv models/demos/deepseek_v3/tests"
 
     tt-run --rank-binding "$RANK_BINDING_YAML" \
         --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
@@ -70,7 +69,7 @@ run_quad_galaxy_deepseekv3_tests() {
 
 run_quad_galaxy_tests() {
   run_quad_galaxy_unit_tests
-  run_quad_galaxy_deepseekv3_tests
+  run_dual_galaxy_deepseekv3_tests_on_quad_galaxy
 }
 
 fail=0


### PR DESCRIPTION
### Summary

This change enables all DeepSeekV3 module and unit tests in CI on the 4x galaxy multihost pipeline. Previously we only ran a single test case.