### PR TITLE
Vsuresh tt/ln d hang

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
@@ -136,17 +136,17 @@ def test_distributed_norm_allclose(
 
 
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("seq_len", [32768])
-@pytest.mark.parametrize("hidden_dim", [1280])
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize("hidden_dim", [4096])
 @pytest.mark.parametrize("eps", [1e-6])
 @pytest.mark.parametrize(
     "norm_type, use_welford",
     [
-        # ("layer_norm", False),  # LayerNorm with Welford
+        ("layer_norm", True),  # LayerNorm with Welford
         ("rms_norm", False),  # RMSNorm without Welford
     ],
     ids=[
-        # "layer_norm_welford",
+        "layer_norm_welford",
         "rms_norm_no_welford"
     ],
 )

--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_exhaustive.py
@@ -136,16 +136,19 @@ def test_distributed_norm_allclose(
 
 
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("seq_len", [1024])
-@pytest.mark.parametrize("hidden_dim", [4096])
+@pytest.mark.parametrize("seq_len", [32768])
+@pytest.mark.parametrize("hidden_dim", [1280])
 @pytest.mark.parametrize("eps", [1e-6])
 @pytest.mark.parametrize(
     "norm_type, use_welford",
     [
-        ("layer_norm", True),  # LayerNorm with Welford
+        # ("layer_norm", False),  # LayerNorm with Welford
         ("rms_norm", False),  # RMSNorm without Welford
     ],
-    ids=["layer_norm_welford", "rms_norm_no_welford"],
+    ids=[
+        # "layer_norm_welford",
+        "rms_norm_no_welford"
+    ],
 )
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -57,8 +57,8 @@ struct x_minus_mean_node {
         .fixed_dest_reg = 0xFFFF,
     };
 };
-constexpr uint32_t do_gamma = get_compile_time_arg_val(4);
-constexpr uint32_t do_beta = get_compile_time_arg_val(5);
+constexpr uint32_t do_gamma = get_compile_time_arg_val(3);
+constexpr uint32_t do_beta = get_compile_time_arg_val(4);
 constexpr uint32_t normed_output_cb =
     do_gamma || do_beta ? cb_x_normed : cb_out;  // (x - E(x)) * 1/sqrt(var+eps) or x * 1/sqrt(E(x**2) + eps)
 struct normed_output_node {
@@ -73,6 +73,9 @@ struct normed_output_node {
     };
 };
 constexpr uint32_t cb_gamma = tt::CBIndex::c_2;
+constexpr uint32_t cb_length = get_compile_time_arg_val(8);
+constexpr uint32_t Wt = get_compile_time_arg_val(0);
+constexpr uint32_t pop_gamma_beta = Wt == cb_length ? 0xDDDD : 0xFFFF;
 
 constexpr uint32_t cb_times_gamma_out = do_beta ? tt::CBIndex::c_13 : cb_out;
 struct gamma_optional_node {
@@ -83,7 +86,7 @@ struct gamma_optional_node {
         .CB_B = cb_gamma,
         .CB_OUT = cb_times_gamma_out,
         .fixed_CB_B_index = 0xFFFF,
-        .fixed_dest_reg = 0xFFFF,
+        .fixed_dest_reg = pop_gamma_beta,
     };
 };
 constexpr uint32_t cb_in_beta = do_gamma ? cb_times_gamma_out : normed_output_cb;
@@ -96,11 +99,12 @@ struct beta_optional_node {
         .CB_B = cb_beta,
         .CB_OUT = cb_out,
         .fixed_CB_B_index = 0xFFFF,
-        .fixed_dest_reg = 0xFFFF,
+        .fixed_dest_reg = pop_gamma_beta,
     };
 };
 void MAIN {
     uint32_t NCHt = get_arg_val<uint32_t>(0);
+    DPRINT << "pop_gamma_beta: " << pop_gamma_beta << ENDL();
     constexpr uint32_t Wt = get_compile_time_arg_val(0);
     constexpr uint32_t blk = get_compile_time_arg_val(1);
     constexpr uint32_t stats_tiles_cols = get_compile_time_arg_val(2);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -99,30 +99,32 @@ void kernel_main() {
                 noc_async_read_barrier();
                 cb_push_back(cb_inp, 1);
             }
+            if (ncht == 0 or cb_iterations != 1) {
 #if defined FUSE_GAMMA || defined FUSE_BETA
 #ifdef FUSE_GAMMA
-            for (uint32_t j = 0; j < cb_length; j++) {
-                cb_reserve_back(cb_gamma, 1);
-                uint32_t l1_write_addr = get_write_ptr(cb_gamma);
-                uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
-                gamma_tile_count++;
-                async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_gamma, 1);
-            }
+                for (uint32_t j = 0; j < cb_length; j++) {
+                    cb_reserve_back(cb_gamma, 1);
+                    uint32_t l1_write_addr = get_write_ptr(cb_gamma);
+                    uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
+                    gamma_tile_count++;
+                    async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_gamma, 1);
+                }
 #endif
 #ifdef FUSE_BETA
-            for (uint32_t j = 0; j < cb_length; j++) {
-                cb_reserve_back(cb_beta, 1);
-                uint32_t l1_write_addr = get_write_ptr(cb_beta);
-                uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
-                beta_tile_count++;
-                async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
-                noc_async_read_barrier();
-                cb_push_back(cb_beta, 1);
+                for (uint32_t j = 0; j < cb_length; j++) {
+                    cb_reserve_back(cb_beta, 1);
+                    uint32_t l1_write_addr = get_write_ptr(cb_beta);
+                    uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
+                    beta_tile_count++;
+                    async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_beta, 1);
+                }
+#endif
+#endif
             }
-#endif
-#endif
         }
         for (uint32_t i = 0; i < cb_leftovers; i++) {
             cb_reserve_back(cb_inp, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -132,30 +132,32 @@ void kernel_main() {
             noc_async_read_barrier();
             cb_push_back(cb_inp, 1);
         }
+        if (ncht == 0 or cb_iterations != 1) {
 #if defined FUSE_GAMMA || defined FUSE_BETA
 #ifdef FUSE_GAMMA
-        for (uint32_t i = 0; i < cb_leftovers; i++) {
-            cb_reserve_back(cb_gamma, 1);
-            uint32_t l1_write_addr = get_write_ptr(cb_gamma);
-            uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
-            gamma_tile_count++;
-            async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_gamma, 1);
-        }
+            for (uint32_t i = 0; i < cb_leftovers; i++) {
+                cb_reserve_back(cb_gamma, 1);
+                uint32_t l1_write_addr = get_write_ptr(cb_gamma);
+                uint64_t gamma_noc_addr = get_noc_addr(gamma_tile_count, addrg);
+                gamma_tile_count++;
+                async_read_row_to_tile<gamma_is_row_major>(gamma_noc_addr, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_gamma, 1);
+            }
 #endif
 #ifdef FUSE_BETA
-        for (uint32_t i = 0; i < cb_leftovers; i++) {
-            cb_reserve_back(cb_beta, 1);
-            uint32_t l1_write_addr = get_write_ptr(cb_beta);
-            uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
-            beta_tile_count++;
-            async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
-            noc_async_read_barrier();
-            cb_push_back(cb_beta, 1);
+            for (uint32_t i = 0; i < cb_leftovers; i++) {
+                cb_reserve_back(cb_beta, 1);
+                uint32_t l1_write_addr = get_write_ptr(cb_beta);
+                uint64_t beta_noc_addr = get_noc_addr(beta_tile_count, addrb);
+                beta_tile_count++;
+                async_read_row_to_tile<beta_is_row_major>(beta_noc_addr, l1_write_addr);
+                noc_async_read_barrier();
+                cb_push_back(cb_beta, 1);
+            }
+#endif
+#endif
         }
-#endif
-#endif
     }  // ncht loop
 }
 template <uint32_t t>

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -73,9 +73,7 @@ void MAIN {
     cb_wait_front(cb_reduce, 1);  // comes from the reader
     cb_wait_front(cb_eps, 1);     // comes from the reader
 
-    DPRINT << "NCHt: " << NCHt << ENDL();
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
-        DPRINT << "NCHt: " << ncht << ENDL();
         constexpr int onetile = 1;
         constexpr int dst0 = 0;
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/device/kernels/compute/rmsnorm_post_allgather.cpp
@@ -73,7 +73,9 @@ void MAIN {
     cb_wait_front(cb_reduce, 1);  // comes from the reader
     cb_wait_front(cb_eps, 1);     // comes from the reader
 
+    DPRINT << "NCHt: " << NCHt << ENDL();
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
+        DPRINT << "NCHt: " << ncht << ENDL();
         constexpr int onetile = 1;
         constexpr int dst0 = 0;
 


### PR DESCRIPTION
## Link to GitHub Issue
#34410

## Problem Description

This change fixes a hang found in **RMSNorm** and a performance regression in **LayerNorm**.

The reader kernel originally assumed that **gamma** and **beta** could fit in L1, so they were read once and reused.

That assumption was later changed to fix an OOM issue in LayerNorm. As a result, **gamma** and **beta** were updated to be read in on each iteration.

However, this assumption does not hold for **RMSNorm**, since its kernel was not updated accordingly. RMSNorm continued to assume that it only needed to wait for the data once, and therefore did not pop the data. This caused a hang, as the reader would eventually get stuck.

Additionally, LayerNorm experienced a performance regression because **gamma** and **beta** were being read multiple times based on the height.

## What’s Changed

The reader kernels for both **LayerNorm** and **RMSNorm** were updated so that:

- **Gamma** and **beta** are not read multiple times when they can fit in L1.
- The sliding window approach is only used when necessary.

This fixes the RMSNorm hang and avoids the unnecessary performance regression in LayerNorm.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
