### PR TITLE
[DM] noc api durations tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -22,6 +22,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/direct_write/test_direct_write.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pcie_read_bw/test_pcie_read_bw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/atomics/test_atomic_semaphore_bandwidth.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/noc_api_latency/test_noc_api_latency.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -53,6 +53,7 @@ Both API versions run the same test cases but use different underlying implement
 | Inline Direct Write         | 500-501                         | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
 | PCIe Read Bandwidth         | 603                             | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
+| NOC API Latency             | 700-706                         | Measures latency (cycles) of NOC API calls using experimental dataflow 2.0 API.         |
 
 
 ## Running Tests

--- a/tests/tt_metal/tt_metal/data_movement/atomics/kernels/atomic_semaphore_receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/kernels/atomic_semaphore_receiver.cpp
@@ -4,7 +4,7 @@
 
 #define PROFILE_KERNEL 1
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 // Atomic semaphore receiver kernel that waits for atomic notifications
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/atomics/kernels/atomic_semaphore_sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/kernels/atomic_semaphore_sender.cpp
@@ -4,7 +4,7 @@
 
 #define PROFILE_KERNEL 1
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 // Atomic semaphore operations test kernel
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
@@ -1,6 +1,6 @@
 # NOC API Latency Tests
 
-This test suite measures the latency (in cycles) of various NOC API calls using the experimental dataflow 2.0 API.
+This test suite measures the issue latency (in cycles) of various NOC API calls using the experimental dataflow 2.0 API.
 
 ## Dispatch Mode
 These tests use **Fast Dispatch (Mesh Device API)** with `GenericMeshDeviceFixture` for optimal performance measurement.

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/README.md
@@ -1,0 +1,55 @@
+# NOC API Latency Tests
+
+This test suite measures the latency (in cycles) of various NOC API calls using the experimental dataflow 2.0 API.
+
+## Dispatch Mode
+These tests use **Fast Dispatch (Mesh Device API)** with `GenericMeshDeviceFixture` for optimal performance measurement.
+
+## Test Description
+
+The tests measure the time taken by NOC API calls themselves, excluding barrier synchronization overhead. Each test:
+1. Performs a sweep over number of transactions (1 to 256)
+2. Performs a sweep over transaction sizes (configurable)
+3. Measures cycles for the API calls only (barriers are outside the measurement window)
+4. Uses experimental NOC 2.0 API (`experimental::Noc`, `experimental::UnicastEndpoint`, etc.)
+
+## Test Parameters
+
+- **num_transactions**: Number of NOC transactions to perform (1-256)
+- **transaction_size**: Size of each transaction in bytes
+- **kernel_type**: Type of NOC operation to measure (compile-time argument)
+
+## Kernel Types
+
+Different kernels test different NOC operations:
+
+1. **Unicast Write**: `noc.async_write()` - measures unicast write API call latency
+2. **Unicast Read**: `noc.async_read()` - measures unicast read API call latency
+3. **Multicast Write**: `noc.async_write_multicast()` - measures multicast write API call latency
+4. **Stateful Write**: `noc.set_async_write_state()` + `noc.async_write_with_state()` - measures stateful write API latency
+5. **Stateful Read**: `noc.set_async_read_state()` + `noc.async_read_with_state()` - measures stateful read API latency
+
+## Test Cases
+
+| Test ID | Description |
+|---------|-------------|
+| 700 | Unicast Write Latency |
+| 701 | Unicast Read Latency |
+| 702 | Stateful Write Latency |
+| 703 | Stateful Read Latency |
+| 704 | Multicast Write Latency 2x2 |
+| 705 | Multicast Write Latency 5x5 |
+| 706 | Multicast Write Latency All Cores |
+
+## Output Metrics
+
+Unlike other data movement tests that measure bandwidth, these tests report:
+- **Cycles per transaction**: Total cycles / number of transactions
+- **Total cycles**: Total measurement window in cycles
+
+## Implementation Details
+
+- Uses `DeviceZoneScopedN()` profiling markers to measure API call latency
+- Barriers are placed outside the profiling zone to exclude synchronization overhead
+- All kernels use experimental dataflow 2.0 API
+- Compile-time kernel selection based on test parameters

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_dest_core_start = get_compile_time_arg_val(4);
+    constexpr uint32_t packed_dest_core_end = get_compile_time_arg_val(5);
+    constexpr uint32_t loopback = get_compile_time_arg_val(7);
+    constexpr uint32_t num_dests = get_compile_time_arg_val(8);
+
+    uint32_t dest_x_start = packed_dest_core_start >> 16;
+    uint32_t dest_y_start = packed_dest_core_start & 0xFFFF;
+    uint32_t dest_x_end = packed_dest_core_end >> 16;
+    uint32_t dest_y_end = packed_dest_core_end & 0xFFFF;
+
+    if (noc_index == 1) {
+        std::swap(dest_x_start, dest_x_end);
+        std::swap(dest_y_start, dest_y_end);
+    }
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+    experimental::MulticastEndpoint mcast_endpoint;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_transactions; i++) {
+            if constexpr (loopback) {
+                noc.async_write_multicast<experimental::Noc::McastMode::INCLUDE_SRC>(
+                    unicast_endpoint,
+                    mcast_endpoint,
+                    transaction_size,
+                    num_dests,
+                    {.addr = l1_local_addr},
+                    {.noc_x_start = dest_x_start,
+                     .noc_y_start = dest_y_start,
+                     .noc_x_end = dest_x_end,
+                     .noc_y_end = dest_y_end,
+                     .addr = l1_local_addr});
+            } else {
+                noc.async_write_multicast<experimental::Noc::McastMode::EXCLUDE_SRC>(
+                    unicast_endpoint,
+                    mcast_endpoint,
+                    transaction_size,
+                    num_dests,
+                    {.addr = l1_local_addr},
+                    {.noc_x_start = dest_x_start,
+                     .noc_y_start = dest_y_start,
+                     .noc_x_end = dest_x_end,
+                     .noc_y_end = dest_y_end,
+                     .addr = l1_local_addr});
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -31,6 +31,7 @@ void kernel_main() {
         loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_multicast<mcast_mode>(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_dest_core_coordinates = get_compile_time_arg_val(4);
+
+    uint32_t src_x_coord = packed_dest_core_coordinates >> 16;
+    uint32_t src_y_coord = packed_dest_core_coordinates & 0xFFFF;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    noc.set_async_read_state(
+        unicast_endpoint, transaction_size, {.noc_x = src_x_coord, .noc_y = src_y_coord, .addr = l1_local_addr});
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_transactions; i++) {
+            noc.async_read_with_state(
+                unicast_endpoint,
+                unicast_endpoint,
+                transaction_size,
+                {.noc_x = src_x_coord, .noc_y = src_y_coord, .addr = l1_local_addr},
+                {.addr = l1_local_addr});
+        }
+    }
+
+    noc.async_read_barrier();
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -11,23 +11,23 @@ void kernel_main() {
     constexpr uint32_t test_id = get_compile_time_arg_val(3);
     constexpr uint32_t packed_dest_core_coordinates = get_compile_time_arg_val(4);
 
-    uint32_t src_x_coord = packed_dest_core_coordinates >> 16;
-    uint32_t src_y_coord = packed_dest_core_coordinates & 0xFFFF;
+    uint32_t dst_x_coord = packed_dest_core_coordinates >> 16;
+    uint32_t dst_y_coord = packed_dest_core_coordinates & 0xFFFF;
 
     experimental::Noc noc(noc_index);
     experimental::UnicastEndpoint unicast_endpoint;
 
     noc.set_async_read_state(
-        unicast_endpoint, transaction_size, {.noc_x = src_x_coord, .noc_y = src_y_coord, .addr = l1_local_addr});
+        unicast_endpoint, transaction_size, {.noc_x = dst_x_coord, .noc_y = dst_y_coord, .addr = l1_local_addr});
 
     {
-        DeviceZoneScopedN("RISCV0");
+        DeviceZoneScopedN("RISCV1");
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read_with_state(
                 unicast_endpoint,
                 unicast_endpoint,
                 transaction_size,
-                {.noc_x = src_x_coord, .noc_y = src_y_coord, .addr = l1_local_addr},
+                {.noc_x = dst_x_coord, .noc_y = dst_y_coord, .addr = l1_local_addr},
                 {.addr = l1_local_addr});
         }
     }

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -22,6 +22,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
+#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_dest_core_coordinates = get_compile_time_arg_val(4);
+
+    uint32_t dest_x_coord = packed_dest_core_coordinates >> 16;
+    uint32_t dest_y_coord = packed_dest_core_coordinates & 0xFFFF;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    noc.set_async_write_state(
+        unicast_endpoint, transaction_size, {.noc_x = dest_x_coord, .noc_y = dest_y_coord, .addr = l1_local_addr});
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_transactions; i++) {
+            noc.async_write_with_state(
+                unicast_endpoint,
+                unicast_endpoint,
+                transaction_size,
+                {.addr = l1_local_addr},
+                {.noc_x = dest_x_coord, .noc_y = dest_y_coord, .addr = l1_local_addr});
+        }
+    }
+
+    noc.async_write_barrier();
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -22,6 +22,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
+#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_dest_core_coordinates = get_compile_time_arg_val(4);
+
+    uint32_t dest_x_coord = packed_dest_core_coordinates >> 16;
+    uint32_t dest_y_coord = packed_dest_core_coordinates & 0xFFFF;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_transactions; i++) {
+            noc.async_read(
+                unicast_endpoint,
+                unicast_endpoint,
+                transaction_size,
+                {.noc_x = dest_x_coord, .noc_y = dest_y_coord, .addr = l1_local_addr},
+                {.addr = l1_local_addr});
+        }
+    }
+
+    noc.async_read_barrier();
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     experimental::UnicastEndpoint unicast_endpoint;
 
     {
-        DeviceZoneScopedN("RISCV0");
+        DeviceZoneScopedN("RISCV1");
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_size = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_dest_core_coordinates = get_compile_time_arg_val(4);
+
+    uint32_t dest_x_coord = packed_dest_core_coordinates >> 16;
+    uint32_t dest_y_coord = packed_dest_core_coordinates & 0xFFFF;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_transactions; i++) {
+            noc.async_write(
+                unicast_endpoint,
+                unicast_endpoint,
+                transaction_size,
+                {.addr = l1_local_addr},
+                {.noc_x = dest_x_coord, .noc_y = dest_y_coord, .addr = l1_local_addr});
+        }
+    }
+
+    noc.async_write_barrier();
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace test_utils;
+
+namespace unit_tests::dm::noc_api_latency {
+
+// Kernel type enum
+enum class KernelType {
+    UNICAST_WRITE = 0,
+    UNICAST_READ = 1,
+    MULTICAST_WRITE = 2,
+    STATEFUL_WRITE = 3,
+    STATEFUL_READ = 4
+};
+
+// Test config
+struct NocApiLatencyConfig {
+    uint32_t test_id = 0;
+    CoreCoord source_core_coord = {0, 0};
+    CoreCoord dest_core_coord = {0, 1};
+    CoreCoord mcast_dest_core_start = {0, 1};
+    CoreCoord mcast_dest_core_end = {0, 1};
+    uint32_t num_transactions = 1;
+    uint32_t transaction_size = 32;  // bytes
+    KernelType kernel_type = KernelType::UNICAST_WRITE;
+    NOC noc_id = NOC::NOC_0;
+    bool loopback = false;  // For multicast: include source in destinations
+};
+
+/// @brief Measures NOC API call latency
+/// @param mesh_device - MeshDevice to run the test on
+/// @param test_config - Configuration of the test -- see struct
+/// @return true if test passes
+bool run_noc_api_latency_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, const NocApiLatencyConfig& test_config) {
+    // Get the actual device for this single-device test
+    IDevice* device = mesh_device->get_device(0);
+
+    /* ================ SETUP ================ */
+
+    // Program
+    Program program = CreateProgram();
+
+    // (Logical) Core coordinates and ranges
+
+    CoreRangeSet sub_logical_core_set({CoreRange(test_config.mcast_dest_core_start, test_config.mcast_dest_core_end)});
+
+    // Obtain L1 Address for Storing Data
+    L1AddressInfo source_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.source_core_coord);
+    L1AddressInfo dest_l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.dest_core_coord);
+
+    // Check if the L1 size is sufficient for the test configuration
+    if (source_l1_info.size < test_config.transaction_size || dest_l1_info.size < test_config.transaction_size) {
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    uint32_t l1_base_address = source_l1_info.base_address;
+
+    // Physical Core Coordinates
+    CoreCoord physical_dest_core = device->worker_core_from_logical_core(test_config.dest_core_coord);
+    uint32_t packed_dest_core_coordinates = physical_dest_core.x << 16 | (physical_dest_core.y & 0xFFFF);
+
+    // For multicast tests, use configured multicast rectangle
+    CoreCoord physical_mcast_dest_start = device->worker_core_from_logical_core(test_config.mcast_dest_core_start);
+    CoreCoord physical_mcast_dest_end = device->worker_core_from_logical_core(test_config.mcast_dest_core_end);
+    uint32_t packed_dest_core_end_coordinates = physical_mcast_dest_end.x << 16 | (physical_mcast_dest_end.y & 0xFFFF);
+
+    // For non-multicast tests, override with unicast destination
+    if (test_config.kernel_type != KernelType::MULTICAST_WRITE) {
+        packed_dest_core_end_coordinates = packed_dest_core_coordinates;
+    } else {
+        // For multicast, update packed_dest_core_coordinates to be the start of the rectangle
+        packed_dest_core_coordinates = physical_mcast_dest_start.x << 16 | (physical_mcast_dest_start.y & 0xFFFF);
+    }
+
+    // Compile-time arguments for kernels
+    vector<uint32_t> compile_args = {
+        (uint32_t)l1_base_address,
+        (uint32_t)test_config.num_transactions,
+        (uint32_t)test_config.transaction_size,
+        (uint32_t)test_config.test_id,
+        (uint32_t)packed_dest_core_coordinates,
+        (uint32_t)packed_dest_core_end_coordinates,
+        (uint32_t)test_config.kernel_type,
+        (uint32_t)test_config.loopback};
+
+    if (test_config.kernel_type == KernelType::MULTICAST_WRITE) {
+        compile_args.push_back(sub_logical_core_set.num_cores());
+    }
+
+    // Select kernel based on type
+    std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/";
+    std::string kernel_filename;
+
+    switch (test_config.kernel_type) {
+        case KernelType::UNICAST_WRITE: kernel_filename = "unicast_write_2_0"; break;
+        case KernelType::UNICAST_READ: kernel_filename = "unicast_read_2_0"; break;
+        case KernelType::MULTICAST_WRITE: kernel_filename = "multicast_write_2_0"; break;
+        case KernelType::STATEFUL_WRITE: kernel_filename = "stateful_write_2_0"; break;
+        case KernelType::STATEFUL_READ: kernel_filename = "stateful_read_2_0"; break;
+        default: log_error(LogTest, "Invalid kernel type"); return false;
+    }
+
+    std::string kernel_path = kernels_dir + kernel_filename + ".cpp";
+
+    // Create kernel on source core
+    CreateKernel(
+        program,
+        kernel_path,
+        test_config.source_core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = test_config.noc_id, .compile_args = compile_args});
+
+    // Assign unique id
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    /* ================ RUNNING THE PROGRAM ================ */
+
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    // For latency tests, we don't validate data correctness - we just measure cycles
+
+    return true;
+}
+
+// Sweep test for unicast write and read
+void unicast_sweep_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, KernelType kernel_type) {
+    auto* device = mesh_device->get_device(0);
+    for (uint32_t transaction_size = 32; transaction_size <= 4096; transaction_size *= 2) {
+        for (uint32_t num_transactions = 1; num_transactions <= 256; num_transactions *= 2) {
+            NocApiLatencyConfig test_config = {
+                .test_id = test_id,
+                .source_core_coord = {0, 0},
+                .dest_core_coord = {0, device->compute_with_storage_grid_size().y - 1},
+                .num_transactions = num_transactions,
+                .transaction_size = transaction_size,
+                .kernel_type = kernel_type,
+                .noc_id = NOC::NOC_0};
+
+            EXPECT_TRUE(run_noc_api_latency_test(mesh_device, test_config));
+        }
+    }
+}
+
+// Sweep test for multicast write with configurable grid
+void multicast_write_sweep_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t test_id,
+    CoreCoord mcast_start,
+    CoreCoord mcast_end,
+    bool loopback) {
+    for (uint32_t transaction_size = 32; transaction_size <= 4096; transaction_size *= 2) {
+        for (uint32_t num_transactions = 1; num_transactions <= 256; num_transactions *= 2) {
+            NocApiLatencyConfig test_config = {
+                .test_id = test_id,
+                .source_core_coord = {0, 0},
+                .dest_core_coord = {0, 0},  // not used
+                .mcast_dest_core_start = mcast_start,
+                .mcast_dest_core_end = mcast_end,
+                .num_transactions = num_transactions,
+                .transaction_size = transaction_size,
+                .kernel_type = KernelType::MULTICAST_WRITE,
+                .noc_id = NOC::NOC_0,
+                .loopback = loopback};
+
+            EXPECT_TRUE(run_noc_api_latency_test(mesh_device, test_config));
+        }
+    }
+}
+
+}  // namespace unit_tests::dm::noc_api_latency
+
+// Test definitions
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastWrite) {
+    uint32_t test_case_id = 700;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
+        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastRead) {
+    uint32_t test_case_id = 701;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
+        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulWrite) {
+    uint32_t test_case_id = 702;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
+        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulRead) {
+    uint32_t test_case_id = 703;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
+        this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite2x2) {
+    uint32_t test_case_id = 704;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
+        this->mesh_device_, test_case_id, {0, 1}, {1, 2}, false);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite5x5) {
+    uint32_t test_case_id = 705;
+    tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
+        this->mesh_device_, test_case_id, {0, 1}, {4, 5}, false);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWriteAll) {
+    uint32_t test_case_id = 706;
+    auto* device = this->mesh_device_->get_device(0);
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
+        this->mesh_device_, test_case_id, {0, 0}, {grid_size.x - 1, grid_size.y - 1}, true);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "data_types.hpp"
 #include "multi_device_fixture.hpp"
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -93,7 +94,6 @@ bool run_noc_api_latency_test(
         (uint32_t)test_config.test_id,
         (uint32_t)packed_dest_core_coordinates,
         (uint32_t)packed_dest_core_end_coordinates,
-        (uint32_t)test_config.kernel_type,
         (uint32_t)test_config.loopback};
 
     if (test_config.kernel_type == KernelType::MULTICAST_WRITE) {
@@ -115,13 +115,18 @@ bool run_noc_api_latency_test(
 
     std::string kernel_path = kernels_dir + kernel_filename + ".cpp";
 
+    auto riscv = DataMovementProcessor::RISCV_0;
+
+    if (test_config.kernel_type == KernelType::UNICAST_READ || test_config.kernel_type == KernelType::STATEFUL_READ) {
+        riscv = DataMovementProcessor::RISCV_1;
+    }
+
     // Create kernel on source core
     CreateKernel(
         program,
         kernel_path,
         test_config.source_core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = test_config.noc_id, .compile_args = compile_args});
+        DataMovementConfig{.processor = riscv, .noc = test_config.noc_id, .compile_args = compile_args});
 
     // Assign unique id
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/test_noc_api_latency.cpp
@@ -200,42 +200,49 @@ void multicast_write_sweep_test(
 
 // Test definitions
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastWrite) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 700;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
         this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_WRITE);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyUnicastRead) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 701;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
         this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::UNICAST_READ);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulWrite) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 702;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
         this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_WRITE);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyStatefulRead) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 703;
     tt::tt_metal::unit_tests::dm::noc_api_latency::unicast_sweep_test(
         this->mesh_device_, test_case_id, unit_tests::dm::noc_api_latency::KernelType::STATEFUL_READ);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite2x2) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 704;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
         this->mesh_device_, test_case_id, {0, 1}, {1, 2}, false);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWrite5x5) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 705;
     tt::tt_metal::unit_tests::dm::noc_api_latency::multicast_write_sweep_test(
         this->mesh_device_, test_case_id, {0, 1}, {4, 5}, false);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixNocApiLatencyMulticastWriteAll) {
+    GTEST_SKIP() << "Skipping test";
     uint32_t test_case_id = 706;
     auto* device = this->mesh_device_->get_device(0);
     CoreCoord grid_size = device->compute_with_storage_grid_size();

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -514,3 +514,48 @@ tests:
       has an input and output port. We have a core that is sending and receiving data at the same time,
       with packets circulating around the torus. This does not happen in Read After Write tests because
       the read requests get stuck behind the larger write requests.
+
+  700:
+    name: "NOC API Latency - Unicast Write"
+    comment: |
+      Measures the latency (in cycles) of NOC unicast write API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+
+  701:
+    name: "NOC API Latency - Unicast Read"
+    comment: |
+      Measures the latency (in cycles) of NOC unicast read API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+
+  702:
+    name: "NOC API Latency - Stateful Write"
+    comment: |
+      Measures the latency (in cycles) of NOC stateful write API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+      The state setup is done outside the measurement window.
+
+  703:
+    name: "NOC API Latency - Stateful Read"
+    comment: |
+      Measures the latency (in cycles) of NOC stateful read API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+      The state setup is done outside the measurement window.
+
+  704:
+    name: "NOC API Latency - Multicast Write 2x2"
+    comment: |
+      Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 2x2 multicast grid.
+
+  705:
+    name: "NOC API Latency - Multicast Write 5x5"
+    comment: |
+      Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 5x5 multicast grid.
+
+  706:
+    name: "NOC API Latency - Multicast Write All Cores"
+    comment: |
+      Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
+      Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a multicast grid
+      covering all compute cores in the device.


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=116830943&issue=tenstorrent%7Ctt-metal%7C24075)

### Problem description
There are already tests that measure and map the performance of API calls. It is beneficial to know how many cycles it takes to issue a full noc transaction.

### What's changed
These tests are using the dataflow api 2.0. We are measuring the issue time of different NoC api calls: Unicast read and write, both stateful and stateless, multicast 2x2, multicast 5x5, and multicast on full grid.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20432231268) CI passes
- [x] [(TM-DM) Data Movement Test Suite
](https://github.com/tenstorrent/tt-metal/actions/runs/20374884748)