### PR TITLE
Improve error when attempting to initialize in-use device.

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -432,14 +432,15 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
 
     TT_FATAL(!this->sdesc_per_chip_.empty(), "Descriptor must be loaded. Try open_driver()");
 
+    // May block waiting for other processes to release the device.
+    this->driver_->start_device(device_params);
+
     if (this->target_type_ == TargetDevice::Silicon && device_params.init_device) {
         for (const auto& mmio_device_id : driver_->get_target_mmio_device_ids()) {
             ll_api::configure_static_tlbs(
                 this->arch_, mmio_device_id, this->get_soc_desc(mmio_device_id), *this->driver_);
         }
     }
-
-    this->driver_->start_device(device_params);
 }
 
 Cluster::~Cluster() {


### PR DESCRIPTION
### Ticket
#34034

### Problem description
When attempting to initialize a MetalContext if another process already has a MetalContext open, we get an error like "Failed to allocate the TLB with size 1048576", which is hard to understand.

### What's changed
Move start_driver before we allocate TLBs. That give a more understandable error like

"Waiting for lock 'CHIP_IN_USE_5_PCIe' which is currently held by thread TID: 72566, PID: 72566"

brosko's continuation:
This actually makes some issues go away completely, since the process might wait on chiplock and the garbage collector might run in the meantime and clean up the old context. The process will wait on this lock before trying to allocate more TLBs

### Testing
All the runs also have a corresponding closest run on main branch, for comparing failures.
All the runs have corresponding statuses. The runs will be retried 3 times automatically, after which failures will be reported.

| Status | Workflow | Run | Main Run |
|--------|----------|-----|----------|
| Success | [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481940790) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20480492036) |
| Running 2 | [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481955310) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20481578380) |
| Success | [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481963480) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20480611351) |
| Success | [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481971620) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20480679266) |
| No new failures | [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481983124) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20241611572) |
| No new failures | [Galaxy unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481991508) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20224960574) |
| No new failures | [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) | [Run](https://github.com/tenstorrent/tt-metal/actions/runs/20481998729) | [Main](https://github.com/tenstorrent/tt-metal/actions/runs/20254630190) |

### Overall Test Status: Processing
