### PR TITLE
Remove ccl test from running on merge gate

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -56,7 +56,6 @@ jobs:
           [[
             # Nightly jobs that currently don't run any tests in the L2-Nightly pipeline are commented out
             { name: "All C++", cmd: '{ [ "$GTEST_FILTER" = "*NIGHTLY_*" ]; } && (echo "Running sdpa_reduce_c C++ nightly (nightly filter: $GTEST_FILTER)" && ./build/test/tt_metal/test_sdpa_reduce_c) && ./tests/scripts/run_cpp_unit_tests.sh', nightly: true }, # 15 minutes -  Only runs on Nightly-L2
-            { name: "CCL", cmd: './build/test/ttnn/unit_tests_ttnn_ccl --gtest_filter=$GTEST_FILTER && ./build/test/ttnn/unit_tests_ttnn_ccl_ops --gtest_filter=$GTEST_FILTER', nightly: false },
             { name: "dispatch", cmd: 'TT_METAL_ENABLE_ERISC_IRAM=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=*', nightly: true },  # Only runs on Nightly-L2
             { name: "dispatch multicmd queue", cmd: 'TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=UnitMeshMultiCQ*Fixture.*', nightly: true }, # Only runs on Nightly-L2
             { name: "distributed", cmd: './build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=* && ./tests/tt_metal/multihost/run_multiprocess_socket_tests.sh', nightly: true, auto-triage: true },  # Only runs on Nightly-L2
@@ -80,15 +79,7 @@ jobs:
           requested_cpp_tests=$(jq --argjson nightly_run "${{ inputs.nightly-run }}" '[.[] | select(.nightly == $nightly_run)]' <<< "$requested_cpp_tests")
           echo "[info] after filtering for requested workflow tests: $requested_cpp_tests"
 
-          # Filter for merge-gate-call: only keep CCL tests
-          if [[ "${{ inputs.merge-gate-call }}" == "true" ]]; then
-            requested_cpp_tests=$(jq '[.[] | select(.name == "CCL")]' <<< "$requested_cpp_tests")
-            echo "[info] after filtering for merge-gate-call (CCL only): $requested_cpp_tests"
-          # Exclude CCL if both nightly-run and merge-gate-call are false
-          elif [[ "${{ inputs.nightly-run }}" == "false" && ( "${{ inputs.runner-label }}" == "N150" || "${{ inputs.runner-label }}" == "N300" ) ]]; then
-            requested_cpp_tests=$(jq '[.[] | select(.name != "CCL")]' <<< "$requested_cpp_tests")
-            echo "[info] after filtering out CCL for regular post-commit: $requested_cpp_tests"
-          fi
+          # If a test runs in merge-gate add filter to include only those tests here
 
           # Check that we have a valid test list that's not empty
           echo "$requested_cpp_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -79,7 +79,7 @@ jobs:
           requested_cpp_tests=$(jq --argjson nightly_run "${{ inputs.nightly-run }}" '[.[] | select(.nightly == $nightly_run)]' <<< "$requested_cpp_tests")
           echo "[info] after filtering for requested workflow tests: $requested_cpp_tests"
 
-          # If a test runs in merge-gate add filter to include only those tests here
+          # If a test needs to run in merge-gate, filter will be added to include only those tests here
 
           # Check that we have a valid test list that's not empty
           echo "$requested_cpp_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -317,29 +317,6 @@ jobs:
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-  cpp-merge-gate-tests:
-    needs: [build, find-changes]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 }
-        ]
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
-      gtest_filter: "*-*NIGHTLY_*"
-      merge-gate-call: true
-
   ttsim-unit-tests:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.any-code-changed == 'true'

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -127,7 +127,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
   cpp-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_APC_cpp_tests }}
+    if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
     needs: build-artifact
     secrets: inherit
     strategy:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -127,7 +127,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
   cpp-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_bos_tests }}
+    if: ${{ github.event_name == 'schedule' || inputs.run_APC_cpp_tests }}
     needs: build-artifact
     secrets: inherit
     strategy:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Remove ccl test from running on merge gate. A place holder is left in cpp-post-commit-unit-tests for future CCL tests that checks relevant changes thoroughly.

### Checklist
- [x] NightlyL2 CI run: https://github.com/tenstorrent/tt-metal/actions/runs/20281602276