### PR TITLE
Revert "Fix logical const correctness of SDMT::get_*_sub_device_manager (#34446)"

### DIFF
--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -131,17 +131,11 @@ void SubDeviceManagerTracker::remove_sub_device_manager(SubDeviceManagerId sub_d
     sub_device_managers_.erase(sub_device_manager);
 }
 
-const SubDeviceManager* SubDeviceManagerTracker::get_active_sub_device_manager() const {
-    return active_sub_device_manager_;
-}
+SubDeviceManager* SubDeviceManagerTracker::get_active_sub_device_manager() const { return active_sub_device_manager_; }
 
-const SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() const {
+SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() const {
     return default_sub_device_manager_;
 }
-
-SubDeviceManager* SubDeviceManagerTracker::get_active_sub_device_manager() { return active_sub_device_manager_; }
-
-SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() { return default_sub_device_manager_; }
 
 SubDeviceManagerId SubDeviceManagerTracker::get_active_sub_device_manager_id() const {
     return active_sub_device_manager_->id();
@@ -171,7 +165,7 @@ std::optional<DeviceAddr> SubDeviceManagerTracker::lowest_occupied_compute_l1_ad
         sub_device_ids = tt::stl::Span<const SubDeviceId>(active_sub_device_manager_->get_sub_device_ids());
     }
     for (const auto& sub_device_id : sub_device_ids) {
-        const auto& allocator = this->get_active_sub_device_manager()->allocator(sub_device_id);
+        const auto& allocator = this->get_active_sub_device_manager()->sub_device_allocator(sub_device_id);
         if (allocator) {
             // Having an allocator means there are Tensix cores in this sub-device
             const auto& cores =

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
@@ -43,11 +43,9 @@ public:
 
     void remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id);
 
-    const SubDeviceManager* get_active_sub_device_manager() const;
+    SubDeviceManager* get_active_sub_device_manager() const;
 
-    const SubDeviceManager* get_default_sub_device_manager() const;
-    SubDeviceManager* get_active_sub_device_manager();
-    SubDeviceManager* get_default_sub_device_manager();
+    SubDeviceManager* get_default_sub_device_manager() const;
 
     // Used for caching program state by manager and buffers to check that the required manager is still active
     SubDeviceManagerId get_active_sub_device_manager_id() const;


### PR DESCRIPTION
…

This reverts commit 4e4f13d89efc34178761b826c5e66a8263247035.

This broke some ttnn APC tests

cc: @jbaumanTT 

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
