### PR TITLE
Compress enums

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.hpp
@@ -30,7 +30,7 @@ using Rank = tt::tt_metal::distributed::multihost::Rank;
     3. socket level patterns (number of connection in each socket)
     Currently patterns are only at the device level,
     going between all host pairs and one connection per socket. */
-enum class PatternType : uint32_t {
+enum class PatternType : std::uint8_t {
     AllToAllDevices = 0,
     AllHostsRandomSockets = 1,
     AllDeviceBroadcast = 2,

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp
@@ -19,10 +19,10 @@
 namespace tt::tt_fabric::fabric_router_tests::multihost::multihost_utils {
 
 // System Types currently supported for testing
-enum class SystemConfig { SPLIT_T3K, DUAL_T3K, NANO_EXABOX, EXABOX };
+enum class SystemConfig : std::uint8_t { SPLIT_T3K, DUAL_T3K, NANO_EXABOX, EXABOX };
 
 // Socket Test Variants
-enum class TestVariant { SINGLE_CONN_BWD, SINGLE_CONN_FWD, MULTI_CONN_FWD, MULTI_CONN_BIDIR };
+enum class TestVariant : std::uint8_t { SINGLE_CONN_BWD, SINGLE_CONN_FWD, MULTI_CONN_FWD, MULTI_CONN_BIDIR };
 
 std::string get_system_config_name(SystemConfig system_config);
 

--- a/tests/tt_metal/test_utils/deprecated/tensor.hpp
+++ b/tests/tt_metal/test_utils/deprecated/tensor.hpp
@@ -13,7 +13,7 @@ using SHAPE = std::array<std::uint32_t, 4>;
 
 namespace tt::deprecated {
 
-enum class Initialize { ZEROS = 0, ONES = 1, INCREMENT = 2, RANDOM = 3 };
+enum class Initialize : std::uint8_t { ZEROS = 0, ONES = 1, INCREMENT = 2, RANDOM = 3 };
 
 template <class T>
 class Tensor {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/kernels/kernel_common.hpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/kernels/kernel_common.hpp
@@ -6,6 +6,6 @@
 #include <cstdint>
 
 // Enum definitions for compile-time parameters
-enum class OperationType : uint32_t { BasicWrite = 0, Scatter = 1, FusedAtomicInc = 2 };
+enum class OperationType : std::uint8_t { BasicWrite = 0, Scatter = 1, FusedAtomicInc = 2 };
 
-enum class ApiVariant : uint32_t { Basic = 0, WithState = 1, SetState = 2 };
+enum class ApiVariant : std::uint8_t { Basic = 0, WithState = 1, SetState = 2 };

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/test_common.hpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/test_common.hpp
@@ -15,7 +15,7 @@ namespace tt::tt_fabric::test {
 using ChipId = tt::tt_metal::distributed::ChipId;
 
 // API variants for addrgen overload testing
-enum class AddrgenApiVariant {
+enum class AddrgenApiVariant : std::uint8_t {
     UnicastWrite,                           // fabric_unicast_noc_unicast_write
     UnicastWriteWithState,                  // fabric_unicast_noc_unicast_write_with_state
     UnicastWriteSetState,                   // fabric_unicast_noc_unicast_write_set_state + _with_state

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -20,9 +20,9 @@
 
 namespace tt::tt_fabric::system_health_tests {
 
-enum class ConnectorType { UNUSED, QSFP, WARP, TRACE, LK1, LK2, LK3, UNKNOWN };
+enum class ConnectorType : std::uint8_t { UNUSED, QSFP, WARP, TRACE, LK1, LK2, LK3, UNKNOWN };
 
-enum class LinkingBoardType {
+enum class LinkingBoardType : std::uint8_t {
     A,
     B,
 };

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -43,7 +43,7 @@ using namespace tt::tt_metal;
 
 namespace unit_tests::runtime_args {
 
-enum class KernelType {
+enum class KernelType : std::uint8_t {
     DATA_MOVEMENT = 0,
     COMPUTE = 1,
 };

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -24,7 +24,7 @@ uint32_t determine_max_grid_dimension(const shared_ptr<distributed::MeshDevice>&
     return (smaller_dimension - 1);
 }
 
-enum class MulticastSchemeType {
+enum class MulticastSchemeType : std::uint8_t {
     // Sender is IN the grid
     SenderInGridTopRight = 1,
     SenderInGridBottomRight,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -46,7 +46,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-enum watcher_features_t {
+enum watcher_features_t : std::uint8_t {
     SanitizeNOCAddress,
     SanitizeNOCAlignmentL1Write,
     SanitizeNOCAlignmentL1Read,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -25,8 +25,8 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
         return t0_to_any_riscfw_end;
     }
     // TODO: use enums from profiler_common.h
-    enum BufferIndex { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
-    enum TimerDataIndex { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };
+    enum BufferIndex : std::uint8_t { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
+    enum TimerDataIndex : std::uint8_t { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     auto worker_cores_used_in_program = device->worker_cores_from_logical_cores(
         program.impl()
@@ -95,13 +95,13 @@ inline T calculate_average(const std::vector<T>& vec, bool skip_first_run = true
     return average;
 }
 
-enum class NOC_INDEX { NOC_RISCV_0, NOC_RISCV_1 };
+enum class NOC_INDEX : std::uint8_t { NOC_RISCV_0, NOC_RISCV_1 };
 
-enum class NOC_DIRECTION { X_PLUS_DIR, Y_MINUS_DIR, X_MINUS_DIR, Y_PLUS_DIR };
+enum class NOC_DIRECTION : std::uint8_t { X_PLUS_DIR, Y_MINUS_DIR, X_MINUS_DIR, Y_PLUS_DIR };
 
-enum class ACCESS_TYPE { READ, WRITE };
+enum class ACCESS_TYPE : std::uint8_t { READ, WRITE };
 
-enum class BUFFER_TYPE { DRAM, L1 };
+enum class BUFFER_TYPE : std::uint8_t { DRAM, L1 };
 
 inline std::string NOC_INDEXToString(NOC_INDEX enumValue) {
     switch (enumValue) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_telemetry.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_telemetry.hpp
@@ -47,7 +47,4 @@ struct CodeProfilingEntry {
 const uint32_t telemetry_addr = ::tt::tt_metal::hal::get_erisc_l1_unreserved_base();
 
 // TODO: Define enum for filtering
-enum class EthCoreFilter {
-    All,
-    IgnoreTunnelerRouter
-};
+enum class EthCoreFilter : std::uint8_t { All, IgnoreTunnelerRouter };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -23,7 +23,7 @@
 namespace tt::tt_fabric::fabric_tests {
 
 // Performance test mode - replaces separate latency_test_mode and benchmark_mode booleans
-enum class PerformanceTestMode {
+enum class PerformanceTestMode : std::uint8_t {
     NONE,       // No performance testing (functional test only)
     BANDWIDTH,  // Bandwidth/throughput test mode (formerly benchmark_mode)
     LATENCY     // Latency measurement test mode (formerly latency_test_mode)
@@ -110,7 +110,7 @@ struct SyncConfig {
     SenderConfig sender_config;  // Sync messages sent by this device
 };
 
-enum class HighLevelTrafficPattern {
+enum class HighLevelTrafficPattern : std::uint8_t {
     AllToAll,
     OneToAll,
     AllToOne,
@@ -212,7 +212,7 @@ constexpr uint32_t DEFAULT_PAYLOAD_CHUNK_SIZE_BYTES = 0x80000;  // 512KB
 constexpr uint32_t DEFAULT_RECEIVER_L1_SIZE = 0x100000;
 }  // namespace detail
 
-enum class CoreType {
+enum class CoreType : std::uint8_t {
     SENDER,
     RECEIVER,
 };
@@ -220,7 +220,7 @@ enum class CoreType {
 constexpr size_t SENDER_TYPE_IDX = static_cast<size_t>(CoreType::SENDER);
 constexpr size_t RECEIVER_TYPE_IDX = static_cast<size_t>(CoreType::RECEIVER);
 
-enum class CoreAllocationPolicy {
+enum class CoreAllocationPolicy : std::uint8_t {
     RoundRobin,    // Cycle through available cores to distribute load.
     ExhaustFirst,  // Fill one core with workers before moving to the next.
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -94,7 +94,7 @@ using tt::tt_fabric::fabric_tests::fetch_pattern_packet_size;
 
 // Bandwidth Summary Statistics
 // If you want to add new statistics, populate this enum with their names
-enum class BandwidthStatistics {
+enum class BandwidthStatistics : std::uint8_t {
     BandwidthMean,
     BandwidthMin,
     BandwidthMax,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -20,7 +20,7 @@ namespace tt::tt_fabric::fabric_tests {
 
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 
-enum class HighLevelTrafficPattern;  // Forward declaration
+enum class HighLevelTrafficPattern : std::uint8_t;  // Forward declaration
 
 class IDeviceInfoProvider {
 public:

--- a/tests/tt_metal/tt_metal/test_gold_impls.hpp
+++ b/tests/tt_metal/tt_metal/test_gold_impls.hpp
@@ -46,7 +46,7 @@ inline std::vector<uint16_t> gold_transpose_hc(std::vector<uint16_t> src_vec, st
 };
 
 struct BcastDim {
-    enum Enum : uint32_t {
+    enum Enum : std::uint8_t {
         W = 2,   // broadcast an H-tensor over destination's W
         H = 1,   // broadcast a W-tensor over destination's H
         HW = 4,  // broadcast a 1-element tensor over destination's HW
@@ -57,7 +57,7 @@ struct BcastDim {
 };
 
 struct BcastOp {
-    enum Enum : uint32_t {
+    enum Enum : std::uint8_t {
         ADD = 0,
         SUB = 1,
         MUL = 2,

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -46,7 +46,7 @@ using std::vector;
 using namespace tt;
 
 struct BinaryOpType {
-    enum Enum { ADD = 0, SUB = 1, MUL = 2 };
+    enum Enum : std::uint8_t { ADD = 0, SUB = 1, MUL = 2 };
     static vector<Enum> all() { return {ADD, SUB, MUL}; }
 };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -49,7 +49,7 @@ using namespace tt::tt_metal;
 using namespace tt::test_utils;
 using namespace tt::test_utils::df;
 
-enum TwoInputReaderKernelWriteMode { LOCAL_WRITEBACK, FABRIC_UNICAST, FABRIC_MULTICAST };
+enum TwoInputReaderKernelWriteMode : std::uint8_t { LOCAL_WRITEBACK, FABRIC_UNICAST, FABRIC_MULTICAST };
 
 static constexpr size_t TEST_WORKERS_SUBDEVICE_INDEX = 0;
 static constexpr size_t TEST_EDM_FABRIC_SUBDEVICE_INDEX = 1;
@@ -262,7 +262,7 @@ struct KernelXY {
     uint32_t to_uint32() const { return y << 16 | x; }
 };
 
-enum Correctness { Correct, Incorrect };
+enum Correctness : std::uint8_t { Correct, Incorrect };
 
 template <typename CONTAINER_T>
 Correctness run_output_check(CONTAINER_T const& inputs, CONTAINER_T output_buffer) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -61,7 +61,7 @@ struct NDShardingSqueezeRankParams {
     Shape expected_tensor_shape_pages;
     Shape expected_shard_shape_pages;
 };
-enum class ShardingTensorSpecMethod {
+enum class ShardingTensorSpecMethod : std::uint8_t {
     ShardedAcrossDims,
     ShardedAcrossDimsExcept,
     WidthSharded,

--- a/tests/ttnn/unit_tests/gtests/test_reflect.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reflect.cpp
@@ -8,7 +8,7 @@
 
 using namespace std::literals;
 
-enum E { A, B };
+enum E : std::uint8_t { A, B };
 struct foo {
     int a;
     E b;

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -30,7 +30,7 @@ namespace tt::scaleout_tools {
 using PortId = ttsl::StrongType<uint32_t, struct PortIdTag>;
 using ChanId = ttsl::StrongType<uint32_t, struct ChanIdTag>;
 
-enum class PortType {
+enum class PortType : std::uint8_t {
     TRACE,
     QSFP_DD,
     WARP100,

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -92,7 +92,7 @@ struct ResolvedGraphInstance {
     std::unordered_map<PortType, std::vector<PortConnection>> internal_connections;
 };
 
-enum class CableLength { CABLE_0P5, CABLE_1, CABLE_2P5, CABLE_3, CABLE_5, UNKNOWN };
+enum class CableLength : std::uint8_t { CABLE_0P5, CABLE_1, CABLE_2P5, CABLE_3, CABLE_5, UNKNOWN };
 
 CableLength calc_cable_length(
     const Host& host1, int tray_id1, const Host& host2, int tray_id2, const std::string& node_type);

--- a/tools/scaleout/node/node.cpp
+++ b/tools/scaleout/node/node.cpp
@@ -136,7 +136,7 @@ public:
     // X_TORUS = 0b01 - X-axis torus only (bit 0)
     // Y_TORUS = 0b10 - Y-axis torus only (bit 1)
     // XY_TORUS = 0b11 - Both X and Y torus (bits 0+1)
-    enum class WHGalaxyTopology {
+    enum class WHGalaxyTopology : std::uint8_t {
         MESH = 0b00,                   // Mesh
         X_TORUS = 0b01,                // X-axis torus only
         Y_TORUS = 0b10,                // Y-axis torus only
@@ -304,7 +304,7 @@ public:
     // X_TORUS = 0b01 - X-axis torus only (bit 0)
     // Y_TORUS = 0b10 - Y-axis torus only (bit 1)
     // XY_TORUS = 0b11 - Both X and Y torus (bits 0+1)
-    enum class BHGalaxyTopology {
+    enum class BHGalaxyTopology : std::uint8_t {
         MESH = 0b00,                   // Mesh
         X_TORUS = 0b01,                // X-axis torus only
         Y_TORUS = 0b10,                // Y-axis torus only

--- a/tools/scaleout/node/node_types.hpp
+++ b/tools/scaleout/node/node_types.hpp
@@ -8,7 +8,7 @@
 
 namespace tt::scaleout_tools {
 
-enum class NodeType {
+enum class NodeType : std::uint8_t {
     N300_LB,
     N300_LB_DEFAULT,
     N300_QB,

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -27,7 +27,7 @@ namespace tt::scaleout_tools {
 using tt::tt_metal::AsicTopology;
 using tt::tt_metal::PhysicalSystemDescriptor;
 
-enum class CommandMode {
+enum class CommandMode : std::uint8_t {
     VALIDATE,
     LINK_RETRAIN,
 };

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -63,7 +63,7 @@ struct LinkMetricsResult {
     std::vector<EthernetLinkMetrics> unhealthy_links;  // Only unhealthy links
 };
 
-enum class WorkloadResult { Completed, TimedOut };
+enum class WorkloadResult : std::uint8_t { Completed, TimedOut };
 
 struct ClusterContext {
     PhysicalSystemDescriptor& physical_system_descriptor;

--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -23,7 +23,7 @@ struct Statistics {
 };
 
 class Buffer;
-enum class BufferType;
+enum class BufferType : std::uint8_t;
 class AllocatorState;
 
 // This is the internal representation for Allocator, not exposed for general usage.

--- a/tt_metal/api/tt-metalium/allocator_state.hpp
+++ b/tt_metal/api/tt-metalium/allocator_state.hpp
@@ -17,7 +17,7 @@ namespace tt::tt_metal {
 class Allocator;
 class BankManager;
 class Buffer;
-enum class BufferType;
+enum class BufferType : std::uint8_t;
 
 /**
  * @brief Represents the complete allocation state across all buffer types

--- a/tt_metal/api/tt-metalium/buffer_types.hpp
+++ b/tt_metal/api/tt-metalium/buffer_types.hpp
@@ -8,26 +8,26 @@
 
 namespace tt::tt_metal {
 
-enum class TensorMemoryLayout {
+enum class TensorMemoryLayout : std::uint8_t {
     INTERLEAVED = 0,
     HEIGHT_SHARDED = 2,
     WIDTH_SHARDED = 3,
     BLOCK_SHARDED = 4,
 };
 
-enum class ShardOrientation {
+enum class ShardOrientation : std::uint8_t {
     ROW_MAJOR = 0,
     COL_MAJOR,
 };
 
-enum class ShardDistributionStrategy {
+enum class ShardDistributionStrategy : std::uint8_t {
     // Distribute each shard to each of the cores in a linearized list in a round-robin manner.
     ROUND_ROBIN_1D = 0,
     // Distribute a 2D grid of shards to a 2D grid of cores with one to one mapping.
     GRID_2D = 1,
 };
 
-enum class BufferType {
+enum class BufferType : std::uint8_t {
     DRAM,
     L1,
     SYSTEM_MEMORY,

--- a/tt_metal/api/tt-metalium/data_types.hpp
+++ b/tt_metal/api/tt-metalium/data_types.hpp
@@ -9,7 +9,7 @@
 
 namespace tt::tt_metal {
 
-enum class DataMovementProcessor {
+enum class DataMovementProcessor : std::uint8_t {
     RISCV_0 = 0,  // BRISC
     RISCV_1 = 1,  // NCRISC
 };

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -39,7 +39,7 @@ address: bytes
 size: bytes
 */
 using MemoryBlockTable = std::vector<std::unordered_map<std::string, std::string>>;
-enum class BufferType;
+enum class BufferType : std::uint8_t;
 
 class Allocator;
 class AllocatorImpl;

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::tt_metal {
 
-enum DispatchWorkerType : uint32_t {
+enum DispatchWorkerType : std::uint8_t {
     PREFETCH = 0,
     PREFETCH_HD = 1,
     PREFETCH_H = 2,
@@ -28,9 +28,9 @@ enum DispatchWorkerType : uint32_t {
     COUNT,
 };
 
-enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
+enum class DispatchCoreType : std::uint8_t { WORKER, ETH, COUNT };
 
-enum class DispatchCoreAxis { ROW, COL, COUNT };
+enum class DispatchCoreAxis : std::uint8_t { ROW, COL, COUNT };
 
 class DispatchCoreConfig {
 private:

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -59,7 +59,7 @@ public:
     bool is_local(const distributed::MeshCoordinate& coord) const;
 
     // Specifies the execution policy for the `transform` and `apply` functions.
-    enum class ProcessShardExecutionPolicy {
+    enum class ProcessShardExecutionPolicy : std::uint8_t {
         SEQUENTIAL,
         PARALLEL,
     };

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -59,7 +59,7 @@ struct LocalMeshBinding {
 
 // In multi-host context, APIs parameterized with MeshScope, can return
 // results for local mesh or global mesh.
-enum class MeshScope {
+enum class MeshScope : std::uint8_t {
     LOCAL,
     GLOBAL,
 };

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -27,7 +27,7 @@ class MeshShape;
 
 namespace tt::tt_fabric {
 class FabricNodeId;
-enum class RoutingDirection;
+enum class RoutingDirection : std::uint8_t;
 struct FabricEriscDatamoverConfig;
 size_t get_tt_fabric_channel_buffer_size_bytes();
 size_t get_tt_fabric_packet_header_size_bytes();

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_edm_types.hpp
@@ -8,7 +8,7 @@
 
 namespace tt::tt_fabric {
 
-enum class Topology { NeighborExchange = 0, Linear = 1, Ring = 2, Mesh = 3, Torus = 4 };
+enum class Topology : std::uint8_t { NeighborExchange = 0, Linear = 1, Ring = 2, Mesh = 3, Torus = 4 };
 
 // Topology classification utilities
 constexpr bool is_2D_topology(Topology topology) { return topology == Topology::Mesh || topology == Topology::Torus; }

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -9,7 +9,7 @@
 
 namespace tt::tt_fabric {
 
-enum class FabricConfig : uint32_t {
+enum class FabricConfig : std::uint8_t {
     DISABLED = 0,
     FABRIC_1D_NEIGHBOR_EXCHANGE = 1,  // 1D topology with no forwarding between non-adjacent devices
     FABRIC_1D = 2,                    // 1D routing and no deadlock avoidance
@@ -23,19 +23,19 @@ enum class FabricConfig : uint32_t {
 
 // tensix extension for fabric routers, used to build connections between worker - fabric router, upstream fabric router
 // - downstream fabric router.
-enum class FabricTensixConfig : uint32_t {
+enum class FabricTensixConfig : std::uint8_t {
     DISABLED = 0,  // not using tensix extension
     MUX = 1,       // using mux kernel as tensix extension
     UDM = 2,       // in udm (unified datamovement) mode, we build both mux and relay kernels as tensix extension
 };
 
 // Unified Datamovement knob for configuring fabric with different parameters
-enum class FabricUDMMode : uint32_t {
+enum class FabricUDMMode : std::uint8_t {
     DISABLED = 0,
     ENABLED = 1,
 };
 
-enum class FabricType {
+enum class FabricType : std::uint8_t {
     MESH = 1 << 0,
     TORUS_X = 1 << 1,  // Connections along mesh_coord[1]
     TORUS_Y = 1 << 2,  // Connections along mesh_coord[0]
@@ -46,7 +46,7 @@ FabricType operator|(FabricType lhs, FabricType rhs);
 FabricType operator&(FabricType lhs, FabricType rhs);
 bool has_flag(FabricType flags, FabricType test_flag);
 
-enum class FabricReliabilityMode : uint32_t {
+enum class FabricReliabilityMode : std::uint8_t {
 
     // When fabric is initialized, user expects live links/devices to exactly match the mesh graph descriptor.
     // Any downed devices/links will result in some sort of error condition being reported.

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -39,7 +39,7 @@ struct ChipSpec {
     std::uint32_t num_z_ports;
 };
 
-enum class RoutingDirection {
+enum class RoutingDirection : std::uint8_t {
     N = 0,
     E = 1,
     S = 2,

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -32,7 +32,7 @@ class Program;
 
 class IGraphProcessor {
 public:
-    enum class RunMode {
+    enum class RunMode : std::uint8_t {
         NORMAL,      // running everything as is
         NO_DISPATCH  // don't do memory allocations and program runs.
     };

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -12,7 +12,7 @@ using DeviceAddr = std::uint64_t;
 
 enum class HalProcessorClassType : uint8_t { DM = 0, COMPUTE = 1 };
 
-enum class HalProgrammableCoreType { TENSIX = 0, ACTIVE_ETH = 1, IDLE_ETH = 2, COUNT = 3 };
+enum class HalProgrammableCoreType : std::uint8_t { TENSIX = 0, ACTIVE_ETH = 1, IDLE_ETH = 2, COUNT = 3 };
 
 static constexpr uint32_t NumHalProgrammableCoreTypes = static_cast<uint32_t>(HalProgrammableCoreType::COUNT);
 

--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/allocator.hpp>
 
 namespace tt::tt_metal {
-enum class BufferType;
+enum class BufferType : std::uint8_t;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -92,7 +92,7 @@ public:
     // Returns a neighbor along the given dimension.
     // `BoundaryMode` specifies how to handle coordinates that are out of bounds.
     // Negative offsets and dim are allowed, and the input coordinate must be within bounds.
-    enum class BoundaryMode { WRAP, CLAMP, NONE };
+    enum class BoundaryMode : std::uint8_t { WRAP, CLAMP, NONE };
 
     std::optional<MeshCoordinate> get_neighbor(
         const MeshShape& shape, int32_t offset, int32_t dim, BoundaryMode mode = BoundaryMode::WRAP) const;

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -9,9 +9,9 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerReadState { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_READ };
-enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
-enum class ProfilerDataBufferSource { L1, DRAM, DRAM_AND_L1 };
+enum class ProfilerReadState : std::uint8_t { NORMAL, ONLY_DISPATCH_CORES, LAST_FD_READ };
+enum class ProfilerSyncState : std::uint8_t { INIT, CLOSE_DEVICE };
+enum class ProfilerDataBufferSource : std::uint8_t { L1, DRAM, DRAM_AND_L1 };
 
 struct DeviceProgramId {
     uint32_t base_program_id = 0;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -111,7 +111,7 @@ struct KernelDescriptor {
         DataMovementConfigDescriptor,
         ComputeConfigDescriptor,
         EthernetConfigDescriptor>;
-    enum class SourceType { FILE_PATH, SOURCE_CODE };
+    enum class SourceType : std::uint8_t { FILE_PATH, SOURCE_CODE };
 
     std::string kernel_source;
     SourceType source_type = SourceType::FILE_PATH;

--- a/tt_metal/api/tt-metalium/tilize_utils.hpp
+++ b/tt_metal/api/tt-metalium/tilize_utils.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 #include <iosfwd>
 
-enum class TensorLayoutType {
+enum class TensorLayoutType : std::uint8_t {
     LIN_ROW_MAJOR = 0,   // standard element-wise row-major
     TILED_SWIZZLED = 1,  // row-major of tiles, each tile is row-major-swizzled
     TILED_NFACES = 2,    // row-major of tiles, each tile is N (N = 1, 2, or 4) faces, each face is

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -45,7 +45,7 @@
 namespace tt::tt_metal {
 class IDevice;
 class Kernel;
-enum class HalProgrammableCoreType;
+enum class HalProgrammableCoreType : std::uint8_t;
 }  // namespace tt::tt_metal
 
 namespace {

--- a/tt_metal/fabric/builder/connection_registry.hpp
+++ b/tt_metal/fabric/builder/connection_registry.hpp
@@ -14,11 +14,11 @@ namespace tt::tt_fabric {
 /**
  * ConnectionType - Categorizes the type of connection between routers
  */
-enum class ConnectionType {
+enum class ConnectionType : std::uint8_t {
     INVALID,
-    INTRA_MESH,   // Connection between mesh routers on different devices
-    MESH_TO_Z,    // Connection from mesh router to Z router (same device)
-    Z_TO_MESH,    // Connection from Z router to mesh router (same device)
+    INTRA_MESH,  // Connection between mesh routers on different devices
+    MESH_TO_Z,   // Connection from mesh router to Z router (same device)
+    Z_TO_MESH,   // Connection from Z router to mesh router (same device)
 };
 
 /**

--- a/tt_metal/fabric/builder/fabric_router_recipe.hpp
+++ b/tt_metal/fabric/builder/fabric_router_recipe.hpp
@@ -15,7 +15,7 @@ namespace tt::tt_fabric {
  * Types of channel pools supported by the fabric router.
  * Must match the enum in fabric_static_channels_ct_args.hpp
  */
-enum class FabricChannelPoolType : uint32_t {
+enum class FabricChannelPoolType : std::uint8_t {
     STATIC = 0,
     ELASTIC = 1,
 };

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1432,7 +1432,7 @@ void write_to_worker_or_fabric_tensix_cores(
         dispatch_mux_cores_translated = tensix_config.get_translated_dispatch_mux_cores();
     }
 
-    enum class CoreType { Worker, FabricTensixExtension, DispatcherMux };
+    enum class CoreType : std::uint8_t { Worker, FabricTensixExtension, DispatcherMux };
 
     auto get_core_type = [&](const CoreCoord& core_coord) -> CoreType {
         if (fabric_mux_cores_translated.find(core_coord) != fabric_mux_cores_translated.end()) {

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -31,7 +31,7 @@ namespace tt::tt_fabric {
 template <class>
 inline constexpr bool always_false_v = false;
 
-enum TerminationSignal : uint32_t {
+enum TerminationSignal : std::uint8_t {
     KEEP_RUNNING = 0,
 
     // Wait for messages to drain

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -24,7 +24,7 @@
 namespace tt::tt_fabric {
 
 // Core type enum for fabric tensix datamover (identifies MUX vs RELAY cores)
-enum class FabricTensixCoreType : uint32_t {
+enum class FabricTensixCoreType : std::uint8_t {
     MUX = 0,   // BRISC - runs MUX kernel
     RELAY = 1  // NCRISC - runs Relay kernel (UDM mode only)
 };

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -22,7 +22,7 @@
 namespace tt::tt_fabric {
 
 // Forward declarations
-enum class FabricTensixCoreType : uint32_t;
+enum class FabricTensixCoreType : std::uint8_t;
 
 // Shared struct for mux/relay connection info (used by both mux→mux and relay→mux connections)
 struct MuxConnectionInfo {
@@ -39,7 +39,7 @@ struct MuxConnectionInfo {
     size_t stream_id;                    // Receiver mux's stream ID for credit tracking
 };
 
-enum class ChannelTypes : uint32_t {
+enum class ChannelTypes : std::uint8_t {
     WORKER_CHANNEL = 0,
     ROUTER_CHANNEL = 1,
     RELAY_TO_MUX_CHANNEL = 2,
@@ -47,14 +47,14 @@ enum class ChannelTypes : uint32_t {
     NUM_CHANNEL_TYPES = 4
 };
 
-enum class UdmMuxRelayToMuxChannelId : uint32_t {
+enum class UdmMuxRelayToMuxChannelId : std::uint8_t {
     LOCAL_RELAY_CHANNEL = 0,          // Relay connects to mux on this channel
     EAST_OR_NORTH_RELAY_CHANNEL = 1,  // Upstream East or North Relay connects to mux on this channel
     WEST_OR_SOUTH_RELAY_CHANNEL = 2,  // Upstream West or South Relay connects to mux on this channel
     NUM_CHANNELS = 3
 };
 
-enum class UdmMuxInterMuxChannelId : uint32_t {
+enum class UdmMuxInterMuxChannelId : std::uint8_t {
     // ==================================================================================
     // Inter-Mux channels
     // Used for forwarding local fabric requests to the correct router endpoint
@@ -86,7 +86,7 @@ enum class UdmMuxInterMuxChannelId : uint32_t {
  * UDM Mode Relay Channel Assignments
  * - Relay has only one channel for upstream fabric router traffic
  */
-enum class UdmRelayChannelId : uint32_t {
+enum class UdmRelayChannelId : std::uint8_t {
     ROUTER_CHANNEL = 0,  // Upstream fabric router connects to relay on this channel
     NUM_CHANNELS = 1
 };
@@ -94,7 +94,7 @@ enum class UdmRelayChannelId : uint32_t {
 /**
  * NoC Assignment for mux and relay
  */
-enum class UdmNoCSelection : uint32_t {
+enum class UdmNoCSelection : std::uint8_t {
     mux_noc = 0,
     relay_noc = 1  // this should be the same as edm_to_local_chip_noc, need to have it in some common files between
                    // host and device.

--- a/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/telemetry/code_profiling_types.hpp
@@ -10,7 +10,7 @@
  * @brief Enumeration of code profiling timer types as bitfield
  * Each timer type is a unique bit position, allowing multiple timers to be enabled simultaneously
  */
-enum class CodeProfilingTimerType : uint32_t {
+enum class CodeProfilingTimerType : std::uint8_t {
     NONE = 0,
     RECEIVER_CHANNEL_FORWARD = 1 << 0,
     // Future timers can be added here:

--- a/tt_metal/fabric/hw/inc/tt_fabric_status.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_status.h
@@ -39,7 +39,7 @@ constexpr uint32_t TX_TEST_IDX_ZERO_DATA_WORDS_SENT_ITER = TT_FABRIC_MISC_INDEX 
 // constexpr uint32_t TX_TEST_IDX_ = TT_FABRIC_MISC_INDEX + ;
 // constexpr uint32_t TX_TEST_IDX_ = TT_FABRIC_MISC_INDEX + ;
 
-enum class pkt_dest_size_choices_t {
+enum class pkt_dest_size_choices_t : std::uint8_t {
     RANDOM = 0,
     SAME_START_RNDROBIN_FIX_SIZE = 1  // max packet size used
 };

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -122,7 +122,7 @@ struct TileSliceHostDev {
     uint8_t data[MAX_BYTES];
 } ATTR_PACK;
 
-enum dprint_tileslice_return_code_enum {
+enum dprint_tileslice_return_code_enum : std::uint8_t {
     DPrintOK = 2,
     DPrintErrorBadTileIdx = 3,
     DPrintErrorBadPointer = 4,
@@ -130,7 +130,7 @@ enum dprint_tileslice_return_code_enum {
     DPrintErrorMath = 6,
     DPrintErrorEthernet = 7,
 };
-enum TypedU32_ARRAY_Format {
+enum TypedU32_ARRAY_Format : std::uint8_t {
     TypedU32_ARRAY_Format_INVALID,
 
     TypedU32_ARRAY_Format_Raw,                                      // A raw uint32_t array

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -14,7 +14,7 @@ namespace kernel_profiler {
 
 static constexpr int SUM_COUNT = 2;
 
-enum BufferIndex {
+enum BufferIndex : std::uint8_t {
     ID_HH,
     ID_HL,
     ID_LH,
@@ -30,7 +30,7 @@ enum BufferIndex {
     CUSTOM_MARKERS
 };
 
-enum ControlBuffer {
+enum ControlBuffer : std::uint8_t {
     HOST_BUFFER_END_INDEX_BR_ER,
     HOST_BUFFER_END_INDEX_NC,
     HOST_BUFFER_END_INDEX_T0,
@@ -54,7 +54,7 @@ enum ControlBuffer {
     TRACE_REPLAY_STATUS
 };
 
-enum PacketTypes { ZONE_START, ZONE_END, ZONE_TOTAL, TS_DATA, TS_EVENT };
+enum PacketTypes : std::uint8_t { ZONE_START, ZONE_END, ZONE_TOTAL, TS_DATA, TS_EVENT };
 
 // TODO: use data types in profile_msg_t rather than addresses/sizes
 constexpr static std::uint32_t PROFILER_L1_CONTROL_VECTOR_SIZE = 32;

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -104,12 +104,12 @@ struct ncrisc_halt_msg_t {
     volatile uint32_t stack_save;
 };
 
-enum dispatch_mode {
+enum dispatch_mode : uint8_t {
     DISPATCH_MODE_DEV,
     DISPATCH_MODE_HOST,
 };
 
-enum noc_index {
+enum noc_index : uint8_t {
     NOC_0 = 0,
     NOC_1 = 1,
 };
@@ -230,7 +230,7 @@ struct debug_insert_delays_msg_t {
     volatile uint32_t feedback = 0;                     // Stores the feedback about delays (used for testing)
 };
 
-enum debug_sanitize_noc_return_code_enum {
+enum debug_sanitize_noc_return_code_enum : uint8_t {
     // 0 and 1 are a common stray values to write, so don't use those
     DebugSanitizeOK = 2,
     DebugSanitizeNocAddrUnderflow = 3,
@@ -253,7 +253,7 @@ struct debug_assert_msg_t {
     volatile uint8_t which;
 };
 
-enum debug_assert_type_t {
+enum debug_assert_type_t : uint8_t {
     DebugAssertOK = 2,
     DebugAssertTripped = 3,
     DebugAssertNCriscNOCReadsFlushedTripped = 4,
@@ -262,7 +262,12 @@ enum debug_assert_type_t {
     DebugAssertNCriscNOCPostedWritesSentTripped = 7
 };
 
-enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };
+enum debug_transaction_type_t : uint8_t {
+    TransactionRead = 0,
+    TransactionWrite = 1,
+    TransactionAtomic = 2,
+    TransactionNumTypes
+};
 
 struct debug_pause_msg_t {
     volatile uint8_t flags[MaxProcessorsPerCoreType];
@@ -292,7 +297,7 @@ struct debug_eth_link_t {
     volatile uint8_t link_down;
 };
 
-enum watcher_enable_msg_t {
+enum watcher_enable_msg_t : uint8_t {
     WatcherDisabled = 2,
     WatcherEnabled = 3,
 };

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -25,7 +25,7 @@ namespace tt::tt_metal::allocator {
 // - Metadata reuse to avoid allocations
 class FreeListOpt : public Algorithm {
 public:
-    enum class SearchPolicy {
+    enum class SearchPolicy : std::uint8_t {
         FIRST,
         BEST,
     };

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -14,7 +14,7 @@
 namespace tt::tt_metal {
 
 // Setup what each core-type is
-enum class AllocCoreType {
+enum class AllocCoreType : std::uint8_t {
     Dispatch,
     ComputeOnly,
     ComputeAndStore,

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/allocator_state.hpp>
 
 namespace tt::tt_metal {
-enum class BufferType;
+enum class BufferType : std::uint8_t;
 namespace allocator {
 class Algorithm;
 }  // namespace allocator

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -21,7 +21,7 @@
 
 namespace tt::tt_metal {
 class IDevice;
-enum class TensorMemoryLayout;
+enum class TensorMemoryLayout : std::uint8_t;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -16,7 +16,7 @@ class Program;
 struct KernelGroup;
 }  // namespace tt_metal
 
-enum data_collector_t {
+enum data_collector_t : std::uint8_t {
     DISPATCH_DATA_CB_CONFIG,
     DISPATCH_DATA_SEMAPHORE,
     DISPATCH_DATA_RTARGS,

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -548,7 +548,7 @@ void dump_issue_queue_entries(
 }
 
 // Define a queue type, for when they're interchangeable.
-enum cq_queue_t { CQ_COMPLETION_QUEUE = 0, CQ_ISSUE_QUEUE = 1 };
+enum cq_queue_t : std::uint8_t { CQ_COMPLETION_QUEUE = 0, CQ_ISSUE_QUEUE = 1 };
 
 void dump_command_queue_raw_data(
     std::ofstream& out_file,

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -22,7 +22,7 @@ struct Event;
 class Trace;
 
 // Only contains the types of commands which are enqueued onto the device
-enum class EnqueueCommandType {
+enum class EnqueueCommandType : std::uint8_t {
     ENQUEUE_READ_BUFFER,
     ENQUEUE_WRITE_BUFFER,
     GET_BUF_ADDR,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -24,7 +24,7 @@ namespace tt::tt_metal {
 
 class IDevice;
 class Program;
-enum DispatchWorkerType : uint32_t;
+enum DispatchWorkerType : std::uint8_t;
 enum NOC : uint8_t;
 
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
@@ -36,7 +36,7 @@ struct noc_selection_t {
     tt::tt_metal::NOC downstream_noc;    // For communicating with downstream dispatch modules
 };
 
-enum class FDKernelType : uint32_t {
+enum class FDKernelType : std::uint8_t {
     UNSET = 0,
     VIRTUAL,   // Not a real kernel
     DISPATCH,  // Dispatch kernels

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -243,7 +243,7 @@ constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE = 0x02;
 
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT = 4;
-enum CQDispatchCmdPackedWriteType {
+enum CQDispatchCmdPackedWriteType : std::uint8_t {
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK = 0xf << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_RTA = 0x1 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH = 0x2 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
@@ -294,7 +294,7 @@ get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cm
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS = 35;
 
-enum CQDispatchCmdPackedWriteLargeType {
+enum CQDispatchCmdPackedWriteLargeType : std::uint8_t {
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_UNKNOWN = 0,
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS = 1,
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_PROGRAM_BINARIES = 2,

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -18,7 +18,7 @@
 namespace tt::tt_metal {
 
 class IDevice;
-enum DispatchWorkerType : uint32_t;
+enum DispatchWorkerType : std::uint8_t;
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
 // is required when setting up Command Queue objects on host.

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -14,7 +14,7 @@
 #include <tt-logger/tt-logger.hpp>
 
 namespace tt::tt_metal {
-enum class HalProgrammableCoreType;
+enum class HalProgrammableCoreType : std::uint8_t;
 
 constexpr uint32_t kernel_config_entry_count = 8;
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -22,7 +22,7 @@
 namespace tt::tt_metal {
 
 struct KernelSource {
-    enum SourceType { FILE_PATH, SOURCE_CODE };
+    enum SourceType : std::uint8_t { FILE_PATH, SOURCE_CODE };
 
     std::string source_;
     SourceType source_type_;

--- a/tt_metal/impl/profiler/profiler_analysis.hpp
+++ b/tt_metal/impl/profiler/profiler_analysis.hpp
@@ -17,9 +17,9 @@
 
 namespace tt::tt_metal {
 
-enum class AnalysisType { PROGRAM_FIRST_TO_LAST_MARKER };
+enum class AnalysisType : std::uint8_t { PROGRAM_FIRST_TO_LAST_MARKER };
 
-enum class AnalysisDimension { PROGRAM };
+enum class AnalysisDimension : std::uint8_t { PROGRAM };
 
 using AnalysisRiscTypes = std::unordered_set<tracy::RiscType>;
 inline const AnalysisRiscTypes AnalysisRiscTypesAny = {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -92,7 +92,7 @@ struct CommandConstants {
     uint32_t packed_write_max_unicast_sub_cmds;
 };
 
-enum DispatchWriteOffsets {
+enum DispatchWriteOffsets : std::uint8_t {
     DISPATCH_WRITE_OFFSET_ZERO = 0,
     DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
     DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE = 2,

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -52,7 +52,7 @@ class MeshWorkload;
 class MeshWorkloadImpl;
 }  // namespace distributed
 
-enum dispatch_core_processor_classes {
+enum dispatch_core_processor_classes : std::uint8_t {
     // Tensix processor classes
     DISPATCH_CLASS_TENSIX_DM0 = 0,
     DISPATCH_CLASS_TENSIX_DM1 = 1,

--- a/tt_metal/jit_build/depend.cpp
+++ b/tt_metal/jit_build/depend.cpp
@@ -18,7 +18,7 @@ namespace tt::jit_build {
 // dep_file = { target ':' { dep } { '\' '\n' { dep } } '\n' }
 ParsedDependencies parse_dependency_file(std::istream& file) {
     ParsedDependencies dependencies;
-    enum class ParseState { Target, Dependencies };
+    enum class ParseState : std::uint8_t { Target, Dependencies };
     ParseState state = ParseState::Target;
     std::string line;
     std::vector<std::string>* current_deps = nullptr;

--- a/tt_metal/llrt/hal/codegen/codegen.py
+++ b/tt_metal/llrt/hal/codegen/codegen.py
@@ -205,7 +205,8 @@ class CodeGen:
             print(enum)
         for struct in self.structs:
             print(
-                f"struct {struct.name} : {self.driver_ns}::StructBuffer<{struct.name}> {{\n" "enum class Field {",
+                f"struct {struct.name} : {self.driver_ns}::StructBuffer<{struct.name}> {{\n"
+                "enum class Field : uint8_t {",
                 end=" ",
             )
             print(*[field.name for field in struct.fields], sep=", ")

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -37,7 +37,7 @@ const char* RunTimeDebugClassNames[RunTimeDebugClassCount] = {"N/A", "worker", "
 // ENVIRONMENT VARIABLE IDs
 // ============================================================================
 // Full definition of EnvVarID enum (forward-declared in rtoptions.hpp)
-enum class EnvVarID {
+enum class EnvVarID : std::uint8_t {
     // ========================================
     // PATH CONFIGURATION
     // ========================================

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -29,14 +29,14 @@
 
 namespace tt::llrt {
 // Forward declaration - full definition in rtoptions.cpp
-enum class EnvVarID;
+enum class EnvVarID : std::uint8_t;
 
 inline std::string g_root_dir;
 inline std::once_flag g_root_once;
 
 // Enumerates the debug features that can be enabled at runtime. These features allow for
 // fine-grained control over targeted cores, chips, harts, etc.
-enum RunTimeDebugFeatures {
+enum RunTimeDebugFeatures : std::uint8_t {
     RunTimeDebugFeatureDprint,
     RunTimeDebugFeatureReadDebugDelay,
     RunTimeDebugFeatureWriteDebugDelay,
@@ -47,7 +47,7 @@ enum RunTimeDebugFeatures {
 };
 
 // Enumerates a class of cores to enable features on at runtime.
-enum RunTimeDebugClass {
+enum RunTimeDebugClass : std::uint8_t {
     RunTimeDebugClassNoneSpecified,
     RunTimeDebugClassWorker,
     RunTimeDebugClassDispatch,

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -53,7 +53,7 @@ using tt_target_dram = std::tuple<int, int, int>;
 
 namespace tt {
 
-enum class EthRouterMode : uint32_t {
+enum class EthRouterMode : std::uint8_t {
     IDLE = 0,
     FABRIC_ROUTER = 1,
 };

--- a/tt_metal/logging/logging.cpp
+++ b/tt_metal/logging/logging.cpp
@@ -17,7 +17,7 @@ namespace tt::tt_metal::logging {
  * verbose (trace) to most severe (critical), with an option to disable
  * logging completely (off).
  */
-enum class level {
+enum class level : std::uint8_t {
     trace,     ///< Most detailed logging level, for tracing program execution
     debug,     ///< Debugging information, useful during development
     info,      ///< General informational messages about program operation

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -60,7 +60,7 @@
 #include <experimental/fabric/control_plane.hpp>
 
 namespace tt::tt_metal {
-enum class FabricConfig : uint32_t;
+enum class FabricConfig : std::uint8_t;
 struct RuntimeArgsData;
 struct TraceDescriptor;
 

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -26,7 +26,7 @@ using json = nlohmann::json;
 
 namespace tt::tt_metal::op_profiler {
 
-enum class OpType { python_fallback, tt_dnn_cpu, tt_dnn_device, unknown };
+enum class OpType : std::uint8_t { python_fallback, tt_dnn_cpu, tt_dnn_device, unknown };
 
 #if defined(TRACY_ENABLE)
 class thread_safe_cached_ops_map {

--- a/ttnn/api/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/api/ttnn/graph/graph_trace_utils.hpp
@@ -23,7 +23,7 @@ struct PeakMemoryUsagePerCore {
     size_t peak_total = 0;
 };
 
-enum class ExecutionStatus { Success, Error };
+enum class ExecutionStatus : std::uint8_t { Success, Error };
 
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 

--- a/ttnn/api/ttnn/tensor/layout/layout.hpp
+++ b/ttnn/api/ttnn/tensor/layout/layout.hpp
@@ -8,7 +8,7 @@
 
 namespace tt::tt_metal {
 
-enum class Layout { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
+enum class Layout : std::uint8_t { ROW_MAJOR = 0, TILE = 1, INVALID = 2 };
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Layout& layout);
 

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -220,13 +220,13 @@ Tensor unpad(
 
 std::ostream& operator<<(std::ostream& os, const DataType& dtype);
 
-enum class TensorPrintProfile {
+enum class TensorPrintProfile : std::uint8_t {
     Empty,
     Short,
     Full,
 };
 
-enum class SciMode {
+enum class SciMode : std::uint8_t {
     Enable,
     Disable,
     Default,

--- a/ttnn/api/ttnn/tensor/tensor_spec.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_spec.hpp
@@ -57,7 +57,7 @@ public:
     /// corresponding core in 2D grid.
     TensorSpec block_sharded(CoreRange grid, ShardOrientation orientation = ShardOrientation::ROW_MAJOR) const;
 
-    enum class ShardShapeAlignment {
+    enum class ShardShapeAlignment : std::uint8_t {
         /// No shard shape alignment will be performed. If the shard shape is not following the alignment requirements,
         /// an exception will be thrown.
         NONE,

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -26,7 +26,7 @@ namespace tt::tt_metal {
 
 static constexpr std::uint8_t VERSION_ID = 5;
 
-enum class DataType {
+enum class DataType : std::uint8_t {
     BFLOAT16 = 0,
     FLOAT32 = 1,
     UINT32 = 2,
@@ -64,7 +64,7 @@ bool is_floating_point(DataType dtype);
 bool is_block_float(DataType dtype);
 
 // Specifies Tensor storage type.
-enum class StorageType {
+enum class StorageType : std::uint8_t {
     HOST = 0,
     DEVICE = 1,
 };

--- a/ttnn/core/distributed/distribution_mode.hpp
+++ b/ttnn/core/distributed/distribution_mode.hpp
@@ -12,7 +12,7 @@
 namespace ttnn::distributed {
 
 // Specifies how a tensor sharded over a specific shape will be distributed to a mesh device
-enum class DistributionMode {
+enum class DistributionMode : std::uint8_t {
     // Tensor shards will be distributed in row-major order over a mesh device.
     ROW_MAJOR,
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -32,7 +32,7 @@ std::pair<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_cb_sizes(
 }  // namespace detail
 
 struct AllToAllDispatchDeviceOperation {
-    enum AllToAllTransferType {
+    enum AllToAllTransferType : std::uint8_t {
         FullPacket,  // All pages are sent to the intermediate buffer and then written to the output buffer later
         PageByPage,  // Each page is sent directly to the output buffer to conserve L1 space via intermediates
     };

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -20,7 +20,7 @@ struct CoreSemPair {
     CoreSemPair(CoreCoord core, uint32_t sem_id) : core(core), sem_id(sem_id) {}
 };
 
-enum class FusedOpSignalerMode {
+enum class FusedOpSignalerMode : std::uint8_t {
     // When signaling the fused op, only one core is signaled
     // when a tensor slice is ready to be processed by the fused op
     SINGLE,
@@ -119,7 +119,7 @@ struct ReduceScatterFusedOpSignaler {
     void push_reduce_scatter_fused_op_rt_args(std::vector<uint32_t>& out_rt_args);
 };
 
-enum class MatmulFusedOpSignalerType {
+enum class MatmulFusedOpSignalerType : std::uint8_t {
     ALL_GATHER,
     REDUCE_SCATTER,
     EMPTY,

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -40,7 +40,7 @@ std::pair<std::vector<ttnn::MeshCoordinate>, std::array<bool, 4>> get_neighbors(
     const std::optional<uint32_t> axis) {
     // For readability use symbolic indices instead of raw numbers when accessing the
     // `directions` array `{East, West, North, South}`.
-    enum Direction : std::size_t { East = 0, West = 1, North = 2, South = 3 };
+    enum Direction : std::uint8_t { East = 0, West = 1, North = 2, South = 3 };
     auto boundary_mode = detail::get_boundary_mode(topology);
 
     std::vector<ttnn::MeshCoordinate> neighbors;

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/sharding_common.hpp
@@ -10,7 +10,7 @@
 
 namespace shard_addr_gen_consts {
 
-enum class ContiguityType {
+enum class ContiguityType : std::uint8_t {
     // Indicates logical sharding placed padding between pages so no contiguous pages exist
     L1_PADDING_BETWEEN_PAGES = 0,
     // Indicates some padding exists in the rightmost shard since the pages did not divide evenly into shards

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -26,16 +26,16 @@
 
 namespace ttnn::ccl {
 
-enum EriscDataMoverBufferSharingMode : uint32_t {
+enum EriscDataMoverBufferSharingMode : std::uint8_t {
     NOT_SHARED = 0,
     ROUND_ROBIN = 1,
     SHARED = 2,
     ROUND_ROBIN_AND_SHARED = 3
 };
 
-enum EriscDataMoverTerminationMode : uint32_t { MESSAGE_COUNT_REACHED = 0, WORKER_INITIATED = 1 };
+enum EriscDataMoverTerminationMode : std::uint8_t { MESSAGE_COUNT_REACHED = 0, WORKER_INITIATED = 1 };
 
-enum EriscDataMoverWorkerSignal : uint32_t {
+enum EriscDataMoverWorkerSignal : std::uint8_t {
     NEXT_MESSAGE_AVAILABLE = 1,
     NEXT_MESSAGE_IS_LAST = 2,
     TERMINATE_IMMEDIATELY = 3,

--- a/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/compute_throttle_utils.hpp
@@ -10,7 +10,7 @@
 
 namespace ttnn::operations::compute_throttle_utils {
 
-enum class ThrottleLevel : uint32_t {
+enum class ThrottleLevel : std::uint8_t {
     NO_THROTTLE = 0,
     LEVEL_1 = 1,
     LEVEL_2 = 2,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -429,7 +429,7 @@ ResultWithOptions result_to_result_with_options(
 }
 
 // Enum to represent the execution path for conv2d operations
-enum class Conv2dExecutionPath {
+enum class Conv2dExecutionPath : std::uint8_t {
     L1,   // Execute conv2d using L1 memory
     DRAM  // Execute conv2d using DRAM slicing
 };

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -20,7 +20,7 @@ namespace ttnn::operations::conv::conv2d {
 constexpr static uint32_t kInvalidCBIndex = 32;
 
 // List of all circular buffers used in Conv2d operations.
-enum class Conv2dCb {
+enum class Conv2dCb : std::uint8_t {
     ACT_SHARDED,
     ACT,
     ACT_ROW_MAJOR_BFLOAT16,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -167,7 +167,12 @@ struct Conv2dConfig {
 };
 
 // TODO: Accept parallelization
-enum class Conv2dOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_REUSE, MULTI_CORE_REUSE_MCAST, SINGLE_CORE };
+enum class Conv2dOpParallelizationStrategy : std::uint8_t {
+    MULTI_CORE,
+    MULTI_CORE_REUSE,
+    MULTI_CORE_REUSE_MCAST,
+    SINGLE_CORE
+};
 
 struct Conv2dParallelizationConfig {
     CoreCoord grid_size;  // (x,y)

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -571,7 +571,7 @@ Result conv_transpose2d_DRAM(
 }
 
 // Enum to represent the execution path for conv2d operations
-enum class ConvT2dExecutionPath {
+enum class ConvT2dExecutionPath : std::uint8_t {
     L1,   // Execute conv2d using L1 memory
     DRAM  // Execute conv2d using DRAM slicing
 };

--- a/ttnn/cpp/ttnn/operations/conv/conv_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_types.hpp
@@ -8,5 +8,5 @@ namespace ttnn::operations::conv {
 // Enum to specify the type of result to be returned, std::get is used to extract the value from the variant
 //
 // The enum values are used to index into the ResultWithOptions variant
-enum class ResultType { OUTPUT = 0, OUTPUT_DIM, OUTPUT_WEIGHTS_AND_BIAS, OUTPUT_DIM_WEIGHTS_AND_BIAS };
+enum class ResultType : std::uint8_t { OUTPUT = 0, OUTPUT_DIM, OUTPUT_WEIGHTS_AND_BIAS, OUTPUT_DIM_WEIGHTS_AND_BIAS };
 }  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast_types.hpp
@@ -9,8 +9,8 @@
 
 namespace ttnn {
 
-enum class BcastOpMath { ADD, SUB, MUL };
-enum class BcastOpDim { H, W, HW };
+enum class BcastOpMath : std::uint8_t { ADD, SUB, MUL };
+enum class BcastOpDim : std::uint8_t { H, W, HW };
 
 namespace bcast_op_utils {
 std::map<std::string, std::string> get_defines(ttnn::BcastOpDim bcast_dim, ttnn::BcastOpMath bcast_math);

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -80,7 +80,7 @@ ttnn::Shape squeeze_or_unsqueeze_shape_to_ND(const ttnn::Shape& shape, const uin
     }
 }
 
-enum DatumIndex { WormholeIndex = 0, BlackholeIndex = 1 };
+enum DatumIndex : std::uint8_t { WormholeIndex = 0, BlackholeIndex = 1 };
 
 float get_transaction_noc_bw(
     uint32_t transaction_size, const std::map<uint32_t, std::array<float, 2>>& dict, int index) {

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -206,7 +206,7 @@ ttnn::Shape compute_padded_shape(
  */
 ttnn::Shape pad_to_tile_shape(const ttnn::Shape& unpadded_shape);
 
-enum class ShardStrategy { BLOCK, HEIGHT, WIDTH };
+enum class ShardStrategy : std::uint8_t { BLOCK, HEIGHT, WIDTH };
 
 // Helper function for creating a sharded memory configuration for a tensor
 // based on its logical shape, a shard strategy and orientation, and a core

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
@@ -9,7 +9,7 @@
 
 namespace ttnn::operations::data_movement::move {
 
-enum class MoveOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_OVERLAP, MULTI_CORE_SHARDED };
+enum class MoveOpParallelizationStrategy : std::uint8_t { MULTI_CORE, MULTI_CORE_OVERLAP, MULTI_CORE_SHARDED };
 
 // Operation attributes - non-tensor parameters
 struct operation_attributes_t {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.hpp
@@ -10,7 +10,7 @@
 
 namespace ttnn {
 
-enum class TileReshapeMapMode {
+enum class TileReshapeMapMode : std::uint8_t {
     CACHE,
     RECREATE,
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -49,7 +49,7 @@ struct CorePageStride {
     PageStride page_stride;
 };
 
-enum class ReshardStridesInRange { ALL_STRIDES, FIRST_HALF, SECOND_HALF };
+enum class ReshardStridesInRange : std::uint8_t { ALL_STRIDES, FIRST_HALF, SECOND_HALF };
 
 std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_reshard(
     std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation_types.hpp
@@ -7,9 +7,9 @@
 
 namespace ttnn::operations::data_movement::transpose {
 
-enum class TransposeOpDim { WH, HC, CN, NH, NW, CW };
+enum class TransposeOpDim : std::uint8_t { WH, HC, CN, NH, NW, CW };
 
-enum class TransposeOpParallelizationStrategy { MULTI_CORE_WH, MULTI_CORE_HC, MULTI_CORE_CN };
+enum class TransposeOpParallelizationStrategy : std::uint8_t { MULTI_CORE_WH, MULTI_CORE_HC, MULTI_CORE_CN };
 
 struct operation_attributes_t {
     TransposeOpDim dim{};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace ttnn::operations::binary {
 
-enum class BinaryOpType {
+enum class BinaryOpType : std::uint8_t {
     ADD,
     SUB,
     MUL,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.hpp
@@ -11,7 +11,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace tt::tt_metal {
-enum class DataType;
+enum class DataType : std::uint8_t;
 }
 
 namespace ttnn::operations::binary::utils {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::operations::binary {
 
-enum class BinaryCompositeOpType {
+enum class BinaryCompositeOpType : std::uint8_t {
     NEXTAFTER,
     ISCLOSE,
     ATAN2,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -11,7 +11,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 namespace ttnn::operations::binary_ng {
 
-enum class SubtileBroadcastType {
+enum class SubtileBroadcastType : std::uint8_t {
     NONE,         // both tensors have equal tile dimensions (H & W)
     SCALAR_A,     // a is a scalar (H = 1, W = 1)
     SCALAR_B,     // b is a scalar (H = 1, W = 1)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -13,7 +13,7 @@
 
 namespace ttnn::operations::binary_ng {
 
-enum class KernelName {
+enum class KernelName : std::uint8_t {
     ReaderNoBcast,
     WriterScalar,
     ComputeNoBcast,
@@ -43,8 +43,8 @@ struct BinaryNgKernelConfig {
 std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu, bool is_where_op);
 
 struct OpConfig {
-    enum class FpuBinaryOp { ADD, SUB, MUL };
-    enum class SfpuBinaryOp {
+    enum class FpuBinaryOp : std::uint8_t { ADD, SUB, MUL };
+    enum class SfpuBinaryOp : std::uint8_t {
         ADD,
         SUB,
         MUL,

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::complex_binary {
 
-enum class ComplexBinaryOpType {
+enum class ComplexBinaryOpType : std::uint8_t {
     ADD,
     SUB,
     MUL,

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::complex_unary {
 
-enum class ComplexUnaryOpType {
+enum class ComplexUnaryOpType : std::uint8_t {
     REAL,
     IMAG,
     ANGLE,

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::complex_unary_backward {
 
-enum class ComplexUnaryBackwardOpType {
+enum class ComplexUnaryBackwardOpType : std::uint8_t {
     POLAR_BW,
     IMAG_BW,
     REAL_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
@@ -14,14 +14,14 @@ namespace ttnn::operations::ternary {
 using TensorScalarVariant = std::variant<float, int, Tensor>;
 
 // Ternary operation types
-enum class TernaryOpType {
+enum class TernaryOpType : std::uint8_t {
     WHERE,    // conditional selection: out = predicate ? value_true : value_false
     LERP,     // linear interpolation: out = input + weight * (end - input)
     ADDCMUL,  // fused multiply-add: out = input_a + value * input_b * input_c
 };
 
 // Variant types for ternary operations
-enum class TernaryVariant {
+enum class TernaryVariant : std::uint8_t {
     TTT,  // tensor-tensor-tensor
     TTS,  // tensor-tensor-scalar
     TST,  // tensor-scalar-tensor
@@ -29,7 +29,7 @@ enum class TernaryVariant {
 };
 
 // Broadcast types for ternary operations
-enum class TernaryBroadcastType {
+enum class TernaryBroadcastType : std::uint8_t {
     NONE,
     OUTER_BCAST,     // bcast for outer dims -5, -4, -3, no subtile bcast.
     COL_BCAST,       // bcast for W-dim and outer dims -5, -4, -3.

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -13,7 +13,7 @@
 
 namespace ttnn::operations::ternary {
 
-enum class KernelName {
+enum class KernelName : std::uint8_t {
     ReaderNoBcastTTT,
     ReaderNoBcastTST,
     ReaderNoBcastTTS,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
@@ -19,7 +19,7 @@
 
 namespace ttnn::operations::ternary {
 
-enum class TernaryCompositeOpType {
+enum class TernaryCompositeOpType : std::uint8_t {
     ADDCMUL,
     ADDCDIV,
     LERP,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -10,7 +10,7 @@
 namespace ttnn::operations::unary {
 
 // These operations have a corresponding LLK available
-enum class UnaryOpType {
+enum class UnaryOpType : std::uint8_t {
     EXP,
     RECIP,
     GELU,
@@ -124,7 +124,7 @@ enum class UnaryOpType {
     LOGIT,
 };
 
-enum class VecMode {
+enum class VecMode : std::uint8_t {
     None = 0,
     R = 1,
     C = 2,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -12,7 +12,7 @@
 
 namespace ttnn::operations::unary {
 
-enum class UnaryCompositeOpType {
+enum class UnaryCompositeOpType : std::uint8_t {
     DIGAMMA,
     LGAMMA,
     MULTIGAMMALN,

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation_types.hpp
@@ -8,8 +8,8 @@
 
 namespace ttnn::operations::embedding {
 
-enum class EmbeddingsType { GENERIC, PADDED, BINARY };
-enum class EmbeddingsIndexType { UINT32, BFP16 };
+enum class EmbeddingsType : std::uint8_t { GENERIC, PADDED, BINARY };
+enum class EmbeddingsIndexType : std::uint8_t { UINT32, BFP16 };
 
 struct operation_attributes_t {
     tt::tt_metal::MemoryConfig output_mem_config;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.hpp
@@ -13,7 +13,7 @@
 #include "ttnn/tensor/shape/shape.hpp"
 
 namespace ttnn::operations::experimental::broadcast_to {
-enum class SubtileBroadcastType {
+enum class SubtileBroadcastType : std::uint8_t {
     NONE,    // both tensors have equal tile dimensions (H & W)
     SCALAR,  // input is a scalar (H = 1, W = 1)
     ROW,     // input has a single tile row

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_utils.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::experimental::broadcast_to {
 
-enum class KernelName {
+enum class KernelName : std::uint8_t {
     ReaderNoBcast,
     ReaderRowBcast,
     ReaderColBcast,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -25,7 +25,7 @@ namespace ttnn {
 
 using ccl::EriscDatamoverBuilder;
 
-enum class AllGatherAsyncVersion {
+enum class AllGatherAsyncVersion : std::uint8_t {
     LLAMA_MINIMAL_SHARDED = 0,
     MINIMAL_DEFAULT = 1,
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion_program_factory.cpp
@@ -24,7 +24,7 @@ using ttnn::operations::unary::UnaryWithParam;
 
 namespace llama_agmm_fusion_helpers {
 
-enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+enum class CORE_TYPE : std::uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
 ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t
 process_agmm_fusion_program_and_create_override_variables(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -18,7 +18,7 @@ namespace {
 using namespace tt::tt_metal;
 using namespace tt::stl;
 
-enum class IntImgCB : uint32_t {
+enum class IntImgCB : std::uint8_t {
     START,
     INPUT,
     ACC,

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation_types.hpp
@@ -8,9 +8,9 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::kv_cache {
-enum class UpdateCacheOpParallelizationStrategy { MULTI_CORE };
+enum class UpdateCacheOpParallelizationStrategy : std::uint8_t { MULTI_CORE };
 
-enum class UpdateCacheOpType { FILL, UPDATE };
+enum class UpdateCacheOpType : std::uint8_t { FILL, UPDATE };
 
 struct operation_attributes_t {
     uint32_t batch_idx = 0;

--- a/ttnn/cpp/ttnn/operations/loss/loss_types.hpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace ttnn::operations::loss {
 
 // /**
@@ -14,14 +16,14 @@ namespace ttnn::operations::loss {
 //  * NLL: https://pytorch.org/docs/stable/generated/torch.nn.NLLLoss.html#torch.nn.NLLLoss
 // */
 
-enum class LossFunction {
+enum class LossFunction : std::uint8_t {
     MSE,  // Mean Squared Error - squared L2 norm
     MAE,  // Mean Absolute Error - L1 norm
     CEL,  // Cross Entropy Loss
     NLL,  // Negative Log Likelihood -
 };
 
-enum class LossReductionMode {
+enum class LossReductionMode : std::uint8_t {
     NONE,
     MEAN,
     SUM,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -17,7 +17,7 @@ namespace ttnn::operations::matmul {
 
 // shared variables between override and program
 
-enum class Matmul1DType { MCAST_IN0, GATHER_IN0, MCAST_IN1 };
+enum class Matmul1DType : std::uint8_t { MCAST_IN0, GATHER_IN0, MCAST_IN1 };
 
 struct matmul_mcast_1d_common_override_variables_t {
     std::vector<tt::tt_metal::KernelHandle> kernels;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1720,7 +1720,7 @@ process_mcast_in1_program_and_create_override_variables(
         ttnn::operations::matmul::Matmul1DType::MCAST_IN1};
 }
 
-enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
+enum class CORE_TYPE : std::uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
 ttnn::operations::matmul::matmul_mcast_1d_common_override_variables_t
 process_gather_in0_program_and_create_override_variables(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
@@ -9,7 +9,7 @@
 
 namespace ttnn::operations::moreh::moreh_softmax {
 
-enum class MorehSoftmaxOpParallelizationStrategy {
+enum class MorehSoftmaxOpParallelizationStrategy : std::uint8_t {
     NONE,
     SMALL_W,
     SMALL_H,
@@ -18,7 +18,7 @@ enum class MorehSoftmaxOpParallelizationStrategy {
     LARGE_C,
 };
 
-enum class MorehSoftmaxOp {
+enum class MorehSoftmaxOp : std::uint8_t {
     SOFTMAX,
     SOFTMIN,
     LOGSOFTMAX,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
@@ -9,7 +9,7 @@
 
 namespace ttnn::operations::moreh::moreh_softmax_backward {
 
-enum class MorehSoftmaxBackwardOpParallelizationStrategy {
+enum class MorehSoftmaxBackwardOpParallelizationStrategy : std::uint8_t {
     NONE,
     SMALL_W,
     SMALL_H,
@@ -18,7 +18,7 @@ enum class MorehSoftmaxBackwardOpParallelizationStrategy {
     LARGE_C,
 };
 
-enum class MorehSoftmaxBackwardOp {
+enum class MorehSoftmaxBackwardOp : std::uint8_t {
     SOFTMAX,
     SOFTMIN,
     LOGSOFTMAX,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -11,7 +11,7 @@
 
 namespace ttnn::operations::normalization::group_norm {
 
-enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
+enum class GroupNormMode : std::uint8_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -12,9 +12,9 @@
 
 namespace ttnn::operations::normalization {
 
-enum class LayerNormType { LAYERNORM, RMSNORM };
+enum class LayerNormType : std::uint8_t { LAYERNORM, RMSNORM };
 
-enum class DistributedLayerNormStage { NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER };
+enum class DistributedLayerNormStage : std::uint8_t { NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER };
 
 struct LayerNormDefaultProgramConfig {
     bool legacy_reduction = false;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_distributed_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_distributed_types.hpp
@@ -15,6 +15,6 @@ struct LayerNormDistributedDefaultProgramConfig {
     bool legacy_rsqrt = true;
 };
 
-enum class LayerNormDistributedType { LAYERNORM, RMSNORM };
+enum class LayerNormDistributedType : std::uint8_t { LAYERNORM, RMSNORM };
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
@@ -10,7 +10,7 @@
 
 namespace tt::tt_metal {
 
-enum class PoolType { AVG };
+enum class PoolType : std::uint8_t { AVG };
 
 Tensor global_avg_pool2d(
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -14,7 +14,7 @@
 
 namespace ttnn::operations::pool {
 
-enum class Pool2DType {
+enum class Pool2DType : std::uint8_t {
     MAX_POOL2D = 0,
     AVG_POOL2D = 1,
 };

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -9,11 +9,11 @@
 
 namespace tt::tt_metal {
 
-enum class ReduceOpMath { SUM, MAX, MIN };
+enum class ReduceOpMath : std::uint8_t { SUM, MAX, MIN };
 
-enum class ReduceOpDim { H, W, HW };
+enum class ReduceOpDim : std::uint8_t { H, W, HW };
 
-enum class ReduceOpParallelizationStrategy { MULTI_CORE_H, MULTI_CORE_W, MULTI_CORE_HW, SINGLE_CORE_HW };
+enum class ReduceOpParallelizationStrategy : std::uint8_t { MULTI_CORE_H, MULTI_CORE_W, MULTI_CORE_HW, SINGLE_CORE_HW };
 
 }  // namespace tt::tt_metal
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -14,7 +14,7 @@
 namespace ttnn {
 namespace operations::reduction {
 
-enum class ReduceType {
+enum class ReduceType : std::uint8_t {
     Sum,
     Mean,
     Max,


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html

There are many enums that can fit into `uint8_t` underlying type.

This PR compresses many/all such enums to test if this can provide any performance boost.

Here is a run of functional_unet to test: https://github.com/tenstorrent/tt-metal/actions/runs/20289377979

### What's changed
- Enable check
- Use Claude to update all flagged enums and their forward declarations to be uint8_t.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes