### PR TITLE
Mchiou/0 t3k frequent workflow - disable ethernet test

### DIFF
--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -39,7 +39,7 @@ jobs:
                   "timeout": 30,
                   "owner_id": "U084B1CES7M" # Borys Bradel
               },
-              # {
+              # { GH #34582
               #     "name": "t3k ethernet tests",
               #     "model": "ethernet",
               #     "arch": "wormhole_b0",

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -39,14 +39,14 @@ jobs:
                   "timeout": 30,
                   "owner_id": "U084B1CES7M" # Borys Bradel
               },
-              {
-                  "name": "t3k ethernet tests",
-                  "model": "ethernet",
-                  "arch": "wormhole_b0",
-                  "cmd": "run_t3000_ethernet_tests",
-                  "timeout": 10,
-                  "owner_id": "ULMEPM2MA" # Sean Nijjar
-              },
+              # {
+              #     "name": "t3k ethernet tests",
+              #     "model": "ethernet",
+              #     "arch": "wormhole_b0",
+              #     "cmd": "run_t3000_ethernet_tests",
+              #     "timeout": 10,
+              #     "owner_id": "ULMEPM2MA" # Sean Nijjar
+              # },
               {
                   "name": "t3k trace stress tests",
                   "model": "trace stress",

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -42,6 +42,7 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
+      tracy: true
   t3000-frequent-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -11,7 +11,7 @@ on:
         options:
           - all
           - tteager
-          - ethernet
+          # - ethernet
           - trace stress
           - falcon40b
           - llama3.2-vision
@@ -42,7 +42,6 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
-      tracy: true
   t3000-frequent-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -11,7 +11,7 @@ on:
         options:
           - all
           - tteager
-          # - ethernet
+          # - ethernet (GH #34582)
           - trace stress
           - falcon40b
           - llama3.2-vision


### PR DESCRIPTION
### Problem description
T3000 Frequent tests - Ethernet section already broken.
https://github.com/tenstorrent/tt-metal/actions/runs/20290725491

### What's happened
Upon Investigation, test was using TT_METAL_PROFILER env var which required a tracy-build in the relevant workflow (this was not enabled).

Enabling tracy build in workflow let the test pass but upon further inspection test was skipped.
https://github.com/tenstorrent/tt-metal/actions/runs/20291578667/job/58277282497

Enabling tracy build does not change any statuses (except the ethernet test suite)
https://github.com/tenstorrent/tt-metal/actions/runs/20291262305

Further inspection showed that this entire ethernet test only ran that test so we are effectively running this ethernet test for nothing since the only test we are running here is skipped.

End Result
Disable t3k frequent - ethernet test
Also changed pytest to return None because this seems to be Pytest convention

Opened a ticket for re-enabling in the future
https://github.com/tenstorrent/tt-metal/issues/34582

```
=========================== short test summary info ============================
SKIPPED [1] tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py:18: skip test due to CI error shows test not complete
```

### Checklist