### PR TITLE
Multiple Exit Nodes on Multi Big-Mesh

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_big_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_big_mesh.textproto
@@ -16,14 +16,14 @@ mesh_descriptors {
 graph_descriptors {
   name: "G0"
   type: "FABRIC"
-  # Instances: mesh ids 0..1 (all 2x4)
   instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
 
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
-    channels { count: 2 }
+    # This is compatible with Mesh topologies. 4 exit nodes per mesh. 4 links per exit node.
+    channels { count: 16 }
   }
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml
@@ -30,7 +30,7 @@ Tests:
     parametrization_params:
       size: [1024, 2048, 4096]
       num_packets: [10000]
-      num_links: [1, 2]
+      num_links: [1, 2, 3, 4]
       ntype: [unicast_write, atomic_inc, fused_atomic_inc, unicast_scatter_write]
 
     patterns:

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -359,7 +359,6 @@ private:
     std::unordered_set<FabricNodeId> get_requested_exit_nodes(
         MeshId my_mesh_id,
         MeshId neighbor_mesh_id,
-        const RequestedIntermeshConnections& requested_intermesh_connections,
         const RequestedIntermeshPorts& requested_intermesh_ports,
         const std::vector<uint64_t>& src_exit_node_chips);
 
@@ -386,6 +385,11 @@ private:
     // Single-Host Intermesh Connectivity Helper Function:
     // Generate intermesh connections for the local host.
     AnnotatedIntermeshConnections generate_intermesh_connections_on_local_host();
+
+    // Validate that the intermesh connections requested in the MGD can be mapped to physical links.
+    void validate_requested_intermesh_connections(
+        const RequestedIntermeshConnections& requested_intermesh_connections,
+        const PortDescriptorTable& port_descriptors);
 
     std::unique_ptr<FabricContext> fabric_context_;
     LocalMeshBinding local_mesh_binding_;


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- With Intermesh VC changes in main, we can support workloads using multiple exit nodes between meshes
- Previously this could cause cycles, leading to a hang

### What's changed
- Modify Galaxy Multi-Mesh MGD and Fabric unit tests to use all exit nodes + all links
- Changes in Control Plane to resolve bugs based on this exercise:
   - Requested Intermesh Connectivity validation is done preemptively in the Multi Big-Mesh case (i.e. this is done on each host based on the local set of exit nodes it has)
   - This causes an assert to be incorrectly hit, since the MGD could specify intermesh connections meant to be spawned across 2 Big Meshes. The validation will be done on each host locally with a reduced set of exit nodes.
   - Move validation downstream (after exit node connectivity across all meshes is consolidated) 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes