### PR TITLE
Add HF mixtral RMSNorm as reference to mixtral rms test

### DIFF
--- a/models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py
@@ -10,7 +10,7 @@ from loguru import logger
 import ttnn
 from models.common.rmsnorm import RMSNorm as RMSNorm
 from models.common.utility_functions import comp_allclose, comp_pcc
-from models.demos.t3000.mixtral8x7b.reference.model import RMSNorm as RefRMSNorm
+from transformers.models.mixtral.modeling_mixtral import MixtralRMSNorm as RefRMSNorm
 from models.tt_transformers.tt.model_config import ModelArgs
 from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 
@@ -53,7 +53,7 @@ def test_rms_norm_inference(
     state_dict_prefix = model_args.get_state_dict_prefix("", 0)
     first_layer_prefix = state_dict_prefix + f"{norm_type}_norm."
     partial_state_dict = {k[-6:]: v for k, v in state_dict.items() if (k.startswith(f"layers.0.{norm_type}_norm."))}
-    reference_model = RefRMSNorm(dim=model_args.dim)
+    reference_model = RefRMSNorm(hidden_size=model_args.dim)
     reference_model.load_state_dict(partial_state_dict)
 
     # Create the inner RMSNormxw

--- a/models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py
@@ -6,11 +6,11 @@ import os
 import pytest
 import torch
 from loguru import logger
+from transformers.models.mixtral.modeling_mixtral import MixtralRMSNorm as RefRMSNorm
 
 import ttnn
 from models.common.rmsnorm import RMSNorm as RMSNorm
 from models.common.utility_functions import comp_allclose, comp_pcc
-from transformers.models.mixtral.modeling_mixtral import MixtralRMSNorm as RefRMSNorm
 from models.tt_transformers.tt.model_config import ModelArgs
 from ttnn import ConcatMeshToTensor, ReplicateTensorToMesh
 


### PR DESCRIPTION
### Ticket
Close https://github.com/tenstorrent/tt-metal/issues/30102

### Problem description
The references for models tests are being changed to HF.

### What's changed
Simply changing the RMSNorm import to HF transfomers version as well as the instantiation of the layer (the name of its only argument is different).

Weights loading is not modified.

### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20303434358) CI passes (failed tests are not related to changes)
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20302701150) CI passes
