### PR TITLE
Fix exp overflow to NaN near x=-88

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -171,8 +171,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     // For large values (e.g. |x| > 89), some intermediate values can overflow
     // To avoid this, we check the value of the input using two thresholds.
     //
-    // These thresholds are applied after scaling x by 1/log(2)
-    // If it were applied before scaling, they would be -88 and 89 respectively
+    // These thresholds are applied after scaling x by 1/log(2) (i.e., on z = x * 1/ln(2)).
+    // Mapped back to the original x domain, they correspond to approximately -88 and 89.
     constexpr float OVERFLOW_THRESHOLD = 128.0f;
     constexpr float UNDERFLOW_THRESHOLD = -127.0f;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -167,9 +167,14 @@ sfpi_inline sfpi::vFloat _sfpu_round_nearest_int32_(sfpi::vFloat z, sfpi::vInt& 
 sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     sfpi::vFloat result = sfpi::vConst0;
 
-    // Clamp to prevent overflow/underflow
+    // Exp computation uses bit-wise manipulation using exponent and mantissa fields
+    // For large values (e.g. |x| > 89), some intermediate values can overflow
+    // To avoid this, we check the value of the input using two thresholds.
+    //
+    // These thresholds are applied after scaling x by 1/log(2)
+    // If it were applied before scaling, they would be -88 and 89 respectively
     constexpr float OVERFLOW_THRESHOLD = 128.0f;
-    constexpr float UNDERFLOW_THRESHOLD = -128.0f;
+    constexpr float UNDERFLOW_THRESHOLD = -127.0f;
 
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -171,8 +171,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     // For large values (e.g. |x| > 89), some intermediate values can overflow
     // To avoid this, we check the value of the input using two thresholds.
     //
-    // These thresholds are applied after scaling x by 1/log(2)
-    // If it were applied before scaling, they would be -88 and 89 respectively
+    // These thresholds are applied after scaling x by 1/log(2) (i.e., on z = x * 1/ln(2)).
+    // Mapped back to the original x domain, they correspond to approximately -88 and 89.
     constexpr float OVERFLOW_THRESHOLD = 128.0f;
     constexpr float UNDERFLOW_THRESHOLD = -127.0f;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -167,9 +167,14 @@ sfpi_inline sfpi::vFloat _sfpu_round_nearest_int32_(sfpi::vFloat z, sfpi::vInt& 
 sfpi_inline sfpi::vFloat _sfpu_exp_f32_accurate_(sfpi::vFloat val) {
     sfpi::vFloat result = sfpi::vConst0;
 
-    // Clamp to prevent overflow/underflow
+    // Exp computation uses bit-wise manipulation using exponent and mantissa fields
+    // For large values (e.g. |x| > 89), some intermediate values can overflow
+    // To avoid this, we check the value of the input using two thresholds.
+    //
+    // These thresholds are applied after scaling x by 1/log(2)
+    // If it were applied before scaling, they would be -88 and 89 respectively
     constexpr float OVERFLOW_THRESHOLD = 128.0f;
-    constexpr float UNDERFLOW_THRESHOLD = -128.0f;
+    constexpr float UNDERFLOW_THRESHOLD = -127.0f;
 
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))


### PR DESCRIPTION
### Ticket
#34511

### Problem description
Exp computation uses bit-wise manipulation using exponent and mantissa fields For large values (e.g. |x| > 89), some intermediate values can overflow To avoid this, we check the value of the input using two thresholds.

The lower threshold was set incorrectly. This meant that some input near -88.0 could still overflow and become NaN. 

Adjusting the threshold to `-127` instead of `-128` fixes this problem. 
Note: these thresholds are used _after_ multiplying input by `1/log(2)` (`88 * 1/log(2) ~= 127`) 

During training, this error would result in a large explosion in the loss function after a number of steps (loss becomes `-inf` at step=82 on N150, or `+inf` on N300 at step = 400).

### What's changed
- Adjusted threshold to prevent NaN outputs from happening where they should not.

#### Proper behavior at x~=88

| x | golden | exp(x) (main) | exp(x) (new) 
| - | - | - | -  
| 1 | 2.7182817459 | 2.7182817459 | 2.7182817459
| -86.599998474 | 2.4552657663e-38 | 2.4552657663e-38 | 2.4552657663e-38 
|  -88 | 0.0 | 0.0 | 0.0
| -88.029685974 | 0.0 | 0.0 | 0.0
| -88.029693604 | 0.0 | nan | 0.0
| -88.029701233 | 0.0 | nan | 0.0
| -100 | 0.0 | 0.0 | 0.0 

#### Behavior of loss function

For loss function
| Step | loss (before regression) | loss (main)  | loss (new) 
| - | - | - | -
| 400 | 2.9375 | -inf | 2.96875 
| 5000 | 1.953125 | -inf | 2.546875

Note that applying the fix right after the exp-f32 commit gives at loss of 1.984375 at step = 5000. 
We've tracking this loss degradation to another recent commit (non-exp related).    

(with this PR, no explosion in loss has been noticed until at least step 5000)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20318903231)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20318907237)
- [x] L2 Nightly [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20318976356)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK, unrelated failure](https://github.com/tenstorrent/tt-metal/actions/runs/20318911510)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK, failures main](https://github.com/tenstorrent/tt-metal/actions/runs/20318915071)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) [OK, failures on main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20318918741) (e.g. [Mistral 7B N150 tests failed in past commit with same error rate](https://github.com/tenstorrent/tt-metal/actions/runs/20280768472/job/58242357501))
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes