### PR TITLE
Copy from device after every trace execution in tt-transformers prefill

### DIFF
--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -175,7 +175,9 @@ class Generator:
                 )
 
                 if chunk_start == last_chunk_start:
-                    logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx_in_chunk % 32))
+                    logits = self.model.process_output_prefill(
+                        tt_logits.cpu(), last_token_idx=(last_token_idx_in_chunk % 32)
+                    )
                     return logits
                 else:
                     del tt_logits
@@ -195,7 +197,7 @@ class Generator:
                 kv_cache=kv_cache,
             )
 
-            logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx % 32))
+            logits = self.model.process_output_prefill(tt_logits.cpu(), last_token_idx=(last_token_idx % 32))
 
             # deallocate device tensors that are not needed by decode
             # [INFO] logits is a torch tensor

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -353,10 +353,11 @@ class Transformer(LightweightModule):
 
     def process_output_prefill(self, tt_out, last_token_idx):
         """
-        Input is ttnn device tensor of logits. Output is torch logits tensor.
+        Input is ttnn host tensor of logits. Output is torch logits tensor.
         NOTE: In this model, prefill always uses get_last_token
         """
-        return self.concat_host_output(tt_out.cpu())[0, 0, last_token_idx, : self.vocab_size]
+        assert tt_out.storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
+        return self.concat_host_output(tt_out)[0, 0, last_token_idx, : self.vocab_size]
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """


### PR DESCRIPTION
We have an issue where the model fails determinism test even though seed is fixed. The culprit was logits corruption during prefill. Logits tensor was sometimes corrupted by the execution of trace by the following user, so the resolution was to copy the tensor to host before executing the next trace.

https://github.com/tenstorrent/tt-metal/issues/34346

- [x] [vllm nightly llama](https://github.com/tenstorrent/tt-metal/actions/runs/20260232100)
- [x] [vllm nightly qwen](https://github.com/tenstorrent/tt-metal/actions/runs/20297140813)
- [x] [llama 8B model ci, seed test passing](https://github.com/tenstorrent/tt-shield/actions/runs/20260818556/job/58174961837#step:9:3370)
- [x] [t3k llama demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20273268045)
