### PR TITLE
[Reduce APC] Remove all Llama tests except for 8B in run_python_model_tests.sh (with approval from models team)

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -49,19 +49,11 @@ run_python_model_tests_wormhole_b0() {
 
     # Llama3.1-8B
     llama8b=meta-llama/Llama-3.1-8B-Instruct
-    # Llama3.2-1B
-    llama1b=meta-llama/Llama-3.2-1B-Instruct
-    # Llama3.2-3B
-    llama3b=meta-llama/Llama-3.2-3B-Instruct
-    # Llama3.2-11B
-    llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
 
-    # Run all Llama3 tests for 8B, 1B, and 3B weights - dummy weights with tight PCC check
-    for hf_model in  "$llama1b" "$llama3b" "$llama8b" "$llama11b"; do
-        tt_cache=$TT_CACHE_HOME/$hf_model
-        HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
-        echo "LOG_METAL: Llama3 tests for $hf_model completed"
-    done
+    # Run all Llama3 tests for 8B - dummy weights with tight PCC check
+    tt_cache=$TT_CACHE_HOME/$llama8b
+    HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
+    echo "LOG_METAL: Llama3 tests for $llama8b completed"
 
     # Mistral-7B-v0.3
     mistral_weights=mistralai/Mistral-7B-Instruct-v0.3


### PR DESCRIPTION
### What's changed
Remove all Llama tests except for 8B in `run_python_model_tests.sh` This request is approved by the models team.

Slack thread: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1765922417226399

### Checklist
- [x] All post commit CI runs as expected: https://github.com/tenstorrent/tt-metal/actions/runs/20307882993/job/58330944006#step:6:1100