### PR TITLE
SDXL add encoder perf test

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -122,6 +122,8 @@ def test_clip_encoder(
     logger.info("executing text encoder...")
     start_time = time.time()
 
+    ttnn.ReadDeviceProfiler(mesh_device)
+
     tt_sequence_output, tt_projected_output = tt_clip(tt_tokens, mesh_device, with_projection=has_projection)
 
     logger.info(f"text encoder TT-NN runtime: {time.time() - start_time}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -63,22 +63,27 @@ def test_clip_encoder(
     )
     ccl_manager = None
 
+    # Build kwargs conditionally to avoid transformers subfolder=None bug
+    model_kwargs = {"local_files_only": is_ci_env or is_ci_v2_env}
+    tokenizer_kwargs = {"local_files_only": is_ci_env or is_ci_v2_env}
+
+    if not is_ci_v2_env:
+        model_kwargs["subfolder"] = clip_path
+        tokenizer_kwargs["subfolder"] = tokenizer_path
+
     if has_projection:
         hf_model = CLIPTextModelWithProjection.from_pretrained(
-            model_name_checkpoint if not is_ci_v2_env else model_location,
-            subfolder=clip_path if not is_ci_v2_env else None,
-            local_files_only=is_ci_env or is_ci_v2_env,
+            model_location if is_ci_v2_env else model_name_checkpoint,
+            **model_kwargs,
         )
     else:
         hf_model = CLIPTextModel.from_pretrained(
-            model_name_checkpoint if not is_ci_v2_env else model_location,
-            subfolder=clip_path if not is_ci_v2_env else None,
-            local_files_only=is_ci_env or is_ci_v2_env,
+            model_location if is_ci_v2_env else model_name_checkpoint,
+            **model_kwargs,
         )
     tokenizer = CLIPTokenizer.from_pretrained(
-        model_name_checkpoint if not is_ci_v2_env else tokenizer_location,
-        subfolder=tokenizer_path if not is_ci_v2_env else None,
-        local_files_only=is_ci_env or is_ci_v2_env,
+        tokenizer_location if is_ci_v2_env else model_name_checkpoint,
+        **tokenizer_kwargs,
     )
 
     hf_model.eval()

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -57,12 +57,6 @@ def test_clip_encoder(
 
     has_projection = clip_path == "text_encoder_2"  # text encoder 2 has text projection, text encoder 1 does not
 
-    # Note: Factor for SDXL should always be 1; since we don't support TP
-    parallel_config = EncoderParallelConfig(
-        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
-    )
-    ccl_manager = None
-
     # Build kwargs conditionally to avoid transformers subfolder=None bug
     model_kwargs = {"local_files_only": is_ci_env or is_ci_v2_env}
     tokenizer_kwargs = {"local_files_only": is_ci_env or is_ci_v2_env}
@@ -106,6 +100,13 @@ def test_clip_encoder(
     start_time = time.time()
 
     # === TT-DiT CLIP ====
+
+    # Note: Factor for SDXL should always be 1; since we don't support TP
+    parallel_config = EncoderParallelConfig(
+        tensor_parallel=ParallelFactor(factor=1, mesh_axis=1),
+    )
+    ccl_manager = None
+
     config = CLIPConfig(
         vocab_size=hf_model.config.vocab_size,
         embed_dim=hf_model.config.hidden_size,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pytest
 
 from models.perf.device_perf_utils import run_model_device_perf_test
@@ -164,6 +165,7 @@ def test_refiner_unet(
 def test_sdxl_perf_device(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
     run_model_device_perf_test(
         command=command,
         expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -52,11 +52,47 @@ def test_unet(
 
 
 @pytest.mark.parametrize(
+    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    [
+        ((1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
+@pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
+def test_refiner_unet(
+    device,
+    input_shape,
+    timestep_shape,
+    encoder_shape,
+    temb_shape,
+    time_ids_shape,
+    iterations,
+    is_ci_env,
+    is_ci_v2_env,
+    model_location_generator,
+    reset_seeds,
+):
+    run_refiner_unet_model(
+        device,
+        input_shape,
+        timestep_shape,
+        encoder_shape,
+        temb_shape,
+        time_ids_shape,
+        debug_mode=False,
+        is_ci_env=is_ci_env,
+        is_ci_v2_env=is_ci_v2_env,
+        model_location_generator=model_location_generator,
+        iterations=iterations,
+    )
+
+
+@pytest.mark.parametrize(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet",
-            191_651_771 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            190_185_744 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet",
             "sdxl_unet",
             1,
@@ -66,7 +102,7 @@ def test_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet",
-            602_265_531 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            549_192_450 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_refiner_unet",
             "sdxl_refiner_unet",
             1,
@@ -76,7 +112,7 @@ def test_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
-            680_239_540,
+            649_249_508,
             "sdxl_vae",
             "sdxl_vae_decode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -86,7 +122,7 @@ def test_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'",
-            343_068_075,
+            326_715_706,
             "sdxl_vae",
             "sdxl_vae_encode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -137,40 +173,4 @@ def test_sdxl_perf_device(
         batch_size=batch_size,
         margin=margin,
         comments=comments,
-    )
-
-
-@pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
-    [
-        ((1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
-    ],
-)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-@pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
-def test_refiner_unet(
-    device,
-    input_shape,
-    timestep_shape,
-    encoder_shape,
-    temb_shape,
-    time_ids_shape,
-    iterations,
-    is_ci_env,
-    is_ci_v2_env,
-    model_location_generator,
-    reset_seeds,
-):
-    run_refiner_unet_model(
-        device,
-        input_shape,
-        timestep_shape,
-        encoder_shape,
-        temb_shape,
-        time_ids_shape,
-        debug_mode=False,
-        is_ci_env=is_ci_env,
-        is_ci_v2_env=is_ci_v2_env,
-        model_location_generator=model_location_generator,
-        iterations=iterations,
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -13,6 +13,7 @@ from models.experimental.stable_diffusion_xl_base.refiner.tests.pcc.test_module_
 
 VAE_DEVICE_TEST_TOTAL_ITERATIONS = 1
 UNET_DEVICE_TEST_TOTAL_ITERATIONS = 1
+CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS = 1
 
 
 @pytest.mark.parametrize(
@@ -194,6 +195,68 @@ def test_sdxl_vae_encode_perf_device():
     )
     prep_device_perf_report(
         model_name=f"sdxl_vae_encode",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_sdxl_clip_encoder_1_perf_device():
+    expected_device_perf_cycles_per_iteration = 13_265_699
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+
+    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    batch_size = 1
+
+    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
+    post_processed_results = run_device_perf(
+        command,
+        subdir="sdxl_clip_encoder_1",
+        num_iterations=CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
+        cols=cols,
+        batch_size=batch_size,
+    )
+    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
+    expected_results = check_device_perf(
+        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+    )
+    prep_device_perf_report(
+        model_name=f"sdxl_clip_encoder_1",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_sdxl_clip_encoder_2_perf_device():
+    expected_device_perf_cycles_per_iteration = 63_966_660
+    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+
+    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    batch_size = 1
+
+    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
+    post_processed_results = run_device_perf(
+        command,
+        subdir="sdxl_clip_encoder_2",
+        num_iterations=CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
+        cols=cols,
+        batch_size=batch_size,
+    )
+    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
+    expected_results = check_device_perf(
+        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+    )
+    prep_device_perf_report(
+        model_name=f"sdxl_clip_encoder_2",
         batch_size=batch_size,
         post_processed_results=post_processed_results,
         expected_results=expected_results,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -2,10 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import pytest
 
-from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+from models.perf.device_perf_utils import run_model_device_perf_test
 
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from models.experimental.stable_diffusion_xl_base.tests.pcc.test_module_tt_unet import run_unet_model
@@ -52,33 +51,92 @@ def test_unet(
     )
 
 
+@pytest.mark.parametrize(
+    "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
+    [
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet",
+            191_651_771 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            "sdxl_unet",
+            "sdxl_unet",
+            1,
+            1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            0.015,
+            f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+        ),
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet",
+            602_265_531 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            "sdxl_refiner_unet",
+            "sdxl_refiner_unet",
+            1,
+            1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            0.06,
+            f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+        ),
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
+            680_239_540,
+            "sdxl_vae",
+            "sdxl_vae_decode",
+            VAE_DEVICE_TEST_TOTAL_ITERATIONS,
+            1,
+            0.015,
+            "",
+        ),
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'",
+            343_068_075,
+            "sdxl_vae",
+            "sdxl_vae_encode",
+            VAE_DEVICE_TEST_TOTAL_ITERATIONS,
+            1,
+            0.015,
+            "",
+        ),
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'",
+            13_265_699,
+            "sdxl_clip_encoder_1",
+            "sdxl_clip_encoder_1",
+            CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
+            1,
+            0.015,
+            "",
+        ),
+        (
+            "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
+            63_966_660,
+            "sdxl_clip_encoder_2",
+            "sdxl_clip_encoder_2",
+            CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
+            1,
+            0.015,
+            "",
+        ),
+    ],
+    ids=[
+        "test_sdxl_unet",
+        "test_sdxl_refiner_unet",
+        "test_sdxl_vae_decode",
+        "test_sdxl_vae_encode",
+        "test_sdxl_clip_encoder_1",
+        "test_sdxl_clip_encoder_2",
+    ],
+)
 @pytest.mark.models_device_performance_bare_metal
-def test_sdxl_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 191_651_771
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-    total_batch_size = batch_size * UNET_DEVICE_TEST_TOTAL_ITERATIONS
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command, subdir="sdxl_unet", num_iterations=1, cols=cols, batch_size=total_batch_size
-    )
-    expected_perf_cols = {
-        inference_time_key: expected_device_perf_cycles_per_iteration * UNET_DEVICE_TEST_TOTAL_ITERATIONS
-    }
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_unet",
-        batch_size=total_batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments=f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+def test_sdxl_perf_device(
+    command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
+):
+    run_model_device_perf_test(
+        command=command,
+        expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,
+        subdir=subdir,
+        model_name=model_name,
+        num_iterations=num_iterations,
+        batch_size=batch_size,
+        margin=margin,
+        comments=comments,
     )
 
 
@@ -115,150 +173,4 @@ def test_refiner_unet(
         is_ci_v2_env=is_ci_v2_env,
         model_location_generator=model_location_generator,
         iterations=iterations,
-    )
-
-
-@pytest.mark.models_device_performance_bare_metal
-def test_sdxl_refiner_unet_perf_device():
-    expected_device_perf_cycles_per_iteration = 602_265_531
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-    total_batch_size = batch_size * UNET_DEVICE_TEST_TOTAL_ITERATIONS
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command, subdir="sdxl_refiner_unet", num_iterations=1, cols=cols, batch_size=total_batch_size
-    )
-    expected_perf_cols = {
-        inference_time_key: expected_device_perf_cycles_per_iteration * UNET_DEVICE_TEST_TOTAL_ITERATIONS
-    }
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.06, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_refiner_unet",
-        batch_size=total_batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments=f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
-    )
-
-
-@pytest.mark.models_device_performance_bare_metal
-def test_sdxl_vae_decode_perf_device():
-    expected_device_perf_cycles_per_iteration = 680_239_540
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command, subdir="sdxl_vae", num_iterations=VAE_DEVICE_TEST_TOTAL_ITERATIONS, cols=cols, batch_size=batch_size
-    )
-    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_vae_decode",
-        batch_size=batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments="",
-    )
-
-
-@pytest.mark.models_device_performance_bare_metal
-def test_sdxl_vae_encode_perf_device():
-    expected_device_perf_cycles_per_iteration = 343_068_075
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command, subdir="sdxl_vae", num_iterations=VAE_DEVICE_TEST_TOTAL_ITERATIONS, cols=cols, batch_size=batch_size
-    )
-    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_vae_encode",
-        batch_size=batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments="",
-    )
-
-
-@pytest.mark.models_device_performance_bare_metal
-def test_sdxl_clip_encoder_1_perf_device():
-    expected_device_perf_cycles_per_iteration = 13_265_699
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command,
-        subdir="sdxl_clip_encoder_1",
-        num_iterations=CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
-        cols=cols,
-        batch_size=batch_size,
-    )
-    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_clip_encoder_1",
-        batch_size=batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments="",
-    )
-
-
-@pytest.mark.models_device_performance_bare_metal
-def test_sdxl_clip_encoder_2_perf_device():
-    expected_device_perf_cycles_per_iteration = 63_966_660
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
-
-    command = f"pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'"
-    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
-
-    batch_size = 1
-
-    inference_time_key = "AVG DEVICE KERNEL DURATION [ns]"
-    post_processed_results = run_device_perf(
-        command,
-        subdir="sdxl_clip_encoder_2",
-        num_iterations=CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
-        cols=cols,
-        batch_size=batch_size,
-    )
-    expected_perf_cols = {inference_time_key: expected_device_perf_cycles_per_iteration}
-    expected_results = check_device_perf(
-        post_processed_results, margin=0.015, expected_perf_cols=expected_perf_cols, assert_on_fail=True
-    )
-    prep_device_perf_report(
-        model_name=f"sdxl_clip_encoder_2",
-        batch_size=batch_size,
-        post_processed_results=post_processed_results,
-        expected_results=expected_results,
-        comments="",
     )


### PR DESCRIPTION
### Ticket
#34506
 
### Problem description
clip encoder didn't have unit test and we missed one regression. 

### What's changed
added device perf regression test for clip encodeer
refactored device perf tests to minimize code bloat

### Checklist
- [x] [SDXL Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20310444350)
- [x] [SDXL Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20308793038)
- [x] [SDXL Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20310579160)
- [x] [SDXL Single card demo](https://github.com/tenstorrent/tt-metal/actions/runs/20311185760)