### PR TITLE
CI: bump t3k_qwen25_tests timeout to 90m

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -161,7 +161,7 @@ jobs:
               "model": "qwen25",
               "arch": "wormhole_b0",
               "cmd": "run_t3000_qwen25_tests",
-              "timeout": 60,
+              "timeout": 90,
               "owner_id": "U03HY7MK4BT" # Mark O'\''Connor
             },
             {


### PR DESCRIPTION
The T3K Qwen2.5 demo test job can hit the 60m step timeout.

CI Sherlock summary:
- Timeout run: https://github.com/tenstorrent/tt-metal/actions/runs/20289694210/job/58271465294
  - The step `Run demo regression tests` timed out after 60 minutes.
  - Within that step, `pytest` is invoked 3 times; in the timeout run it took ~12m + ~35m, then the 3rd invocation was killed by the 60m step limit.

For comparison, an earlier main-branch run completed the same job within the step timeout - _barely_:
- https://github.com/tenstorrent/tt-metal/actions/runs/19807297327/job/56743768413

This PR bumps only `t3k_qwen25_tests` timeout from 60 -> 90 minutes to avoid spurious failures.