### PR TITLE
Remove Tensix Syncs from Pool2D Compute

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -220,3 +220,8 @@ inline void llk_unpack_tilizeA_B_block(
         llk_unpack_tilizeA_B<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces, unpA_face_r_dim);
     }
 }
+
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+    std::uint32_t operand_id = get_operand_id(operand);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -221,7 +221,8 @@ inline void llk_unpack_tilizeA_B_block(
     }
 }
 
-inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -271,3 +271,9 @@ inline void llk_unpack_fast_tilize_block(
     _llk_unpack_fast_tilize_block_(
         base_address, tile_index, unpack_src_format[operand_id], unit_dim, num_units, full_dim);
 }
+
+inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
+    std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+}

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -477,4 +477,6 @@ ALWI void fast_tilize_block(
 #endif
 }
 
+ALWI void unpack_tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -477,6 +477,30 @@ ALWI void fast_tilize_block(
 #endif
 }
 
+// clang-format off
+/**
+ * Uninitializes the unpack tilizeA_B configuration and restores unpacker state
+ * modified by _llk_unpack_tilizeA_B_init_.
+ *
+ * Return value: None
+ *
+ * Parameters:
+ *
+ * | Param Type | Name | Description           | Type     | Valid Range | Required |
+ * |------------|------|-----------------------|----------|-------------|----------|
+ * | Function   | icb  | Input circular buffer | uint32_t | 0 - 31.     | True     |
+ *
+ * Restored hardware state:
+ *
+ * | Field / Setting           | Scope      | Description                                           | Restored value / behavior                                                                  |
+ * |---------------------------|------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------|
+ * | X-dim & base (ADCXX)      | UNP_A/B    | Face X-extent for address counters                    | face_r_dim * FACE_C_DIM elements, start at 0                                               |
+ * | XY address counters       | UNP_A/B    | X/Y counters used by tilizeA_B y-stride pattern       | Counters reset to 0 (mask selects CH0/CH1 X/Y)                                             |
+ * | ZW address counters       | UNP_A/B    | Z/W counters used for face/row stepping               | Counters reset to 0 for both unpackers                                                     |
+ * | Out_data_format/config[0] | THCON_SEC0 | Unpack config[0]: out format, throttle, tilize, shift | out_data_format = unpack_dst_format; throttle_mode = 2; tileize_mode = 0; shift_amount = 0 |
+ * | Tile_x_dim (cntx0)        | THCON_SEC0 | Tile X dimension per context for unpacker             | Restored to FACE_DIM_16x16 (16 | (16 << 16))                                               |
+ */
+// clang-format on
 ALWI void unpack_tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -275,14 +275,7 @@ void MAIN {
                         cb_wait_front(pre_tilize_cb_id, TILE_HEIGHT * in_ntiles_c);
                         PACK((pack_untilize_uninit(pre_tilize_cb_id)));
 
-                        // Workaround until #27504 is not closed
-                        // We should be calling tilizeA_B_uninit and for BFP4 output may be a reconfig_data_format
-                        // and also remove the tensix_syncs. Currently they are incomplete and hence the full call
-                        // to unpack_A_hw_configure.
-                        tensix_sync();
-                        UNPACK((llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE, StochRndType::None, false>(
-                            pre_tilize_cb_id)));
-                        tensix_sync();
+                        unpack_tilizeA_B_uninit(curr_in_cb_id);
                         pack_reconfig_data_format(out_cb_id);
 
                         fast_tilize_init(pre_tilize_cb_id, in_ntiles_c, out_cb_id);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27504

Should replace the need for this PR:
https://github.com/tenstorrent/tt-metal/pull/33369

### Problem description
Tensix syncs were required to deal with Pool2D race conditions.

### What's changed
tilize uninit has been added and the tensix syncs removed.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20311939014)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20311951707) - failing on main, unrelated to this PR