### PR TITLE
Add TT::MetaliumFabricProto target for external proto consumers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,7 +291,14 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["ls", "-hal", "runtime"], cwd=source_dir, env=build_env)
 
         # Copy needed C++ shared libraries and runtime assets into wheel (sfpi, FW etc)
-        lib_patterns = ["_ttnn.so", "_ttnncpp.so", "libtt_metal.so", "libdevice.so", "libtt_stl.so"]
+        lib_patterns = [
+            "_ttnn.so",
+            "_ttnncpp.so",
+            "libtt_metal.so",
+            "libdevice.so",
+            "libtt_stl.so",
+            "libtt_metalium_fabric_proto.so*",
+        ]
         runtime_patterns = [
             "hw/**/*",
         ]

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -102,15 +102,52 @@ set_source_files_properties(
             TRUE
 )
 
-# Add the generated protobuf files to your target
-target_sources(fabric PRIVATE ${GENERATED_PROTO_SRCS})
+# =============================================================================
+# Fabric Proto Library (for external consumers like fabric-manager)
+# =============================================================================
+# Create a separate shared library for proto types. This allows external projects
+# to use MeshGraphDescriptor, PhysicalSystemDescriptor, etc. without causing
+# protobuf descriptor double-registration crashes.
+#
+# After install, consumers use: target_link_libraries(app TT::MetaliumFabricProto)
 
+add_library(MetaliumFabricProto SHARED)
+add_library(TT::MetaliumFabricProto ALIAS MetaliumFabricProto)
+
+target_sources(MetaliumFabricProto PRIVATE ${GENERATED_PROTO_SRCS})
+
+target_link_libraries(MetaliumFabricProto PRIVATE protobuf::libprotobuf)
+
+target_include_directories(
+    MetaliumFabricProto
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tt-metalium>
+)
+
+# Ensure all proto symbols are exported (default visibility)
+set_target_properties(
+    MetaliumFabricProto
+    PROPERTIES
+        CXX_VISIBILITY_PRESET
+            default
+        VISIBILITY_INLINES_HIDDEN
+            OFF
+        OUTPUT_NAME
+            tt_metalium_fabric_proto
+        SOVERSION
+            1
+)
+
+# =============================================================================
+# Main fabric target dependencies
+# =============================================================================
 target_include_directories(fabric PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(fabric SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(
     fabric
     PRIVATE
+        TT::MetaliumFabricProto
         TT::ScaleoutTools
         Metalium::Metal::LLRT
         umd::device
@@ -136,6 +173,29 @@ install(
         DESTINATION
             ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/fabric # FIXME: fix the include paths for jit_build
         COMPONENT metalium-runtime
+)
+
+# Install proto shared library for external consumers
+# Exported as TT::MetaliumFabricProto (namespace defined in tt_metal/CMakeLists.txt)
+install(
+    TARGETS
+        MetaliumFabricProto
+    EXPORT Metalium
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT metalium-runtime
+)
+
+# Install generated proto headers for external consumers
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/protobuf/mesh_graph_descriptor.pb.h
+        ${CMAKE_CURRENT_BINARY_DIR}/protobuf/physical_system_descriptor.pb.h
+        ${CMAKE_CURRENT_BINARY_DIR}/protobuf/router_port_directions.pb.h
+        ${CMAKE_CURRENT_BINARY_DIR}/protobuf/port_descriptor_table.pb.h
+        ${CMAKE_CURRENT_BINARY_DIR}/protobuf/intermesh_connection_table.pb.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tt-metalium/protobuf
+    COMPONENT metalium-dev
 )
 
 # Install proto schema files for external use


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently the TT::Metalium target has a private linkage against the fabric proto types and does not get exposed in the library symbol table. For downstream clients, the proto files are installed, but then require a separate recompile of the proto files to make use of the proto classes.

This can cause a double-registration for some of those proto classes which result in some runtime issues.

### What's changed
- Exports new fabric TT::MetaliumFabricProto target to fully make use of the proto classes under single compile and registration.
- No breaking changes for clients linking against existing TT::MetaliumFabricProto since it still remain as PRIVATE linkage.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/20319884924