### PR TITLE
Bump tolerance ratio for Llama3.1-70B on T3K

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1462,7 +1462,7 @@ def test_demo_text(
                 # N300 targets
                 "N300_Qwen2.5-7B": (95, 1.20),  # (value, high_tolerance_ratio)
                 # T3K targets
-                "T3K_Llama-3.1-70B": 205,
+                "T3K_Llama-3.1-70B": (205, 1.25),
                 "T3K_Qwen2.5-72B": (290, 1.35),  # (value, high_tolerance_ratio)
                 # Faster-than-expected TTFT observed in CI; lower the target and keep tolerance to avoid false failures.
                 "T3K_Qwen2.5-Coder-32B": (100, 1.27),  # (value, high_tolerance_ratio)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Issue reported in [Slack message](https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1765985884378849), which reports:
> t3000-demo-tests / t3k_llama3_70b_tests  [@Colman Glagovich](https://tenstorrent.enterprise.slack.com/team/U06UEFWB4P9)
https://github.com/tenstorrent/tt-metal/actions/runs/20289694210/job/58271465272
FAILED models/tt_transformers/demo/simple_text_demo.py::test_demo_text[wormhole_b0-8-device_params0-performance-ci-32] - AssertionError: Prefill or decode perf is either lower or higher than {'prefill_time_to_token': 0.205, 'decode_t/s/u': 15, 'decode_t/s': 480}. See earlier warnings for more details.

Looking through the recent runs in CI, I can see two extreme data points on TTFT: [163](https://github.com/tenstorrent/tt-metal/actions/runs/20289694210/job/58271465272#step:7:3706) and [203](https://github.com/tenstorrent/tt-metal/actions/runs/20051294145/job/57508076633#step:7:3254). This indicates a wider variance than the default perf check allows. 

### What's changed
Increase the tolerance ratio number for this particular model-system combo in perf check. 

### Checklist
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes
  -  https://github.com/tenstorrent/tt-metal/actions/runs/20314593617