### PR TITLE
tt_transformer: fixed Penalties sharding for T3K

### DIFF
--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -128,7 +128,13 @@ class TTPenalties(LightweightModule):
 
     def _alloc_int_buffer(self, shard_dims, host=None, layout=ttnn.TILE_LAYOUT):
         if host is None:
-            host = torch.zeros((self.max_batch_size, self.vocab_size), dtype=torch.int32)
+            host = torch.zeros(
+                (
+                    self.max_batch_size,
+                    self.num_devices * (((self.vocab_size + self.num_devices - 1) // self.num_devices)),
+                ),
+                dtype=torch.int32,
+            )
         return ttnn.from_torch(
             host,
             dtype=ttnn.int32,


### PR DESCRIPTION
Currently running [Qwen/Qwen3-Embedding-8B ](https://huggingface.co/Qwen/Qwen3-Embedding-8B) on tt_transformers fails due to sharding allocating less space than vocabulary size. To fix this, I padded the tensor to match the number of devices.

Error Before:
```
models/tt_transformers/demo/simple_text_demo.py:917: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
models/tt_transformers/demo/simple_text_demo.py:228: in prepare_generator_args
    model_args_i, model_i, tt_kv_cache_i, state_dict = create_tt_model(
models/tt_transformers/tt/common.py:733: in create_tt_model
    model = Transformer(
models/tt_transformers/tt/model.py:138: in __init__
    self.sampling = SamplingGenerator(
models/common/sampling/generator.py:58: in __init__
    self.tt_penalties = TTPenalties(mesh_device=mesh_device, args=args)
models/common/sampling/tt_penalties.py:105: in __init__
    self.prompt_mask = self._alloc_int_buffer(shard_dims=shard_dims)
models/common/sampling/tt_penalties.py:132: in _alloc_int_buffer
    return ttnn.from_torch(
ttnn/ttnn/decorators.py:377: in __call__
    result = self.function(*function_args, **function_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

tensor = tensor([[0, 0, 0,  ..., 0, 0, 0],
        [0, 0, 0,  ..., 0, 0, 0],
        [0, 0, 0,  ..., 0, 0, 0],
        ...,
        [0, 0, 0,  ..., 0, 0, 0],
        [0, 0, 0,  ..., 0, 0, 0],
        [0, 0, 0,  ..., 0, 0, 0]], dtype=torch.int32)
dtype = <DataType.INT32: 7>

    @ttnn.register_python_operation(name="ttnn.from_torch", golden_function=_golden_function)
    def from_torch(
        tensor: Optional["torch.Tensor"],
        dtype: Optional[ttnn.DataType] = None,
        *,
        spec: Optional[ttnn.TensorSpec] = None,
        tile: Optional[ttnn.Tile] = None,
        pad_value: Optional[float] = None,
        layout: Optional[ttnn.Layout] = None,
        device: Optional[ttnn.MeshDevice] = None,
        memory_config: Optional[ttnn.MemoryConfig] = None,
        mesh_mapper: Optional[ttnn.CppTensorToMesh | ttnn.ReplicateTensorToMeshWrapper] = None,
        cq_id: Optional[int] = None,
    ) -> Optional[ttnn.Tensor]:
        """
        Converts the `torch.Tensor` tensor into a `ttnn.Tensor`. If `tensor` is `None`, the function returns `None`.
    
        For bfloat8_b or bfloat4_b format, the function itself is called twice,
        first call runs in bfloat16 format, and calls to_layout to convert from row_major layout to tile layout (for padding purpose in case input
        is not tile padded). Second call runs in desired format and does not call to_layout for bfloat8_b or bfloat4_b as we now convert
        to tile layout during tensor creation (ttnn.Tensor).
    
        Args:
            tensor (torch.Tensor | None): the input tensor. If `tensor` is `None`, the function returns `None`.
            dtype (ttnn.DataType, optional): the desired `ttnn` data type. Defaults to `None`.
    
        Keyword Args:
            spec (ttnn.TensorSpec, optional): the desired `ttnn` tensor spec. Defaults to `None`.
            tile (ttnn.Tile, optional): the desired tiling configuration for the tensor. Defaults to `None`.
            pad_value (float, optional): the desired padding value for tiling. Only used if `layout` is `TILE_LAYOUT`. Defaults to `None`.
            layout (ttnn.Layout, optional): the desired `ttnn` layout. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
            device (ttnn.MeshDevice, optional): the desired `ttnn` device. Defaults to `None`.
            memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
            mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
            cq_id (int, optional): The command queue ID to use. Defaults to `0`.
    
        Returns:
            ttnn.Tensor | None: A `ttnn.Tensor` created from the input `torch.Tensor`, or `None` if `tensor` is `None`.
        """
    
        if tensor is None:
            return None
    
        if spec is not None:
            if spec.shape != tensor.shape:
                raise RuntimeError(
                    f"ttnn.from_torch: spec shape {spec.shape} must be the same as tensor shape {tensor.shape}"
                )
            if dtype is not None:
                raise RuntimeError("ttnn.from_torch: dtype must be None when spec is specified")
            if layout is not None:
                raise RuntimeError("ttnn.from_torch: layout must be None when spec is specified")
            if memory_config is not None:
                raise RuntimeError("ttnn.from_torch: memory_config must be None when spec is specified")
            if tile is not None:
                raise RuntimeError("ttnn.from_torch: tile must be None when spec is specified")
    
            dtype = spec.dtype
            layout = spec.layout
            memory_config = spec.memory_config
            tile = spec.tile
    
        if memory_config is not None and memory_config.is_sharded():
            if memory_config.shard_spec is None and memory_config.nd_shard_spec is None:
                raise RuntimeError("ttnn.from_torch: Shard spec must not be None for sharded tensors")
    
>       return ttnn.Tensor(
            tensor=tensor,
            data_type=dtype,
            device=device,
            layout=layout,
            mem_config=memory_config,
            tile=tile,
            cq_id=cq_id,
            pad_value=pad_value,
            mesh_mapper=mesh_mapper.unwrap() if isinstance(mesh_mapper, ttnn.ReplicateTensorToMeshWrapper) else mesh_mapper,
        )
E       RuntimeError: TT_FATAL @ /home/ttuser/salnahari/tt-metal/ttnn/core/distributed/distributed_tensor.cpp:74: shard_shape.value() == xtensor_shard_shape
E       info:
E       Shard shape mismatch: expected Shape([32, 18977]) but got Shape([32, 18970])
```
I rounded up the vocabulary from `151809` to `151816` and it seems to work.