### PR TITLE
Fix Qwen Bad PCC Drop due to prefetcher global cb corruption in FF1

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
@@ -161,6 +161,7 @@ def test_qwen_attention_ttt_inference(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_decoder_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_decoder_ttt.py
@@ -147,6 +147,7 @@ def test_qwen_decoder_ttt_inference(
         mesh_device,
         n_tensors=5,  # More tensors needed for decoder (attention + MLP)
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head.py
@@ -64,6 +64,7 @@ def test_qwen_lm_head_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=0,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
 
     mesh_device.set_sub_device_stall_group(

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head_ttt.py
@@ -77,6 +77,7 @@ def test_qwen_lm_head_ttt_inference(seq_len, batch_size, mesh_device, reset_seed
         mesh_device,
         n_tensors=0,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
 
     mesh_device.set_sub_device_stall_group(

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_mlp_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_mlp_ttt.py
@@ -77,6 +77,7 @@ def test_qwen_mlp_ttt_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=3,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_qk_norm.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_qk_norm.py
@@ -51,6 +51,7 @@ def test_qwen3_tg_qk_norm(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
@@ -141,6 +141,7 @@ def test_qwen_attention_inference(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
@@ -82,6 +82,7 @@ def test_llama_decoder_inference(
         mesh_device,
         n_tensors=5,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
@@ -84,6 +84,7 @@ def test_qwen_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=3,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -146,6 +146,7 @@ class TtTransformer(LightweightModule):
             mode="prefill",
             mesh_sub_device_manager_id_prefill=mesh_sub_device_manager_id_prefill,
             save_tensor_addresses=True,
+            is_qwen=self.args.is_qwen,
         )
         self.mesh_sub_device_manager_id_prefill = self.prefetcher_setup.mesh_sub_device_manager_id_prefill
         self.mesh_device.set_sub_device_stall_group([self.prefetcher_setup.worker_sub_device_id])
@@ -168,6 +169,7 @@ class TtTransformer(LightweightModule):
             n_layers=self.n_layers,
             mesh_sub_device_manager_id_decode=mesh_sub_device_manager_id_decode,
             save_tensor_addresses=True,
+            is_qwen=self.args.is_qwen,
         )
         self.mesh_sub_device_manager_id_decode = self.prefetcher_setup.mesh_sub_device_manager_id_decode
         self.mesh_device.set_sub_device_stall_group(


### PR DESCRIPTION
### Ticket
Parent issue: https://github.com/tenstorrent/tt-metal/issues/34008
Specific issue with the FF1 + Prefetcher: https://github.com/tenstorrent/tt-metal/issues/34413

### Problem description
We were seeing memory corruption in the FF1 outputs when there is prefetcher used, specifically the PCC would drop slightly to 0.89 only on the second run of the model (second run of prefetcher). This can be reproduced in the prefetcher unit tests (to be published as this PR gets reviewed so we understand root cause for the corruption). We found that increasing global cb size avoids this memory corruption, exact reason is still being investigated and will be reported back in the issue.

New accuracy metrics with this fix: (provided by @kpaigwar )
MLP weights=bfp8 | Top-1: 85% | Top-5: 100%
MLP weights=bfp16 | Top-1: 86% | Top-5: 100% 

### What's changed
- Increase global cb size to 800 tiles for qwen specifically

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes