### PR TITLE
qwen accuracy changes

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_transformer.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_transformer.py
@@ -134,6 +134,7 @@ def test_qwen_transformer_inference(
         weight_cache_path=model_args.weight_cache_path(dtype),
         paged_attention_config=paged_attention_config,
         mode="decode",
+        decode_mode_only=True,
     )
 
     seqlen = 1

--- a/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
@@ -135,6 +135,7 @@ class TtTransformerBlock(LightweightModule):
         # x contains input in layer 0 and ffout of previous layer thereafter, x should be dealocated
         # h contains 0 in layer 0 and h_prev+x_prev+attn_out_prev thereafter, h is persistent
         skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
+        residual_dtype = ttnn.bfloat16
         assert (
             x.memory_config() == skip_mem_cfg
         ), f"decoder input memcfg mismatch: {x.memory_config()} != {skip_mem_cfg}"
@@ -150,7 +151,7 @@ class TtTransformerBlock(LightweightModule):
         else:
             # In subsequent Layers we take the h tensor from before and modify it in place
             if self.unfuse_res_add:
-                h = ttnn.add(x, h)
+                h = ttnn.add(x, h, dtype=residual_dtype)
                 attn_in_sharded, _ = self.attention_norm(h, None, mode)
             else:
                 attn_in_sharded, _ = self.attention_norm(x, h, mode)
@@ -173,7 +174,7 @@ class TtTransformerBlock(LightweightModule):
             ff_in_sharded, _ = self.ff_norm(h, None, mode)
         if mode == "decode":
             if self.unfuse_res_add:
-                h = ttnn.add(attn_out, h)
+                h = ttnn.add(attn_out, h, dtype=residual_dtype)
                 ff_in_sharded, _ = self.ff_norm(h, None, mode)
             else:
                 ff_in_sharded, _ = self.ff_norm(attn_out, h, mode)

--- a/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
@@ -183,7 +183,7 @@ class TtTransformerBlock(LightweightModule):
         # MLP takes replicated inputs and produces fractured outputs
         ff_out = self.feed_forward.forward(ff_in_sharded, mode)
         if self.layer_num == self.n_layers - 1 or mode == "prefill":
-            out = ttnn.add(ff_out, h, memory_config=skip_mem_cfg)  # , dtype=ttnn.bfloat16)
+            out = ttnn.add(ff_out, h, memory_config=skip_mem_cfg, dtype=residual_dtype)
             if mode == "decode":
                 ff_out.deallocate(True)
             if mode == "prefill":

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -63,7 +63,7 @@ class TtLlamaMLP(LightweightModule):
         ]  # args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices, args.dim)
         as_sharded_tensor = lambda name, type, dim: ttnn.as_tensor(
             torch_weight(name[:2]).unsqueeze(0).unsqueeze(0),  # Grab only the wX part of the name
-            dtype=type if not args.is_qwen else ttnn.bfloat16,
+            dtype=type if not args.is_qwen else ttnn.bfloat8_b,
             device=self.mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dim, mesh_shape=args.cluster_shape),
             layout=ttnn.TILE_LAYOUT,

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -687,11 +687,6 @@ class TtTransformer(LightweightModule):
         if mode == "decode":
             ttnn.deallocate(garbage_tensor)
 
-            # Pre-allocated output of AllReduce in LM Head to avoid memory cloberring
-            self.tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(
-                self.tt_ccl.tt_lm_head_buffer, self.tt_ccl.lm_head_buffer_mem_cfg
-            )
-
         if mode == "prefill":
             return x
         # Output norm

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -180,10 +180,11 @@ class LMHead(LightweightModule):
                 outputs.append(output)
 
         outputs_reduced = []
-        # Move the pre-allocated buffer to L1 memory after the LM Head matmul to avoid OOM
-        self.tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(
-            self.tt_ccl.tt_lm_head_buffer, self.tt_ccl.lm_head_buffer_mem_cfg
-        )
+        if mode == "decode":
+            # Move the pre-allocated buffer to L1 memory after the LM Head matmul to avoid OOM
+            self.tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(
+                self.tt_ccl.tt_lm_head_buffer, self.tt_ccl.lm_head_buffer_mem_cfg
+            )
         for output in outputs:
             output_reduced = self.tt_ccl.line_all_reduce(
                 output,

--- a/models/demos/llama3_70b_galaxy/tt/lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tt/lm_head.py
@@ -180,6 +180,10 @@ class LMHead(LightweightModule):
                 outputs.append(output)
 
         outputs_reduced = []
+        # Move the pre-allocated buffer to L1 memory after the LM Head matmul to avoid OOM
+        self.tt_ccl.tt_lm_head_buffer_l1 = ttnn.to_memory_config(
+            self.tt_ccl.tt_lm_head_buffer, self.tt_ccl.lm_head_buffer_mem_cfg
+        )
         for output in outputs:
             output_reduced = self.tt_ccl.line_all_reduce(
                 output,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Changes to uplift accuracy for Qwen3-32b with bfp8 mlp weights
MLP weights=bfp8 | Top-1: 85% | Top-5: 100%
MLP weights=bfp16 | Top-1: 86% | Top-5: 100%

### What's changed
1. BF16->BFP8  MLP weights for qwen
2. BF16 residual stream always
3. BF16 input for lmhead


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes