### PR TITLE
Fix CI failure for llama3.1 accuracy test in T3K

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -431,7 +431,13 @@ void calculate_exponential_first_column(int scale_bf16) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             val = val * sfpi::s2vFloat16b(scale_bf16);
-            sfpi::vFloat result = ckernel::sfpu::_sfpu_exp_improved_<DST_ACCUM_MODE>(val);
+            sfpi::vFloat result;
+            if constexpr (!DST_ACCUM_MODE) {
+                result = ckernel::sfpu::_sfpu_exp_21f_<false>(val);
+            } else {
+                result = ckernel::sfpu::_sfpu_exp_61f_(val);
+            }
+
             sfpi::dst_reg[0] = result;
 
             // Stride by 2 to skip columns 8:16 of the face

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -433,8 +433,11 @@ void calculate_exponential_first_column(int scale_bf16) {
             val = val * sfpi::s2vFloat16b(scale_bf16);
             sfpi::vFloat result;
             if constexpr (!DST_ACCUM_MODE) {
+                // bfloat16-accurate implementation of exp ( < 1 ULP)
                 result = ckernel::sfpu::_sfpu_exp_21f_<false>(val);
             } else {
+                // float32 version of exp (< 150 float32 ULP)
+                // this is more accurate than exp_21f, but also slower
                 result = ckernel::sfpu::_sfpu_exp_61f_(val);
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -365,8 +365,11 @@ void calculate_exponential_first_column(int scale_bf16) {
             val = val * sfpi::s2vFloat16b(scale_bf16);
             sfpi::vFloat result;
             if constexpr (!DST_ACCUM_MODE) {
+                // bfloat16-accurate implementation of exp ( < 1 ULP)
                 result = ckernel::sfpu::_sfpu_exp_21f_<false>(val);
             } else {
+                // float32 version of exp (< 150 float32 ULP)
+                // this is more accurate than exp_21f, but also slower
                 result = ckernel::sfpu::_sfpu_exp_61f_(val);
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -363,7 +363,13 @@ void calculate_exponential_first_column(int scale_bf16) {
         for (int d = 0; d < ITERATIONS_HALF_FACE; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             val = val * sfpi::s2vFloat16b(scale_bf16);
-            sfpi::vFloat result = ckernel::sfpu::_sfpu_exp_improved_<DST_ACCUM_MODE>(val);
+            sfpi::vFloat result;
+            if constexpr (!DST_ACCUM_MODE) {
+                result = ckernel::sfpu::_sfpu_exp_21f_<false>(val);
+            } else {
+                result = ckernel::sfpu::_sfpu_exp_61f_(val);
+            }
+
             sfpi::dst_reg[0] = result;
 
             // Stride by 2 to skip columns 8:16 of the face


### PR DESCRIPTION
### Ticket
#34580

### Problem description
PR #33563 introduced a high accuracy version of `exp`. 
However, this broke `llama3.1 8B accuracy tests` on T3K. 

Pipeline before exp (Top-1 Token accuracy = 90.6%): https://github.com/tenstorrent/tt-metal/actions/runs/20302884585/job/58313781999#step:6:706
Pipeline with exp (+NaN fix) (Top-1 Token accuracy = 89.0%): https://github.com/tenstorrent/tt-metal/actions/runs/20305037513/job/58321440919#step:6:710

The second pipeline fails because its Top-1 token accuracy is lower than the specified threshold of 89.5%.

Note: Looking at the generated text of the failing test cases, the text does not seem to be coherent in either branches (c.f. prompt and output in previous links)

Looking into more details, the only place in llama3 where this float32 version of exp is SDPA (prefill + decode), more specifically in `calculate_exponential_first_column()/exp_tile_first_column()/sub_exp_block()`.
 
Looking at the output of exp (verified on every possible float32 input value), this failure is surprising. 
But given the output, it may be a numerical stability problem due to another op. 
In the short term, we'd like to fix the tests. 


### What's changed

This PR updates `calculate_exponential_first_column()` in SDPA implementations to directly call the `_sfpu_exp_21f` (bfloat16) or `sfpu_exp_61f_` (float32). 

For SDPA, this reverts its numerical behavior to that of before the accurate exp PR. 

Notes: 
- This is a short term solution. We'd like to figure out why this degradation happens when accuracy of exp increases.  
- SDPA probably does not need fp32-level accuracy. 


#### T3K llama3 accuracy Pipeline status

- main: [Not OK](https://github.com/tenstorrent/tt-metal/actions/runs/20286795254)
- With this fix: [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20368806686)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20369620020)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK, fails on TLB allocation/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20369624594)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20369628200)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20369631518)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20369635494) CI passes (if applicable) [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20369635494)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [x] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release) [OK, failures in main](https://github.com/tenstorrent/tt-metal/actions/runs/20369641607)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
- [x] - T3000 frequent tests [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20373072332)