### PR TITLE
Pre-fill RTA payload with known garbage when Watcher is enabled

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -31,6 +31,7 @@
 #include <tt_stl/span.hpp>
 
 #include "device_fixture.hpp"
+#include "../debug_tools/debug_tools_fixture.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
@@ -775,4 +776,64 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
     }
 }
 
+// Test if RTA payload region initialized by HostMemDeviceCommand
+// is filled with known garbage (with 0xBEEF####) for cores with unset RTAs
+TEST_F(MeshWatcherFixture, WatcherKnownGarbageRTAs) {
+    // First run the program with the initial runtime args
+    CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+    CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(4, 4));
+    CoreRangeSet core_range_set(std::vector{first_core_range, second_core_range});
+
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    const std::vector<uint32_t> rtas = {0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD, 0xEEEEEEEE};
+
+    // Configure CB to store read-back args
+    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t cb_size = tt::align(rtas.size() * sizeof(uint32_t), l1_alignment);
+    CircularBufferConfig cb_config =
+        CircularBufferConfig(cb_size, {{0, tt::DataFormat::Float32}}).set_page_size(0, cb_size);
+
+    distributed::MeshWorkload workload;
+    Program program;
+    CreateCircularBuffer(program, core_range_set, cb_config);
+
+    auto kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/runtime_args_test.cpp",
+        core_range_set,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // SetRuntimeArgs only for first_core_range ; second_core_range has unset RTAs and should read known garbage back
+    SetRuntimeArgs(program, kernel, first_core_range, rtas);
+
+    workload.add_program(device_range, std::move(program));
+    EXPECT_NO_THROW(distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false));
+    distributed::Finish(mesh_device->mesh_command_queue());
+
+    std::vector<uint32_t> read_result;
+    // Verify each core in first_core_range (valid data)
+    for (const auto& core : first_core_range) {
+        read_result.clear();
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
+        EXPECT_EQ(read_result.size(), rtas.size());
+        for (uint32_t i = 0; i < read_result.size(); i++) {
+            EXPECT_EQ(read_result[i], rtas[i]);
+        }
+    }
+
+    // Verify each core in second_core_range (expect known garbage: 0xBEEF####)
+    for (const auto& core : second_core_range) {
+        read_result.clear();
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
+        EXPECT_EQ(read_result.size(), rtas.size());
+        for (const auto& result : read_result) {
+            EXPECT_EQ(result & 0xFFFF0000, 0xBEEF0000);
+        }
+    }
+}
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -31,7 +31,6 @@
 #include <tt_stl/span.hpp>
 
 #include "device_fixture.hpp"
-#include "../debug_tools/debug_tools_fixture.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 // Access to internal API: ProgramImpl::num_kernel, get_kernel
@@ -776,69 +775,4 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
     }
 }
 
-// Test if RTA payload region initialized by HostMemDeviceCommand
-// is filled with known garbage (with 0xBEEF####) for cores with unset RTAs
-TEST_F(MeshWatcherFixture, WatcherKnownGarbageRTAs) {
-    auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-    if (slow_dispatch) {
-        GTEST_SKIP() << "This test can only be run with fast dispatch mode";
-    }
-
-    // First run the program with the initial runtime args
-    CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
-    CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(4, 4));
-    CoreRangeSet core_range_set(std::vector{first_core_range, second_core_range});
-
-    auto mesh_device = devices_[0];
-    auto* device = mesh_device->get_devices()[0];
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-
-    const std::vector<uint32_t> rtas = {0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD, 0xEEEEEEEE};
-
-    // Configure CB to store read-back args
-    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    uint32_t cb_size = tt::align(rtas.size() * sizeof(uint32_t), l1_alignment);
-    CircularBufferConfig cb_config =
-        CircularBufferConfig(cb_size, {{0, tt::DataFormat::Float32}}).set_page_size(0, cb_size);
-
-    distributed::MeshWorkload workload;
-    Program program;
-    CreateCircularBuffer(program, core_range_set, cb_config);
-
-    auto kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_runtime_args_prefill.cpp",
-        core_range_set,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
-    // SetRuntimeArgs only for first_core_range ; second_core_range has unset RTAs and should read known garbage back
-    SetRuntimeArgs(program, kernel, first_core_range, rtas);
-
-    workload.add_program(device_range, std::move(program));
-    EXPECT_NO_THROW(distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false));
-    distributed::Finish(mesh_device->mesh_command_queue());
-
-    std::vector<uint32_t> read_result;
-    // Verify each core in first_core_range (valid data)
-    for (const auto& core : first_core_range) {
-        read_result.clear();
-        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
-        EXPECT_EQ(read_result.size(), rtas.size());
-        for (uint32_t i = 0; i < read_result.size(); i++) {
-            EXPECT_EQ(read_result[i], rtas[i]);
-        }
-    }
-
-    // Verify each core in second_core_range (expect known garbage: 0xBEEF####)
-    for (const auto& core : second_core_range) {
-        read_result.clear();
-        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
-        EXPECT_EQ(read_result.size(), rtas.size());
-        for (const auto& result : read_result) {
-            EXPECT_EQ(result & 0xFFFF0000, 0xBEEF0000);
-        }
-    }
-}
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -779,6 +779,11 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
 // Test if RTA payload region initialized by HostMemDeviceCommand
 // is filled with known garbage (with 0xBEEF####) for cores with unset RTAs
 TEST_F(MeshWatcherFixture, WatcherKnownGarbageRTAs) {
+    auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (slow_dispatch) {
+        GTEST_SKIP() << "This test can only be run with fast dispatch mode";
+    }
+
     // First run the program with the initial runtime args
     CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
     CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(4, 4));
@@ -804,7 +809,7 @@ TEST_F(MeshWatcherFixture, WatcherKnownGarbageRTAs) {
 
     auto kernel = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/runtime_args_test.cpp",
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_runtime_args_prefill.cpp",
         core_range_set,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -18,6 +18,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_ringbuf.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_stack_usage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_waypoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_runtime_args_known_garbage.cpp
 )
 
 function(create_unit_test_executable)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "debug_tools_fixture.hpp"
+
+namespace tt::tt_metal {
+
+// Test if RTA payload region initialized by HostMemDeviceCommand
+// is filled with known garbage (with 0xBEEF####) for cores with unset RTAs
+TEST_F(MeshWatcherFixture, WatcherKnownGarbageRTAs) {
+    auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (slow_dispatch) {
+        GTEST_SKIP() << "This test can only be run with fast dispatch mode";
+    }
+
+    // First run the program with the initial runtime args
+    CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+    CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(4, 4));
+    CoreRangeSet core_range_set(std::vector{first_core_range, second_core_range});
+
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    const std::vector<uint32_t> rtas = {0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD, 0xEEEEEEEE};
+
+    // Configure CB to store read-back args
+    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t cb_size = tt::align(rtas.size() * sizeof(uint32_t), l1_alignment);
+    CircularBufferConfig cb_config =
+        CircularBufferConfig(cb_size, {{0, tt::DataFormat::Float32}}).set_page_size(0, cb_size);
+
+    distributed::MeshWorkload workload;
+    Program program;
+    CreateCircularBuffer(program, core_range_set, cb_config);
+
+    auto kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_runtime_args_prefill.cpp",
+        core_range_set,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // SetRuntimeArgs only for first_core_range ; second_core_range has unset RTAs and should read known garbage back
+    SetRuntimeArgs(program, kernel, first_core_range, rtas);
+
+    workload.add_program(device_range, std::move(program));
+    EXPECT_NO_THROW(distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false));
+    distributed::Finish(mesh_device->mesh_command_queue());
+
+    std::vector<uint32_t> read_result;
+    // Verify each core in first_core_range (valid data)
+    for (const auto& core : first_core_range) {
+        read_result.clear();
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
+        EXPECT_EQ(read_result.size(), rtas.size());
+        for (uint32_t i = 0; i < read_result.size(); i++) {
+            EXPECT_EQ(read_result[i], rtas[i]);
+        }
+    }
+
+    // Verify each core in second_core_range (expect known garbage: 0xBEEF####)
+    for (const auto& core : second_core_range) {
+        read_result.clear();
+        tt::tt_metal::detail::ReadFromDeviceL1(device, core, cb_addr, rtas.size() * sizeof(uint32_t), read_result);
+        EXPECT_EQ(read_result.size(), rtas.size());
+        for (const auto& result : read_result) {
+            EXPECT_EQ(result & 0xFFFF0000, 0xBEEF0000);
+        }
+    }
+}
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_runtime_args_prefill.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/test_runtime_args_prefill.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    uint32_t l1_write_addr = get_write_ptr(cb_in0);
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(l1_write_addr);
+
+    // Write all args to L1 to check
+    ptr[0] = get_arg_val<uint32_t>(0);
+    ptr[1] = get_arg_val<uint32_t>(1);
+    ptr[2] = get_arg_val<uint32_t>(2);
+    ptr[3] = get_arg_val<uint32_t>(3);
+    ptr[4] = get_arg_val<uint32_t>(4);
+}

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -750,9 +750,11 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
     increment_sizeB = tt::align(packed_data_sizeB, this->l1_alignment);
     uint32_t num_data_copies = no_stride ? 1 : num_sub_cmds;
     for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
-        TT_ASSERT(data_collection[i].first != nullptr);
-        this->memcpy(
-            (char*)this->cmd_region + this->cmd_write_offsetB, data_collection[i].first, data_collection[i].second);
+        if (data_collection[i].first) {
+            this->memcpy(
+                (char*)this->cmd_region + this->cmd_write_offsetB, data_collection[i].first, data_collection[i].second);
+        }
+        // Always advanced by the packed stride, even if no data was copied
         this->cmd_write_offsetB += increment_sizeB;
     }
 
@@ -829,9 +831,11 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
     for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
         uint32_t offset = 0;
         for (const auto& data : data_collection[i]) {
-            TT_ASSERT(std::get<0>(data) != nullptr);
-            this->memcpy(
-                (char*)this->cmd_region + this->cmd_write_offsetB + offset, std::get<0>(data), std::get<1>(data));
+            if (std::get<0>(data)) {
+                this->memcpy(
+                    (char*)this->cmd_region + this->cmd_write_offsetB + offset, std::get<0>(data), std::get<1>(data));
+            }
+            // Always advanced by the stride, even if no data was copied
             offset += std::get<2>(data);
         }
         this->cmd_write_offsetB += increment_sizeB;

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -750,6 +750,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
     increment_sizeB = tt::align(packed_data_sizeB, this->l1_alignment);
     uint32_t num_data_copies = no_stride ? 1 : num_sub_cmds;
     for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
+        TT_ASSERT(data_collection[i].first != nullptr);
         this->memcpy(
             (char*)this->cmd_region + this->cmd_write_offsetB, data_collection[i].first, data_collection[i].second);
         this->cmd_write_offsetB += increment_sizeB;
@@ -828,6 +829,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
     for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
         uint32_t offset = 0;
         for (const auto& data : data_collection[i]) {
+            TT_ASSERT(std::get<0>(data) != nullptr);
             this->memcpy(
                 (char*)this->cmd_region + this->cmd_write_offsetB + offset, std::get<0>(data), std::get<1>(data));
             offset += std::get<2>(data);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -477,14 +477,13 @@ void generate_runtime_args_cmds(
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
             uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
             uint32_t* command_start_ptr =
-                reinterpret_cast<uint32_t*>(command_obj.data()) + data_offset / sizeof(uint32_t);
+                reinterpret_cast<uint32_t*>(command_obj.data()) + (data_offset / sizeof(uint32_t));
             thread_local static std::mt19937 gen(std::random_device{}());
             std::uniform_int_distribution<int> dist(0, 65535);
             for (uint32_t count = 0; count < total_words; count++) {
                 uint16_t rnd = static_cast<uint16_t>(dist(gen));
                 const uint32_t known_garbage = 0xBEEF0000 | rnd;
-                *command_start_ptr = known_garbage;
-                command_start_ptr++;
+                command_start_ptr[count] = known_garbage;
             }
         }
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <variant>
 #include <vector>
+#include <random>
 
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
@@ -468,7 +469,25 @@ void generate_runtime_args_cmds(
             max_runtime_args_len * sizeof(uint32_t),
             constants.packed_write_max_unicast_sub_cmds,
             no_stride);
-        runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+        auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+        uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
+        // Watcher only: pre-fill the RTA payload region with 0xBEEF0000 | rand16
+        // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand
+        // This makes any unused runtime-arg slots obvious on device (equality tests likely to fail)
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+            uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
+            uint32_t* command_start_ptr =
+                reinterpret_cast<uint32_t*>(command_obj.data()) + data_offset / sizeof(uint32_t);
+            thread_local static std::mt19937 gen(std::random_device{}());
+            std::uniform_int_distribution<int> dist(0, 65535);
+            for (uint32_t count = 0; count < total_words; count++) {
+                uint16_t rnd = static_cast<uint16_t>(dist(gen));
+                const uint32_t known_garbage = 0xBEEF0000 | rnd;
+                *command_start_ptr = known_garbage;
+                command_start_ptr++;
+            }
+        }
+
         runtime_args_command_sequences.back().add_dispatch_write_packed<PackedSubCmd>(
             CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_RTA,
             num_packed_cmds,
@@ -485,7 +504,6 @@ void generate_runtime_args_cmds(
             runtime_args_command_sequences.back().size_bytes() ==
             runtime_args_command_sequences.back().write_offset_bytes());
 
-        uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
         const uint32_t data_inc = tt::align(max_runtime_args_len * sizeof(uint32_t), l1_alignment);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34256

### Problem description
In Fast Dispatch, when a core has fewer Runtime Arguments (RTAs) than the maximum in its kernel group, the `HostMemDeviceCommand` initializes the data buffer to zeros. This masks kernel bugs where a core reads Runtime Arguments (RTAs) that were never explicitly set. If a kernel relies on these unset RTAs being zero to function correctly (e.g. loop bounds), it passes silently.

### What's changed
- When Watcher is enabled, we pre-fill the RTA payload region initialized by `HostMemDeviceCommand` with `0xBEEF0000 | rand16()`. This forces any read of unset/padded RTAs to return a random non-zero value e.g. `for (i=0; i<args[0]; i++)` where `args[0]` was unset will likely fail or produce garbage, exposing the bug. 
- Added a unit test for test this debug feature

In `DeviceCommand.cpp`:
- Added `if(ptr)` checks in packed write dispatch commands, so null RTA slots are skipped instead of memcpy'd - avoids UB while allowing kernels on cores with no RTAs.

Note: a more robust solution is for watcher to assert for out-of-bounds RTA reads. This debug feature will be added soon.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes