### PR TITLE
Profiler updates to support Device 2.0 API debug data collection

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -316,6 +316,64 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
+def test_device_api_debugger_non_dropping():
+    ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
+    assert ENV_VAR_ARCH_NAME in ["grayskull", "wormhole_b0", "blackhole"]
+
+    testCommand = f"build/{PROG_EXMP_DIR}/test_device_api_debugger"
+    clear_profiler_runtime_artifacts()
+
+    envVars = "TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1 "
+
+    profilerRun = os.system(f"cd {TT_METAL_HOME} && {envVars} {testCommand}")
+    assert profilerRun == 0, f"Test command failed with exit code {profilerRun}"
+
+    # Verify the NOC trace JSON file exists
+    expected_trace_file = f"{PROFILER_LOGS_DIR}/noc_trace_dev0_ID0.json"
+    assert os.path.isfile(expected_trace_file), f"Expected trace file '{expected_trace_file}' does not exist"
+
+    # Read and parse the JSON file
+    with open(expected_trace_file, "r") as nocTraceJson:
+        try:
+            noc_trace_data = json.load(nocTraceJson)
+        except json.JSONDecodeError:
+            raise ValueError(f"noc trace file '{expected_trace_file}' is not a valid JSON file")
+
+    assert isinstance(noc_trace_data, list), f"noc trace file '{expected_trace_file}' format is incorrect"
+    assert len(noc_trace_data) > 0, f"noc trace file '{expected_trace_file}' is empty"
+
+    brisc_dst_addrs_found = set()
+    ncrisc_dst_addrs_found = set()
+
+    for event in noc_trace_data:
+        assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"
+        if event.get("type") == "READ" and "dst_addr" in event and "proc" in event:
+            proc = event["proc"]
+            dst_addr = event["dst_addr"]
+            if proc == "BRISC":
+                brisc_dst_addrs_found.add(dst_addr)
+            elif proc == "NCRISC":
+                ncrisc_dst_addrs_found.add(dst_addr)
+
+    expected_dst_addrs = set(range(10000))  # 0 to 9999
+
+    # Verify BRISC has all expected dst_addr values
+    missing_brisc_dst_addrs = expected_dst_addrs - brisc_dst_addrs_found
+    assert len(missing_brisc_dst_addrs) == 0, (
+        f"Missing dst_addr values in BRISC JSON events: {sorted(missing_brisc_dst_addrs)[:20]}"
+        f"{'...' if len(missing_brisc_dst_addrs) > 20 else ''} "
+        f"(found {len(brisc_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    )
+
+    # Verify NCRISC has all expected dst_addr values
+    missing_ncrisc_dst_addrs = expected_dst_addrs - ncrisc_dst_addrs_found
+    assert len(missing_ncrisc_dst_addrs) == 0, (
+        f"Missing dst_addr values in NCRISC JSON events: {sorted(missing_ncrisc_dst_addrs)[:20]}"
+        f"{'...' if len(missing_ncrisc_dst_addrs) > 20 else ''} "
+        f"(found {len(ncrisc_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    )
+
+
 def wildcard_match(pattern, words):
     if not pattern.endswith("*"):
         return [word for word in words if pattern == word]

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -13,6 +13,7 @@
 namespace kernel_profiler {
 
 static constexpr int SUM_COUNT = 2;
+static constexpr uint32_t DRAM_PROFILER_ADDRESS_STALLED = 0xFFFFFFFF;
 
 enum BufferIndex {
     ID_HH,
@@ -43,7 +44,7 @@ enum ControlBuffer {
     DEVICE_BUFFER_END_INDEX_T2,
     FW_RESET_H,
     FW_RESET_L,
-    DRAM_PROFILER_ADDRESS,
+    DRAM_PROFILER_ADDRESS_DEFAULT,  // Used in normal profiler operation
     RUN_COUNTER,
     NOC_X,
     NOC_Y,
@@ -51,7 +52,14 @@ enum ControlBuffer {
     CORE_COUNT_PER_DRAM,
     DROPPED_ZONES,
     PROFILER_DONE,
-    TRACE_REPLAY_STATUS
+    TRACE_REPLAY_STATUS,
+    // Used for device debug dump mode. Needs to come last in the control buffer
+    // because we first update the host buffer end index and then the DRAM buffer address
+    DRAM_PROFILER_ADDRESS_BR_ER_0,
+    DRAM_PROFILER_ADDRESS_NC_0,
+    DRAM_PROFILER_ADDRESS_T0_0,
+    DRAM_PROFILER_ADDRESS_T1_0,
+    DRAM_PROFILER_ADDRESS_T2_0,
 };
 
 enum PacketTypes { ZONE_START, ZONE_END, ZONE_TOTAL, TS_DATA, TS_EVENT };

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -443,7 +443,7 @@ MetalContext::MetalContext() {
             platform_arch,
             is_base_routing_fw_enabled,
             rtoptions_.get_enable_2_erisc_mode(),
-            get_profiler_dram_bank_size_per_risc_bytes(rtoptions_));
+            get_profiler_dram_bank_size_for_hal_allocation(rtoptions_));
         rtoptions_.ParseAllFeatureEnv(*hal_);
         cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
         distributed_context_ = distributed::multihost::DistributedContext::get_current_world();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -212,6 +212,11 @@ void DeviceManager::init_profiler() const {
         }
     }
     detail::ProfilerSync(ProfilerSyncState::INIT);
+
+    if (tt::tt_metal::MetalContext::instance().profiler_state_manager() &&
+        tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled()) {
+        tt::tt_metal::LaunchIntervalBasedProfilerReadThread(this->get_all_active_devices());
+    }
 #endif
 }
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -771,7 +771,8 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                             // This is the trailer for this LocalNocEvent - merge dst_addr into the event data
                             auto local_noc_event_trailer =
                                 std::get<EMD::LocalNocEventTrailer>(EMD(next_device_marker.data).getContents());
-                            data["dst_addr"] = local_noc_event_trailer.dst_addr;
+                            uint32_t dst_addr = local_noc_event_trailer.dst_addr;
+                            data["dst_addr"] = dst_addr;
                             // Mark this trailer as matched so we skip it when processing trailers
                             matched_trailers.insert(std::make_tuple(
                                 next_device_marker.timestamp,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -103,7 +103,6 @@ uint32_t risc_type_to_control_buffer_device_index_offset(tracy::RiscType risc_ty
     }
     return static_cast<uint32_t>(offset);
 }
-#endif
 
 DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_core) {
     const auto& hal = MetalContext::instance().hal();
@@ -114,6 +113,7 @@ DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_cor
                                 dev_msgs::profiler_msg_t::Field::control_vector);
     return control_vector_addr;
 }
+#endif
 
 }  // namespace
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -60,6 +60,61 @@ namespace {
 kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
     return static_cast<kernel_profiler::PacketTypes>((timer_id >> 16) & 0x7);
 }
+
+#if defined(TRACY_ENABLE)
+uint32_t risc_type_to_control_buffer_dram_address_offset(tracy::RiscType risc_type) {
+    kernel_profiler::ControlBuffer offset;
+    switch (risc_type) {
+        case tracy::RiscType::BRISC: [[fallthrough]];
+        case tracy::RiscType::ERISC: offset = kernel_profiler::ControlBuffer::DRAM_PROFILER_ADDRESS_BR_ER_0; break;
+        case tracy::RiscType::NCRISC: offset = kernel_profiler::ControlBuffer::DRAM_PROFILER_ADDRESS_NC_0; break;
+        case tracy::RiscType::TRISC_0: offset = kernel_profiler::ControlBuffer::DRAM_PROFILER_ADDRESS_T0_0; break;
+        case tracy::RiscType::TRISC_1: offset = kernel_profiler::ControlBuffer::DRAM_PROFILER_ADDRESS_T1_0; break;
+        case tracy::RiscType::TRISC_2: offset = kernel_profiler::ControlBuffer::DRAM_PROFILER_ADDRESS_T2_0; break;
+        default: TT_THROW("Invalid RISC type {}", risc_type);
+    }
+    return static_cast<uint32_t>(offset);
+}
+
+uint32_t risc_type_to_control_buffer_host_index_offset(tracy::RiscType risc_type) {
+    kernel_profiler::ControlBuffer offset;
+    switch (risc_type) {
+        case tracy::RiscType::BRISC: [[fallthrough]];
+        case tracy::RiscType::ERISC: offset = kernel_profiler::ControlBuffer::HOST_BUFFER_END_INDEX_BR_ER; break;
+        case tracy::RiscType::NCRISC: offset = kernel_profiler::ControlBuffer::HOST_BUFFER_END_INDEX_NC; break;
+        case tracy::RiscType::TRISC_0: offset = kernel_profiler::ControlBuffer::HOST_BUFFER_END_INDEX_T0; break;
+        case tracy::RiscType::TRISC_1: offset = kernel_profiler::ControlBuffer::HOST_BUFFER_END_INDEX_T1; break;
+        case tracy::RiscType::TRISC_2: offset = kernel_profiler::ControlBuffer::HOST_BUFFER_END_INDEX_T2; break;
+        default: TT_THROW("Invalid RISC type {}", risc_type);
+    }
+    return static_cast<uint32_t>(offset);
+}
+
+uint32_t risc_type_to_control_buffer_device_index_offset(tracy::RiscType risc_type) {
+    kernel_profiler::ControlBuffer offset;
+    switch (risc_type) {
+        case tracy::RiscType::BRISC: [[fallthrough]];
+        case tracy::RiscType::ERISC: offset = kernel_profiler::ControlBuffer::DEVICE_BUFFER_END_INDEX_BR_ER; break;
+        case tracy::RiscType::NCRISC: offset = kernel_profiler::ControlBuffer::DEVICE_BUFFER_END_INDEX_NC; break;
+        case tracy::RiscType::TRISC_0: offset = kernel_profiler::ControlBuffer::DEVICE_BUFFER_END_INDEX_T0; break;
+        case tracy::RiscType::TRISC_1: offset = kernel_profiler::ControlBuffer::DEVICE_BUFFER_END_INDEX_T1; break;
+        case tracy::RiscType::TRISC_2: offset = kernel_profiler::ControlBuffer::DEVICE_BUFFER_END_INDEX_T2; break;
+        default: TT_THROW("Invalid RISC type {}", risc_type);
+    }
+    return static_cast<uint32_t>(offset);
+}
+#endif
+
+DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_core) {
+    const auto& hal = MetalContext::instance().hal();
+    const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device->id(), virtual_core);
+    DeviceAddr profiler_msg_addr = hal.get_dev_addr(core_type, HalL1MemAddrType::PROFILER);
+    DeviceAddr control_vector_addr =
+        profiler_msg_addr + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
+                                dev_msgs::profiler_msg_t::Field::control_vector);
+    return control_vector_addr;
+}
+
 }  // namespace
 
 tracy::TTDeviceMarkerType get_marker_type_from_packet_type(kernel_profiler::PacketTypes packet_type) {
@@ -414,8 +469,10 @@ bool compareCoalescedMarkersByCoreAndTimestamp(
     auto b_marker = std::holds_alternative<tracy::TTDeviceMarker>(b)
                         ? std::get<tracy::TTDeviceMarker>(b)
                         : std::get<FabricEventMarkers>(b).local_noc_write_marker;
-    return std::tie(a_marker.core_x, a_marker.core_y, a_marker.risc, a_marker.timestamp) <
-           std::tie(b_marker.core_x, b_marker.core_y, b_marker.risc, b_marker.timestamp);
+    // Include marker_id in sort order to ensure trailers (marker_id = M+1) come immediately after their events
+    // (marker_id = M)
+    return std::tie(a_marker.core_x, a_marker.core_y, a_marker.risc, a_marker.timestamp, a_marker.marker_id) <
+           std::tie(b_marker.core_x, b_marker.core_y, b_marker.risc, b_marker.timestamp, b_marker.marker_id);
 }
 
 auto coalesceFabricEvents(
@@ -623,9 +680,12 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
     // Convert to json
     std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> json_events_by_op;
     for (auto& [program_execution_uid, markers] : coalesced_events_by_op) {
-        for (auto marker : markers) {
-            if (std::holds_alternative<tracy::TTDeviceMarker>(marker)) {
-                auto device_marker = std::get<tracy::TTDeviceMarker>(marker);
+        // Track matched trailers to skip them when processing (avoid erasing during iteration)
+        std::set<std::tuple<uint64_t, ChipId, uint64_t, uint64_t, tracy::RiscType, uint16_t>> matched_trailers;
+
+        for (auto marker_it = markers.begin(); marker_it != markers.end(); ++marker_it) {
+            if (std::holds_alternative<tracy::TTDeviceMarker>(*marker_it)) {
+                auto device_marker = std::get<tracy::TTDeviceMarker>(*marker_it);
 
                 if (isMarkerAZoneEndpoint(device_marker)) {
                     tracy::TTDeviceMarkerType zone_phase =
@@ -643,7 +703,7 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                         {"sy", device_marker.core_y},
                         {"timestamp", device_marker.timestamp},
                     });
-                } else {
+                } else if (std::holds_alternative<EMD::LocalNocEvent>(EMD(device_marker.data).getContents())) {
                     auto local_noc_event = std::get<EMD::LocalNocEvent>(EMD(device_marker.data).getContents());
 
                     nlohmann::ordered_json data = {
@@ -689,11 +749,63 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                         data["dy"] = phys_coord.y;
                     }
 
+                    // Check if there's a trailer for this LocalNocEvent
+                    // Trailers have the same timestamp, core, risc, and marker_id = timer_id + 1
+                    // Due to sorting by (core_x, core_y, risc, timestamp, marker_id), trailers should be immediately
+                    // after their events Only check the immediate next marker to avoid scanning through many unrelated
+                    // markers
+                    auto next_marker_it = std::next(marker_it);
+                    if (next_marker_it != markers.end() &&
+                        std::holds_alternative<tracy::TTDeviceMarker>(*next_marker_it)) {
+                        auto next_device_marker = std::get<tracy::TTDeviceMarker>(*next_marker_it);
+                        // Check if this is the matching trailer (same timestamp, core, risc, chip_id, and marker_id +
+                        // 1)
+                        if (std::holds_alternative<EMD::LocalNocEventTrailer>(
+                                EMD(next_device_marker.data).getContents()) &&
+                            next_device_marker.timestamp == device_marker.timestamp &&
+                            next_device_marker.chip_id == device_marker.chip_id &&
+                            next_device_marker.core_x == device_marker.core_x &&
+                            next_device_marker.core_y == device_marker.core_y &&
+                            next_device_marker.risc == device_marker.risc &&
+                            next_device_marker.marker_id == device_marker.marker_id + 1) {
+                            // This is the trailer for this LocalNocEvent - merge dst_addr into the event data
+                            auto local_noc_event_trailer =
+                                std::get<EMD::LocalNocEventTrailer>(EMD(next_device_marker.data).getContents());
+                            data["dst_addr"] = local_noc_event_trailer.dst_addr;
+                            // Mark this trailer as matched so we skip it when processing trailers
+                            matched_trailers.insert(std::make_tuple(
+                                next_device_marker.timestamp,
+                                next_device_marker.chip_id,
+                                next_device_marker.core_x,
+                                next_device_marker.core_y,
+                                next_device_marker.risc,
+                                next_device_marker.marker_id));
+                        }
+                    }
+
                     json_events_by_op[program_execution_uid].push_back(data);
+                } else if (std::holds_alternative<EMD::LocalNocEventTrailer>(EMD(device_marker.data).getContents())) {
+                    // Check if this trailer was already matched and merged with its LocalNocEvent
+                    auto trailer_key = std::make_tuple(
+                        device_marker.timestamp,
+                        device_marker.chip_id,
+                        device_marker.core_x,
+                        device_marker.core_y,
+                        device_marker.risc,
+                        device_marker.marker_id);
+                    if (matched_trailers.contains(trailer_key)) {
+                        // This trailer was already merged - skip it
+                        continue;
+                    }
+                    // This trailer wasn't matched (shouldn't happen in normal operation)
+                    // Skip it to avoid duplicate entries
+                    continue;
+                } else {
+                    TT_THROW("Invalid event type found in noc trace packet!");
                 }
-            } else if (std::holds_alternative<FabricEventMarkers>(marker)) {
+            } else if (std::holds_alternative<FabricEventMarkers>(*marker_it)) {
                 // coalesce fabric event markers into a single logical trace event with extra 'fabric_send' metadata
-                auto fabric_event_markers = std::get<FabricEventMarkers>(marker);
+                auto fabric_event_markers = std::get<FabricEventMarkers>(*marker_it);
 
                 auto first_fabric_write_marker = fabric_event_markers.fabric_write_markers[0];
                 auto fabric_routing_fields_marker = fabric_event_markers.fabric_routing_fields_marker;
@@ -1009,7 +1121,12 @@ bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device) {
     return MetalContext::instance().device_manager()->is_dispatch_firmware_active() && !isGalaxyMMIODevice(mesh_device, device);
 }
 
-void writeToCoreControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, const std::vector<uint32_t>& data) {
+void writeToCoreControlBuffer(
+    distributed::MeshDevice* mesh_device,
+    IDevice* device,
+    const CoreCoord& virtual_core,
+    const std::vector<uint32_t>& data,
+    bool force_slow_dispatch) {
     ZoneScoped;
 
     const auto& hal = MetalContext::instance().hal();
@@ -1018,7 +1135,7 @@ void writeToCoreControlBuffer(distributed::MeshDevice* mesh_device, IDevice* dev
     DeviceAddr control_vector_addr =
         profiler_msg_addr + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
                                 dev_msgs::profiler_msg_t::Field::control_vector);
-    if (useFastDispatch(mesh_device, device)) {
+    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
         if (mesh_device) {
             distributed::FDMeshCommandQueue& mesh_cq =
                 dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
@@ -1034,10 +1151,10 @@ void writeToCoreControlBuffer(distributed::MeshDevice* mesh_device, IDevice* dev
     }
 }
 
-void DeviceProfiler::issueFastDispatchReadFromProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device) {
+void DeviceProfiler::issueFastDispatchReadFromProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index) {
     ZoneScoped;
     TT_ASSERT(MetalContext::instance().device_manager()->is_dispatch_firmware_active());
-    const DeviceAddr profiler_addr = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::PROFILER);
+    const DeviceAddr profiler_addr = getProfilerDramBufferAddress(active_dram_buffer_index);
     uint32_t profile_buffer_idx = 0;
 
     const CoreCoord dram_grid_size = device->dram_grid_size();
@@ -1050,32 +1167,32 @@ void DeviceProfiler::issueFastDispatchReadFromProfilerBuffer(distributed::MeshDe
                     .enqueue_read_shard_from_core(
                         distributed::DeviceMemoryAddress{device_coord, dram_core, profiler_addr},
                         &(profile_buffer[profile_buffer_idx]),
-                        profile_buffer_bank_size_bytes,
+                        getProfileBufferBankSizeBytes(),
                         true);
             } else {
                 TT_FATAL(false, "Fast dispatch read from profiler buffer requires mesh device support");
             }
-            profile_buffer_idx += profile_buffer_bank_size_bytes / sizeof(uint32_t);
+            profile_buffer_idx += getProfileBufferBankSizeBytes() / sizeof(uint32_t);
         }
     }
 }
 
-void DeviceProfiler::issueSlowDispatchReadFromProfilerBuffer(IDevice* device) {
+void DeviceProfiler::issueSlowDispatchReadFromProfilerBuffer(IDevice* device, uint8_t active_dram_buffer_index) {
     ZoneScoped;
-    const DeviceAddr profiler_addr = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::PROFILER);
+    const DeviceAddr profiler_addr = getProfilerDramBufferAddress(active_dram_buffer_index);
     uint32_t profile_buffer_idx = 0;
 
     const int num_dram_channels = device->num_dram_channels();
     for (int dram_channel = 0; dram_channel < num_dram_channels; ++dram_channel) {
-        std::vector<uint32_t> profile_buffer_bank_data(profile_buffer_bank_size_bytes / sizeof(uint32_t), 0);
+        std::vector<uint32_t> profile_buffer_bank_data(getProfileBufferBankSizeBytes() / sizeof(uint32_t), 0);
         MetalContext::instance().get_cluster().read_dram_vec(
-            profile_buffer_bank_data.data(), profile_buffer_bank_size_bytes, device_id, dram_channel, profiler_addr);
+            profile_buffer_bank_data.data(), getProfileBufferBankSizeBytes(), device_id, dram_channel, profiler_addr);
 
         std::copy(
             profile_buffer_bank_data.begin(),
             profile_buffer_bank_data.end(),
             profile_buffer.begin() + profile_buffer_idx);
-        profile_buffer_idx += profile_buffer_bank_size_bytes / sizeof(uint32_t);
+        profile_buffer_idx += getProfileBufferBankSizeBytes() / sizeof(uint32_t);
     }
 }
 
@@ -1125,26 +1242,32 @@ void DeviceProfiler::issueSlowDispatchReadFromL1DataBuffer(
         kernel_profiler::PROFILER_L1_BUFFER_SIZE * hal.get_num_risc_processors(core_type));
 }
 
-void DeviceProfiler::readL1DataBufferForCore(distributed::MeshDevice* mesh_device,
-    IDevice* device, const CoreCoord& virtual_core, std::vector<uint32_t>& core_l1_data_buffer) {
+void DeviceProfiler::readL1DataBufferForCore(
+    distributed::MeshDevice* mesh_device,
+    IDevice* device,
+    const CoreCoord& virtual_core,
+    std::vector<uint32_t>& core_l1_data_buffer,
+    bool force_slow_dispatch) {
     ZoneScoped;
-    if (useFastDispatch(mesh_device, device)) {
+    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
         issueFastDispatchReadFromL1DataBuffer(mesh_device, virtual_core, core_l1_data_buffer);
     } else {
         issueSlowDispatchReadFromL1DataBuffer(device, virtual_core, core_l1_data_buffer);
     }
 }
 
-void DeviceProfiler::readL1DataBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores) {
+void DeviceProfiler::readL1DataBuffers(
+    distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch) {
     ZoneScoped;
 
     for (const CoreCoord& virtual_core : virtual_cores) {
         std::vector<uint32_t>& core_l1_data_buffer = core_l1_data_buffers[virtual_core];
-        readL1DataBufferForCore(mesh_device, device, virtual_core, core_l1_data_buffer);
+        readL1DataBufferForCore(mesh_device, device, virtual_core, core_l1_data_buffer, force_slow_dispatch);
     }
 }
 
-void DeviceProfiler::readControlBufferForCore(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core) {
+void DeviceProfiler::readControlBufferForCore(
+    distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, bool force_slow_dispatch) {
     ZoneScoped;
     const auto& hal = MetalContext::instance().hal();
     const HalProgrammableCoreType core_type = tt::llrt::get_core_type(device_id, virtual_core);
@@ -1152,7 +1275,7 @@ void DeviceProfiler::readControlBufferForCore(distributed::MeshDevice* mesh_devi
     DeviceAddr control_vector_addr =
         profiler_msg + hal.get_dev_msgs_factory(core_type).offset_of<dev_msgs::profiler_msg_t>(
                            dev_msgs::profiler_msg_t::Field::control_vector);
-    if (useFastDispatch(mesh_device, device)) {
+    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
         if (mesh_device) {
             distributed::FDMeshCommandQueue& mesh_cq =
                 dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
@@ -1173,14 +1296,14 @@ void DeviceProfiler::readControlBufferForCore(distributed::MeshDevice* mesh_devi
     }
 }
 
-void DeviceProfiler::readControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores) {
+void DeviceProfiler::readControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch) {
     ZoneScoped;
     for (const CoreCoord& virtual_core : virtual_cores) {
-        readControlBufferForCore(mesh_device, device, virtual_core);
+        readControlBufferForCore(mesh_device, device, virtual_core, force_slow_dispatch);
     }
 }
 
-void DeviceProfiler::resetControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores) {
+void DeviceProfiler::resetControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch) {
     ZoneScoped;
     std::unordered_map<CoreCoord, std::vector<uint32_t>> core_control_buffer_resets;
     for (const CoreCoord& virtual_core : virtual_cores) {
@@ -1188,24 +1311,36 @@ void DeviceProfiler::resetControlBuffers(distributed::MeshDevice* mesh_device, I
 
         std::vector<uint32_t>& core_control_buffer_reset = core_control_buffer_resets[virtual_core];
         core_control_buffer_reset.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
-        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS] =
-            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_DEFAULT] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_DEFAULT];
         core_control_buffer_reset[kernel_profiler::FLAT_ID] = control_buffer[kernel_profiler::FLAT_ID];
         core_control_buffer_reset[kernel_profiler::CORE_COUNT_PER_DRAM] =
             control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_NC_0] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_NC_0];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_T0_0] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T0_0];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_T1_0] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T1_0];
+        core_control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS_T2_0] =
+            control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T2_0];
+        // Reset active indices to zero
+        this->active_dram_buffer_per_core_risc_map[virtual_core].clear();
     }
 
     for (const auto& [virtual_core, control_buffer_reset] : core_control_buffer_resets) {
-        writeToCoreControlBuffer(mesh_device, device, virtual_core, control_buffer_reset);
+        writeToCoreControlBuffer(mesh_device, device, virtual_core, control_buffer_reset, force_slow_dispatch);
     }
 }
 
-void DeviceProfiler::readProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device) {
+void DeviceProfiler::readProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index, bool force_slow_dispatch) {
     ZoneScoped;
-    if (useFastDispatch(mesh_device, device)) {
-        issueFastDispatchReadFromProfilerBuffer(mesh_device, device);
+    if (useFastDispatch(mesh_device, device) && !force_slow_dispatch) {
+        issueFastDispatchReadFromProfilerBuffer(mesh_device, device, active_dram_buffer_index);
     } else {
-        issueSlowDispatchReadFromProfilerBuffer(device);
+        issueSlowDispatchReadFromProfilerBuffer(device, active_dram_buffer_index);
     }
 }
 
@@ -1230,12 +1365,13 @@ void DeviceProfiler::readRiscProfilerResults(
     IDevice* device,
     const CoreCoord& worker_core,
     const ProfilerDataBufferSource data_source,
-    const std::optional<ProfilerOptionalMetadata>& metadata) {
+    const std::optional<ProfilerOptionalMetadata>& metadata,
+    const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include) {
     ZoneScoped;
 
     if (data_source == ProfilerDataBufferSource::DRAM_AND_L1) {
-        readRiscProfilerResults(device, worker_core, ProfilerDataBufferSource::DRAM, metadata);
-        readRiscProfilerResults(device, worker_core, ProfilerDataBufferSource::L1, metadata);
+        readRiscProfilerResults(device, worker_core, ProfilerDataBufferSource::DRAM, metadata, riscs_to_include);
+        readRiscProfilerResults(device, worker_core, ProfilerDataBufferSource::L1, metadata, riscs_to_include);
         return;
     }
 
@@ -1297,6 +1433,12 @@ void DeviceProfiler::readRiscProfilerResults(
             riscType = static_cast<tracy::RiscType>(riscEndIndex);
         } else {
             riscType = tracy::RiscType::ERISC;
+        }
+
+        if (riscs_to_include.has_value()) {
+            if (!riscs_to_include->contains(worker_core) || !riscs_to_include->at(worker_core).contains(riscType)) {
+                continue;
+            }
         }
 
         if (bufferEndIndex > 0) {
@@ -1432,6 +1574,22 @@ void DeviceProfiler::readRiscProfilerResults(
                             index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
                             uint32_t data_H = data_buffer.at(index);
                             uint32_t data_L = data_buffer.at(index + 1);
+                            uint64_t timestamp = (uint64_t(time_H) << 32) | time_L;
+                            uint64_t data = (uint64_t(data_H) << 32) | data_L;
+
+                            // Check if this is a LocalNocEvent (not a fabric event or other type)
+                            KernelProfilerNocEventMetadata event_check(data);
+                            bool is_local_noc_event = !KernelProfilerNocEventMetadata::isFabricEventType(
+                                                          event_check.data.raw_event.noc_xfer_type) &&
+                                                      !KernelProfilerNocEventMetadata::isFabricRoutingFields(
+                                                          event_check.data.raw_event.noc_xfer_type) &&
+                                                      !KernelProfilerNocEventMetadata::isLocalEventTrailer(
+                                                          event_check.data.raw_event.noc_xfer_type);
+
+                            // Multicast events don't have trailers (recordMulticastNocEvent doesn't write them)
+                            bool is_multicast_event = event_check.data.raw_event.noc_xfer_type ==
+                                                      KernelProfilerNocEventMetadata::NocEventType::WRITE_MULTICAST;
+
                             readDeviceMarkerData(
                                 device_markers_for_core_risc,
                                 runHostCounterRead,
@@ -1440,9 +1598,88 @@ void DeviceProfiler::readRiscProfilerResults(
                                 device_id,
                                 phys_coord,
                                 riscType,
-                                (uint64_t(data_H) << 32) | data_L,
+                                data,
                                 timer_id,
-                                (uint64_t(time_H) << 32) | time_L);
+                                timestamp);
+
+                            // Check if the next entry is a trailer (only when device debug dump is enabled)
+                            // When device debug dump is enabled (NON_DROPPING), trailers are guaranteed to be written
+                            // atomically immediately after LocalNocEvent data: Format: Timestamp -> LocalNocEvent ->
+                            // EventTrailer The device-side code ensures there's enough space for both before writing
+                            // either Note: Multicast events don't have trailers, so we skip the check for them
+                            if (getDeviceDebugDumpEnabled() && is_local_noc_event && !is_multicast_event) {
+                                // Check if trailer is within buffer bounds (use <= to include boundary case)
+                                // The trailer might be at the exact boundary if bufferEndIndex doesn't account for it
+                                uint32_t trailer_index = index + kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
+                                if (trailer_index + kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE <=
+                                        (bufferRiscShift + bufferEndIndex) &&
+                                    trailer_index + 1 < static_cast<uint32_t>(data_buffer.size())) {
+                                    uint32_t next_data_H = data_buffer.at(trailer_index);
+                                    uint32_t next_data_L = data_buffer.at(trailer_index + 1);
+                                    uint64_t next_data = (uint64_t(next_data_H) << 32) | next_data_L;
+
+                                    // Check if this is a trailer by examining the event type in the data
+                                    KernelProfilerNocEventMetadata trailer_check(next_data);
+                                    if (KernelProfilerNocEventMetadata::isLocalEventTrailer(
+                                            trailer_check.data.raw_event.noc_xfer_type)) {
+                                        // This is a trailer - create a separate marker with the same timestamp
+                                        // Post-processing will match it with the preceding LocalNocEvent based on
+                                        // timestamp Use a modified timer_id to make trailers unique (TTDeviceMarker
+                                        // comparison uses marker_id) We add 1 to the timer_id to distinguish trailers
+                                        // from their corresponding LocalNocEvent
+                                        uint32_t trailer_timer_id = timer_id + 1;
+                                        readDeviceMarkerData(
+                                            device_markers_for_core_risc,
+                                            runHostCounterRead,
+                                            deviceTraceCounterRead,
+                                            opname,
+                                            device_id,
+                                            phys_coord,
+                                            riscType,
+                                            next_data,
+                                            trailer_timer_id,
+                                            timestamp);
+                                        // Skip past the trailer data so we don't try to read it as a timestamp marker
+                                        index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
+                                    } else {
+                                        // Expected trailer but didn't find one - this indicates a problem
+                                        TT_THROW(
+                                            "Expected trailer after LocalNocEvent when device debug dump is enabled. "
+                                            "Event type: {}, timestamp: {}, core: ({}, {}), risc: {}, bufferEndIndex: "
+                                            "{}, "
+                                            "current index: {}, bufferRiscShift: {}, trailer index: {}, next data: "
+                                            "0x{:016x}",
+                                            static_cast<int>(event_check.data.raw_event.noc_xfer_type),
+                                            timestamp,
+                                            worker_core.x,
+                                            worker_core.y,
+                                            enchantum::to_string(riscType),
+                                            bufferEndIndex,
+                                            index,
+                                            bufferRiscShift,
+                                            trailer_index,
+                                            next_data);
+                                    }
+                                } else {
+                                    // Expected trailer but buffer ended - this indicates a problem
+                                    // This should not happen if device-side atomic writes are working correctly
+                                    TT_THROW(
+                                        "Expected trailer after LocalNocEvent when device debug dump is enabled, but "
+                                        "buffer ended. "
+                                        "Event type: {}, timestamp: {}, core: ({}, {}), risc: {}, bufferEndIndex: {}, "
+                                        "current index: {}, bufferRiscShift: {}, trailer index: {}, buffer size: {}",
+                                        static_cast<int>(event_check.data.raw_event.noc_xfer_type),
+                                        timestamp,
+                                        worker_core.x,
+                                        worker_core.y,
+                                        enchantum::to_string(riscType),
+                                        bufferEndIndex,
+                                        index,
+                                        bufferRiscShift,
+                                        trailer_index,
+                                        data_buffer.size());
+                                }
+                            }
                             continue;
                         }
                         case kernel_profiler::TS_EVENT: {
@@ -1588,6 +1825,7 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
     };
 
     auto device_marker_it = device_markers.begin();
+    // log_info(tt::LogMetal, "Processing {} device markers", device_markers.size());
     while (device_marker_it != device_markers.end()) {
         tracy::TTDeviceMarker marker = *device_marker_it;
         tracy::MarkerDetails marker_details = this->getMarkerDetails(marker.marker_id);
@@ -1741,6 +1979,19 @@ void DeviceProfiler::setLastFDReadAsNotDone() { this->is_last_fd_read_done = fal
 
 void DeviceProfiler::setLastFDReadAsDone() { this->is_last_fd_read_done = true; }
 
+uint32_t DeviceProfiler::getProfileBufferBankSizeBytes() const { return this->profile_buffer_bank_size_bytes; }
+
+void DeviceProfiler::setProfileBufferBankSizeBytes(uint32_t size, uint32_t num_dram_banks) {
+    this->profile_buffer_bank_size_bytes = size;
+    this->profile_buffer.resize(size * num_dram_banks / sizeof(uint32_t));
+}
+
+DeviceAddr DeviceProfiler::getProfilerDramBufferAddress(uint8_t active_dram_buffer_index) const {
+    const auto base_address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::PROFILER);
+    const auto offset = getProfileBufferBankSizeBytes() * active_dram_buffer_index;
+    return base_address + offset;
+}
+
 bool DeviceProfiler::isLastFDReadDone() const { return this->is_last_fd_read_done; }
 
 DeviceProfiler::DeviceProfiler(const IDevice* device, const bool new_logs [[maybe_unused]]) :
@@ -1892,26 +2143,31 @@ void DeviceProfiler::readResults(
 
     TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores));
 
+    bool force_slow_dispatch = MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled();
+
+    constexpr uint8_t default_dram_buffer_index = 0;
+
     if (data_source == ProfilerDataBufferSource::DRAM) {
-        readControlBuffers(mesh_device, device, virtual_cores);
+        readControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
 
-        readProfilerBuffer(mesh_device, device);
+        readProfilerBuffer(mesh_device, device, default_dram_buffer_index, force_slow_dispatch);
 
-        resetControlBuffers(mesh_device, device, virtual_cores);
+        resetControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
     } else if (data_source == ProfilerDataBufferSource::L1) {
-        readControlBuffers(mesh_device, device, virtual_cores);
+        readControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
 
-        resetControlBuffers(mesh_device, device, virtual_cores);
-        readL1DataBuffers(mesh_device, device, virtual_cores);
+        resetControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
+
+        readL1DataBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
     } else {
         TT_ASSERT(data_source == ProfilerDataBufferSource::DRAM_AND_L1);
-        readControlBuffers(mesh_device, device, virtual_cores);
+        readControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
 
-        readProfilerBuffer(mesh_device, device);
+        readProfilerBuffer(mesh_device, device, default_dram_buffer_index, force_slow_dispatch);
 
-        readL1DataBuffers(mesh_device, device, virtual_cores);
+        readL1DataBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
 
-        resetControlBuffers(mesh_device, device, virtual_cores);
+        resetControlBuffers(mesh_device, device, virtual_cores, force_slow_dispatch);
     }
 #endif
 }
@@ -1921,7 +2177,8 @@ void DeviceProfiler::processResults(
     const std::vector<CoreCoord>& virtual_cores,
     const ProfilerReadState state,
     const ProfilerDataBufferSource data_source,
-    const std::optional<ProfilerOptionalMetadata>& metadata) {
+    const std::optional<ProfilerOptionalMetadata>& metadata,
+    const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include) {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
     if (!getDeviceProfilerState()) {
@@ -1933,7 +2190,7 @@ void DeviceProfiler::processResults(
     ZoneName(zone_name.c_str(), zone_name.size());
 
     for (const auto& virtual_core : virtual_cores) {
-        readRiscProfilerResults(device, virtual_core, data_source, metadata);
+        readRiscProfilerResults(device, virtual_core, data_source, metadata, riscs_to_include);
     }
 #endif
 }
@@ -2196,7 +2453,224 @@ void DeviceProfiler::destroyTracyContexts() {
 #endif
 }
 
+void DeviceProfiler::pollDebugDumpResults(
+    IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool is_final_poll) {
+#if defined(TRACY_ENABLE)
+    if (!getDeviceProfilerState()) {
+        return;
+    }
+
+    TT_ASSERT(device_id == device->id());
+
+    // Populate hash_to_zone_src_locations before processing markers
+    // This is needed so that getMarkerDetails can look up zone names, source files, and line numbers
+    hash_to_zone_src_locations = generateZoneSourceLocationsHashes();
+
+    // Handle worker cores: use ping-pong DRAM buffer logic
+    if (virtual_cores.empty()) {
+        return;
+    }
+
+    auto* mesh_device = device->get_mesh_device().get();
+
+    readControlBuffers(mesh_device, device, virtual_cores, /*force_slow_dispatch=*/true);
+
+    // Write control buffers into a temporary map because readProfilerBuffer and processResults relies on
+    // the control buffer contents. Update the control buffer after calling the processing functions.
+
+    // Not Stalled but have data
+    std::map<CoreCoord, std::vector<uint32_t>> temp_control_buffers;
+    std::map<CoreCoord, std::set<tracy::RiscType>> cores_with_data;
+
+    // Stalled because full
+    std::map<CoreCoord, std::vector<uint32_t>> temp_stalled_control_buffers;
+    std::map<CoreCoord, std::set<tracy::RiscType>> stalled_cores_with_data;
+
+    for (const auto& virtual_core : virtual_cores) {
+        bool is_eth = MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, device->id());
+
+        for (tracy::RiscType risc_type : enchantum::values_generator<tracy::RiscType>) {
+            if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || (is_eth && risc_type != tracy::RiscType::ERISC) ||
+                (!is_eth && risc_type == tracy::RiscType::ERISC)) {
+                continue;
+            }
+
+            const uint8_t active_dram_buffer_index =
+                this->active_dram_buffer_per_core_risc_map[virtual_core][risc_type];
+
+            TT_ASSERT(active_dram_buffer_index < 2, "DRAM Buffer Index can only be 0 or 1");
+
+            const uint8_t control_buffer_dram_addr_index = risc_type_to_control_buffer_dram_address_offset(risc_type);
+            const uint8_t control_buffer_host_index_index = risc_type_to_control_buffer_host_index_offset(risc_type);
+            const DeviceAddr dram_buffer_address = core_control_buffers[virtual_core][control_buffer_dram_addr_index];
+
+            // Check if buffer has data by looking at HOST_BUFFER_END_INDEX
+            const uint32_t buffer_end_index = core_control_buffers[virtual_core][control_buffer_host_index_index];
+            const bool buffer_has_data = buffer_end_index > 0;
+
+            if (dram_buffer_address == kernel_profiler::DRAM_PROFILER_ADDRESS_STALLED) {
+                if (!temp_stalled_control_buffers.contains(virtual_core)) {
+                    temp_stalled_control_buffers[virtual_core] = core_control_buffers.at(virtual_core);
+                }
+
+                const uint8_t next_active_dram_buffer_index = 1 - active_dram_buffer_index;
+                temp_stalled_control_buffers[virtual_core][control_buffer_dram_addr_index] =
+                    this->getProfilerDramBufferAddress(next_active_dram_buffer_index);
+                temp_stalled_control_buffers[virtual_core][control_buffer_host_index_index] = 0;
+                stalled_cores_with_data[virtual_core].insert(risc_type);
+
+                // Note: Do not use the writeToCoreControlBuffer function as it will overwrite the entire control
+                // buffer. We only want to update the fields for the stalled riscs.
+                const auto dram_profiler_address_offset = risc_type_to_control_buffer_dram_address_offset(risc_type);
+                const DeviceAddr addr =
+                    getControlVectorAddress(device, virtual_core) + (dram_profiler_address_offset * sizeof(uint32_t));
+                // Need to use write_reg to guarantee a single write to the control buffer
+                // Host index will be updated by the risc once it receives the new dram address
+                MetalContext::instance().get_cluster().write_reg(
+                    &temp_stalled_control_buffers[virtual_core][control_buffer_dram_addr_index],
+                    tt_cxy_pair(device->id(), virtual_core),
+                    addr);
+            } else if (buffer_has_data) {
+                if (!temp_control_buffers.contains(virtual_core)) {
+                    temp_control_buffers[virtual_core] = core_control_buffers.at(virtual_core);
+                }
+                cores_with_data[virtual_core].insert(risc_type);
+            } else {
+                // Buffer has no data and is not stalled - nothing to do
+                // This should match, otherwise it means something went out of sync with the host and device
+                TT_ASSERT(
+                    dram_buffer_address == this->getProfilerDramBufferAddress(active_dram_buffer_index),
+                    "DRAM Buffer Address on risc {} virtual core {} is not valid. Host and Device state mismatch. DRAM "
+                    "buffer address on device: {}, "
+                    "Expected DRAM buffer address: {}, index: {}",
+                    enchantum::to_string(risc_type),
+                    virtual_core.str(),
+                    dram_buffer_address,
+                    this->getProfilerDramBufferAddress(active_dram_buffer_index),
+                    active_dram_buffer_index);
+            }
+        }
+    }
+    // For final poll, merge NOT STALLED cores with data into stalled cores
+    if (is_final_poll) {
+        for (const auto& [virtual_core, risc_types] : cores_with_data) {
+            for (const auto& risc_type : risc_types) {
+                stalled_cores_with_data[virtual_core].insert(risc_type);
+                if (!temp_control_buffers.contains(virtual_core)) {
+                    temp_control_buffers[virtual_core] = core_control_buffers.at(virtual_core);
+                }
+                const uint8_t control_buffer_host_index_index =
+                    risc_type_to_control_buffer_host_index_offset(risc_type);
+                temp_control_buffers[virtual_core][control_buffer_host_index_index] = 0;
+            }
+        }
+    }
+
+    // Figure out which DRAM profiler addresses need to be read
+    std::set<uint8_t> stalled_dram_buffer_indices;
+    std::vector<CoreCoord> virtual_cores_with_data;
+    for (const auto& [virtual_core, risc_types] : stalled_cores_with_data) {
+        virtual_cores_with_data.push_back(virtual_core);
+        for (const auto& risc_type : risc_types) {
+            stalled_dram_buffer_indices.insert(this->active_dram_buffer_per_core_risc_map[virtual_core][risc_type]);
+        }
+    }
+
+    // Read DRAM
+    for (uint8_t buffer_index : stalled_dram_buffer_indices) {
+        TT_ASSERT(buffer_index < 2, "DRAM Buffer Index can only be 0 or 1");
+        readProfilerBuffer(mesh_device, device, buffer_index, /*force_slow_dispatch=*/true);
+
+        std::map<CoreCoord, std::set<tracy::RiscType>> cores_with_data_in_current_buffer;
+        for (const auto& [virtual_core, risc_types] : stalled_cores_with_data) {
+            for (const auto& risc_type : risc_types) {
+                if (this->active_dram_buffer_per_core_risc_map.at(virtual_core).at(risc_type) == buffer_index) {
+                    cores_with_data_in_current_buffer[virtual_core].insert(risc_type);
+                }
+            }
+        }
+
+        std::vector<CoreCoord> virtual_cores_for_current_buffer;
+        virtual_cores_for_current_buffer.reserve(cores_with_data_in_current_buffer.size());
+        for (const auto& [virtual_core, risc_types] : cores_with_data_in_current_buffer) {
+            virtual_cores_for_current_buffer.push_back(virtual_core);
+        }
+
+        processResults(
+            device,
+            virtual_cores_for_current_buffer,
+            ProfilerReadState::NORMAL,
+            ProfilerDataBufferSource::DRAM,
+            {},
+            cores_with_data_in_current_buffer);
+    }
+
+    // Remaining L1 data not flushed to DRAM yet
+    if (is_final_poll) {
+        std::vector<CoreCoord> cores_with_l1_data;
+        std::map<CoreCoord, std::set<tracy::RiscType>> riscs_with_l1_data;
+
+        for (const auto& virtual_core : virtual_cores) {
+            bool is_eth = MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, device->id());
+            bool core_has_l1_data = false;
+
+            for (tracy::RiscType risc_type : enchantum::values_generator<tracy::RiscType>) {
+                if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || (is_eth && risc_type != tracy::RiscType::ERISC) ||
+                    (!is_eth && risc_type == tracy::RiscType::ERISC)) {
+                    continue;
+                }
+
+                const uint8_t control_buffer_device_index_index =
+                    risc_type_to_control_buffer_device_index_offset(risc_type);
+                const uint32_t device_buffer_end_index =
+                    core_control_buffers[virtual_core][control_buffer_device_index_index];
+
+                if (device_buffer_end_index > 0) {
+                    riscs_with_l1_data[virtual_core].insert(risc_type);
+                    core_has_l1_data = true;
+                }
+            }
+
+            if (core_has_l1_data) {
+                cores_with_l1_data.push_back(virtual_core);
+            }
+        }
+
+        // Read and process L1 buffers with unflushed data
+        if (!cores_with_l1_data.empty()) {
+            readL1DataBuffers(mesh_device, device, cores_with_l1_data, true);
+            processResults(
+                device,
+                cores_with_l1_data,
+                ProfilerReadState::NORMAL,
+                ProfilerDataBufferSource::L1,
+                {},
+                riscs_with_l1_data);
+        }
+    }
+
+    // Commit the DeviceProfiler state updates on the host side
+    for (const auto& [virtual_core, risc_types] : stalled_cores_with_data) {
+        if (temp_stalled_control_buffers.contains(virtual_core)) {
+            this->core_control_buffers[virtual_core] = temp_stalled_control_buffers[virtual_core];
+            for (const auto& risc_type : risc_types) {
+                const uint8_t old_index = this->active_dram_buffer_per_core_risc_map[virtual_core][risc_type];
+                this->active_dram_buffer_per_core_risc_map[virtual_core][risc_type] = 1 - old_index;
+            }
+        } else if (temp_control_buffers.contains(virtual_core) && is_final_poll) {
+            // Non-stalled core that was merged into stalled_cores_with_data on final poll
+            // Update control buffer (with cleared host index) but don't switch buffer index
+            this->core_control_buffers[virtual_core] = temp_control_buffers[virtual_core];
+        }
+    }
+#endif
+}
+
 bool getDeviceProfilerState() { return MetalContext::instance().rtoptions().get_profiler_enabled(); }
+
+bool getDeviceDebugDumpEnabled() {
+    return MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled();
+}
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -119,30 +119,43 @@ private:
     // Runtime ids associated with each trace
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>> runtime_ids_per_trace;
 
+    // Number of bytes reserved in each DRAM bank for storing device profiling data
+    uint32_t profile_buffer_bank_size_bytes{};
+
+    // Map which DRAM buffer is currently being written to by the RISC cores. Used for debug dump mode with double
+    // buffering.
+    std::map<CoreCoord, std::map<tracy::RiscType, uint8_t>> active_dram_buffer_per_core_risc_map;
+
+    // Map to store buffer end indices for inactive buffers (before they're reset)
+    // Key: (core, risc_type, buffer_index) -> buffer_end_index
+    std::map<CoreCoord, std::map<tracy::RiscType, std::map<uint8_t, uint32_t>>> inactive_buffer_end_indices;
+
+    DeviceAddr getProfilerDramBufferAddress(uint8_t active_dram_buffer_index) const;
+
     // Read all control buffers
-    void readControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores);
+    void readControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch);
 
     // Read control buffer for a single core
-    void readControlBufferForCore(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core);
+    void readControlBufferForCore(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, bool force_slow_dispatch);
 
     // Reset all control buffers
-    void resetControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores);
+    void resetControlBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch);
 
     // Read all L1 data buffers
-    void readL1DataBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores);
+    void readL1DataBuffers(distributed::MeshDevice* mesh_device, IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool force_slow_dispatch);
 
     // Read L1 data buffer for a single core
     void readL1DataBufferForCore(distributed::MeshDevice* mesh_device,
-        IDevice* device, const CoreCoord& virtual_core, std::vector<uint32_t>& core_l1_data_buffer);
+        IDevice* device, const CoreCoord& virtual_core, std::vector<uint32_t>& core_l1_data_buffer, bool force_slow_dispatch);
 
     // Read device profiler buffer
-    void readProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device);
+    void readProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index, bool force_slow_dispatch);
 
     // Read data from profiler buffer using fast dispatch
-    void issueFastDispatchReadFromProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device);
+    void issueFastDispatchReadFromProfilerBuffer(distributed::MeshDevice* mesh_device, IDevice* device, uint8_t active_dram_buffer_index = 0);
 
     // Read data from profiler buffer using slow dispatch
-    void issueSlowDispatchReadFromProfilerBuffer(IDevice* device);
+    void issueSlowDispatchReadFromProfilerBuffer(IDevice* device, uint8_t active_dram_buffer_index = 0);
 
     // Read data from L1 data buffer using fast dispatch
     // NOLINTNEXTLINE(readability-make-member-function-const)
@@ -158,7 +171,8 @@ private:
     void readRiscProfilerResults(IDevice* device,
         const CoreCoord& worker_core,
         ProfilerDataBufferSource data_source,
-        const std::optional<ProfilerOptionalMetadata>& metadata);
+        const std::optional<ProfilerOptionalMetadata>& metadata,
+        const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include = {});
 
     // Read marker data to be displayed
     void readDeviceMarkerData(
@@ -216,9 +230,6 @@ public:
     // DRAM Vector
     std::vector<uint32_t> profile_buffer;
 
-    // Number of bytes reserved in each DRAM bank for storing device profiling data
-    uint32_t profile_buffer_bank_size_bytes{};
-
     // Device markers grouped by (physical core, risc type)
     std::map<CoreCoord, std::map<tracy::RiscType, std::set<tracy::TTDeviceMarker>>> device_markers_per_core_risc_map;
 
@@ -252,7 +263,8 @@ public:
         const std::vector<CoreCoord>& virtual_cores,
         ProfilerReadState state = ProfilerReadState::NORMAL,
         ProfilerDataBufferSource data_source = ProfilerDataBufferSource::DRAM,
-        const std::optional<ProfilerOptionalMetadata>& metadata = {});
+        const std::optional<ProfilerOptionalMetadata>& metadata = {},
+        const std::optional<std::map<CoreCoord, std::set<tracy::RiscType>>>& riscs_to_include = {});
 
     void dumpRoutingInfo() const;
 
@@ -288,10 +300,18 @@ public:
     void setLastFDReadAsNotDone();
 
     bool isLastFDReadDone() const;
+
+    uint32_t getProfileBufferBankSizeBytes() const;
+
+    void setProfileBufferBankSizeBytes(uint32_t size, uint32_t num_dram_banks);
+
+    // Read control buffer for each core, check if the host buffer for any risc is full. If it's full,
+    // swap the active DRAM buffer to unblock the risc and then read out the buffer
+    void pollDebugDumpResults(IDevice* device, const std::vector<CoreCoord>& virtual_cores, bool is_final_poll);
 };
 
 bool useFastDispatch(distributed::MeshDevice* mesh_device, IDevice* device);
 
-void writeToCoreControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, const std::vector<uint32_t>& data);
+void writeToCoreControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, const CoreCoord& virtual_core, const std::vector<uint32_t>& data, bool force_slow_dispatch);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler_state.hpp
+++ b/tt_metal/impl/profiler/profiler_state.hpp
@@ -9,4 +9,7 @@ namespace tt::tt_metal {
 // Get global device profiling state based on build flag and environment variables
 bool getDeviceProfilerState();
 
+// Get if the device debug dump is enabled
+bool getDeviceDebugDumpEnabled();
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler_state_manager.cpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.cpp
@@ -10,6 +10,8 @@
 #include "hostdevcommon/profiler_common.h"
 #include "context/metal_context.hpp"
 #include "math.hpp"
+#include "tt_cluster.hpp"
+#include <tt-metalium/device.hpp>
 
 namespace tt::tt_metal {
 
@@ -19,14 +21,22 @@ constexpr static uint32_t DEFAULT_PROFILER_L1_PROGRAM_MIN_OPTIONAL_MARKER_COUNT 
 uint32_t get_profiler_dram_bank_size_per_risc_bytes(llrt::RunTimeOptions& rtoptions) {
     std::optional<uint32_t> profiler_program_support_count = rtoptions.get_profiler_program_support_count();
     const bool do_profiler_sum = rtoptions.get_profiler_sum();
+    const bool debug_dump_enabled = rtoptions.get_experimental_device_debug_dump_enabled();
 
     if (!profiler_program_support_count.has_value()) {
         profiler_program_support_count = DEFAULT_PROFILER_PROGRAM_SUPPORT_COUNT;
+        if (debug_dump_enabled) {
+            profiler_program_support_count = profiler_program_support_count.value() / 2;
+            log_info(
+                tt::LogMetal,
+                "Device Debug Dump enabled: reducing profiler program support count to {} to maintain same DRAM usage",
+                profiler_program_support_count.value());
+        }
     }
 
     const uint32_t profiler_l1_program_min_optional_marker_count =
         do_profiler_sum ? DEFAULT_PROFILER_L1_PROGRAM_MIN_OPTIONAL_MARKER_COUNT : 0;
-    const uint32_t dram_bank_size_per_risc_bytes_single_program =
+    uint32_t dram_bank_size_per_risc_bytes_single_program =
         kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE *
         (kernel_profiler::PROFILER_L1_PROGRAM_ID_COUNT + kernel_profiler::PROFILER_L1_GUARANTEED_MARKER_COUNT +
          profiler_l1_program_min_optional_marker_count) *
@@ -59,9 +69,28 @@ uint32_t get_profiler_dram_bank_size_per_risc_bytes() {
     return get_profiler_dram_bank_size_per_risc_bytes(rtoptions);
 }
 
+uint32_t get_profiler_dram_bank_size_for_hal_allocation(llrt::RunTimeOptions& rtoptions) {
+    const uint32_t per_buffer_size = get_profiler_dram_bank_size_per_risc_bytes(rtoptions);
+    const bool debug_dump_enabled = rtoptions.get_experimental_device_debug_dump_enabled();
+
+    // There are 2 DRAM buffers per risc when debug dump is enabled.
+    // The size of each buffer returned by get_profiler_dram_bank_size_per_risc_bytes is half to maintain the same
+    // total profiler size.
+    if (debug_dump_enabled) {
+        return per_buffer_size * 2;
+    }
+    return per_buffer_size;
+}
+
 ProfilerStateManager::ProfilerStateManager() : do_sync_on_close(true) {}
 
 void ProfilerStateManager::cleanup_device_profilers() {
+    // This thread only exists when debug dump is enabled
+    if (this->debug_dump_thread.joinable()) {
+        this->stop_debug_dump_thread = true;
+        this->stop_debug_dump_thread_cv.notify_all();
+        this->debug_dump_thread.join();
+    }
     std::vector<std::thread> threads(this->device_profiler_map.size());
 
     uint32_t i = 0;
@@ -83,6 +112,7 @@ void ProfilerStateManager::cleanup_device_profilers() {
 }
 
 uint32_t ProfilerStateManager::calculate_optimal_num_threads_for_device_profiler_thread_pool() const {
+    std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
     const uint32_t num_threads_available = std::thread::hardware_concurrency();
 
     if (num_threads_available == 0 || this->device_profiler_map.size() > num_threads_available) {
@@ -98,26 +128,89 @@ uint32_t ProfilerStateManager::calculate_optimal_num_threads_for_device_profiler
 
 void ProfilerStateManager::mark_trace_begin(ChipId device_id, uint32_t trace_id) {
     TT_ASSERT(this->device_profiler_map.contains(device_id));
+    std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
     DeviceProfiler& device_profiler = this->device_profiler_map.at(device_id);
     device_profiler.markTraceBegin(trace_id);
 }
 
 void ProfilerStateManager::mark_trace_end(ChipId device_id, uint32_t trace_id) {
     TT_ASSERT(this->device_profiler_map.contains(device_id));
+    std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
     DeviceProfiler& device_profiler = this->device_profiler_map.at(device_id);
     device_profiler.markTraceEnd(trace_id);
 }
 
 void ProfilerStateManager::mark_trace_replay(ChipId device_id, uint32_t trace_id) {
     TT_ASSERT(this->device_profiler_map.contains(device_id));
+    std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
     DeviceProfiler& device_profiler = this->device_profiler_map.at(device_id);
     device_profiler.markTraceReplay(trace_id);
 }
 
 void ProfilerStateManager::add_runtime_id_to_trace(ChipId device_id, uint32_t trace_id, uint32_t runtime_id) {
     TT_ASSERT(this->device_profiler_map.contains(device_id));
+    std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
     DeviceProfiler& device_profiler = this->device_profiler_map.at(device_id);
     device_profiler.addRuntimeIdToTrace(trace_id, runtime_id);
+}
+
+void ProfilerStateManager::start_debug_dump_thread(
+    std::vector<IDevice*> active_devices, std::unordered_map<ChipId, std::vector<CoreCoord>> virtual_cores_map) {
+    TT_ASSERT(!this->debug_dump_thread.joinable());
+    const auto interval = std::chrono::seconds(
+        MetalContext::instance().rtoptions().get_experimental_device_debug_dump_interval_seconds());
+
+    this->debug_dump_thread = std::thread([this,
+                                           active_devices = std::move(active_devices),
+                                           virtual_cores_map = std::move(virtual_cores_map),
+                                           interval = interval]() {
+        while (true) {
+            {
+                std::lock_guard<std::recursive_mutex> lock{this->device_profiler_map_mutex};
+                for (auto* device : active_devices) {
+                    auto profiler_it = this->device_profiler_map.find(device->id());
+                    TT_ASSERT(this->device_profiler_map.contains(device->id()));
+                    DeviceProfiler& profiler = profiler_it->second;
+                    // Only process stalled buffers during periodic polling
+                    profiler.pollDebugDumpResults(device, virtual_cores_map.at(device->id()), /*is_final_poll=*/false);
+                }
+            }
+
+            std::unique_lock<std::mutex> lock{this->debug_dump_thread_mutex};
+            if (this->stop_debug_dump_thread_cv.wait_for(
+                    lock, interval, [&] { return this->stop_debug_dump_thread.load(); })) {
+                for (auto* device : active_devices) {
+                    {
+                        auto profiler_it = this->device_profiler_map.find(device->id());
+                        TT_ASSERT(profiler_it != this->device_profiler_map.end());
+                        DeviceProfiler& profiler = profiler_it->second;
+                        profiler.pollDebugDumpResults(
+                            device, virtual_cores_map.at(device->id()), /*is_final_poll=*/true);
+                    }
+                    constexpr auto state = ProfilerReadState::LAST_FD_READ;
+                    detail::ReadDeviceProfilerResultsInternal(
+                        device->get_mesh_device().get(), device, virtual_cores_map.at(device->id()), state, {});
+
+                    auto profiler_it = this->device_profiler_map.find(device->id());
+                    TT_ASSERT(profiler_it != this->device_profiler_map.end());
+                    DeviceProfiler& profiler = profiler_it->second;
+                    if (MetalContext::instance().rtoptions().get_profiler_trace_only()) {
+                        profiler.processResults(
+                            device,
+                            virtual_cores_map.at(device->id()),
+                            state,
+                            ProfilerDataBufferSource::DRAM_AND_L1,
+                            {});
+                    } else {
+                        profiler.processResults(
+                            device, virtual_cores_map.at(device->id()), state, ProfilerDataBufferSource::DRAM, {});
+                    }
+                    // cleanup_device_profilers() handles the final dump
+                }
+                break;
+            }
+        }
+    });
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler_state_manager.hpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.hpp
@@ -24,8 +24,19 @@ class RunTimeOptions;
 
 namespace tt_metal {
 
+namespace detail {
+void ReadDeviceProfilerResultsInternal(
+    distributed::MeshDevice* mesh_device,
+    IDevice* device,
+    const std::vector<CoreCoord>& virtual_cores,
+    ProfilerReadState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata);
+}  // namespace detail
+
+void LaunchIntervalBasedProfilerReadThread(const std::vector<IDevice*>& active_devices);
 uint32_t get_profiler_dram_bank_size_per_risc_bytes(llrt::RunTimeOptions& rtoptions);
 uint32_t get_profiler_dram_bank_size_per_risc_bytes();
+uint32_t get_profiler_dram_bank_size_for_hal_allocation(llrt::RunTimeOptions& rtoptions);
 
 struct ProfilerStateManager {
 public:
@@ -34,7 +45,8 @@ public:
     ~ProfilerStateManager() = default;
 
     void cleanup_device_profilers();
-
+    void start_debug_dump_thread(
+        std::vector<IDevice*> active_devices, std::unordered_map<ChipId, std::vector<CoreCoord>> virtual_cores_map);
     uint32_t calculate_optimal_num_threads_for_device_profiler_thread_pool() const;
 
     void mark_trace_begin(ChipId device_id, uint32_t trace_id);
@@ -50,6 +62,7 @@ public:
     static constexpr CoreCoord SYNC_CORE = {0, 0};
 
     std::unordered_map<ChipId, DeviceProfiler> device_profiler_map;
+    mutable std::recursive_mutex device_profiler_map_mutex;
 
     std::map<ChipId, std::vector<std::set<experimental::ProgramAnalysisData>>> device_programs_perf_analyses_map;
 
@@ -64,6 +77,11 @@ public:
 
     std::mutex log_file_write_mutex;
     std::mutex programs_perf_report_write_mutex;
+
+    std::thread debug_dump_thread;
+    std::mutex debug_dump_thread_mutex;
+    std::atomic<bool> stop_debug_dump_thread = false;
+    std::condition_variable stop_debug_dump_thread_cv;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -66,7 +66,7 @@ namespace tt::tt_metal {
 
 namespace detail {
 
-void setControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, std::vector<uint32_t>& control_buffer) {
+void setControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, std::vector<uint32_t>& control_buffer, bool force_slow_dispatch = false) {
 #if defined(TRACY_ENABLE)
     if (!getDeviceProfilerState()) {
         return;
@@ -81,7 +81,7 @@ void setControlBuffer(distributed::MeshDevice* mesh_device, IDevice* device, std
 
         control_buffer[kernel_profiler::FLAT_ID] = core.second;
 
-        writeToCoreControlBuffer(mesh_device, device, curr_core, control_buffer);
+        writeToCoreControlBuffer(mesh_device, device, curr_core, control_buffer, force_slow_dispatch);
     }
 #endif
 }
@@ -731,18 +731,28 @@ void InitDeviceProfiler(IDevice* device) {
     const uint32_t num_cores_per_dram_bank = soc_desc.profiler_ceiled_core_count_perf_dram_bank;
     const uint32_t bank_size_bytes =
         get_profiler_dram_bank_size_per_risc_bytes() * hal.get_max_processors_per_core() * num_cores_per_dram_bank;
-    TT_ASSERT(bank_size_bytes <= hal.get_dev_size(HalDramMemAddrType::PROFILER));
+    const uint32_t profiler_size = hal.get_dev_size(HalDramMemAddrType::PROFILER);
+    TT_ASSERT(bank_size_bytes <= profiler_size);
 
     const uint32_t num_dram_banks = soc_desc.get_num_dram_views();
 
     auto& profiler = profiler_state_manager->device_profiler_map.at(device_id);
     profiler.setLastFDReadAsNotDone();
-    profiler.profile_buffer_bank_size_bytes = bank_size_bytes;
-    profiler.profile_buffer.resize(profiler.profile_buffer_bank_size_bytes * num_dram_banks / sizeof(uint32_t));
+    profiler.setProfileBufferBankSizeBytes(bank_size_bytes, num_dram_banks);
 
     std::vector<uint32_t> control_buffer(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
-    control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
-    detail::setControlBuffer(nullptr, device, control_buffer);
+    control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_DEFAULT] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+
+    if (MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled()) {
+        // Split into two buffers. Assign the active DRAM buffer address to all control buffer indices.
+        control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+        control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_NC_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+        control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T0_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+        control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T1_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+        control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_T2_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
+    }
+
+    setControlBuffer(nullptr, device, control_buffer);
 
     if (MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
         profiler.dumpRoutingInfo();
@@ -780,7 +790,8 @@ bool onlyProfileDispatchCores(const ProfilerReadState state) {
            state == ProfilerReadState::ONLY_DISPATCH_CORES;
 }
 
-void ReadDeviceProfilerResults(
+// Shared implementation for reading device profiler results
+static void ReadDeviceProfilerResultsImpl(
     distributed::MeshDevice* mesh_device,
     IDevice* device,
     const std::vector<CoreCoord>& virtual_cores,
@@ -846,6 +857,32 @@ void ReadDeviceProfilerResults(
         profiler.readResults(mesh_device, device, virtual_cores, state, ProfilerDataBufferSource::DRAM, metadata);
     }
 #endif
+}
+
+void ReadDeviceProfilerResults(
+    distributed::MeshDevice* mesh_device,
+    IDevice* device,
+    const std::vector<CoreCoord>& virtual_cores,
+    ProfilerReadState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
+#if defined(TRACY_ENABLE)
+    if (getDeviceDebugDumpEnabled()) {
+        return;
+    }
+
+    ReadDeviceProfilerResultsImpl(mesh_device, device, virtual_cores, state, metadata);
+#endif
+}
+
+void ReadDeviceProfilerResultsInternal(
+    distributed::MeshDevice* mesh_device,
+    IDevice* device,
+    const std::vector<CoreCoord>& virtual_cores,
+    ProfilerReadState state,
+    const std::optional<ProfilerOptionalMetadata>& metadata) {
+    // Note: This function bypasses the getDeviceDebugDumpEnabled() check
+    // It is intended only for use by ProfilerStateManager during cleanup
+    ReadDeviceProfilerResultsImpl(mesh_device, device, virtual_cores, state, metadata);
 }
 
 bool dumpDeviceProfilerDataMidRun(const ProfilerReadState state) {
@@ -948,6 +985,12 @@ void ReadDeviceProfilerResults(
         return;
     }
 
+    // Manual reading of device profiler results is not supported when there is already another thread reading the
+    // results
+    if (getDeviceDebugDumpEnabled()) {
+        return;
+    }
+
     TT_ASSERT(device->is_initialized());
 
     const std::unique_ptr<ProfilerStateManager>& profiler_state_manager =
@@ -1041,6 +1084,12 @@ void ReadMeshDeviceProfilerResults(
     ZoneScoped;
 
     if (!getDeviceProfilerState()) {
+        return;
+    }
+
+    // Manual reading of device profiler results is not supported when there is already another thread reading the
+    // results
+    if (getDeviceDebugDumpEnabled()) {
         return;
     }
 
@@ -1150,6 +1199,17 @@ std::map<ChipId, std::set<ProgramAnalysisData>> GetAllProgramsPerfData() {
 }
 
 }  // namespace experimental
+
+void LaunchIntervalBasedProfilerReadThread(const std::vector<IDevice*>& active_devices) {
+#if defined(TRACY_ENABLE)
+    std::unordered_map<ChipId, std::vector<CoreCoord>> virtual_cores_map;
+    for (IDevice* device : active_devices) {
+        virtual_cores_map[device->id()] = detail::getVirtualCoresForProfiling(device, ProfilerReadState::NORMAL);
+    }
+
+    MetalContext::instance().profiler_state_manager()->start_debug_dump_thread(active_devices, virtual_cores_map);
+#endif
+}
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -193,6 +193,9 @@ void JitBuildEnv::init(
         }
         this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
     }
+    if (rtoptions.get_experimental_device_debug_dump_enabled()) {
+        this->defines_ += "-DDEVICE_DEBUG_DUMP=1 ";
+    }
     if (rtoptions.get_profiler_perf_counter_mode() != 0) {
         // force profiler on if perf counters are being captured
         TT_ASSERT(tt::tt_metal::getDeviceProfilerState());

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -119,6 +119,7 @@ enum class EnvVarID {
     TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
     TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
     TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE,  // Terminal command to execute on dispatch timeout.
+    TT_METAL_DEVICE_DEBUG_DUMP_ENABLED,            // Enable experimental debug dump mode for profiler
 
     // ========================================
     // WATCHER SYSTEM
@@ -830,6 +831,19 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             // Only disable pushing to Tracy GUI if device profiler is also enabled
             if (this->profiler_enabled && is_env_enabled(value)) {
                 this->profiler_disable_push_to_tracy = true;
+            }
+            break;
+        }
+
+        // TT_METAL_DEVICE_DEBUG_DUMP_ENABLED
+        // Enable and sets the polling interval in seconds for experimental debug dump mode for profiler. In this mode,
+        // the profiler infrastructure will be used to continuously dump debug packets to a file. Default: false (debug
+        // dump mode disabled) Usage: export TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1
+        case EnvVarID::TT_METAL_DEVICE_DEBUG_DUMP_ENABLED: {
+            if (is_env_enabled(value)) {
+                this->profiler_enabled = true;
+                this->profiler_noc_events_enabled = true;
+                this->experimental_device_debug_dump_interval_seconds = std::stoi(value);
             }
             break;
         }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -178,6 +178,7 @@ class RunTimeOptions {
     bool profiler_disable_dump_to_files = false;
     bool profiler_disable_push_to_tracy = false;
     std::optional<uint32_t> profiler_program_support_count = std::nullopt;
+    uint32_t experimental_device_debug_dump_interval_seconds = 0;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -515,6 +516,12 @@ public:
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
     bool get_profiler_disable_dump_to_files() const { return profiler_disable_dump_to_files; }
     bool get_profiler_disable_push_to_tracy() const { return profiler_disable_push_to_tracy; }
+    bool get_experimental_device_debug_dump_enabled() const {
+        return experimental_device_debug_dump_interval_seconds > 0;
+    }
+    uint32_t get_experimental_device_debug_dump_interval_seconds() const {
+        return experimental_device_debug_dump_interval_seconds;
+    }
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }

--- a/tt_metal/programming_examples/profiler/CMakeLists.txt
+++ b/tt_metal/programming_examples/profiler/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROFILER_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_cores/test_dispatch_cores.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_timestamped_events/test_timestamped_events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_noc_event_profiler/test_noc_event_profiler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_device_api_debugger/test_device_api_debugger.cpp
 )
 
 CREATE_PGM_EXAMPLES_EXE("${PROFILER_EXAMPLES_SRCS}" "profiler")

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -9,9 +9,11 @@
 using EMD = KernelProfilerNocEventMetadata;
 
 void kernel_main() {
+#if defined(PROFILE_NOC_EVENTS)
     riscv_wait(START_DELAY);
     // Make this really large so it exceeds the max profiler sizes to test mid run dumps
     for (uint32_t i = 0; i < 10000; ++i) {
         noc_event_profiler::recordNocEvent(EMD::NocEventType::READ, my_x[0], my_y[0], 1000, 0, 0, i);
     }
+#endif
 }

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -12,6 +12,6 @@ void kernel_main() {
     riscv_wait(START_DELAY);
     // Make this really large so it exceeds the max profiler sizes to test mid run dumps
     for (uint32_t i = 0; i < 10000; ++i) {
-        noc_event_profiler::recordNocEvent(EMD::NocEventType::READ, 0, 0, 1000, 0, 0, i);
+        noc_event_profiler::recordNocEvent(EMD::NocEventType::READ, my_x[0], my_y[0], 1000, 0, 0, i);
     }
 }

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "tools/profiler/event_metadata.hpp"
+#include "tools/profiler/noc_event_profiler.hpp"
+
+using EMD = KernelProfilerNocEventMetadata;
+
+void kernel_main() {
+    riscv_wait(START_DELAY);
+    // Make this really large so it exceeds the max profiler sizes to test mid run dumps
+    for (uint32_t i = 0; i < 10000; ++i) {
+        noc_event_profiler::recordNocEvent(EMD::NocEventType::READ, 0, 0, 1000, 0, 0, i);
+    }
+}

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
@@ -41,12 +41,7 @@ void RunFillUpAllBuffers(const std::shared_ptr<distributed::MeshDevice>& mesh_de
             .defines = {{"START_DELAY", "1000"}}});
 
     workload.add_program(device_range, std::move(program));
-    if (fast_dispatch) {
-        // Enqueue the same mesh workload multiple times to generate profiler events
-        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
-    } else {
-        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
-    }
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
 }
 
 int main() {

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-metalium/distributed.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+void RunFillUpAllBuffers(const std::shared_ptr<distributed::MeshDevice>& mesh_device, bool fast_dispatch) {
+    constexpr CoreCoord core = {0, 0};
+
+    // Mesh workload + device range span the mesh; program encapsulates kernels
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    tt_metal::CreateKernel(
+        program,
+        "tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .defines = {{"START_DELAY", "0"}}});
+
+    tt_metal::CreateKernel(
+        program,
+        "tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .defines = {{"START_DELAY", "1000"}}});
+
+    workload.add_program(device_range, std::move(program));
+    if (fast_dispatch) {
+        // Enqueue the same mesh workload multiple times to generate profiler events
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    } else {
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    }
+}
+
+int main() {
+    int device_id = 0;
+    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+
+    const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
+
+    RunFillUpAllBuffers(mesh_device, USE_FAST_DISPATCH);
+
+    return 0;
+}

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/test_device_api_debugger.cpp
@@ -14,7 +14,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-void RunFillUpAllBuffers(const std::shared_ptr<distributed::MeshDevice>& mesh_device, bool fast_dispatch) {
+void RunFillUpAllBuffers(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     constexpr CoreCoord core = {0, 0};
 
     // Mesh workload + device range span the mesh; program encapsulates kernels
@@ -50,7 +50,12 @@ int main() {
 
     const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
 
-    RunFillUpAllBuffers(mesh_device, USE_FAST_DISPATCH);
+    if (!USE_FAST_DISPATCH) {
+        fmt::print("Fast Dispatch Required\n");
+        return 0;
+    }
+
+    RunFillUpAllBuffers(mesh_device);
 
     return 0;
 }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -20,6 +20,8 @@
 
 #include "hostdev/dev_msgs.h"
 
+#include "internal/ethernet/erisc.h"
+
 #define DO_PRAGMA(x) _Pragma(#x)
 
 #define Stringize(L) #L
@@ -86,6 +88,17 @@ constexpr uint32_t myRiscID = 0;
 constexpr uint32_t myRiscID = PROCESSOR_INDEX;
 #endif
 
+#if defined(DEVICE_DEBUG_DUMP)
+// Each risc has their own DRAM profiler address index
+constexpr bool NON_DROPPING = true;
+constexpr uint32_t DRAM_PROFILER_ADDRESS = DRAM_PROFILER_ADDRESS_BR_ER_0 + myRiscID;
+#else
+constexpr bool NON_DROPPING = false;
+constexpr uint32_t DRAM_PROFILER_ADDRESS = DRAM_PROFILER_ADDRESS_DEFAULT;
+#endif
+
+constexpr uint32_t HOST_BUFFER_END_INDEX = HOST_BUFFER_END_INDEX_BR_ER + myRiscID;
+
 constexpr uint32_t Hash32_CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261)) {
     return n == 0 ? basis : Hash32_CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
 }
@@ -140,15 +153,15 @@ inline __attribute__((always_inline)) uint32_t get_id(uint32_t id, PacketTypes t
 }
 
 template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
-inline __attribute__((always_inline)) bool bufferHasRoom() {
+inline __attribute__((always_inline)) bool bufferHasRoom(uint32_t additional_slots = 0) {
     bool bufferHasRoom = false;
     if constexpr (dispatch == DoingDispatch::DISPATCH) {
-        bufferHasRoom = wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - DISPATCH_HEADROOM_SIZE);
+        bufferHasRoom = wIndex + additional_slots < (PROFILER_L1_VECTOR_SIZE - stackSize - DISPATCH_HEADROOM_SIZE);
     } else if constexpr (dispatch == DoingDispatch::DISPATCH_META) {
-        bufferHasRoom =
-            wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
+        bufferHasRoom = wIndex + additional_slots < (PROFILER_L1_VECTOR_SIZE - stackSize -
+                                                     (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
     } else {
-        bufferHasRoom = wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize);
+        bufferHasRoom = wIndex + additional_slots < (PROFILER_L1_VECTOR_SIZE - stackSize);
     }
     return bufferHasRoom;
 }
@@ -285,6 +298,19 @@ void profiler_noc_async_flush_posted_write(uint8_t noc = noc_index) {
 
 #endif
 
+// Signal the host that this RISC's destination DRAM buffer is full and wait for a new DRAM profiler address
+__attribute__((noinline)) void signal_host_buffer_full(uint32_t control_buffer_index_for_dram = DRAM_PROFILER_ADDRESS) {
+    profiler_control_buffer[control_buffer_index_for_dram] = DRAM_PROFILER_ADDRESS_STALLED;
+
+    // Wait for host to give new profiler address
+    do {
+        invalidate_l1_cache();
+#if defined(COMPILE_FOR_ERISC)
+        internal_::risc_context_switch(false);
+#endif
+    } while (profiler_control_buffer[control_buffer_index_for_dram] == DRAM_PROFILER_ADDRESS_STALLED);
+}
+
 __attribute__((noinline)) void finish_profiler() {
     risc_finished_profiling();
 #if defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)) || \
@@ -295,6 +321,7 @@ __attribute__((noinline)) void finish_profiler() {
     uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
     uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
     bool is_dram_set = profiler_control_buffer[DRAM_PROFILER_ADDRESS] != 0;
+    int dramProfilerAddressIndex = DRAM_PROFILER_ADDRESS;
 
     uint32_t pageSize =
         PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * MaxProcessorsPerCoreType * profiler_core_count_per_dram;
@@ -302,6 +329,12 @@ __attribute__((noinline)) void finish_profiler() {
     NocRegisterStateSave noc_state;
     for (uint32_t riscID = 0; riscID < PROCESSOR_COUNT; riscID++) {
         bool do_noc = true;
+
+        if constexpr (NON_DROPPING) {
+            dramProfilerAddressIndex = kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0 + riscID;
+            is_dram_set = profiler_control_buffer[dramProfilerAddressIndex] != 0;
+        }
+
 #if defined(COMPILE_FOR_IDLE_ERISC)
         profiler_data_buffer[riscID].data[ID_LH] = ((core_flat_id & 0xFF) << 3) | riscID;
 #else
@@ -309,7 +342,7 @@ __attribute__((noinline)) void finish_profiler() {
         profiler_data_buffer[riscID].data[ID_LH] =
             ((traceCount & 0xFFFF) << 11) | ((core_flat_id & 0xFF) << 3) | riscID;
 #endif
-        int hostIndex = riscID;
+        int hostIndex = kernel_profiler::HOST_BUFFER_END_INDEX_BR_ER + riscID;
         int deviceIndex = kernel_profiler::DEVICE_BUFFER_END_INDEX_BR_ER + riscID;
         if (profiler_control_buffer[deviceIndex]) {
             uint32_t currEndIndexAll = profiler_control_buffer[deviceIndex] + profiler_control_buffer[hostIndex];
@@ -319,6 +352,16 @@ __attribute__((noinline)) void finish_profiler() {
                                        PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
                                    hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
                                    profiler_control_buffer[hostIndex] * sizeof(uint32_t);
+
+            if constexpr (NON_DROPPING) {
+                // Send everything
+                if (currEndIndexAll > PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
+                    signal_host_buffer_full(dramProfilerAddressIndex);
+                    // Host index is reset because we got a new DRAM buffer
+                    profiler_control_buffer[hostIndex] = 0;
+                    currEndIndexAll = profiler_control_buffer[deviceIndex] + profiler_control_buffer[hostIndex];
+                }
+            }
 
             if (currEndIndexAll <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
                 send_size = profiler_control_buffer[deviceIndex] * sizeof(uint32_t);
@@ -337,7 +380,7 @@ __attribute__((noinline)) void finish_profiler() {
             if (do_noc && is_dram_set) {
                 const auto s = TensorAccessor(
                     tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(),
-                    profiler_control_buffer[DRAM_PROFILER_ADDRESS],
+                    profiler_control_buffer[dramProfilerAddressIndex],
                     pageSize);
 
                 uint64_t dram_bank_dst_noc_addr =
@@ -390,10 +433,24 @@ __attribute__((noinline)) void quick_push() {
         ((traceCount & 0xFFFF) << 11) | ((core_flat_id & 0xFF) << 3) | myRiscID;
 #endif
 
+    uint32_t currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX] + wIndex;
+
+    mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
+    wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
+
+    if constexpr (NON_DROPPING) {
+        if (currEndIndex > PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC) {
+            signal_host_buffer_full();
+            // Host index is reset because we got a new DRAM buffer
+            profiler_control_buffer[HOST_BUFFER_END_INDEX] = 0;
+            currEndIndex = wIndex;
+        }
+    }
+
     uint32_t dram_offset = (core_flat_id % profiler_core_count_per_dram) * MaxProcessorsPerCoreType *
                                PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
-                           (HOST_BUFFER_END_INDEX_BR_ER + myRiscID) * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
-                           profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] * sizeof(uint32_t);
+                           HOST_BUFFER_END_INDEX * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                           profiler_control_buffer[HOST_BUFFER_END_INDEX] * sizeof(uint32_t);
 
     const auto s = TensorAccessor(
         tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(),
@@ -402,14 +459,11 @@ __attribute__((noinline)) void quick_push() {
 
     uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
 
-    mark_time_at_index_inlined(wIndex, get_const_id(hash, ZONE_END));
-    wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
-
     for (uint32_t i = 0; i < (wIndex % NOC_ALIGNMENT_FACTOR); i++) {
         mark_padding();
     }
 
-    uint32_t currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] + wIndex;
+    currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX] + wIndex;
 
     // If sending all optional markers still leaves room for the two guaranteed end markers, send everything
     if (currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC -
@@ -421,9 +475,9 @@ __attribute__((noinline)) void quick_push() {
             wIndex * sizeof(uint32_t));
 
         profiler_noc_async_flush_posted_write();
-        profiler_control_buffer[HOST_BUFFER_END_INDEX_BR_ER + myRiscID] = currEndIndex;
+        profiler_control_buffer[HOST_BUFFER_END_INDEX] = currEndIndex;
     } else {
-        mark_dropped_timestamps(HOST_BUFFER_END_INDEX_BR_ER + myRiscID);
+        mark_dropped_timestamps(HOST_BUFFER_END_INDEX);
     }
 
     wIndex = CUSTOM_MARKERS;
@@ -547,8 +601,8 @@ struct profileScopeAccumulate {
 
 // performs quick push to DRAM if buffers appear full
 template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
-inline __attribute__((always_inline)) void flush_to_dram_if_full() {
-    if (not bufferHasRoom<dispatch>()) {
+inline __attribute__((always_inline)) void flush_to_dram_if_full(uint32_t additional_slots = 0) {
+    if (not bufferHasRoom<dispatch>(additional_slots)) {
         quick_push();
     }
 }

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -48,6 +48,33 @@ FORCE_INLINE std::pair<uint32_t, uint32_t> decode_noc_id_into_coord(uint32_t id,
         interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc) >> NOC_COORD_REG_OFFSET);
 }
 
+FORCE_INLINE void recordNocEventTrailer(
+    KernelProfilerNocEventMetadata::NocEventType noc_event_type, uint32_t dst_addr) {
+    static_assert(
+        KernelProfilerNocEventMetadata::NocEventType::WRITE_ >
+            KernelProfilerNocEventMetadata::NocEventType::READ_DRAM_SHARDED_WITH_STATE,
+        "WRITE events must be greater than READ events");
+    KernelProfilerNocEventMetadata::NocEventType trailer_type;
+    if (noc_event_type >= KernelProfilerNocEventMetadata::NocEventType::WRITE_) {
+        trailer_type = KernelProfilerNocEventMetadata::NocEventType::WRITE_TRAILER;
+    } else {
+        trailer_type = KernelProfilerNocEventMetadata::NocEventType::READ_TRAILER;
+    }
+
+    KernelProfilerNocEventMetadata ev_md;
+    auto& local_noc_event_trailer = ev_md.data.local_event_trailer;
+    local_noc_event_trailer.noc_xfer_type = trailer_type;
+    local_noc_event_trailer.dst_addr = dst_addr;
+
+    // Write trailer data directly after the NOC event (no new timestamp marker)
+    // Space was already checked in recordNocEvent, so we can write directly
+    uint64_t trailer_data = ev_md.asU64();
+    kernel_profiler::profiler_data_buffer[kernel_profiler::myRiscID].data[kernel_profiler::wIndex++] =
+        trailer_data >> 32;
+    kernel_profiler::profiler_data_buffer[kernel_profiler::myRiscID].data[kernel_profiler::wIndex++] =
+        (trailer_data << 32) >> 32;
+}
+
 template <uint32_t STATIC_ID = 12345>
 FORCE_INLINE void recordNocEvent(
     KernelProfilerNocEventMetadata::NocEventType noc_event_type,
@@ -55,7 +82,8 @@ FORCE_INLINE void recordNocEvent(
     int32_t dst_y = -1,
     uint32_t num_bytes = 0,
     int8_t vc = -1,
-    uint8_t noc = noc_index) {
+    uint8_t noc = noc_index,
+    uint32_t dst_addr = 0) {
     KernelProfilerNocEventMetadata ev_md;
 
     auto& local_noc_event = ev_md.data.local_event;
@@ -67,8 +95,20 @@ FORCE_INLINE void recordNocEvent(
     local_noc_event.noc_type =
         (noc == 1) ? KernelProfilerNocEventMetadata::NocType::NOC_1 : KernelProfilerNocEventMetadata::NocType::NOC_0;
 
-    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>();
+    // Calculate total slots needed: TS_DATA (timestamp marker + data = 4 uint32s) + trailer (2 uint32s) = 6 uint32s
+    uint32_t slots_needed =
+        kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE * 2;  // TS_DATA: timestamp + data (4 uint32s)
+    if constexpr (kernel_profiler::NON_DROPPING) {
+        slots_needed += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;  // Trailer: raw data (2 uint32s)
+    }
+    // Ensure we have enough contiguous space for both event and trailer before writing either
+    kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>(slots_needed);
     kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
+
+    if constexpr (kernel_profiler::NON_DROPPING) {
+        // Space was already guaranteed by flush_to_dram_if_full above, so we can write the trailer directly
+        recordNocEventTrailer(noc_event_type, dst_addr);
+    }
 }
 
 template <uint32_t STATIC_ID = 12345>

--- a/tt_telemetry/telemetry/hal/hal.cpp
+++ b/tt_telemetry/telemetry/hal/hal.cpp
@@ -22,5 +22,5 @@ std::unique_ptr<tt::tt_metal::Hal> create_hal(const std::unique_ptr<tt::umd::Clu
         tt::tt_metal::get_platform_architecture(rtoptions),
         is_base_routing_fw_enabled,
         is_2_erisc_mode,
-        tt::tt_metal::get_profiler_dram_bank_size_per_risc_bytes(rtoptions));
+        tt::tt_metal::get_profiler_dram_bank_size_for_hal_allocation(rtoptions));
 }


### PR DESCRIPTION
### Ticket
https://github.com/issues?q=is%3Aissue+state%3Aopen+archived%3Afalse+assignee%3A%40me+sort%3Aupdated-desc+is%3Ablocked&issue=tenstorrent%7Ctt-metal%7C29601

### Problem description
- Current profiler infrastructure is being used for NoC Tracing capture. It will drop packets when the buffers get full. For Device 2.0 API debug tooling, we need to be able to capture various events in a non-dropping manner. This change will also benefit NoC Tracing if they want to enable long captures.

### What's changed

The following changes to support non dropping profiler packet collection is enabled with `TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1`.

**Device Side Changes**
- Update the DRAM Profiler Address to be on the RISC granularity (profiler_common.h). BRISC may be writing to a different DRAM address than NCRISC if buffers became full and released at different times.
- Add `signal_host_buffer_full()` which will be used by the RISC to signal to the host thread that it's DRAM buffer is full and stall until the host gives it a new destination
- Update other functions to support writing more than uint64_t. This is needed because profiler slots are fixed to uint64_t. We need to support writing large event metadata such  `timestamp - event data - event data 1 - event data 2`.

**Host Side Changes**
- Host to spawn a thread which will manage the double buffering.
1. Read control vectors
2. Determine which RISCs are stalled
3. Unstall the RISC by giving it a free DRAM address (the _other_ address)
4. Read and process data from the stalled DRAM buffer

- Device profiler state to additionally keep track of DRAM addresses per RISC
- Add locks to the device profiler
- Manual calls to dump device profiler data are non operational

**Unit Tests**
Add a unit test which will overflow the profiler buffers multiple times and ensure all packets are captured by the host
  - pytest tests/tt_metal/tools/profiler/test_device_profiler.py::test_device_api_debugger_non_dropping

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/20764992436
Blackhole Post Commit
https://github.com/tenstorrent/tt-metal/actions/runs/20736362597
APC Nightly Debug
https://github.com/tenstorrent/tt-metal/actions/runs/20664125381
T3K Profiler Test
https://github.com/tenstorrent/tt-metal/actions/runs/20629466826
(Galaxy) profiler tests
https://github.com/tenstorrent/tt-metal/actions/runs/20629465953
Profiler Tests
https://github.com/tenstorrent/tt-metal/actions/runs/20626388619