### PR TITLE
Convert DeepSeekV3 MLA caches on device

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -723,7 +723,6 @@ class MLA1D(AbstractModule):
         )
         if caches is None:
             caches = (torch.zeros(cache_shape),) * mesh_device.shape[0]
-
         # Store CCL object for runtime semaphore initialization
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
@@ -738,14 +737,19 @@ class MLA1D(AbstractModule):
         caches: tuple[torch.Tensor, ...],
         mesh_device: ttnn.MeshDevice,
     ) -> ttnn.Tensor:
-        return ttnn.as_tensor(
-            torch.concatenate(caches),
-            dtype=ttnn.bfloat8_b,
+        def to_device(
+            weight,
+            device,
+            mesh_mapper,
             layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
+            dtype=ttnn.bfloat8_b,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, 0),
-        )
+        ):
+            weight = ttnn.from_torch(weight, device=device, mesh_mapper=mesh_mapper)
+            return ttnn.to_layout(weight, dtype=dtype, layout=layout, memory_config=memory_config)
+
+        caches = torch.concatenate(caches)
+        return to_device(caches, mesh_device, ttnn.ShardTensorToMesh(mesh_device, 0))
 
     @classmethod
     def forward_decode(


### PR DESCRIPTION
### Summary

This change updates `MLA.create_state()` to performance layout and data type conversions on device. This reduces time to generate the cache for a single MLA layer by 5x (36 seconds to 7 seconds). 

### Checklist
- [ ] [DeepSeek unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/20324871098
- [ ] [Galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI : https://github.com/tenstorrent/tt-metal/actions/runs/20324873906