### PR TITLE
#33250: Add missing ops to docs.

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -40,20 +40,21 @@ Core
    :template: function.rst
 
    ttnn.as_tensor
-   ttnn.from_torch
-   ttnn.to_torch
-   ttnn.to_device
-   ttnn.from_device
-   ttnn.to_layout
-   ttnn.dump_tensor
-   ttnn.load_tensor
-   ttnn.deallocate
-   ttnn.reallocate
-   ttnn.to_memory_config
-   ttnn.split_work_to_cores
    ttnn.copy_device_to_host_tensor
    ttnn.copy_host_to_device_tensor
+   ttnn.deallocate
+   ttnn.dump_tensor
+   ttnn.from_device
+   ttnn.from_torch
+   ttnn.get_device_tensors
+   ttnn.load_tensor
+   ttnn.reallocate
+   ttnn.split_work_to_cores
+   ttnn.to_device
    ttnn.to_dtype
+   ttnn.to_layout
+   ttnn.to_memory_config
+   ttnn.to_torch
    ttnn.typecast
 
 Tensor Creation
@@ -65,20 +66,20 @@ Tensor Creation
    :template: function.rst
 
    ttnn.arange
-   ttnn.empty
-   ttnn.empty_like
-   ttnn.zeros
-   ttnn.zeros_like
-   ttnn.ones
-   ttnn.ones_like
-   ttnn.full
-   ttnn.full_like
-   ttnn.rand
-   ttnn.from_buffer
    ttnn.bernoulli
    ttnn.complex_tensor
+   ttnn.empty
+   ttnn.empty_like
+   ttnn.from_buffer
+   ttnn.full
+   ttnn.full_like
    ttnn.index_fill
+   ttnn.ones
+   ttnn.ones_like
+   ttnn.rand
    ttnn.uniform
+   ttnn.zeros
+   ttnn.zeros_like
 
 Matrix Multiplication
 =====================
@@ -113,201 +114,201 @@ Pointwise Unary
    :template: function.rst
 
    ttnn.abs
+   ttnn.abs_bw
    ttnn.acos
+   ttnn.acos_bw
    ttnn.acosh
+   ttnn.acosh_bw
+   ttnn.alt_complex_rotate90
+   ttnn.angle
+   ttnn.angle_bw
    ttnn.asin
+   ttnn.asin_bw
    ttnn.asinh
+   ttnn.asinh_bw
    ttnn.atan
+   ttnn.atan_bw
    ttnn.atanh
+   ttnn.atanh_bw
    ttnn.bitcast
-   ttnn.bitwise_not
    ttnn.bitwise_left_shift
+   ttnn.bitwise_not
    ttnn.bitwise_right_shift
-   ttnn.logical_left_shift
-   ttnn.logical_right_shift
    ttnn.cbrt
    ttnn.ceil
+   ttnn.ceil_bw
    ttnn.celu
+   ttnn.celu_bw
    ttnn.clamp
+   ttnn.clamp_bw
    ttnn.clip
+   ttnn.clip_bw
    ttnn.clone
+   ttnn.conj
+   ttnn.conj_bw
    ttnn.cos
+   ttnn.cos_bw
    ttnn.cosh
+   ttnn.cosh_bw
    ttnn.deg2rad
+   ttnn.deg2rad_bw
    ttnn.digamma
+   ttnn.digamma_bw
+   ttnn.div_no_nan_bw
+   ttnn.elu_bw
+   ttnn.eqz
+   ttnn.erf
+   ttnn.erf_bw
+   ttnn.erfc
+   ttnn.erfc_bw
+   ttnn.erfinv
+   ttnn.erfinv_bw
+   ttnn.exp
+   ttnn.exp2
+   ttnn.exp2_bw
+   ttnn.exp_bw
    ttnn.experimental.dropout
    ttnn.experimental.gelu_bw
    ttnn.elu
-   ttnn.eqz
-   ttnn.erf
-   ttnn.erfc
-   ttnn.erfinv
-   ttnn.exp
-   ttnn.exp2
    ttnn.expm1
+   ttnn.expm1_bw
    ttnn.fill
+   ttnn.fill_bw
+   ttnn.fill_zero_bw
    ttnn.floor
+   ttnn.floor_bw
    ttnn.frac
+   ttnn.frac_bw
    ttnn.geglu
    ttnn.gelu
-   ttnn.glu
+   ttnn.gelu_bw
    ttnn.gez
+   ttnn.glu
    ttnn.gtz
+   ttnn.hardmish
    ttnn.hardshrink
+   ttnn.hardshrink_bw
    ttnn.hardsigmoid
+   ttnn.hardsigmoid_bw
    ttnn.hardswish
+   ttnn.hardswish_bw
    ttnn.hardtanh
+   ttnn.hardtanh_bw
    ttnn.heaviside
    ttnn.i0
+   ttnn.i0_bw
    ttnn.i1
    ttnn.identity
+   ttnn.imag
+   ttnn.imag_bw
+   ttnn.is_imag
+   ttnn.is_real
    ttnn.isfinite
    ttnn.isinf
    ttnn.isnan
    ttnn.isneginf
    ttnn.isposinf
    ttnn.leaky_relu
+   ttnn.leaky_relu_bw
    ttnn.lez
    ttnn.lgamma
+   ttnn.lgamma_bw
    ttnn.log
    ttnn.log10
+   ttnn.log10_bw
    ttnn.log1p
+   ttnn.log1p_bw
    ttnn.log2
+   ttnn.log2_bw
+   ttnn.log_bw
    ttnn.log_sigmoid
+   ttnn.log_sigmoid_bw
+   ttnn.logical_left_shift
    ttnn.logical_not
    ttnn.logical_not_
+   ttnn.logical_right_shift
    ttnn.logit
+   ttnn.logit_bw
+   ttnn.logiteps_bw
    ttnn.ltz
    ttnn.mish
-   ttnn.hardmish
    ttnn.multigammaln
+   ttnn.multigammaln_bw
    ttnn.neg
+   ttnn.neg_bw
    ttnn.nez
    ttnn.normalize_global
    ttnn.normalize_hw
+   ttnn.polar
+   ttnn.polar_bw
    ttnn.polygamma
+   ttnn.polygamma_bw
+   ttnn.pow_bw
    ttnn.prelu
+   ttnn.prod_bw
    ttnn.rad2deg
+   ttnn.rad2deg_bw
    ttnn.rdiv
+   ttnn.rdiv_bw
+   ttnn.real
+   ttnn.real_bw
    ttnn.reciprocal
+   ttnn.reciprocal_bw
    ttnn.reglu
    ttnn.relu
+   ttnn.relu6
+   ttnn.relu6_bw
+   ttnn.relu_bw
    ttnn.relu_max
    ttnn.relu_min
-   ttnn.relu6
    ttnn.remainder
+   ttnn.repeat_bw
    ttnn.round
+   ttnn.round_bw
+   ttnn.rpow_bw
    ttnn.rsqrt
+   ttnn.rsqrt_bw
    ttnn.selu
+   ttnn.selu_bw
    ttnn.sigmoid
    ttnn.sigmoid_accurate
+   ttnn.sigmoid_bw
    ttnn.sign
+   ttnn.sign_bw
    ttnn.signbit
    ttnn.silu
+   ttnn.silu_bw
    ttnn.sin
+   ttnn.sin_bw
    ttnn.sinh
-   ttnn.std_hw
-   ttnn.var_hw
+   ttnn.sinh_bw
    ttnn.softplus
+   ttnn.softplus_bw
    ttnn.softshrink
+   ttnn.softshrink_bw
    ttnn.softsign
+   ttnn.softsign_bw
    ttnn.sqrt
+   ttnn.sqrt_bw
    ttnn.square
+   ttnn.square_bw
+   ttnn.std_hw
    ttnn.swiglu
    ttnn.swish
    ttnn.tan
+   ttnn.tan_bw
    ttnn.tanh
+   ttnn.tanh_bw
    ttnn.tanhshrink
+   ttnn.tanhshrink_bw
    ttnn.threshold
+   ttnn.threshold_bw
    ttnn.tril
    ttnn.triu
    ttnn.trunc
-   ttnn.unary_chain
-   ttnn.clamp_bw
-   ttnn.clip_bw
-   ttnn.hardtanh_bw
-   ttnn.threshold_bw
-   ttnn.softplus_bw
-   ttnn.rdiv_bw
-   ttnn.pow_bw
-   ttnn.exp_bw
-   ttnn.tanh_bw
-   ttnn.sqrt_bw
-   ttnn.multigammaln_bw
-   ttnn.lgamma_bw
-   ttnn.fill_bw
-   ttnn.hardsigmoid_bw
-   ttnn.cos_bw
-   ttnn.acosh_bw
-   ttnn.acos_bw
-   ttnn.atan_bw
-   ttnn.rad2deg_bw
-   ttnn.frac_bw
    ttnn.trunc_bw
-   ttnn.log_sigmoid_bw
-   ttnn.fill_zero_bw
-   ttnn.i0_bw
-   ttnn.tan_bw
-   ttnn.sigmoid_bw
-   ttnn.rsqrt_bw
-   ttnn.neg_bw
-   ttnn.relu_bw
-   ttnn.logit_bw
-   ttnn.hardshrink_bw
-   ttnn.softshrink_bw
-   ttnn.leaky_relu_bw
-   ttnn.elu_bw
-   ttnn.celu_bw
-   ttnn.rpow_bw
-   ttnn.floor_bw
-   ttnn.round_bw
-   ttnn.log_bw
-   ttnn.relu6_bw
-   ttnn.abs_bw
-   ttnn.silu_bw
-   ttnn.selu_bw
-   ttnn.square_bw
-   ttnn.prod_bw
-   ttnn.hardswish_bw
-   ttnn.tanhshrink_bw
-   ttnn.atanh_bw
-   ttnn.asin_bw
-   ttnn.asinh_bw
-   ttnn.sin_bw
-   ttnn.sinh_bw
-   ttnn.log10_bw
-   ttnn.log1p_bw
-   ttnn.erfc_bw
-   ttnn.ceil_bw
-   ttnn.softsign_bw
-   ttnn.cosh_bw
-   ttnn.logiteps_bw
-   ttnn.log2_bw
-   ttnn.sign_bw
-   ttnn.div_no_nan_bw
-   ttnn.exp2_bw
-   ttnn.expm1_bw
-   ttnn.reciprocal_bw
-   ttnn.digamma_bw
-   ttnn.erfinv_bw
-   ttnn.erf_bw
-   ttnn.deg2rad_bw
-   ttnn.polygamma_bw
-   ttnn.gelu_bw
-   ttnn.repeat_bw
-   ttnn.real
-   ttnn.imag
-   ttnn.angle
-   ttnn.is_imag
-   ttnn.is_real
-   ttnn.polar_bw
-   ttnn.imag_bw
-   ttnn.real_bw
-   ttnn.angle_bw
-   ttnn.conj_bw
-   ttnn.conj
-   ttnn.polar
-   ttnn.alt_complex_rotate90
+   ttnn.unary_chain
+   ttnn.var_hw
 
 Pointwise Binary
 ================
@@ -319,90 +320,90 @@ Pointwise Binary
 
    ttnn.add
    ttnn.add_
+   ttnn.add_bw
    ttnn.addalpha
-   ttnn.subalpha
-   ttnn.multiply
-   ttnn.multiply_
-   ttnn.subtract
-   ttnn.subtract_
-   ttnn.div
-   ttnn.div_no_nan
-   ttnn.divide
-   ttnn.divide_
-   ttnn.floor_div
-   ttnn.remainder
-   ttnn.fmod
-   ttnn.gcd
-   ttnn.lcm
-   ttnn.logical_and_
-   ttnn.logical_or_
-   ttnn.logical_xor_
-   ttnn.rpow
-   ttnn.rsub
-   ttnn.rsub_
-   ttnn.ldexp
-   ttnn.ldexp_
-   ttnn.logical_and
-   ttnn.logical_or
-   ttnn.logical_xor
+   ttnn.addalpha_bw
+   ttnn.assign_bw
+   ttnn.atan2
+   ttnn.atan2_bw
+   ttnn.bias_gelu
+   ttnn.bias_gelu_
+   ttnn.bias_gelu_bw
    ttnn.bitwise_and
    ttnn.bitwise_or
    ttnn.bitwise_xor
-   ttnn.logaddexp
-   ttnn.logaddexp_
-   ttnn.logaddexp2
-   ttnn.logaddexp2_
-   ttnn.hypot
-   ttnn.xlogy
-   ttnn.squared_difference
-   ttnn.squared_difference_
+   ttnn.concat_bw
+   ttnn.div
+   ttnn.div_bw
+   ttnn.div_no_nan
+   ttnn.divide
+   ttnn.divide_
+   ttnn.embedding_bw
+   ttnn.eq
+   ttnn.eq_
+   ttnn.floor_div
+   ttnn.fmod
+   ttnn.fmod_bw
+   ttnn.gcd
+   ttnn.ge
+   ttnn.ge_
    ttnn.gt
    ttnn.gt_
-   ttnn.lt_
-   ttnn.ge_
-   ttnn.le_
-   ttnn.eq_
-   ttnn.ne_
-   ttnn.ge
-   ttnn.lt
-   ttnn.le
-   ttnn.eq
-   ttnn.ne
+   ttnn.hypot
+   ttnn.hypot_bw
    ttnn.isclose
-   ttnn.nextafter
+   ttnn.lcm
+   ttnn.ldexp
+   ttnn.ldexp_
+   ttnn.ldexp_bw
+   ttnn.le
+   ttnn.le_
+   ttnn.logaddexp
+   ttnn.logaddexp2
+   ttnn.logaddexp2_
+   ttnn.logaddexp2_bw
+   ttnn.logaddexp_
+   ttnn.logaddexp_bw
+   ttnn.logical_and
+   ttnn.logical_and_
+   ttnn.logical_or
+   ttnn.logical_or_
+   ttnn.logical_xor
+   ttnn.logical_xor_
+   ttnn.lt
+   ttnn.lt_
+   ttnn.max_bw
    ttnn.maximum
+   ttnn.min_bw
    ttnn.minimum
+   ttnn.mul_bw
+   ttnn.multiply
+   ttnn.multiply_
+   ttnn.ne
+   ttnn.ne_
+   ttnn.nextafter
    ttnn.outer
-   ttnn.pow
    ttnn.polyval
+   ttnn.pow
+   ttnn.prim.binary
+   ttnn.remainder
+   ttnn.remainder_bw
+   ttnn.rpow
+   ttnn.rsub
+   ttnn.rsub_
+   ttnn.rsub_bw
    ttnn.scatter
    ttnn.scatter_add
-   ttnn.atan2
-   ttnn.bias_gelu
-   ttnn.bias_gelu_
-   ttnn.add_bw
-   ttnn.assign_bw
-   ttnn.atan2_bw
-   ttnn.bias_gelu_bw
-   ttnn.div_bw
-   ttnn.embedding_bw
-   ttnn.fmod_bw
-   ttnn.remainder_bw
-   ttnn.addalpha_bw
-   ttnn.subalpha_bw
-   ttnn.xlogy_bw
-   ttnn.hypot_bw
-   ttnn.ldexp_bw
-   ttnn.logaddexp_bw
-   ttnn.logaddexp2_bw
-   ttnn.mul_bw
-   ttnn.sub_bw
+   ttnn.squared_difference
+   ttnn.squared_difference_
    ttnn.squared_difference_bw
-   ttnn.concat_bw
-   ttnn.rsub_bw
-   ttnn.min_bw
-   ttnn.max_bw
-   ttnn.prim.binary
+   ttnn.sub_bw
+   ttnn.subalpha
+   ttnn.subalpha_bw
+   ttnn.subtract
+   ttnn.subtract_
+   ttnn.xlogy
+   ttnn.xlogy_bw
 
 Pointwise Ternary
 =================
@@ -413,14 +414,14 @@ Pointwise Ternary
    :template: function.rst
 
    ttnn.addcdiv
+   ttnn.addcdiv_bw
    ttnn.addcmul
+   ttnn.addcmul_bw
+   ttnn.lerp
+   ttnn.lerp_bw
    ttnn.mac
    ttnn.where
-   ttnn.lerp
-   ttnn.addcmul_bw
-   ttnn.addcdiv_bw
    ttnn.where_bw
-   ttnn.lerp_bw
 
 Quantization
 ============
@@ -430,9 +431,9 @@ Quantization
    :nosignatures:
    :template: function.rst
 
+   ttnn.dequantize
    ttnn.quantize
    ttnn.requantize
-   ttnn.dequantize
 
 Losses
 ======
@@ -453,21 +454,21 @@ Reduction
    :nosignatures:
    :template: function.rst
 
+   ttnn.argmax
    ttnn.cumprod
+   ttnn.cumsum
    ttnn.ema
+   ttnn.manual_seed
    ttnn.max
    ttnn.mean
    ttnn.min
+   ttnn.moe
+   ttnn.prod
+   ttnn.sampling
    ttnn.std
    ttnn.sum
-   ttnn.var
-   ttnn.argmax
-   ttnn.prod
    ttnn.topk
-   ttnn.cumsum
-   ttnn.manual_seed
-   ttnn.moe
-   ttnn.sampling
+   ttnn.var
 
 Data Movement
 =============
@@ -477,47 +478,47 @@ Data Movement
    :nosignatures:
    :template: function.rst
 
-   ttnn.concat
-   ttnn.nonzero
-   ttnn.pad
-   ttnn.permute
-   ttnn.reshape
-   ttnn.repeat
-   ttnn.repeat_interleave
-   ttnn.slice
-   ttnn.tilize
-   ttnn.tilize_with_val_padding
-   ttnn.fill_rm
-   ttnn.fill_ones_rm
-   ttnn.untilize
-   ttnn.untilize_with_unpadding
-   ttnn.indexed_fill
-   ttnn.gather
-   ttnn.sort
    ttnn.assign
    ttnn.bcast
    ttnn.chunk
+   ttnn.concat
    ttnn.copy
    ttnn.expand
    ttnn.fill_implicit_tile_padding
+   ttnn.fill_ones_rm
+   ttnn.fill_rm
    ttnn.fold
+   ttnn.gather
+   ttnn.indexed_fill
    ttnn.interleaved_to_sharded
    ttnn.interleaved_to_sharded_partial
    ttnn.moe_expert_token_remap
    ttnn.moe_routing_remap
    ttnn.move
+   ttnn.nonzero
+   ttnn.pad
+   ttnn.permute
+   ttnn.repeat
+   ttnn.repeat_interleave
+   ttnn.reshape
    ttnn.reshape_on_device
    ttnn.reshard
    ttnn.roll
    ttnn.sharded_to_interleaved
    ttnn.sharded_to_interleaved_partial
+   ttnn.slice
+   ttnn.sort
    ttnn.split
    ttnn.squeeze
    ttnn.stack
+   ttnn.tilize
+   ttnn.tilize_with_val_padding
    ttnn.tilize_with_zero_padding
    ttnn.transpose
    ttnn.unsqueeze
    ttnn.unsqueeze_to_4D
+   ttnn.untilize
+   ttnn.untilize_with_unpadding
    ttnn.view
 
 Normalization
@@ -528,19 +529,19 @@ Normalization
    :nosignatures:
    :template: function.rst
 
+   ttnn.batch_norm
    ttnn.group_norm
    ttnn.layer_norm
-   ttnn.layer_norm_pre_all_gather
    ttnn.layer_norm_post_all_gather
+   ttnn.layer_norm_pre_all_gather
    ttnn.rms_norm
-   ttnn.rms_norm_pre_all_gather
    ttnn.rms_norm_post_all_gather
-   ttnn.batch_norm
-   ttnn.softmax
-   ttnn.scale_mask_softmax
-   ttnn.softmax_in_place
-   ttnn.scale_mask_softmax_in_place
+   ttnn.rms_norm_pre_all_gather
    ttnn.scale_causal_mask_hw_dims_softmax_in_place
+   ttnn.scale_mask_softmax
+   ttnn.scale_mask_softmax_in_place
+   ttnn.softmax
+   ttnn.softmax_in_place
 
 Normalization Program Configs
 =============================
@@ -550,8 +551,8 @@ Normalization Program Configs
    :nosignatures:
    :template: class.rst
 
-   ttnn.SoftmaxProgramConfig
    ttnn.SoftmaxDefaultProgramConfig
+   ttnn.SoftmaxProgramConfig
    ttnn.SoftmaxShardedMultiCoreProgramConfig
 
 Transformer
@@ -562,14 +563,11 @@ Transformer
    :nosignatures:
    :template: function.rst
 
-   ttnn.transformer.split_query_key_value_and_split_heads
-   ttnn.transformer.concatenate_heads
    ttnn.transformer.attention_softmax
    ttnn.transformer.attention_softmax_
-   ttnn.transformer.scaled_dot_product_attention
-   ttnn.transformer.scaled_dot_product_attention_decode
    ttnn.transformer.chunked_flash_mla_prefill
    ttnn.transformer.chunked_scaled_dot_product_attention
+   ttnn.transformer.concatenate_heads
    ttnn.transformer.flash_mla_prefill
    ttnn.transformer.flash_multi_latent_attention_decode
    ttnn.transformer.joint_scaled_dot_product_attention
@@ -577,6 +575,9 @@ Transformer
    ttnn.transformer.paged_scaled_dot_product_attention_decode
    ttnn.transformer.ring_distributed_scaled_dot_product_attention
    ttnn.transformer.ring_joint_scaled_dot_product_attention
+   ttnn.transformer.scaled_dot_product_attention
+   ttnn.transformer.scaled_dot_product_attention_decode
+   ttnn.transformer.split_query_key_value_and_split_heads
    ttnn.transformer.windowed_scaled_dot_product_attention
 
 CCL
@@ -587,16 +588,16 @@ CCL
    :nosignatures:
    :template: function.rst
 
+   ttnn.all_broadcast
    ttnn.all_gather
-   ttnn.reduce_scatter
    ttnn.all_reduce
-   ttnn.broadcast
    ttnn.all_to_all_combine
    ttnn.all_to_all_dispatch
+   ttnn.broadcast
    ttnn.mesh_partition
    ttnn.point_to_point
+   ttnn.reduce_scatter
    ttnn.reduce_to_root
-   ttnn.all_broadcast
 
 Embedding
 =========
@@ -617,13 +618,12 @@ Convolution
 
    ttnn.conv1d
    ttnn.conv2d
-   ttnn.experimental.conv3d
    ttnn.conv_transpose2d
-   ttnn.prepare_conv_weights
+   ttnn.experimental.conv3d
    ttnn.prepare_conv_bias
-   ttnn.prepare_conv_transpose2d_weights
    ttnn.prepare_conv_transpose2d_bias
-
+   ttnn.prepare_conv_transpose2d_weights
+   ttnn.prepare_conv_weights
 
 .. autosummary::
    :toctree: api
@@ -641,12 +641,12 @@ Pooling
    :nosignatures:
    :template: function.rst
 
-   ttnn.global_avg_pool2d
-   ttnn.max_pool2d
-   ttnn.avg_pool2d
    ttnn.adaptive_avg_pool2d
    ttnn.adaptive_max_pool2d
+   ttnn.avg_pool2d
+   ttnn.global_avg_pool2d
    ttnn.grid_sample
+   ttnn.max_pool2d
 
 Prefetcher
 ==========

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -596,6 +596,7 @@ CCL
    ttnn.mesh_partition
    ttnn.point_to_point
    ttnn.reduce_to_root
+   ttnn.all_broadcast
 
 Embedding
 =========

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -114,93 +114,56 @@ Pointwise Unary
    :template: function.rst
 
    ttnn.abs
-   ttnn.abs_bw
    ttnn.acos
-   ttnn.acos_bw
    ttnn.acosh
-   ttnn.acosh_bw
    ttnn.alt_complex_rotate90
    ttnn.angle
-   ttnn.angle_bw
    ttnn.asin
-   ttnn.asin_bw
    ttnn.asinh
-   ttnn.asinh_bw
    ttnn.atan
-   ttnn.atan_bw
    ttnn.atanh
-   ttnn.atanh_bw
    ttnn.bitcast
    ttnn.bitwise_left_shift
    ttnn.bitwise_not
    ttnn.bitwise_right_shift
    ttnn.cbrt
    ttnn.ceil
-   ttnn.ceil_bw
    ttnn.celu
-   ttnn.celu_bw
    ttnn.clamp
-   ttnn.clamp_bw
    ttnn.clip
-   ttnn.clip_bw
    ttnn.clone
    ttnn.conj
-   ttnn.conj_bw
    ttnn.cos
-   ttnn.cos_bw
    ttnn.cosh
-   ttnn.cosh_bw
    ttnn.deg2rad
-   ttnn.deg2rad_bw
    ttnn.digamma
-   ttnn.digamma_bw
-   ttnn.div_no_nan_bw
-   ttnn.elu_bw
    ttnn.eqz
    ttnn.erf
-   ttnn.erf_bw
    ttnn.erfc
-   ttnn.erfc_bw
    ttnn.erfinv
-   ttnn.erfinv_bw
    ttnn.exp
    ttnn.exp2
-   ttnn.exp2_bw
-   ttnn.exp_bw
    ttnn.experimental.dropout
-   ttnn.experimental.gelu_bw
    ttnn.elu
    ttnn.expm1
-   ttnn.expm1_bw
    ttnn.fill
-   ttnn.fill_bw
-   ttnn.fill_zero_bw
    ttnn.floor
-   ttnn.floor_bw
    ttnn.frac
-   ttnn.frac_bw
    ttnn.geglu
    ttnn.gelu
-   ttnn.gelu_bw
    ttnn.gez
    ttnn.glu
    ttnn.gtz
    ttnn.hardmish
    ttnn.hardshrink
-   ttnn.hardshrink_bw
    ttnn.hardsigmoid
-   ttnn.hardsigmoid_bw
    ttnn.hardswish
-   ttnn.hardswish_bw
    ttnn.hardtanh
-   ttnn.hardtanh_bw
    ttnn.heaviside
    ttnn.i0
-   ttnn.i0_bw
    ttnn.i1
    ttnn.identity
    ttnn.imag
-   ttnn.imag_bw
    ttnn.is_imag
    ttnn.is_real
    ttnn.isfinite
@@ -209,104 +172,63 @@ Pointwise Unary
    ttnn.isneginf
    ttnn.isposinf
    ttnn.leaky_relu
-   ttnn.leaky_relu_bw
    ttnn.lez
    ttnn.lgamma
-   ttnn.lgamma_bw
    ttnn.log
    ttnn.log10
-   ttnn.log10_bw
    ttnn.log1p
-   ttnn.log1p_bw
    ttnn.log2
-   ttnn.log2_bw
-   ttnn.log_bw
    ttnn.log_sigmoid
-   ttnn.log_sigmoid_bw
    ttnn.logical_left_shift
    ttnn.logical_not
    ttnn.logical_not_
    ttnn.logical_right_shift
    ttnn.logit
-   ttnn.logit_bw
-   ttnn.logiteps_bw
    ttnn.ltz
    ttnn.mish
    ttnn.multigammaln
-   ttnn.multigammaln_bw
    ttnn.neg
-   ttnn.neg_bw
    ttnn.nez
    ttnn.normalize_global
    ttnn.normalize_hw
    ttnn.polar
-   ttnn.polar_bw
    ttnn.polygamma
-   ttnn.polygamma_bw
-   ttnn.pow_bw
    ttnn.prelu
-   ttnn.prod_bw
    ttnn.rad2deg
-   ttnn.rad2deg_bw
    ttnn.rdiv
-   ttnn.rdiv_bw
    ttnn.real
-   ttnn.real_bw
    ttnn.reciprocal
-   ttnn.reciprocal_bw
    ttnn.reglu
    ttnn.relu
    ttnn.relu6
-   ttnn.relu6_bw
-   ttnn.relu_bw
    ttnn.relu_max
    ttnn.relu_min
    ttnn.remainder
-   ttnn.repeat_bw
    ttnn.round
-   ttnn.round_bw
-   ttnn.rpow_bw
    ttnn.rsqrt
-   ttnn.rsqrt_bw
    ttnn.selu
-   ttnn.selu_bw
    ttnn.sigmoid
    ttnn.sigmoid_accurate
-   ttnn.sigmoid_bw
    ttnn.sign
-   ttnn.sign_bw
    ttnn.signbit
    ttnn.silu
-   ttnn.silu_bw
    ttnn.sin
-   ttnn.sin_bw
    ttnn.sinh
-   ttnn.sinh_bw
    ttnn.softplus
-   ttnn.softplus_bw
    ttnn.softshrink
-   ttnn.softshrink_bw
    ttnn.softsign
-   ttnn.softsign_bw
    ttnn.sqrt
-   ttnn.sqrt_bw
    ttnn.square
-   ttnn.square_bw
    ttnn.std_hw
    ttnn.swiglu
    ttnn.swish
    ttnn.tan
-   ttnn.tan_bw
    ttnn.tanh
-   ttnn.tanh_bw
    ttnn.tanhshrink
-   ttnn.tanhshrink_bw
    ttnn.threshold
-   ttnn.threshold_bw
    ttnn.tril
    ttnn.triu
    ttnn.trunc
-   ttnn.trunc_bw
    ttnn.unary_chain
    ttnn.var_hw
 
@@ -320,50 +242,37 @@ Pointwise Binary
 
    ttnn.add
    ttnn.add_
-   ttnn.add_bw
    ttnn.addalpha
-   ttnn.addalpha_bw
-   ttnn.assign_bw
    ttnn.atan2
-   ttnn.atan2_bw
    ttnn.bias_gelu
    ttnn.bias_gelu_
-   ttnn.bias_gelu_bw
    ttnn.bitwise_and
    ttnn.bitwise_or
    ttnn.bitwise_xor
-   ttnn.concat_bw
    ttnn.div
-   ttnn.div_bw
    ttnn.div_no_nan
    ttnn.divide
    ttnn.divide_
-   ttnn.embedding_bw
    ttnn.eq
    ttnn.eq_
    ttnn.floor_div
    ttnn.fmod
-   ttnn.fmod_bw
    ttnn.gcd
    ttnn.ge
    ttnn.ge_
    ttnn.gt
    ttnn.gt_
    ttnn.hypot
-   ttnn.hypot_bw
    ttnn.isclose
    ttnn.lcm
    ttnn.ldexp
    ttnn.ldexp_
-   ttnn.ldexp_bw
    ttnn.le
    ttnn.le_
    ttnn.logaddexp
    ttnn.logaddexp2
    ttnn.logaddexp2_
-   ttnn.logaddexp2_bw
    ttnn.logaddexp_
-   ttnn.logaddexp_bw
    ttnn.logical_and
    ttnn.logical_and_
    ttnn.logical_or
@@ -372,11 +281,8 @@ Pointwise Binary
    ttnn.logical_xor_
    ttnn.lt
    ttnn.lt_
-   ttnn.max_bw
    ttnn.maximum
-   ttnn.min_bw
    ttnn.minimum
-   ttnn.mul_bw
    ttnn.multiply
    ttnn.multiply_
    ttnn.ne
@@ -387,23 +293,17 @@ Pointwise Binary
    ttnn.pow
    ttnn.prim.binary
    ttnn.remainder
-   ttnn.remainder_bw
    ttnn.rpow
    ttnn.rsub
    ttnn.rsub_
-   ttnn.rsub_bw
    ttnn.scatter
    ttnn.scatter_add
    ttnn.squared_difference
    ttnn.squared_difference_
-   ttnn.squared_difference_bw
-   ttnn.sub_bw
    ttnn.subalpha
-   ttnn.subalpha_bw
    ttnn.subtract
    ttnn.subtract_
    ttnn.xlogy
-   ttnn.xlogy_bw
 
 Pointwise Ternary
 =================
@@ -414,14 +314,10 @@ Pointwise Ternary
    :template: function.rst
 
    ttnn.addcdiv
-   ttnn.addcdiv_bw
    ttnn.addcmul
-   ttnn.addcmul_bw
    ttnn.lerp
-   ttnn.lerp_bw
    ttnn.mac
    ttnn.where
-   ttnn.where_bw
 
 Quantization
 ============
@@ -645,7 +541,6 @@ Pooling
    ttnn.adaptive_max_pool2d
    ttnn.avg_pool2d
    ttnn.global_avg_pool2d
-   ttnn.grid_sample
    ttnn.max_pool2d
 
 Prefetcher
@@ -666,6 +561,7 @@ Vision
    :nosignatures:
    :template: function.rst
 
+   ttnn.grid_sample
    ttnn.upsample
 
 Generic
@@ -691,6 +587,118 @@ KV Cache
    ttnn.fill_cache
    ttnn.update_cache
 
+Backward operations
+===================
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+   :template: function.rst
+
+   ttnn.abs_bw
+   ttnn.acos_bw
+   ttnn.acosh_bw
+   ttnn.add_bw
+   ttnn.addalpha_bw
+   ttnn.addcdiv_bw
+   ttnn.addcmul_bw
+   ttnn.angle_bw
+   ttnn.asin_bw
+   ttnn.asinh_bw
+   ttnn.assign_bw
+   ttnn.atan2_bw
+   ttnn.atan_bw
+   ttnn.atanh_bw
+   ttnn.bias_gelu_bw
+   ttnn.ceil_bw
+   ttnn.celu_bw
+   ttnn.clamp_bw
+   ttnn.clip_bw
+   ttnn.concat_bw
+   ttnn.conj_bw
+   ttnn.cos_bw
+   ttnn.cosh_bw
+   ttnn.deg2rad_bw
+   ttnn.digamma_bw
+   ttnn.div_bw
+   ttnn.div_no_nan_bw
+   ttnn.elu_bw
+   ttnn.embedding_bw
+   ttnn.erf_bw
+   ttnn.erfc_bw
+   ttnn.erfinv_bw
+   ttnn.exp2_bw
+   ttnn.exp_bw
+   ttnn.experimental.gelu_bw
+   ttnn.expm1_bw
+   ttnn.fill_bw
+   ttnn.fill_zero_bw
+   ttnn.floor_bw
+   ttnn.fmod_bw
+   ttnn.frac_bw
+   ttnn.gelu_bw
+   ttnn.hardshrink_bw
+   ttnn.hardsigmoid_bw
+   ttnn.hardswish_bw
+   ttnn.hardtanh_bw
+   ttnn.hypot_bw
+   ttnn.i0_bw
+   ttnn.imag_bw
+   ttnn.ldexp_bw
+   ttnn.leaky_relu_bw
+   ttnn.lerp_bw
+   ttnn.lgamma_bw
+   ttnn.log10_bw
+   ttnn.log1p_bw
+   ttnn.log2_bw
+   ttnn.log_bw
+   ttnn.log_sigmoid_bw
+   ttnn.logaddexp2_bw
+   ttnn.logaddexp_bw
+   ttnn.logit_bw
+   ttnn.logiteps_bw
+   ttnn.max_bw
+   ttnn.min_bw
+   ttnn.mul_bw
+   ttnn.multigammaln_bw
+   ttnn.neg_bw
+   ttnn.polar_bw
+   ttnn.polygamma_bw
+   ttnn.pow_bw
+   ttnn.prod_bw
+   ttnn.rad2deg_bw
+   ttnn.rdiv_bw
+   ttnn.real_bw
+   ttnn.reciprocal_bw
+   ttnn.relu6_bw
+   ttnn.relu_bw
+   ttnn.remainder_bw
+   ttnn.repeat_bw
+   ttnn.round_bw
+   ttnn.rpow_bw
+   ttnn.rsqrt_bw
+   ttnn.rsub_bw
+   ttnn.selu_bw
+   ttnn.sigmoid_bw
+   ttnn.sign_bw
+   ttnn.silu_bw
+   ttnn.sin_bw
+   ttnn.sinh_bw
+   ttnn.softplus_bw
+   ttnn.softshrink_bw
+   ttnn.softsign_bw
+   ttnn.sqrt_bw
+   ttnn.square_bw
+   ttnn.squared_difference_bw
+   ttnn.sub_bw
+   ttnn.subalpha_bw
+   ttnn.tan_bw
+   ttnn.tanh_bw
+   ttnn.tanhshrink_bw
+   ttnn.threshold_bw
+   ttnn.trunc_bw
+   ttnn.where_bw
+   ttnn.xlogy_bw
 
 Model Conversion
 ****************

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -51,7 +51,10 @@ Core
    ttnn.reallocate
    ttnn.to_memory_config
    ttnn.split_work_to_cores
-
+   ttnn.copy_device_to_host_tensor
+   ttnn.copy_host_to_device_tensor
+   ttnn.to_dtype
+   ttnn.typecast
 
 Tensor Creation
 ===============
@@ -72,6 +75,10 @@ Tensor Creation
    ttnn.full_like
    ttnn.rand
    ttnn.from_buffer
+   ttnn.bernoulli
+   ttnn.complex_tensor
+   ttnn.index_fill
+   ttnn.uniform
 
 Matrix Multiplication
 =====================
@@ -116,6 +123,8 @@ Pointwise Unary
    ttnn.bitwise_not
    ttnn.bitwise_left_shift
    ttnn.bitwise_right_shift
+   ttnn.logical_left_shift
+   ttnn.logical_right_shift
    ttnn.cbrt
    ttnn.ceil
    ttnn.celu
@@ -150,6 +159,7 @@ Pointwise Unary
    ttnn.hardtanh
    ttnn.heaviside
    ttnn.i0
+   ttnn.i1
    ttnn.identity
    ttnn.isfinite
    ttnn.isinf
@@ -169,6 +179,7 @@ Pointwise Unary
    ttnn.logit
    ttnn.ltz
    ttnn.mish
+   ttnn.hardmish
    ttnn.multigammaln
    ttnn.neg
    ttnn.nez
@@ -195,6 +206,8 @@ Pointwise Unary
    ttnn.silu
    ttnn.sin
    ttnn.sinh
+   ttnn.std_hw
+   ttnn.var_hw
    ttnn.softplus
    ttnn.softshrink
    ttnn.softsign
@@ -305,12 +318,17 @@ Pointwise Binary
    :template: function.rst
 
    ttnn.add
+   ttnn.add_
    ttnn.addalpha
    ttnn.subalpha
    ttnn.multiply
+   ttnn.multiply_
    ttnn.subtract
+   ttnn.subtract_
    ttnn.div
    ttnn.div_no_nan
+   ttnn.divide
+   ttnn.divide_
    ttnn.floor_div
    ttnn.remainder
    ttnn.fmod
@@ -321,7 +339,9 @@ Pointwise Binary
    ttnn.logical_xor_
    ttnn.rpow
    ttnn.rsub
+   ttnn.rsub_
    ttnn.ldexp
+   ttnn.ldexp_
    ttnn.logical_and
    ttnn.logical_or
    ttnn.logical_xor
@@ -329,10 +349,13 @@ Pointwise Binary
    ttnn.bitwise_or
    ttnn.bitwise_xor
    ttnn.logaddexp
+   ttnn.logaddexp_
    ttnn.logaddexp2
+   ttnn.logaddexp2_
    ttnn.hypot
    ttnn.xlogy
    ttnn.squared_difference
+   ttnn.squared_difference_
    ttnn.gt
    ttnn.gt_
    ttnn.lt_
@@ -353,7 +376,10 @@ Pointwise Binary
    ttnn.pow
    ttnn.polyval
    ttnn.scatter
+   ttnn.scatter_add
    ttnn.atan2
+   ttnn.bias_gelu
+   ttnn.bias_gelu_
    ttnn.add_bw
    ttnn.assign_bw
    ttnn.atan2_bw
@@ -376,6 +402,7 @@ Pointwise Binary
    ttnn.rsub_bw
    ttnn.min_bw
    ttnn.max_bw
+   ttnn.prim.binary
 
 Pointwise Ternary
 =================
@@ -394,6 +421,18 @@ Pointwise Ternary
    ttnn.addcdiv_bw
    ttnn.where_bw
    ttnn.lerp_bw
+
+Quantization
+============
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+   :template: function.rst
+
+   ttnn.quantize
+   ttnn.requantize
+   ttnn.dequantize
 
 Losses
 ======
@@ -428,6 +467,7 @@ Reduction
    ttnn.cumsum
    ttnn.manual_seed
    ttnn.moe
+   ttnn.sampling
 
 Data Movement
 =============
@@ -454,6 +494,31 @@ Data Movement
    ttnn.indexed_fill
    ttnn.gather
    ttnn.sort
+   ttnn.assign
+   ttnn.bcast
+   ttnn.chunk
+   ttnn.copy
+   ttnn.expand
+   ttnn.fill_implicit_tile_padding
+   ttnn.fold
+   ttnn.interleaved_to_sharded
+   ttnn.interleaved_to_sharded_partial
+   ttnn.moe_expert_token_remap
+   ttnn.moe_routing_remap
+   ttnn.move
+   ttnn.reshape_on_device
+   ttnn.reshard
+   ttnn.roll
+   ttnn.sharded_to_interleaved
+   ttnn.sharded_to_interleaved_partial
+   ttnn.split
+   ttnn.squeeze
+   ttnn.stack
+   ttnn.tilize_with_zero_padding
+   ttnn.transpose
+   ttnn.unsqueeze
+   ttnn.unsqueeze_to_4D
+   ttnn.view
 
 Normalization
 =============
@@ -501,9 +566,18 @@ Transformer
    ttnn.transformer.concatenate_heads
    ttnn.transformer.attention_softmax
    ttnn.transformer.attention_softmax_
-   ttnn.experimental.rotary_embedding
    ttnn.transformer.scaled_dot_product_attention
    ttnn.transformer.scaled_dot_product_attention_decode
+   ttnn.transformer.chunked_flash_mla_prefill
+   ttnn.transformer.chunked_scaled_dot_product_attention
+   ttnn.transformer.flash_mla_prefill
+   ttnn.transformer.flash_multi_latent_attention_decode
+   ttnn.transformer.joint_scaled_dot_product_attention
+   ttnn.transformer.paged_flash_multi_latent_attention_decode
+   ttnn.transformer.paged_scaled_dot_product_attention_decode
+   ttnn.transformer.ring_distributed_scaled_dot_product_attention
+   ttnn.transformer.ring_joint_scaled_dot_product_attention
+   ttnn.transformer.windowed_scaled_dot_product_attention
 
 CCL
 ===
@@ -516,6 +590,12 @@ CCL
    ttnn.all_gather
    ttnn.reduce_scatter
    ttnn.all_reduce
+   ttnn.broadcast
+   ttnn.all_to_all_combine
+   ttnn.all_to_all_dispatch
+   ttnn.mesh_partition
+   ttnn.point_to_point
+   ttnn.reduce_to_root
 
 Embedding
 =========
@@ -563,6 +643,19 @@ Pooling
    ttnn.global_avg_pool2d
    ttnn.max_pool2d
    ttnn.avg_pool2d
+   ttnn.adaptive_avg_pool2d
+   ttnn.adaptive_max_pool2d
+   ttnn.grid_sample
+
+Prefetcher
+==========
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+   :template: function.rst
+
+   ttnn.dram_prefetcher
 
 Vision
 ========
@@ -574,6 +667,16 @@ Vision
 
    ttnn.upsample
 
+Generic
+=======
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+   :template: function.rst
+
+   ttnn.generic_op
+
 KV Cache
 ========
 
@@ -584,6 +687,8 @@ KV Cache
 
    ttnn.kv_cache.fill_cache_for_user_
    ttnn.kv_cache.update_cache_for_token_
+   ttnn.fill_cache
+   ttnn.update_cache
 
 
 Model Conversion

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/all_broadcast_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/all_broadcast_nanobind.cpp
@@ -19,34 +19,34 @@ namespace ttnn::operations::ccl {
 
 void bind_all_broadcast(nb::module_& mod) {
     const auto* doc =
-        R"doc(all_broadcast(input_tensor: ttnn.Tensor, *, cluster_axis: Optional[int] = None, subdevice_id: Optional[ttnn.SubDeviceId] = None, memory_config: Optional[ttnn.MemoryConfig] = None, num_links: Optional[int] = 1, topology: Optional[ttnn.Topology] = ttnn.Topology.Linear) -> List[ttnn.Tensor]
+        R"doc(
+        All-broadcast operation across devices. This operation broadcasts data from all devices to all other devices in the mesh, returning a vector of tensors where each tensor contains the data from a corresponding device in the mesh. The output tensors are identical across all devices along the cluster axis if specified, otherwise they are identical across all devices in the mesh.
 
-            All-broadcast operation across devices. This operation broadcasts data from all devices to all other devices in the mesh, returning a vector of tensors where each tensor contains the data from a corresponding device in the mesh. The output tensors are identical across all devices along the cluster axis if specified, otherwise they are identical across all devices in the mesh.
+        Args:
+            input_tensor (ttnn.Tensor): Input tensor to be broadcast.
 
-            Args:
-                input_tensor (ttnn.Tensor): Input tensor to be broadcast.
+        Keyword Args:
+            cluster_axis (int, optional): The axis on the mesh device to broadcast across. Defaults to `None`.
+            subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
+            memory_config (ttnn.MemoryConfig, optional): Output memory configuration. Defaults to input tensor memory config.
+            num_links (int, optional): The number of links to use for the all-broadcast operation. Defaults to `1`.
+            topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
 
-            Keyword Args:
-                cluster_axis (int, optional): The axis on the mesh device to broadcast across. Defaults to `None`.
-                subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
-                memory_config (ttnn.MemoryConfig, optional): Output memory configuration. Defaults to input tensor memory config.
-                num_links (int, optional): The number of links to use for the all-broadcast operation. Defaults to `1`.
-                topology (ttnn.Topology, optional): Fabric topology. Defaults to `ttnn.Topology.Linear`.
+        Returns:
+            List[ttnn.Tensor]: A list of tensors, one from each device, where each tensor has the same shape as the input.
 
-           Returns:
-               List[ttnn.Tensor]: A list of tensors, one from each device, where each tensor has the same shape as the input.
+        Example:
 
-            Example:
-                >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
-                >>> input_tensor = ttnn.from_torch(
-                                torch.rand([1, 1, 32, 256]),
-                                dtype=ttnn.bfloat16,
-                                device=mesh_device,
-                                layout=ttnn.TILE_LAYOUT,
-                                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device))
-                >>> output = ttnn.all_broadcast(input_tensor)
-                >>> # output is a list of 8 tensors, each with shape [1, 1, 32, 256]
-                )doc";
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8))
+            >>> input_tensor = ttnn.from_torch(
+                            torch.rand([1, 1, 32, 256]),
+                            dtype=ttnn.bfloat16,
+                            device=mesh_device,
+                            layout=ttnn.TILE_LAYOUT,
+                            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device))
+            >>> output = ttnn.all_broadcast(input_tensor)
+            >>> # output is a list of 8 tensors, each with shape [1, 1, 32, 256]
+    )doc";
 
     using OperationType = decltype(ttnn::all_broadcast);
     ttnn::bind_registered_operation(

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy_nanobind.cpp
@@ -39,25 +39,6 @@ std::string get_binary_doc_string(
         input_a,
         input_b);
 }
-
-std::string get_unary_doc_string(
-    std::string_view op_name, std::string_view input, fmt::format_string<std::string_view&> op_desc) {
-    return fmt::format(
-        R"doc(
-        {0}
-
-        Input tensor must have BFLOAT16 data type.
-
-        Output tensor will have BFLOAT16 data type.
-
-        .. csv-table::
-            :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-            "{1}", "Tensor {2} is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes")doc",
-        fmt::format(op_desc, input),
-        input,
-        op_name);
-}
 }  // namespace
 
 namespace ttnn::operations::data_movement::detail {
@@ -83,24 +64,18 @@ void bind_copy(nb::module_& mod) {
 }
 
 void bind_assign(nb::module_& mod) {
-    auto doc = get_unary_doc_string(
-        "assign", "input", R"doc(  Returns a new tensor which is a new copy of input tensor ``{0}``.
+    const auto* doc =
+        R"doc(
+    Returns a new tensor which is a new copy of input tensor. Alternatively, copies input tensor ``input_a`` to ``input_b`` if their shapes and memory layouts match, and returns input_b tensor.
 
+    Input tensor must have BFLOAT16 data type.
+    Output tensor will have BFLOAT16 data type.
 
-    Alternatively, copies input tensor ``input_a`` to ``input_b`` if their
-    shapes and memory layouts match, and returns input_b tensor.
+    Args:
+        input_tensor_a (ttnn.Tensor): Tensor assign is applied to. Tensor of shape [W, Z, Y, X].
+        input_tensor_b (ttnn.Tensor): Input tensor. Tensor of shape [W, Z, Y, X]. Only if performing assign to from tensor_a.
 
-    Input tensors can be of any data type.
-
-    Output tensor will be of same data type as Input tensor.
-
-    .. csv-table::
-        :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-        "input_a", "Tensor assign is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-        "input_b", "Input tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-
-    )doc");
+    )doc";
 
     bind_registered_operation(
         mod,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
@@ -28,11 +28,11 @@ void bind_fold_operation(nb::module_& mod) {
             Fold TT Tensor.
             Input tensor must be on TT accelerator device, in ROW_MAJOR.
             Output tensor will be on TT accelerator device, in ROW_MAJOR.
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-                "input", "Input tensor", "Tensor", "Tensor of shape [N, H, W, C]", "Yes"
-                "stride_h", "Stride along the H-dimension", "int", "", "Yes"
-                "stride_w", "Stride along the W-dimension", "int", "", "Yes"
+
+            Args:
+                input (ttnn.Tensor): Input tensor to be folded. Tensor of shape [N, H, W, C].
+                stride_h (int): Stride along the H-dimension.
+                stride_w (int): Stride along the W-dimension.
         )doc",
         ttnn::nanobind_overload_t{
             [](const decltype(ttnn::fold)& op,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
@@ -55,6 +55,7 @@ void bind_reshape(nb::module_& mod) {
         Equivalent pytorch code:
 
         .. code-block:: python
+
             input_tensor = torch.arange(4.)
             W = 1
             Z = 1

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_nanobind.cpp
@@ -53,16 +53,13 @@ void bind_squeeze(nb::module_& mod) {
         Equivalent pytorch code:
 
         .. code-block:: python
+
             input_tensor = torch.rand((1,1,1,256), dtype=torch.bfloat16)
             output_tensor = torch.squeeze(input_tensor, 2) # tensor of shape (1,1,256), where at dimension 2 we removed it
-
-
 
         Args:
             * :attr:`input_tensor`: Input Tensor.
             * :attr:`dim`: Dim where we want to squeeze
-
-
         )doc");
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze_nanobind.cpp
@@ -40,16 +40,13 @@ void bind_unsqueeze(nb::module_& mod) {
         Equivalent pytorch code:
 
         .. code-block:: python
+
             input_tensor = torch.rand((1,1,256), dtype=torch.bfloat16)
             output_tensor = torch.unsqueeze(input_tensor, 2) # tensor of shape (1,1,1,256), where at dimension 2 we added a new dim of size 1
-
-
 
         Args:
             * :attr:`input_tensor`: Input Tensor.
             * :attr:`dim`: Dim where we want to unsqueeze (add a new dimension of size 1)
-
-
         )doc");
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -1952,22 +1952,26 @@ void bind_logical_inplace_operation(
 
 template <typename binary_operation_t>
 void bind_binary_inplace_operation(
-    nb::module_& mod, const binary_operation_t& operation, const std::string& description) {
+    nb::module_& mod, const binary_operation_t& operation, const std::string& description, const std::string& math) {
     auto doc = fmt::format(
         R"doc(
             {2}
 
-            {3}
+            {4}
+
+            .. math::
+                {3}
 
             Args:
                 * :attr:`input_a` (ttnn.Tensor)
                 * :attr:`input_b` (ttnn.Tensor or Number)
             Keyword args:
-            * :attr:`activations` (Optional[List[str]]): list of activation functions to apply to the output tensor
+                * :attr:`activations` (Optional[List[str]]): list of activation functions to apply to the output tensor
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
         description,
+        math,
         BINARY_BROADCAST_DOC);
 
     bind_registered_operation(
@@ -2197,8 +2201,8 @@ void py_module(nb::module_& mod) {
     detail::bind_binary_inplace_operation(
         mod,
         ttnn::add_,
-        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place
-        .. math:: \mathrm{{input\_tensor\_a}}_i + \mathrm{{input\_tensor\_b}}_i)doc");
+        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i + \mathrm{{input\_tensor\_b}}_i)doc");
 
     detail::bind_binary_operation(
         mod,
@@ -2211,8 +2215,8 @@ void py_module(nb::module_& mod) {
     detail::bind_binary_inplace_operation(
         mod,
         ttnn::subtract_,
-        R"doc(Subtracts :attr:`input_tensor_b` from :attr:`input_tensor_a` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place
-        .. math:: \mathrm{{input\_tensor\_a}}_i - \mathrm{{input\_tensor\_b}}_i)doc");
+        R"doc(Subtracts :attr:`input_tensor_b` from :attr:`input_tensor_a` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i - \mathrm{{input\_tensor\_b}}_i)doc");
 
     detail::bind_binary_operation(
         mod,
@@ -2225,8 +2229,8 @@ void py_module(nb::module_& mod) {
     detail::bind_binary_inplace_operation(
         mod,
         ttnn::multiply_,
-        R"doc(Multiplies :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place
-        .. math:: \mathrm{{input\_tensor\_a}}_i \times \mathrm{{input\_tensor\_b}}_i)doc");
+        R"doc(Multiplies :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a` in-place)doc",
+        R"doc(\mathrm{{input\_tensor\_a}}_i \times \mathrm{{input\_tensor\_b}}_i)doc");
 
     detail::bind_binary_operation(
         mod,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_nanobind.cpp
@@ -26,45 +26,57 @@ void bind_grid_sample_op(nb::module_& mod) {
 
         Args:
             input_tensor (ttnn.Tensor): Input tensor of shape (N, H_in, W_in, C) - channel last format
-            grid (ttnn.Tensor): Sampling grid with flexible batching support:
-                               * Standard mode (use_precomputed_grid=False):
-                                 - Shape (N, H_grid, W_grid, 2*K) where K is the grid batching factor
-                                 - Contains K sets of normalized coordinates in range [-1, 1] packed into the last dimension
-                                 - Each coordinate pair (x, y): x=-1 (leftmost), x=+1 (rightmost), y=-1 (topmost), y=+1 (bottommost)
-                                 - Data type: BFLOAT16 or FLOAT32 (FLOAT32 provides higher precision for coordinate calculations)
-                                 - When K=1: standard single coordinate per location (maps 1:1 to PyTorch F.grid_sample behavior)
-                                 - When K>1: K coordinate sets are packed per spatial location, typically created by reshaping
-                                   a larger grid from (N, H_grid, W_grid*K, 2) to (N, H_grid, W_grid, 2*K), where the desired grid shape would be W_grid*K
-                               * Precomputed mode (use_precomputed_grid=True):
-                                 - Shape (N, H_grid, W_grid, 6*K) containing K sets of precomputed data packed into the last dimension
-                                 - Each set has 6 elements: pixel coordinates and bilinear interpolation weights
-                                 - Data type: BFLOAT16 only (precomputed grids must be BFLOAT16)
-                                 - When K=1: standard precomputed grid
-                                 - When K>1: K precomputed sets are packed per spatial location, typically created by reshaping
-                                   a larger precomputed grid from (N, H_grid, W_grid*K, 6) to (N, H_grid, W_grid, 6*K), where the desired grid shape would be W_grid*K
-                                 - Generated using ttnn.prepare_grid_sample_grid() for K=1, then ttnn.reshape() for K>1, both being done on host side
+            grid (ttnn.Tensor): Sampling grid with flexible batching support.
 
+                * Standard mode (use_precomputed_grid=False):
+
+                  - Shape (N, H_grid, W_grid, 2*K) where K is the grid batching factor
+                  - Contains K sets of normalized coordinates in range [-1, 1] packed into the last dimension
+                  - Each coordinate pair (x, y): x=-1 (leftmost), x=+1 (rightmost), y=-1 (topmost), y=+1 (bottommost)
+                  - Data type: BFLOAT16 or FLOAT32 (FLOAT32 provides higher precision for coordinate calculations)
+                  - When K=1: standard single coordinate per location (maps 1:1 to PyTorch F.grid_sample behavior)
+                  - When K>1: K coordinate sets are packed per spatial location, typically created by reshaping
+                    a larger grid from (N, H_grid, W_grid*K, 2) to (N, H_grid, W_grid, 2*K), where the desired grid shape would be W_grid*K
+
+                * Precomputed mode (use_precomputed_grid=True):
+
+                  - Shape (N, H_grid, W_grid, 6*K) containing K sets of precomputed data packed into the last dimension
+                  - Each set has 6 elements: pixel coordinates and bilinear interpolation weights
+                  - Data type: BFLOAT16 only (precomputed grids must be BFLOAT16)
+                  - When K=1: standard precomputed grid
+                  - When K>1: K precomputed sets are packed per spatial location, typically created by reshaping
+                    a larger precomputed grid from (N, H_grid, W_grid*K, 6) to (N, H_grid, W_grid, 6*K), where the desired grid shape would be W_grid*K
+                  - Generated using ttnn.prepare_grid_sample_grid() for K=1, then ttnn.reshape() for K>1, both being done on host side
         Keyword Args:
             mode (str): Interpolation mode.
             padding_mode (str): How to handle out-of-bounds coordinates. Currently only "zeros" is supported.
             align_corners (bool): Whether to align corners when mapping normalized coordinates to pixel indices.
             use_precomputed_grid (bool): Whether to use precomputed grid coordinates.
-                                   When False (default): grid should be normalized coordinates in [-1, 1]
-                                   When True: grid should be preprocessed using ttnn.prepare_grid_sample_grid()
-            batch_output_channels (bool): Controls how grid batching factor K affects output dimensions:
-                                    When False (default): extend W dimension - output shape (N, H_grid, W_grid*K, C)
-                                     The K coordinate sets produce K spatial outputs, expanding the width dimension
-                                   When True: batch output channels - output shape (N, H_grid, W_grid, C*K)
-                                     The K coordinate sets produce K channel groups, expanding the channel dimension
-                                   Setting this argument to True requires for K (grid batching factor) to be larger than one
-                                   Note: K doesn't disappear when batch_output_channels=False, it just gets distributed to the width dimension
+
+                When False (default): grid should be normalized coordinates in [-1, 1]
+
+                When True: grid should be preprocessed using ttnn.prepare_grid_sample_grid()
+
+            batch_output_channels (bool): Controls how grid batching factor K affects output dimensions.
+
+                When False (default): extend W dimension - output shape (N, H_grid, W_grid*K, C).
+                The K coordinate sets produce K spatial outputs, expanding the width dimension.
+
+                When True: batch output channels - output shape (N, H_grid, W_grid, C*K).
+                The K coordinate sets produce K channel groups, expanding the channel dimension.
+
+                Setting this argument to True requires for K (grid batching factor) to be larger than one.
+                Note: K doesn't disappear when batch_output_channels=False, it just gets distributed to the width dimension.
+
             memory_config (ttnn.MemoryConfig, optional): Output memory configuration for the operation.
 
         Returns:
-            ttnn.Tensor: Output tensor shape depends on batch_output_channels flag:
-                        - When batch_output_channels=False (default): (N, H_grid, W_grid*K, C) - W dimension extended
-                        - When batch_output_channels=True: (N, H_grid, W_grid, C*K) - channels batched
-                        Where K is the grid batching factor.
+            ttnn.Tensor: Output tensor shape depends on batch_output_channels flag.
+
+                - When batch_output_channels=False (default): (N, H_grid, W_grid*K, C) - W dimension extended
+                - When batch_output_channels=True: (N, H_grid, W_grid, C*K) - channels batched
+
+                Where K is the grid batching factor.
 
         Example:
             >>> # Create input tensor (N=1, H=4, W=4, C=32) - channel last format
@@ -160,12 +172,13 @@ void bind_prepare_grid_sample_grid(nb::module_& mod) {
 
         Returns:
             ttnn.Tensor: Precomputed grid tensor of shape (N, H_out, W_out, 6) where:
-                        - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
-                        - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
-                        - [:, :, :, 2]: Weight for north-west pixel
-                        - [:, :, :, 3]: Weight for north-east pixel
-                        - [:, :, :, 4]: Weight for south-west pixel
-                        - [:, :, :, 5]: Weight for south-east pixel
+
+                - [:, :, :, 0]: North-west height coordinate (as integer stored in bfloat16)
+                - [:, :, :, 1]: North-west width coordinate (as integer stored in bfloat16)
+                - [:, :, :, 2]: Weight for north-west pixel
+                - [:, :, :, 3]: Weight for north-east pixel
+                - [:, :, :, 4]: Weight for south-west pixel
+                - [:, :, :, 5]: Weight for south-east pixel
 
         Example:
             >>> # Create a normalized grid with coordinates in [-1, 1] range

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher_nanobind.cpp
@@ -23,15 +23,10 @@ void bind_dram_prefetcher_operation(nb::module_& mod) {
 
             Args:
                 tensors (List[ttnn.Tensor]): A list of tensor objects to be pre-fetched.
-                tensor_addrs (ttnn.Tensor): A tensor (row major layout) that contains memory addresses
-                    corresponding to the tensor locations in DRAM. The format should be as follows:
-                        [t1_l1, t2_l1, ..., t1_l2, t2_l2, ..., t1_l3, t2_l3, ...]
-                num_layers (int): The number of layers in the pipeline or the model
-                    for which tensors need to be pre-fetched.
-                global_cb (GlobalCircularBuffer): A global cb object, used internally to manage data movement
-                    across dram reader cores, and downstream consumer cores.
-                enable_performance_mode (bool, optional): If set to true, the operation will be optimized for performance.
-                    May lead to ND behavior on wormhole 4U systems!
+                tensor_addrs (ttnn.Tensor): A tensor (row major layout) that contains memory addresses corresponding to the tensor locations in DRAM. The format should be as follows: [t1_l1, t2_l1, ..., t1_l2, t2_l2, ..., t1_l3, t2_l3, ...]
+                num_layers (int): The number of layers in the pipeline or the model for which tensors need to be pre-fetched.
+                global_cb (GlobalCircularBuffer): A global cb object, used internally to manage data movement across dram reader cores, and downstream consumer cores.
+                enable_performance_mode (bool, optional): If set to true, the operation will be optimized for performance. May lead to ND behavior on wormhole 4U systems!
 
             Returns:
                 ttnn.Tensor: empty tensor (TODO: Should return None)

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -19,28 +19,28 @@ namespace ttnn::operations::reduction::detail {
 void bind_reduction_sampling_operation(nb::module_& mod) {
     const auto* doc =
         R"doc(
-          Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
+        Samples from the :attr:`input_values_tensor` based on provided top-k and top-p constraints.
 
-          This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
-          and :attr:`p` (top-p nucleus sampling). The operation uses the :attr:`input_indices_tensor` for indexing and applies sampling
-          under the given seed for reproducibility.
+        This operation samples values from the :attr:`input_values_tensor` based on the provided thresholds :attr:`k` (top-k sampling)
+        and :attr:`p` (top-p nucleus sampling). The operation uses the :attr:`input_indices_tensor` for indexing and applies sampling
+        under the given seed for reproducibility.
 
-          The op first converts the :attr:`input_values_tensor` into probabilities by doing a softmax.
+        The op first converts the :attr:`input_values_tensor` into probabilities by doing a softmax.
 
-          In top-k sampling, the op considers only the k highest-probability values from the input distribution. The remaining values are ignored, regardless of their probabilities.
-          In top-p sampling, the op selects values from the input distribution such that the cumulative probability mass is less than or equal to a threshold p.
-          When combining top-k and top-p sampling, the op first applies the top-k filter and then the top-p filter.
+        In top-k sampling, the op considers only the k highest-probability values from the input distribution. The remaining values are ignored, regardless of their probabilities.
+        In top-p sampling, the op selects values from the input distribution such that the cumulative probability mass is less than or equal to a threshold p.
+        When combining top-k and top-p sampling, the op first applies the top-k filter and then the top-p filter.
 
-          Within this selected corpus, multinomial sampling is applied. Multinomial sampling selects values from a given distribution by comparing each probability with a randomly generated number between 0 and 1. Specifically, the operation identifies the largest cumulative probability that exceeds the random threshold.
+        Within this selected corpus, multinomial sampling is applied. Multinomial sampling selects values from a given distribution by comparing each probability with a randomly generated number between 0 and 1. Specifically, the operation identifies the largest cumulative probability that exceeds the random threshold.
 
-          The op finally returns input_indices_tensor[final_index]  where final_index is the index of the largest cumulative probability > random number found in the multinomial sampling.
+        The op finally returns input_indices_tensor[final_index]  where final_index is the index of the largest cumulative probability > random number found in the multinomial sampling.
 
-          Currently, this operation supports inputs and outputs with specific memory layout and data type constraints.
+        Currently, this operation supports inputs and outputs with specific memory layout and data type constraints.
 
-          Equivalent PyTorch code:
-              .. code-block:: python
+        Equivalent PyTorch code:
+            .. code-block:: python
 
-                  return torch.sampling(
+               return torch.sampling(
                       input_values_tensor,
                       input_indices_tensor,
                       k=k,
@@ -50,96 +50,97 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                       optional_output_tensor=optional_output_tensor,
                   )
 
-            Args:
-                input_values_tensor (ttnn.Tensor): The input tensor containing values to sample from.
-                input_indices_tensor (ttnn.Tensor): The input tensor containing indices to assist with sampling.
-                k (ttnn.Tensor): Top-k values for sampling.
-                p (ttnn.Tensor): Top-p (nucleus) probabilities for sampling.
-                temp (ttnn.Tensor): Temperature tensor for scaling (1/T).
-                seed (int, optional): Seed for sampling randomness. Defaults to `0`.
-                sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
-                optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+        Args:
+            input_values_tensor (ttnn.Tensor): The input tensor containing values to sample from.
+            input_indices_tensor (ttnn.Tensor): The input tensor containing indices to assist with sampling.
+            k (ttnn.Tensor): Top-k values for sampling.
+            p (ttnn.Tensor): Top-p (nucleus) probabilities for sampling.
+            temp (ttnn.Tensor): Temperature tensor for scaling (1/T).
+            seed (int, optional): Seed for sampling randomness. Defaults to `0`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
-              Note:
-                This operations only supports inputs and outputs according to the following data types and layout:
+        Note:
+            This operations only supports inputs and outputs according to the following data types and layout:
 
-                .. list-table:: input_values_tensor
-                    :header-rows: 1
+            .. list-table:: input_values_tensor
+                :header-rows: 1
 
-                    * - dtype
-                      - layout
-                    * - BFLOAT16
-                      - TILE
+                * - dtype
+                  - layout
+                * - BFLOAT16
+                  - TILE
 
 
-                .. list-table:: input_indices_tensor
-                    :header-rows: 1
+            .. list-table:: input_indices_tensor
+                :header-rows: 1
 
-                    * - dtype
-                      - layout
-                    * - UINT32, INT32
-                      - ROW_MAJOR
+                * - dtype
+                  - layout
+                * - UINT32, INT32
+                  - ROW_MAJOR
 
-                .. list-table:: k
-                    :header-rows: 1
+            .. list-table:: k
+                :header-rows: 1
 
-                    * - dtype
-                      - layout
-                    * - UINT32
-                      - ROW_MAJOR
+                * - dtype
+                  - layout
+                * - UINT32
+                  - ROW_MAJOR
 
-                .. list-table:: p, temp
-                    :header-rows: 1
+            .. list-table:: p, temp
+                :header-rows: 1
 
-                    * - dtype
-                      - layout
-                    * - BFLOAT16
-                      - ROW_MAJOR
+                * - dtype
+                  - layout
+                * - BFLOAT16
+                  - ROW_MAJOR
 
-                If no :attr:`output_tensor` is provided, the return tensor will be as follows:
-                .. list-table:: output_tensor (default)
-                    :header-rows: 1
+            If no :attr:`output_tensor` is provided, the return tensor will be as follows:
 
-                    * - dtype
-                      - layout
-                    * - UINT32
-                      - ROW_MAJOR
+            .. list-table:: output_tensor (default)
+                :header-rows: 1
 
-                If :attr:`output_tensor` is provided, the supported data types and layout are:
+                * - dtype
+                  - layout
+                * - UINT32
+                  - ROW_MAJOR
 
-                .. list-table:: output_tensor (if provided)
-                    :header-rows: 1
+            If :attr:`output_tensor` is provided, the supported data types and layout are:
 
-                    * - dtype
-                      - layout
-                    * - INT32, UINT32
-                      - ROW_MAJOR
+            .. list-table:: output_tensor (if provided)
+                :header-rows: 1
+
+                * - dtype
+                  - layout
+                * - INT32, UINT32
+                  - ROW_MAJOR
 
             Returns:
                 ttnn.Tensor: The output tensor containing sampled indices.
 
             Memory Support:
-              - Interleaved: DRAM and L1
+                - Interleaved: DRAM and L1
 
             Limitations:
-              - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
-              - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
-              - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
-              - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
-              - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
-              - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
-              - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
+                - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
+                - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
+                - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
+                - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
+                - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
+                - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
+                - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
 
-            Example:
-                .. code-block:: python
+        Example:
+            .. code-block:: python
 
-                  input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
-                  input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                  k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                  p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                  temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
+                input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+                temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-                  output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+                output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/sdpa_windowed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/sdpa_windowed_nanobind.cpp
@@ -23,9 +23,9 @@ void bind_sdpa_windowed(nb::module_& mod) {
         Qwen2.5-VL where attention is restricted to specific windows in the sequence.
 
         Args:
-            input_tensor_q (ttnn.Tensor): the query tensor.     [b x nqh x s x dh]
-            input_tensor_k (ttnn.Tensor): the key tensor.       [b x nkv x s x dh]
-            input_tensor_v (ttnn.Tensor): the value tensor.     [b x nkv x s x dh]
+            input_tensor_q (ttnn.Tensor): the query tensor. [b x nqh x s x dh]
+            input_tensor_k (ttnn.Tensor): the key tensor. [b x nkv x s x dh]
+            input_tensor_v (ttnn.Tensor): the value tensor. [b x nkv x s x dh]
             cu_window_seqlens (ttnn.Tensor): cumulative window sequence lengths that define attention boundaries. [window_count + 1]
 
         Keyword args:
@@ -39,11 +39,13 @@ void bind_sdpa_windowed(nb::module_& mod) {
 
         Example:
 
-            # For a sequence with 3 windows of sizes 10, 15, and 20 tokens:
-            cu_window_seqlens = [0, 10, 25, 45]
-            output = ttnn.transformer.windowed_scaled_dot_product_attention(
-                q, k, v, cu_window_seqlens
-            )
+            .. code-block:: python
+
+                # For a sequence with 3 windows of sizes 10, 15, and 20 tokens:
+                cu_window_seqlens = [0, 10, 25, 45]
+                output = ttnn.transformer.windowed_scaled_dot_product_attention(
+                    q, k, v, cu_window_seqlens
+                )
         )doc";
 
     using OperationType = decltype(ttnn::transformer::windowed_scaled_dot_product_attention);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/sdpa_windowed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/sdpa_windowed_nanobind.cpp
@@ -38,6 +38,7 @@ void bind_sdpa_windowed(nb::module_& mod) {
             ttnn.Tensor: the output tensor [b x nqh x s x dh].
 
         Example:
+
             # For a sequence with 3 windows of sizes 10, 15, and 20 tokens:
             cu_window_seqlens = [0, 10, 25, 45]
             output = ttnn.transformer.windowed_scaled_dot_product_attention(


### PR DESCRIPTION
### Ticket

#33250
Also solving: #30274, #23507

### Problem description
Many existing TTNN operations are missing from the documentation. They do not appear on the operations list at https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api.html#operations, and they also lack example entries in `examples_mapping.py`.

### What's changed
- Compared list of operations from `ttnn.query_registered_operations()` and in `api.rst`,
- Added missing OPs to `api.rst` file,
- Corrected bindings of operations that caused docs crash,
- Updated document https://docs.google.com/spreadsheets/d/1Z3nduLHMEJqLs2VveyULptdOAaaLlbKnhD-U4sgISu8/edit?usp=sharing,
- Sorted operations alphabetically,

Note: Skipped all experimental and Moreh operations.

### Next steps

- Create tickets for individual teams based on findings from spreadsheet under #32364 - Done, ready to assign,
- Add check to pipeline (preferably `.pre-commit-config.yaml`) to check if new OP was added and is not in docs for new operations. #34667

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20333850243