### PR TITLE
cross attention block to hf

### DIFF
--- a/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
@@ -167,7 +167,9 @@ def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_d
             cache_position=[layer_idx],
             full_text_row_masked_out_mask=full_text_mask,
             attention_mask=None,
-        )[0]
+        )[
+            0
+        ]  # 0 element is the actuall feature map/hidden state needed for comparison
 
         if mode == "prefill":
             full_text_mask_expand_11SD = full_text_mask.expand(-1, -1, -1, dim)

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
@@ -51,16 +51,10 @@ def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_d
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     first_layer_prefix = "text_model.cross_attention_layers.0."
-    partial_state_dict = {
-        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if (k.startswith(first_layer_prefix))
-    }
-
     dim = model_args.dim
     head_dim = model_args.head_dim
     n_heads = model_args.n_heads
     n_kv_heads = model_args.n_kv_heads
-    # reference_model = llama_reference_mod.CrossAttentionTransformerBlock(args=model_args, layer_id=0, no_ffn=False)
-    # reference_model.load_state_dict(partial_state_dict)
 
     # Initialization of HF subclass parameters
     hf_weights_repo_name = os.getenv("HF_MODEL")
@@ -169,7 +163,7 @@ def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_d
             attention_mask=None,
         )[
             0
-        ]  # 0 element is the actuall feature map/hidden state needed for comparison
+        ]  # 0 element is the actual feature map/hidden state needed for comparison
 
         if mode == "prefill":
             full_text_mask_expand_11SD = full_text_mask.expand(-1, -1, -1, dim)

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
@@ -31,18 +31,18 @@ from models.tt_transformers.tt.multimodal.llama_cross_block import TtLlamaCrossA
     ],
     indirect=True,
 )
-# @pytest.mark.parametrize(
-#     "batch",
-#     (1, 2),
-#     ids=[
-#         "batch_1",
-#         "batch_2",
-#     ],
-# )
 @pytest.mark.parametrize(
     "batch",
-    (1,),
+    (1, 2),
+    ids=[
+        "batch_1",
+        "batch_2",
+    ],
 )
+# @pytest.mark.parametrize(
+#     "batch",
+#     (1,),
+# )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_device, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
@@ -39,10 +39,6 @@ from models.tt_transformers.tt.multimodal.llama_cross_block import TtLlamaCrossA
         "batch_2",
     ],
 )
-# @pytest.mark.parametrize(
-#     "batch",
-#     (1,),
-# )
 @pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_device, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16
@@ -169,11 +165,9 @@ def test_cross_attention_transformer_block_inference(text_seq_len, batch, mesh_d
             past_key_value=past_key_values,
             cross_attention_mask=xattn_mask,
             cache_position=[layer_idx],
-            full_text_row_masked_out_mask=full_text_mask.squeeze(1),
+            full_text_row_masked_out_mask=full_text_mask,
             attention_mask=None,
-        )[
-            0
-        ]  # * full_text_mask.squeeze(1)
+        )[0]
 
         if mode == "prefill":
             full_text_mask_expand_11SD = full_text_mask.expand(-1, -1, -1, dim)

--- a/models/tt_transformers/tests/multimodal/utils.py
+++ b/models/tt_transformers/tests/multimodal/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import torch.nn.functional as F

--- a/models/tt_transformers/tests/multimodal/utils.py
+++ b/models/tt_transformers/tests/multimodal/utils.py
@@ -1,0 +1,32 @@
+import os
+
+import torch.nn.functional as F
+
+
+def load_partial_weights(auto_model, weights_path, layer_prefix):
+    partial_state_dict = {}
+    model = auto_model.from_pretrained(weights_path, torch_dtype="auto", local_files_only=os.getenv("CI") == "true")
+    weights = model.state_dict()
+    keys = weights.keys()
+    for key in keys:
+        if layer_prefix in key:
+            # Caution it may cause potential failures. In future versions and different formats the below prefix may change
+            key_name = key[len(layer_prefix) :]
+            partial_state_dict.update({key_name: weights[key]})
+    return partial_state_dict
+
+
+def expand_num_tokens_to_mult8(tensor):
+    num_padding_patches = (8 - (tensor.shape[-2] % 8)) % 8
+    # Compute padding tuple for pad function
+    padding = (0, 0, 0, num_padding_patches)  # (pad_left, pad_right, pad_left for dim -2, pad_right for dim -2)
+    # Pad the tensor
+    tensor = F.pad(tensor, padding, mode="constant", value=0)
+    slice_index = -num_padding_patches if num_padding_patches > 0 else 0
+    return tensor, slice_index
+
+
+def contract_num_tokens_from_mult8(tensor, slice_index):
+    if slice_index == 0:
+        return tensor
+    return tensor[:, :, :slice_index, :]


### PR DESCRIPTION
### Ticket
Close https://github.com/tenstorrent/tt-metal/issues/30085

### Problem description
Cross attention block applied to text branch using vision's branch features of mulitmodal Llama needs to be migrated from meta lib to HF.

### What's changed
HF internally may use different attention implementations, by default eager mode is always active. This mode uses an attention implementation that if combined with making a continuous block of memory using .contiguous() and nn.Linear layer generates minor numerical deviations in the generated tensor. Thus when testing Llama model attention its implementation is switched to the following "config.text_config._attn_implementation = "sdpa"" to use torch.nn.functional.scaled_dot_product_attention as in meta lib (this diminishes any numerical fluctuations).
Additionally cached key and value projections had replicated values by .repeat_interleave(). These were contracted to the number of KV heads instead of the number of attention heads. That helped reduce cache memory usage and match tt_model expected dimensionality.
Note: 
`full_text_mask` applied differently in HF (after mlp layer comparing to meta lib that is applied exactly after sdpa in crossattention layer) but it does not affect the result.

### Checklist
- [x] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20338894557) CI passes  for `test_llama_cross_block.py` with relevant CI tasks `t3k llama3.2-90b-vision tests`, `t3k n300 mesh llama3.2-11b-vision tests`, `t3k llama3.2-11b-vision tests`