### PR TITLE
Add more regular and sharded move tests

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py
@@ -74,16 +74,20 @@ if is_wormhole_b0():
     ids=["out_DRAM", "out_L1"],
 )
 @pytest.mark.parametrize(
-    "dtype, layout",
+    "dtype",
     (
-        (ttnn.bfloat8_b, ttnn.TILE_LAYOUT),
-        (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
-        (ttnn.bfloat16, ttnn.TILE_LAYOUT),
-        (ttnn.int32, ttnn.ROW_MAJOR_LAYOUT),
-        (ttnn.int32, ttnn.TILE_LAYOUT),
+        ttnn.bfloat4_b,
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+        ttnn.float32,
+        ttnn.uint8,
+        ttnn.uint16,
+        ttnn.uint32,
+        ttnn.int32,
     ),
-    ids=["BFLOAT8_B-TILE", "BFLOAT16-RM", "BFLOAT16-TILE", "INT32-RM", "INT32-TILE"],
+    ids=["BFLOAT4_B", "BFLOAT8_B", "BFLOAT16", "FLOAT32", "UINT8", "UINT16", "UINT32", "INT32"],
 )
+@pytest.mark.parametrize("layout", (ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT), ids=["TILE", "RM"])
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("test_id", (0, 1), ids=["overlap", "non_overlap"])
 def test_move_op(test_id, shape, layout, dtype, in0_mem_config, output_mem_config, device):
@@ -92,7 +96,10 @@ def test_move_op(test_id, shape, layout, dtype, in0_mem_config, output_mem_confi
     run_move_op(test_id, shape, layout, dtype, in0_mem_config, output_mem_config, device)
 
 
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32, ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32],
+)
 def test_move_op_with_program_cache(dtype, device):
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
     layout = ttnn.TILE_LAYOUT

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -1,35 +1,62 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
 from loguru import logger
 
-
 import ttnn
-from models.common.utility_functions import comp_pcc, is_blackhole
+from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
 import torch
-import ttnn
-
-shapes = [
-    [1, 1, 25088, 64],
-]
 
 
-@pytest.mark.parametrize("shape", shapes)
-def test_move_op(shape, device):
-    is_p100 = (
-        is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
+def run_move_sharded_test(
+    shape,
+    layout,
+    shard_grid,
+    shard_shape,
+    shard_orientation,
+    buffer_type,
+    device,
+    dtype=ttnn.bfloat16,
+):
+    """Run move sharded and check results with torch.equal."""
+
+    dtype_map = {
+        ttnn.bfloat16: torch.bfloat16,
+        ttnn.float32: torch.float32,
+        ttnn.int32: torch.int32,
+        ttnn.uint32: torch.uint32,
+    }
+    torch_dtype = dtype_map.get(dtype, torch.bfloat16)
+
+    if torch_dtype in (torch.bfloat16, torch.float32):
+        torch_tensor = torch.randn(shape, dtype=torch_dtype)
+    else:
+        torch_tensor = torch.randint(0, 100, shape, dtype=torch_dtype)
+
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
+    mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=buffer_type,
+        shard_spec=shard_spec,
     )
-    if is_p100:
-        pytest.skip(reason="see #34415")
-    run_move_op(shape, device)
+    tt_tensor = ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout, device=device, memory_config=mem_config)
+
+    output = ttnn.move(tt_tensor, memory_config=mem_config)
+    tt_host = output.cpu().to(layout)
+    pyt_got_back = tt_host.to_torch().to(torch_tensor.dtype)
+
+    return torch.equal(pyt_got_back, torch_tensor)
 
 
-def run_move_op(shape, device):
-    """
-    For non_overlap, multi-core is run for num_tiles > 1.
-    """
+@pytest.mark.parametrize(
+    "memory_layout", [ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.TensorMemoryLayout.WIDTH_SHARDED]
+)
+@pytest.mark.parametrize("shape", [[1, 1, 25088, 64]])
+def test_move_sharded_op(memory_layout, shape, device):
+    """Validate move sharded on a large tensor with explicit sharding."""
+
     torch.manual_seed(1234)
     compute_grid_size = device.compute_with_storage_grid_size()
     if (compute_grid_size.x * compute_grid_size.y) < 98:
@@ -41,61 +68,30 @@ def run_move_op(shape, device):
     dtype = ttnn.bfloat16
     layout = ttnn.ROW_MAJOR_LAYOUT
     shard_orientation = ttnn.ShardOrientation.ROW_MAJOR
-    if (compute_grid_size.x * compute_grid_size.y) < 98:
-        shard_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(4, 4),
-                ),
-            }
-        )
-    else:
-        shard_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(11, 7),
-                ),
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 8),
-                    ttnn.CoreCoord(1, 8),
-                ),
-            }
-        )
+    shard_grid = get_shard_grid_from_num_cores(core_count, device)
     assert shape[0] == 1 and shape[1] == 1
     assert shape[2] % core_count == 0 and shape[3] % 32 == 0
-    shard_shape = [(int)(shape[2] / core_count), shape[3]]
-    shard_spec = ttnn.ShardSpec(
-        shard_grid,
-        shard_shape,
-        shard_orientation,
-    )
-    # make dummy shape half of shape, so we will test move sharded with overlap
-    dummy_shape = [shape[0], shape[1], (int)(shape[2] / 2), shape[3]]
-    dummy_shard_shape = [(int)(dummy_shape[2] / core_count), dummy_shape[3]]
-    dummy_shard_spec = ttnn.ShardSpec(
-        shard_grid,
-        dummy_shard_shape,
-        shard_orientation,
-    )
+    shard_shape = [shape[2] // core_count, shape[3]]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
+
+    dummy_shape = [shape[0], shape[1], shape[2] // 2, shape[3]]
+    dummy_shard_shape = [dummy_shape[2] // core_count, dummy_shape[3]]
+    dummy_shard_spec = ttnn.ShardSpec(shard_grid, dummy_shard_shape, shard_orientation)
     dummy_tensor = torch.zeros(dummy_shape)
     tt_dummy_tensor = ttnn.Tensor(dummy_tensor, dtype)
     dummy_mem_config = ttnn.MemoryConfig(
-        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        memory_layout=memory_layout,
         buffer_type=ttnn.BufferType.L1,
         shard_spec=dummy_shard_spec,
     )
     tt_dummy_tensor = tt_dummy_tensor.to(device, dummy_mem_config)
-    logger.info(f"shape={shape}")
+
+    logger.debug(f"shape={shape}")
     input_volume = shape[2] * shape[3]
-    tensor = []
-    for val in range(1, input_volume + 1):
-        tensor.append(val)
-    torch_tensor = torch.tensor(tensor).reshape(shape)
+    torch_tensor = torch.arange(1, input_volume + 1, dtype=torch.float32).reshape(shape).to(torch.bfloat16)
     tt_tensor = ttnn.Tensor(torch_tensor, dtype)
     height_sharded_mem_config = ttnn.MemoryConfig(
-        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        memory_layout=memory_layout,
         buffer_type=ttnn.BufferType.L1,
         shard_spec=shard_spec,
     )
@@ -105,12 +101,125 @@ def run_move_op(shape, device):
     tt_dummy_tensor.deallocate()
 
     output = ttnn.move(tt_tensor, memory_config=height_sharded_mem_config)
+    tt_host_rm = output.cpu().to(layout)
+    pyt_got_back_rm = tt_host_rm.to_torch().to(torch_tensor.dtype)
 
-    tt_host_rm = output.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-    pyt_got_back_rm = tt_host_rm.to_torch()
+    assert torch.equal(pyt_got_back_rm, torch_tensor)
 
-    passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm, torch_tensor, 0.99)
-    logger.debug(f"Passing={passing_pcc}")
-    logger.debug(f"Output pcc={output_pcc}")
 
-    assert passing_pcc
+@pytest.mark.parametrize("core_count", [1, 4, 8, 16, 32])
+def test_move_sharded_single_core_to_many_cores(core_count, device):
+    """Test move sharded with various core counts, including single core."""
+
+    torch.manual_seed(42)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    max_cores = compute_grid_size.x * compute_grid_size.y
+
+    if core_count > max_cores:
+        pytest.skip(f"Device only has {max_cores} cores, skipping {core_count} core test")
+
+    height_per_core = 128
+    width = 64
+    total_height = core_count * height_per_core
+
+    shape = [1, 1, total_height, width]
+    dtype = ttnn.bfloat16
+    shard_orientation = ttnn.ShardOrientation.ROW_MAJOR
+
+    shard_grid = get_shard_grid_from_num_cores(core_count, device)
+    shard_shape = [height_per_core, width]
+
+    assert run_move_sharded_test(
+        shape, ttnn.ROW_MAJOR_LAYOUT, shard_grid, shard_shape, shard_orientation, ttnn.BufferType.L1, device, dtype
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_move_sharded_different_layout_and_orientation(dtype, shard_orientation, layout, buffer_type, device):
+    """Test move sharded with different buffer types."""
+
+    torch.manual_seed(789)
+
+    if buffer_type == ttnn.BufferType.DRAM:
+        try:
+            dram_grid_size = device.dram_grid_size()
+        except AttributeError:
+            pytest.skip("Device does not support dram_grid_size()")
+
+        max_dram_cores = dram_grid_size.x
+        core_count = min(8, max_dram_cores)
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(core_count - 1, 0))})
+    else:
+        compute_grid_size = device.compute_with_storage_grid_size()
+        core_count = min(16, compute_grid_size.x * compute_grid_size.y)
+        shard_grid = get_shard_grid_from_num_cores(core_count, device)
+
+    height_per_core = 128
+    width = 64
+    total_height = core_count * height_per_core
+    shape = [1, 1, total_height, width]
+
+    shard_shape = [height_per_core, width]
+
+    assert run_move_sharded_test(
+        shape,
+        layout,
+        shard_grid,
+        shard_shape,
+        shard_orientation,
+        buffer_type,
+        device,
+        dtype,
+    )
+
+
+def test_move_sharded_custom_grid(device):
+    """Test move sharded with custom core grid."""
+
+    torch.manual_seed(111)
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    if compute_grid_size.x >= 3:
+        shard_ranges = {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+        }
+    elif compute_grid_size.y >= 3:
+        shard_ranges = {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(0, 2), ttnn.CoreCoord(0, 2)),
+        }
+    else:
+        pytest.skip("Device grid too small to form custom shard grid")
+
+    shard_grid = ttnn.CoreRangeSet(shard_ranges)
+    shard_ranges_list = list(shard_grid.ranges())
+    assert len(shard_ranges_list) > 1, "Shard grid should span multiple disjoint ranges"
+    logger.debug(f"Custom shard ranges: {shard_ranges_list}")
+
+    core_count = sum(
+        (core_range.end.x - core_range.start.x + 1) * (core_range.end.y - core_range.start.y + 1)
+        for core_range in shard_ranges_list
+    )
+
+    height_per_core = 128
+    width = 64
+    total_height = core_count * height_per_core
+    shape = [1, 1, total_height, width]
+    dtype = ttnn.bfloat16
+
+    shard_shape = [height_per_core, width]
+
+    assert run_move_sharded_test(
+        shape,
+        ttnn.ROW_MAJOR_LAYOUT,
+        shard_grid,
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        ttnn.BufferType.L1,
+        device,
+        dtype,
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/5863

### Problem description
Originally there was a problem with code placement on dispatch cores (described in the ticked), which is not reproducible now.
Issue is gone, but sharded move is still poorly covered with tests.

### What's changed
Add more sharded move tests.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vlad/fix-bh-sharded-move)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=vlad/fix-bh-sharded-move)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-bh-sharded-move)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-bh-sharded-move)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-bh-sharded-move)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/fix-bh-sharded-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-bh-sharded-move)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [x] other selection - specify runs