### PR TITLE
Removed is_gemma and other model references from Gemma3 code

### DIFF
--- a/models/demos/gemma3/demo/vision_demo.py
+++ b/models/demos/gemma3/demo/vision_demo.py
@@ -67,7 +67,6 @@ def create_multimodal_model(
 ):
     from models.demos.gemma3.tt.gemma_e2e_model import TtGemmaModel
     from models.demos.gemma3.tt.model_config import ModelArgs
-    from models.tt_transformers.tt.multimodal.llama_vision_model import CrossAttentionTransformer
 
     # limit length or we'll run out of space
     tt_model_args = ModelArgs(
@@ -87,25 +86,15 @@ def create_multimodal_model(
     if checkpoint is None:
         checkpoint = tt_model_args.load_state_dict()
 
-    if tt_model_args.is_gemma:
-        model = TtGemmaModel(
-            mesh_device=mesh_device,
-            state_dict=checkpoint,
-            weight_cache_path=tt_model_args.weight_cache_path(ttnn.bfloat8_b),
-            dtype=ttnn.bfloat8_b,
-            args=tt_model_args,
-            use_paged_kv_cache=use_paged_kv_cache,
-            paged_attention_config=paged_attention_config,
-        )
-    else:
-        model = CrossAttentionTransformer(
-            mesh_device,
-            state_dict=checkpoint,
-            weight_cache_path=tt_model_args.weight_cache_path(dtype),
-            dtype=dtype,
-            configuration=tt_model_args,
-            use_paged_kv_cache=use_paged_kv_cache,
-        )
+    model = TtGemmaModel(
+        mesh_device=mesh_device,
+        state_dict=checkpoint,
+        weight_cache_path=tt_model_args.weight_cache_path(ttnn.bfloat8_b),
+        dtype=ttnn.bfloat8_b,
+        args=tt_model_args,
+        use_paged_kv_cache=use_paged_kv_cache,
+        paged_attention_config=paged_attention_config,
+    )
     return tt_model_args, model, checkpoint
 
 

--- a/models/demos/gemma3/tt/gemma_image_attention.py
+++ b/models/demos/gemma3/tt/gemma_image_attention.py
@@ -95,11 +95,7 @@ class TtGemmaImageAttention(LightweightModule):
             torch.chunk(w, configuration.num_devices) for w in [wq_padded, wk_padded, wv_padded]
         )
 
-        self.qkv_program_config = lambda seq_len, MAX_MM_SEQ_LEN: (
-            None
-            if self.configuration.is_gemma
-            else self.model_config["IMAGE_ATTN_QKV_PROGCFG"](seq_len, MAX_MM_SEQ_LEN)
-        )
+        self.qkv_program_config = lambda seq_len, MAX_MM_SEQ_LEN: None
 
         self.wqkv = ttnn.as_tensor(
             torch.concat(
@@ -233,7 +229,7 @@ class TtGemmaImageAttention(LightweightModule):
         if len(x_11SH.shape) == 3:
             x_11SH = ttnn.reshape(x_11SH, (batch_size, 1, seq_len, -1))
 
-        MAX_MM_SEQ_LEN = seq_len if self.configuration.is_gemma else self.configuration.VISION_MAX_MM_SEQ
+        MAX_MM_SEQ_LEN = seq_len
 
         if seq_len > MAX_MM_SEQ_LEN:
             x_11SH = ttnn.reshape(x_11SH, [batch_size, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])

--- a/models/demos/gemma3/tt/gemma_image_mlp.py
+++ b/models/demos/gemma3/tt/gemma_image_mlp.py
@@ -75,7 +75,7 @@ class TtGemmaImageFeedForward(LightweightModule):
         batch_size = x.shape[0]
 
         # Depends on whether we are padding or not
-        MAX_MM_SEQ_LEN = seq_len if self.args.is_gemma else self.args.VISION_MAX_MM_SEQ
+        MAX_MM_SEQ_LEN = seq_len
 
         x_in = x
         if seq_len >= MAX_MM_SEQ_LEN:  # Too big to compute. Set different program configs based on seqlen


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/29659)

### Problem description
Gemma3 ModelArgs and other files had couple of `is_gemma` and other models that are not gemma3 references.

### What's changed
Removed all unnecessary references from Gemma3 code in order to maintain it easier.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20344054061)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20344063338/job/58451882173)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20344066387/job/58451892173)
- [x] [(T3K) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20344069634/job/58451910553)
- [x] [(T3K) Unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20344072290/job/58451898407)