### PR TITLE
[Reduce APC] Remove mistral from APC (with approval from models team)

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -55,10 +55,6 @@ run_python_model_tests_wormhole_b0() {
     HF_MODEL=$llama8b TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama8b completed"
 
-    # Mistral-7B-v0.3
-    mistral_weights=mistralai/Mistral-7B-Instruct-v0.3
-    tt_cache_mistral=$TT_CACHE_HOME/$mistral_weights
-    HF_MODEL=$mistral_weights TT_CACHE_PATH=$tt_cache_mistral pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
 }
 
 run_python_model_tests_slow_runtime_mode_wormhole_b0() {


### PR DESCRIPTION
### What's changed
Remove all mistral tests in `run_python_model_tests.sh` This
request is approved by the models team.

Slack conversation: https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1766026380270839?thread_ts=1765922417.226399&cid=C05GRJC4J4A

The removed tests are still defined in single card demo here: https://github.com/tenstorrent/tt-metal/blob/main/tests/scripts/single_card/run_single_card_demo_tests.sh#L32
and run in the single-card demo pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/20338257485/job/58430820249

### Checklist
- [x] All post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/20346902766/job/58462396940