### PR TITLE
Fix Galaxy Quick Benchmark Data Upload

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -94,7 +94,7 @@ jobs:
           if [ -d "generated/fabric" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
-          else 
+          else
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
             echo "Benchmark files not found, database upload will be skipped"
           fi

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -86,9 +86,21 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Check for benchmark data
+        id: check-benchmark-data
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
+        shell: bash
+        run: |
+          if [ -d "generated/fabric" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            echo "Benchmark files found, will upload to database"
+          else 
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            echo "Benchmark files not found, database upload will be skipped"
+          fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
https://github.com/issues/assigned?issue=tenstorrent%7Ctt-metal%7C34521

### Problem description
To monitor fabric performance, every Galaxy Quick test that is run on `main` uploads its results to a database. However, when the fabric tests in Galaxy Quick were disabled, the test failed while uploading the results. This is because the workflow did not first check for the presence of the generated files, before trying to initiate the upload.

### What's changed
- Modified `galaxy-quick-impl.yaml` so that it first checks for the presence of files generated by `test_tt_fabric` before uploading benchmark data. 
- Because all data uploaded to the database is persistent, I did not test actual benchmark data upload. Instead, I disabled benchmark data upload and verified that Galaxy Quick went along the proper control paths and checked for files correctly:
- Galaxy quick with fabric tests disabled (should not upload benchmark data): https://github.com/tenstorrent/tt-metal/actions/runs/20344544373
- Galaxy quick with fabric tests enabled (should upload benchmark data):  https://github.com/tenstorrent/tt-metal/actions/runs/20342602696

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/20346742104)
- [x] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable) (https://github.com/tenstorrent/tt-metal/actions/runs/20346760018/job/58463242802) (Passes wh-glx-health, quick fails but it also fails on main)