### PR TITLE
Fix convs

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
@@ -214,9 +214,10 @@ def run_conv_transpose2d(
         logger.info(f"Threshold: {threshold}")
         diff = torch.abs(ref - out) / ref.abs().mean()
         assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "
-    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
-    logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
-    assert passing
+    else:
+        passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
+        logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
+        assert passing
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 64 * 1024}], indirect=True)

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
@@ -135,7 +135,6 @@ def run_conv_transpose2d(
             mirror_kernel=mirror_kernel,
             input_dtype=activations_dtype,
             dram_slice_config=dram_slice_config,
-            output_dtype=activations_dtype,
         )
 
         tt_bias_tensor = (
@@ -159,7 +158,6 @@ def run_conv_transpose2d(
                 compute_config=compute_config,
                 input_dtype=activations_dtype,
                 dram_slice_config=dram_slice_config,
-                output_dtype=activations_dtype,
             )
             if has_bias
             else None

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
@@ -11,6 +11,7 @@ from models.common.utility_functions import (
     is_blackhole,
 )
 from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
+import math
 
 SliceHeight = ttnn.Conv2dDRAMSliceHeight
 SliceWidth = ttnn.Conv2dDRAMSliceWidth
@@ -50,6 +51,7 @@ def run_conv_transpose2d(
     preprocess_weights_bias=False,
     config_tensors_in_dram=False,
     dram_slice_config=None,
+    fast_compare=True,
 ):
     torch.manual_seed(0)
     conv_input_shape = [batch_size, input_channels, input_height, input_width]
@@ -86,7 +88,7 @@ def run_conv_transpose2d(
             torch_bias_tensor, weights_dtype if weights_dtype != ttnn.bfloat8_b else ttnn.float32
         )
 
-    tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, layout=layout, device=device)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, activations_dtype, layout=layout, device=device)
 
     if auto_shard:
         shard_layout = None
@@ -133,6 +135,7 @@ def run_conv_transpose2d(
             mirror_kernel=mirror_kernel,
             input_dtype=activations_dtype,
             dram_slice_config=dram_slice_config,
+            output_dtype=activations_dtype,
         )
 
         tt_bias_tensor = (
@@ -156,6 +159,7 @@ def run_conv_transpose2d(
                 compute_config=compute_config,
                 input_dtype=activations_dtype,
                 dram_slice_config=dram_slice_config,
+                output_dtype=activations_dtype,
             )
             if has_bias
             else None
@@ -203,6 +207,15 @@ def run_conv_transpose2d(
         pcc = 0.998
 
     ref = torch_out_golden_tensor
+    torch.set_printoptions(precision=3, sci_mode=False)
+    if fast_compare:
+        if fp32_accum and activations_dtype != ttnn.bfloat8_b and weights_dtype != ttnn.bfloat8_b:
+            threshold = 3e-1 + 5e-3 * math.log(input_channels * filter_height * filter_width, 2)
+        else:
+            threshold = 3e-1 + 1e-1 * math.log(input_channels * filter_height * filter_width, 2)
+        logger.info(f"Threshold: {threshold}")
+        diff = torch.abs(ref - out) / ref.abs().mean()
+        assert torch.all(diff < threshold), f"Max diff: {diff.max()}, Threshold: {threshold} "
     passing, pcc_msg = check_with_pcc_without_tensor_printout(out, ref, pcc=pcc)
     logger.info(f"PCC = {pcc_msg}. Threshold = {pcc}")
     assert passing

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d_sweeps.py
@@ -15,7 +15,7 @@ import pytest
 
 
 @pytest.mark.parametrize("input_spec", parameters_conv_transpose2d["short_sweep_suite"]["input_specs"])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32 * 1024}], indirect=True)
 def test_conv_transpose2d_sweep(device, input_spec):
     if device.core_grid.y != 8 and is_wormhole_b0():
         pytest.skip("Needs 8x8 grid for wormhole_b0")

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -414,20 +414,20 @@ public:
         const DeviceComputeKernelConfig& compute_config,
         MeshDevice* device);
     std::tuple<std::tuple<IOShape, IOShape>, std::array<uint32_t, 4>> get_input_slice_and_padding(
-        const IOShape& output_slice_start, const IOShape& output_slice_end);
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const;
     std::tuple<IOShape, IOShape> get_input_slice(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
     uint32_t get_L1_usage(
         const IOShape& output_slice_start,
         const IOShape& output_slice_end,
-        const op_slicing::Op2DSliceConfig& slice_config) override;
+        const op_slicing::Op2DSliceConfig& slice_config) const override;
     tt::tt_metal::MemoryConfig get_input_memory_config(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
     ttnn::Tensor run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,
         const IOShape& output_slice_start,
         const IOShape& output_slice_end) override;
-    std::string name() override;
+    std::string name() const override;
 };
 
 // This function is used for DRAM Slicing
@@ -703,7 +703,7 @@ Conv2dSliceAttr::Conv2dSliceAttr(
 
 std::tuple<std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape>, std::array<uint32_t, 4>>
 Conv2dSliceAttr::get_input_slice_and_padding(
-    const Conv2dSliceAttr::IOShape& output_slice_start, const Conv2dSliceAttr::IOShape& output_slice_end) {
+    const Conv2dSliceAttr::IOShape& output_slice_start, const Conv2dSliceAttr::IOShape& output_slice_end) const {
     auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
     auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
     auto [input_height, input_width] = input_shape;
@@ -777,14 +777,14 @@ Conv2dSliceAttr::get_input_slice_and_padding(
 }
 
 std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape> Conv2dSliceAttr::get_input_slice(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) {
+    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
     return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
 }
 
 uint32_t Conv2dSliceAttr::get_L1_usage(
     const IOShape& output_slice_start,
     const IOShape& output_slice_end,
-    const op_slicing::Op2DSliceConfig& slice_config) {
+    const op_slicing::Op2DSliceConfig& slice_config) const {
     // Remove this->conv_config from scope so that for each slice, conv_config can be calculated independently.
     auto conv_config = this->conv_config;
     bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
@@ -808,7 +808,6 @@ uint32_t Conv2dSliceAttr::get_L1_usage(
         output_slice_height,
         output_slice_width);
 
-    bool auto_shard = !conv_config.shard_layout.has_value();
     auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
     if (!conv_config.shard_layout.has_value()) {
         conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
@@ -843,15 +842,14 @@ uint32_t Conv2dSliceAttr::get_L1_usage(
         slice_config.num_slices,
         sliced_input_tensor_memory_config,
         conv_L1_usage);
-    if (auto_shard) {
-        this->conv_config.shard_layout = std::nullopt;
-    }
     return std::max(conv_L1_usage.halo_input_size + conv_L1_usage.halo_output_size, conv_L1_usage.total_size);
 }
 
 tt::tt_metal::MemoryConfig Conv2dSliceAttr::get_input_memory_config(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) {
+    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
     auto compute_grid_size = device->compute_with_storage_grid_size();
+    auto conv_config = this->conv_config;
+
     auto [input_start, input_end] = get_input_slice(output_slice_start, output_slice_end);
     uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
     uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
@@ -906,7 +904,7 @@ tt::tt_metal::MemoryConfig Conv2dSliceAttr::get_input_memory_config(
     return sliced_input_tensor_memory_config;
 }
 
-std::string Conv2dSliceAttr::name() { return "Conv2D"; }
+std::string Conv2dSliceAttr::name() const { return "Conv2D"; }
 
 ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     const ttnn::Tensor& sliced_input_tensor, const IOShape& output_slice_start, const IOShape& output_slice_end) {
@@ -919,6 +917,9 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
     uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
 
+    if (!conv_config.shard_layout.has_value()) {
+        conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
+    }
     auto conv_config_l1 = conv_config;
 
     conv_config_l1.deallocate_activation = true;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -917,7 +917,7 @@ ttnn::Tensor Conv2dSliceAttr::run_L1_op(
     uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
     uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
 
-    if (!conv_config.shard_layout.has_value()) {
+    if (!conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
         conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
     }
     auto conv_config_l1 = conv_config;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -371,31 +371,6 @@ ResultWithOptions result_to_result_with_options(
     return std::get<0>(result);
 }
 
-// Enum to represent the execution path for conv2d operations
-enum class Conv2dExecutionPath {
-    L1,   // Execute conv2d using L1 memory
-    DRAM  // Execute conv2d using DRAM slicing
-};
-
-// Helper function to determine which conv2d execution path to take based on
-// slice configuration and input tensor properties
-Conv2dExecutionPath determine_conv2d_execution_path(
-    const ttnn::Tensor& input_tensor, const std::optional<const Conv2dSliceConfig>& slice_config) {
-    // If slice config explicitly specifies L1_FULL, use L1 path
-    if (slice_config.has_value() && slice_config->slice_type == Conv2dSliceConfig::SliceType::L1_FULL) {
-        return Conv2dExecutionPath::L1;
-    }
-
-    // If no slice config and input is already on device in L1, use L1 path
-    if (!slice_config.has_value() && tt::tt_metal::is_device_tensor(input_tensor) &&
-        input_tensor.memory_config().is_l1()) {
-        return Conv2dExecutionPath::L1;
-    }
-
-    // Otherwise, use DRAM path
-    return Conv2dExecutionPath::DRAM;
-}
-
 class Conv2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
     using OptionalRefTensor = std::optional<std::reference_wrapper<ttnn::Tensor>>;
     using RefTensor = std::reference_wrapper<ttnn::Tensor>;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -374,4 +374,16 @@ struct ConvDRAMParamters {
 
 void tilize_with_optional_deallocation(Tensor& input_tensor_on_device, bool deallocate);
 
+// Enum to represent the execution path for conv2d operations
+enum class Conv2dExecutionPath {
+    L1,   // Execute conv2d using L1 memory
+    DRAM  // Execute conv2d using DRAM slicing
+};
+
+// Helper function to determine which conv2d execution path to take based on
+// slice configuration and input tensor properties
+Conv2dExecutionPath determine_conv2d_execution_path(
+    const ttnn::Tensor& input_tensor, const std::optional<const Conv2dSliceConfig>& slice_config);
+Conv2dExecutionPath determine_conv2d_execution_path(
+    bool input_is_in_L1, const std::optional<const Conv2dSliceConfig>& slice_config);
 }  // namespace ttnn::operations::conv

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1094,7 +1094,7 @@ static uint32_t calculate_out_channels_padded(uint32_t out_channels, const Paral
 }
 
 static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
-    const ttnn::MemoryConfig& input_memory_config,
+    ttnn::MemoryConfig input_memory_config,
     Layout input_layout,
     uint32_t in_channels,
     uint32_t out_channels,
@@ -1239,6 +1239,10 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
                           kernel_size[1] - padding_n4[2];
             padding_n4[3] = 0;  // No padding on right for sliced width
         }
+        input_memory_config = conv2d_slice_attr->get_input_memory_config(
+            {0, 0},                        // Slice Start
+            {output_height, output_width}  // Slice End
+        );
     }
 
     auto opt_conv_op_block_config = get_opt_block_config(
@@ -1305,7 +1309,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
             mm_conv,
             device->compute_with_storage_grid_size(),
             input_layout,
-            BufferType::L1,
+            is_dram_conv ? BufferType::DRAM : BufferType::L1,
             parallel_config,
             conv_config.act_block_h_override);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1208,6 +1208,10 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
             "Auto determined DRAM Slice Config in Prepare Conv2d Weights as {} for {}",
             dram_slice_config,
             conv2d_slice_attr->name());
+        if (dram_slice_config.num_slices == 1) {
+            log_info(tt::LogOp, "DRAM Slicing is not needed as only one slice is required.");
+            is_dram_conv = false;
+        }
         uint32_t slice_rounding_value = 1;
         if (conv_config.output_layout == tt_metal::Layout::TILE &&
             dram_slice_config.slice_type == Conv2dSliceConfig::SliceType::DRAM_WIDTH) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1150,7 +1150,7 @@ static Conv2dWeightsBiasPrepConfig setup_conv_prep_config(
     // Conv1D doesn't support DRAM
     bool is_dram_conv = (conv_execution_path == Conv2dExecutionPath::DRAM) && !is_conv1d;
 
-    if (is_dram_conv && !mm_conv /*DRAM with Mamtul doesn't need slicing*/) {
+    if (is_dram_conv && !mm_conv /*DRAM with Matmul doesn't need slicing*/) {
         Tensor dummy_weight_tensor = tt::tt_metal::create_device_tensor(
             tt::tt_metal::TensorSpec(
                 ttnn::Shape({out_channels, in_channels / groups, kernel_size[0], kernel_size[1]}),

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -916,7 +916,7 @@ ttnn::Tensor ConvT2DSliceAttr::run_L1_op(
         output_slice_height_end - output_slice_height_start,
         output_slice_width_end - output_slice_width_start);
 
-    if (!this->conv_config.shard_layout.has_value()) {
+    if (!this->conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
         this->conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
     }
     auto conv_config_l1 = conv_config;

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -319,7 +319,7 @@ ttnn::Tensor prepare_conv_transpose2d_weights(
         return prepare_conv_weights(
             mirrored_weight_tensor,
             input_memory_config,
-            Layout::ROW_MAJOR,
+            dram_slice_config.num_slices > 1 ? Layout::ROW_MAJOR : input_layout,
             weights_format,
             in_channels,
             out_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp
@@ -72,7 +72,7 @@ ttnn::Tensor transform_weights_for_conv_transpose2d(const ttnn::Tensor& conv_wei
 
 ttnn::Tensor prepare_conv_transpose2d_weights(
     const ttnn::Tensor& weight_tensor,
-    const ttnn::MemoryConfig& input_memory_config,
+    ttnn::MemoryConfig input_memory_config,
     Layout input_layout,
     const std::string& weights_format,
     uint32_t in_channels,

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -32,20 +32,20 @@ public:
     virtual ~OpSliceAttr() = default;
     using IOShape = std::tuple<uint32_t, uint32_t>;
     virtual std::tuple<IOShape, IOShape> get_input_slice(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) = 0;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const = 0;
 
     virtual uint32_t get_L1_usage(
         const IOShape& output_slice_start,
         const IOShape& output_slice_end,
-        const op_slicing::Op2DSliceConfig& slice_config) = 0;
+        const op_slicing::Op2DSliceConfig& slice_config) const = 0;
 
     virtual tt::tt_metal::MemoryConfig get_input_memory_config(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) = 0;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const = 0;
     virtual ttnn::Tensor run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,
         const IOShape& output_slice_start,
         const IOShape& output_slice_end) = 0;
-    virtual std::string name() = 0;
+    virtual std::string name() const = 0;
 };
 
 Op2DSliceConfig determine_slice_config(

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -359,13 +359,6 @@ std::vector<ShardBoundary> generate_shard_boundaries(const SlidingWindowConfig& 
         output_index_start = output_index_end + 1;
     }
 
-    for ([[maybe_unused]] auto& boundary : shard_boundaries) {
-        log_trace(
-            tt::LogOp,
-            "shard_boundary={}, input_size = {}",
-            boundary,
-            boundary.input_range.end - boundary.input_range.start);
-    };
     return shard_boundaries;
 }
 


### PR DESCRIPTION
### Problem description
TTNN Conv2D tutorial fails.
conv_transpose2d unit tests with prepare weights fails on blackhole.


### What's changed
Fix bug in prepare weights for matmul based convs with dram. Matmul based convs don't need slicing, but prepare weights didn't account for that.

Fix bug in conv_transpose2d get_L1_usage where conv_config.shard_layout was being set inside the auto slicing logic, leading to a wrong shard layout. 

Fix bug in prepare weights where incorrect input_memory_config was used. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20391704882)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20391672002) (if applicable)
- [x] Nightly L2 [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20421968134/job/58685605030)
- [x] Frequent models [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/20393775719)
- [x] New/Existing tests provide coverage for changes