### PR TITLE
Collection of fixes for deepseek_v3_b1 ops

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_compute.cpp
@@ -52,7 +52,7 @@ void MAIN {
         // in0 tile index: k (from sharded input)
         // in1 tile index: k (from sharded weights)
         // dst index: 0 (single output tile, accumulating)
-        matmul_tiles(in0_cb, in1_cb, k, k, 0, false);
+        matmul_tiles(in0_cb, in1_cb, k, k, 0);
     }
 
     tile_regs_commit();

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_reader.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_reader.cpp
@@ -21,18 +21,17 @@ void kernel_main() {
     // Generate both scalar tiles in scalars_cb
     // Tile 0: epsilon
     // Tile 1: reduction scalar (1/sqrt(num_elements))
-    cb_reserve_back(scalars_cb, 2);
+    cb_reserve_back(scalars_cb, 1);
     volatile tt_l1_ptr uint16_t* epsilon_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(scalars_cb));
     epsilon_ptr[0] = epsilon;
     cb_push_back(scalars_cb, 1);
 
     generate_reduce_scaler<tiny_tile>(scalars_cb, scalar);
-    cb_push_back(scalars_cb, 1);
 
     // Signal that input and gamma buffers are ready (backed by L1 shards)
-    cb_reserve_back(input_cb, num_tiles);
-    cb_push_back(input_cb, num_tiles);
     cb_reserve_back(gamma_cb, num_tiles);
     cb_push_back(gamma_cb, num_tiles);
+    cb_reserve_back(input_cb, num_tiles);
+    cb_push_back(input_cb, num_tiles);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
@@ -35,7 +35,15 @@ class RMSNormSingleCore:
         return normalized * gamma_tensor
 
     @staticmethod
-    def op(input_tensor, gamma_tensor, output_tensor, epsilon=1e-6, numel=None, fp32_dest_acc_en=False):
+    def op(
+        input_tensor,
+        gamma_tensor,
+        output_tensor,
+        epsilon=1e-6,
+        numel=None,
+        fp32_dest_acc_en=False,
+        rsqrt_fast_approx=False,
+    ):
         """
         Execute RMS norm operation using generic_op.
 
@@ -46,6 +54,7 @@ class RMSNormSingleCore:
             epsilon: Small value to avoid division by zero
             numel: Number of elements to use for RMS calculation (defaults to input logical volume)
             fp32_dest_acc_en: Whether to enable FP32 accumulation in compute kernel
+            rsqrt_fast_approx: Whether to use fast approximation for rsqrt
 
         Returns:
             Output tensor with RMS norm applied
@@ -193,6 +202,7 @@ class RMSNormSingleCore:
             num_tiles,
             0,  # epsilon_index
             1,  # scalar_index
+            1 if rsqrt_fast_approx else 0,
         ]
 
         compute_kernel_descriptor = ttnn.KernelDescriptor(

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -210,7 +210,8 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
                 return self.get_tile_size(datatype_to_dataformat_converter(dtype));
             },
             nb::arg("dtype"),
-            "Get tile size in bytes for the given data type");
+            "Get tile size in bytes for the given data type")
+        .def(nb::self == nb::self);
 
     auto pyTensorSpec = static_cast<nb::class_<TensorSpec>>(m_tensor.attr("TensorSpec"));
     pyTensorSpec


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Minor issues in some of the new deepseek_v3_b1 ops.

### What's changed
Remove deprecated arg from `matmul_tiles` call.
Remove extra `cb_push_back` from RMSNorm scalar generation.
Add comparison binding for Tile

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes