### PR TITLE
fix bh perf using correct noc and pkt size

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -36,6 +36,7 @@ void get_max_page_size_and_num_pages(
     tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
+    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
     uint32_t noc_max_page_size;
     if (device->arch() == tt::ARCH::WORMHOLE_B0) {
         noc_max_page_size = 8192;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -32,10 +32,20 @@ tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const tt
     return a.device()->get_device(coord);
 }
 
-void get_max_page_size_and_num_pages(uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
     uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
 
-    page_size = (8192 / tile_size) * tile_size;
+    uint32_t noc_max_page_size;
+    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+        noc_max_page_size = 8192;
+    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+        noc_max_page_size = 16384;
+    } else {
+        TT_FATAL(false, "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported.");
+    }
+
+    page_size = (noc_max_page_size / tile_size) * tile_size;
     while (total_size % page_size != 0 && page_size >= tile_size) {
         page_size -= tile_size;
     }
@@ -137,7 +147,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     // get the dram readers
     std::vector<CoreCoord> all_worker_cores_ordered;
     CoreRangeSet all_worker_cores;
-    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in0_noc);
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
 
     // dram banks
     uint32_t num_dram_banks = all_worker_cores_ordered.size();
@@ -234,11 +244,12 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
 
     // get the max page size based on num tiles
     uint32_t in1_buffer_page_size, in1_buffer_num_pages;
-    get_max_page_size_and_num_pages(in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
 
     uint32_t bias_buffer_page_size, bias_buffer_num_pages;
     get_max_page_size_and_num_pages(
-        in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+        device, in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
 
     uint32_t num_worker_cores = num_dram_banks;
 


### PR DESCRIPTION
### Problem description
There was a bug introduced to use wrong noc for dram read in blackhole, fixed it. 
Change max noc packet txn to 16K

### What's changed
change from in0 noc to in1 noc for when selecting optimal dram banks
change from 8K packet to 16K max packet

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20350445012
- [ ] [Blackhole Post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20350457876