### PR TITLE
Launch dispatch kernels in parallel on multiple devices

### DIFF
--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -486,7 +486,6 @@ void DeviceManager::initialize_active_devices() {
             continue;
         }
         events.emplace_back(detail::async([&, dev, mmio_device_id]() {
-
             auto tunnels_from_mmio =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
             dev->init_command_queue_device();
@@ -502,7 +501,7 @@ void DeviceManager::initialize_active_devices() {
                     }
                 }
             }
-        );
+        }));
     }
     for (const auto& event : events) {
         event.get();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -476,7 +476,8 @@ void DeviceManager::initialize_active_devices() {
     // Compile programs
     compile_cq_programs();
 
-    // Init command queue
+    std::vector<std::shared_future<void>> events;
+    // Init command queues in parallel.
     for (auto* dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices
         const auto& mmio_device_id =
@@ -484,22 +485,27 @@ void DeviceManager::initialize_active_devices() {
         if (mmio_device_id != dev->id()) {
             continue;
         }
+        events.emplace_back(detail::async([&, dev, mmio_device_id]() {
 
-        auto tunnels_from_mmio =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
-        dev->init_command_queue_device();
-        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
-        if (not this->skip_remote_devices_) {
-            for (const auto& tunnel : tunnels_from_mmio) {
-                // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnel[ts];
-                    auto* device = get_device(mmio_controlled_device_id);
-                    device->init_command_queue_device();
-                    log_info(tt::LogMetal, "Command Queue initialized on Device {}", device->id());
+            auto tunnels_from_mmio =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+            dev->init_command_queue_device();
+            log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+            if (not this->skip_remote_devices_) {
+                for (const auto& tunnel : tunnels_from_mmio) {
+                    // Need to create devices from farthest to the closest.
+                    for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                        uint32_t mmio_controlled_device_id = tunnel[ts];
+                        auto* device = get_device(mmio_controlled_device_id);
+                        device->init_command_queue_device();
+                        log_info(tt::LogMetal, "Command Queue initialized on Device {}", device->id());
+                    }
                 }
             }
-        }
+        );
+    }
+    for (const auto& event : events) {
+        event.get();
     }
     dispatch_firmware_active_ = true;
 }

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -22,6 +22,7 @@
 namespace tt::tt_metal {
 
 const tt_cxy_pair& dispatch_core_manager::prefetcher_core(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.prefetcher.has_value()) {
         return assignment.prefetcher.value();
@@ -35,11 +36,13 @@ const tt_cxy_pair& dispatch_core_manager::prefetcher_core(ChipId device_id, uint
 }
 
 bool dispatch_core_manager::is_prefetcher_core_allocated(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.prefetcher.has_value();
 }
 
 const tt_cxy_pair& dispatch_core_manager::prefetcher_d_core(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.prefetcher_d.has_value()) {
         return assignment.prefetcher_d.value();
@@ -51,12 +54,14 @@ const tt_cxy_pair& dispatch_core_manager::prefetcher_d_core(ChipId device_id, ui
 }
 
 bool dispatch_core_manager::is_prefetcher_d_core_allocated(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.prefetcher_d.has_value();
 }
 
 const tt_cxy_pair& dispatch_core_manager::completion_queue_writer_core(
     ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.completion_queue_writer.has_value()) {
         return assignment.completion_queue_writer.value();
@@ -79,11 +84,17 @@ const tt_cxy_pair& dispatch_core_manager::completion_queue_writer_core(
 
 bool dispatch_core_manager::is_completion_queue_writer_core_allocated(
     ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.completion_queue_writer.has_value();
 }
 
 const tt_cxy_pair& dispatch_core_manager::dispatcher_core(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
+    return this->dispatcher_core_locked(device_id, channel, cq_id);
+}
+
+const tt_cxy_pair& dispatch_core_manager::dispatcher_core_locked(ChipId device_id, uint16_t channel, uint8_t cq_id) {
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.dispatcher.has_value()) {
         return assignment.dispatcher.value();
@@ -101,21 +112,29 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_core(ChipId device_id, uint
 }
 
 bool dispatch_core_manager::is_dispatcher_core_allocated(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.dispatcher.has_value();
 }
 
 bool dispatch_core_manager::is_dispatcher_s_core_allocated(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.dispatcher_s.has_value();
 }
 
 bool dispatch_core_manager::is_dispatcher_d_core_allocated(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.dispatcher_d.has_value();
 }
 
 const tt_cxy_pair& dispatch_core_manager::dispatcher_d_core(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
+    return this->dispatcher_d_core_locked(device_id, channel, cq_id);
+}
+
+const tt_cxy_pair& dispatch_core_manager::dispatcher_d_core_locked(ChipId device_id, uint16_t channel, uint8_t cq_id) {
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.dispatcher_d.has_value()) {
         return assignment.dispatcher_d.value();
@@ -128,6 +147,7 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_d_core(ChipId device_id, ui
 
 const tt_cxy_pair& dispatch_core_manager::fabric_mux_core(
     ChipId device_id, uint16_t channel, uint8_t cq_id, int tunnel) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (!assignment.fabric_mux.contains(tunnel)) {
         CoreCoord coord = this->get_next_available_dispatch_core(device_id);
@@ -139,11 +159,13 @@ const tt_cxy_pair& dispatch_core_manager::fabric_mux_core(
 
 bool dispatch_core_manager::is_fabric_mux_core_allocated(
     ChipId device_id, uint16_t channel, uint8_t cq_id, int tunnel) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     return assignment.fabric_mux.contains(tunnel);
 }
 
 const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(ChipId device_id, uint16_t channel, uint8_t cq_id) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.dispatcher_s.has_value()) {
         return assignment.dispatcher_s.value();
@@ -154,10 +176,10 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(ChipId device_id, ui
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
         if (mmio_device_id == device_id) {
             // dispatch_s is on the same tensix core as dispatch_hd
-            dispatcher_s_coord = this->dispatcher_core(device_id, channel, cq_id);
+            dispatcher_s_coord = this->dispatcher_core_locked(device_id, channel, cq_id);
         } else {
             // dispatch_s is on the same tensix as dispatch_d
-            dispatcher_s_coord = this->dispatcher_d_core(device_id, channel, cq_id);
+            dispatcher_s_coord = this->dispatcher_d_core_locked(device_id, channel, cq_id);
         }
     } else {
         dispatcher_s_coord = this->get_next_available_dispatch_core(device_id);
@@ -172,6 +194,11 @@ CoreType dispatch_core_manager::get_dispatch_core_type() { return this->dispatch
 DispatchCoreConfig dispatch_core_manager::get_dispatch_core_config() { return this->dispatch_core_config_; }
 
 void dispatch_core_manager::add_dispatch_core_to_device(ChipId device_id, const CoreCoord& core) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
+    this->add_dispatch_core_to_device_locked(device_id, core);
+}
+
+void dispatch_core_manager::add_dispatch_core_to_device_locked(ChipId device_id, const CoreCoord& core) {
     // TODO: remove this API, we should read the core descriptor once, should not have backdoors like this to add cores
     auto& dispatch_cores = available_dispatch_cores_by_device.at(device_id);
     if (std::find(dispatch_cores.begin(), dispatch_cores.end(), core) == dispatch_cores.end()) {
@@ -191,6 +218,7 @@ dispatch_core_manager::dispatch_core_manager(const DispatchCoreConfig& dispatch_
 
 void dispatch_core_manager::reset_dispatch_core_manager(
     const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
+    std::lock_guard<std::mutex> lock(this->dispatch_core_assignments_mutex);
     this->dispatch_core_assignments.clear();
     this->available_dispatch_cores_by_device.clear();
     this->dispatch_core_config_ = dispatch_core_config;
@@ -209,7 +237,7 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         if (dispatch_core_config.get_core_type() == CoreType::ETH) {
             for (const auto& idle_eth_core :
                  tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
-                add_dispatch_core_to_device(device_id, idle_eth_core);
+                add_dispatch_core_to_device_locked(device_id, idle_eth_core);
             }
         }
     }

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -158,7 +158,22 @@ private:
     /// @brief getting any available dispatch core for a device
     /// @param device_id
     /// @return
+    /// @note This method is not thread safe, it should be called with the dispatch_core_assignments_mutex held
     CoreCoord get_next_available_dispatch_core(ChipId device_id);
+
+    /// @brief Internal version of dispatcher_core that assumes the caller already holds dispatch_core_assignments_mutex
+    /// @note This method is not thread safe, it should be called with the dispatch_core_assignments_mutex held
+    const tt_cxy_pair& dispatcher_core_locked(ChipId device_id, uint16_t channel, uint8_t cq_id);
+
+    /// @brief Internal version of dispatcher_d_core that assumes the caller already holds
+    /// dispatch_core_assignments_mutex
+    /// @note This method is not thread safe, it should be called with the dispatch_core_assignments_mutex held
+    const tt_cxy_pair& dispatcher_d_core_locked(ChipId device_id, uint16_t channel, uint8_t cq_id);
+
+    /// @brief Internal version of add_dispatch_core_to_device that assumes the caller already holds
+    /// dispatch_core_assignments_mutex
+    /// @note This method is not thread safe, it should be called with the dispatch_core_assignments_mutex held
+    void add_dispatch_core_to_device_locked(ChipId device_id, const CoreCoord& core);
 
     void log_dispatch_assignment(
         std::string name,
@@ -168,6 +183,7 @@ private:
         uint8_t cq_id,
         bool force_ethernet = false);
 
+    std::mutex dispatch_core_assignments_mutex;
     // {device ID : {channel (hugepage) : {cq_id : dispatch assignment}}}
     // Each device has an assigned hugepage at a specific channel that holds (up to 2) hardware command queues
     // (represented by cq_id)

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -392,6 +392,7 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq_fabric = 
 };
 // clang-format on
 
+// TODO: Move into MetalContext or DeviceManager.
 std::vector<FDKernel*> node_id_to_kernel;
 detail::ProgramCompileGroup command_queue_compile_group;
 std::unordered_map<ChipId, std::unordered_set<CoreCoord>> dispatch_cores;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -157,6 +157,7 @@ using SemaphoresGetter = std::function<const std::vector<Semaphore>&()>;
 // Internal class for holding a group of programs for parallel compilation.
 class ProgramCompileGroup {
 private:
+    std::mutex mutex_;
     std::unordered_map<IDevice*, std::unique_ptr<Program>> program_device_map_;
 
 public:


### PR DESCRIPTION
### Ticket
#29833

### Problem description
Initializing dispatch kernels can take around 64 ms on a loudbox.

### What's changed
Group devices based on what mmio device they tunnel through, and launch dispatch kernels on those groups in parallel. Also add a lock around ProgramCompileGroup methods, since remove_program is now called from multiple threads. This reduces time to launch dispatch kernels to around 27ms on loudbox.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes