### PR TITLE
Turn on nb leak warnings

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -78,7 +78,7 @@ namespace nb = nanobind;
 namespace ttnn::operations {
 
 void py_module(nb::module_& mod) {
-    nb::set_leak_warnings(false);  // TODO_NANOBIND: REENABLE THIS
+    nb::set_leak_warnings(true);
 
     auto m_core = mod.def_submodule("core", "core operations");
     core::py_module_types(m_core);


### PR DESCRIPTION

### Ticket
N/A

### Problem description
nanobind leak checks were disabled for development

### What's changed
leak checks now explicitly enabled.

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/20359058691