### PR TITLE
Temporarily removed mistral7b from single card demo

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -81,7 +81,8 @@ jobs:
             { name: "squeezebert", runner-label: "N300", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, #Joseph Chu
             { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
             { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+            # Return N150 mistral7b tests after https://github.com/tenstorrent/tt-metal/issues/34763 is done
+            # { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
             { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
             { name: "llama3", runner-label: "N300", performance: true, cmd: run_llama3_perf, owner_id: U03PUAKE719}, # Miguel Tairum
             { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini


### PR DESCRIPTION
### Ticket
#34763 

### Problem description
`Mistral7b` is red on Single Card Demo tests on main for last couple of days:
https://github.com/tenstorrent/tt-metal/actions/runs/20278067177/job/58232833711
https://github.com/tenstorrent/tt-metal/actions/runs/20346619208/job/58462348571

### What's changed
- temporarily removing Mistral7b from Single Card Demo CI

### Checklist
- [X] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20364943703)