### PR TITLE
[skip ci] Bumped expected inference time for TG resnet50

### DIFF
--- a/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py
@@ -18,7 +18,7 @@ PERF_EXPECTATIONS = {
         "test_perf": {"inference_time": 0.017, "compile_time": 60},
         "test_perf_trace": {"inference_time": 0.0068, "compile_time": 60},
         "test_perf_2cqs": {"inference_time": 0.0175, "compile_time": 60},
-        "test_perf_trace_2cqs": {"inference_time": 0.0052, "compile_time": 60},
+        "test_perf_trace_2cqs": {"inference_time": 0.0055, "compile_time": 60},
     },
 }
 


### PR DESCRIPTION
### Problem description
In the last two weeks the range for resnet50 `test_perf_trace_2cqs` on TG was `[0.0044 - 0.0059]`
The lower part of the range was covered with expected value of `0.0052` but the upper one wasn't  (`>0.0058`)

latest red example: https://github.com/tenstorrent/tt-metal/actions/runs/20333220734/job/58414158456

### What's changed
- bumped expected inference time to `0.0055` (`[0.0044 - 0.0060]` range)