### PR TITLE
Temporary removal of resnet50 on TG Models Perf CI

### DIFF
--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -37,6 +37,15 @@ jobs:
           # Create matrix in two parts: disabled and active models
           DISABLED_MODELS=$(jq -n '[
             {
+              "name": "Galaxy CNN model perf tests",
+              "model-type": "CNN",
+              "model-name": "cnn",
+              "arch": "wormhole_b0",
+              "save-perf-data": false,
+              "timeout": 50,
+              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py --upper-threshold 1.10"
+            }, # Pavle Josipovic
+            {
               "name": "Galaxy Llama 70B model perf tests",
               "model-type": "Llama-70B",
               "model-name": "llama70b",
@@ -79,15 +88,6 @@ jobs:
           ]' --compact-output)
 
           ACTIVE_MODELS=$(jq -n '[
-            {
-              "name": "Galaxy CNN model perf tests",
-              "model-type": "CNN",
-              "model-name": "cnn",
-              "arch": "wormhole_b0",
-              "save-perf-data": false,
-              "timeout": 50,
-              "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py --upper-threshold 1.10"
-            }, # Pavle Josipovic
             {
               "name": "Galaxy DiT SD3.5 model perf tests",
               "model-type": "SD3.5",

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -10,10 +10,10 @@ on:
         type: choice
         options:
           - all
+#          - cnn
 #          - llama70b
 #          - llama_unit_tests
 #          - llama70b_prefill
-          - cnn
           - sd35
           - flux1-dev
           - motif


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34769

### Problem description
- resnet50 is currently flaky on TG, needs investigation

### What's changed
- disabled resnet50 tests on TG models perf CI