### PR TITLE
Restore DeepSeek prefill syncs

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -958,6 +958,9 @@ class MLA1D(AbstractModule):
         )
         tt_q = ttnn.experimental.all_gather_async(tt_q, **ccl.populate_all_gather_runtime_args(cfg["wq_a_ag_prefill"]))
 
+        # Bug: https://github.com/tenstorrent/tt-metal/issues/29935
+        ttnn.synchronize_device(cfg["mesh_device"])
+
         tt_q = RMSNorm.forward_prefill(tt_q, cfg["q_norm"])
         tt_q = ttnn.linear(tt_q, **cfg["wq_b"])
 
@@ -1027,6 +1030,8 @@ class MLA1D(AbstractModule):
             batch_idx=local_batch_idx,
             mesh_coords=set(get_mesh_coords(mesh_shape, row_idx, col_idx)),
         )
+        # Bug: https://github.com/tenstorrent/tt-metal/issues/33589
+        ttnn.synchronize_device(cfg["mesh_device"])
 
         # FlashMLA
         attn_out = ttnn.transformer.flash_mla_prefill(


### PR DESCRIPTION
## Summary
- restore the two `ttnn.synchronize_device` workarounds in `models/demos/deepseek_v3/tt/mla/mla1d.py` that were removed in 5adafe1407dd (multi-device paged_fill_cache change)
- intent is to unblock DeepSeek v3 dual-galaxy prefill hang seen on run https://github.com/tenstorrent/tt-metal/actions/runs/20321502994/job/58378363484 (hangs starting second prefill) compared to passing run https://github.com/tenstorrent/tt-metal/actions/runs/20276933656/job/58228820003

## Testing
- [![Galaxy DeepSeek v3 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=fix/deepseek-prefill-sync)](https://github.com/tenstorrent/tt-metal/actions/runs/20371719942)
triggered with `model=deepseek_v3`