### PR TITLE
SDXL perf targets reverted (#34779)

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -93,7 +93,7 @@ def test_refiner_unet(
     [
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet",
-            190_185_744 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            191_651_771 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet",
             "sdxl_unet",
             1,
@@ -103,7 +103,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet",
-            549_192_450 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            602_265_531 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_refiner_unet",
             "sdxl_refiner_unet",
             1,
@@ -113,7 +113,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
-            649_249_508,
+            680_239_540,
             "sdxl_vae",
             "sdxl_vae_decode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -123,7 +123,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'",
-            326_715_706,
+            343_068_075,
             "sdxl_vae",
             "sdxl_vae_encode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
### Problem description
SDXL perf test fails of main; as I've accidentally committed perf targets without throttling in #34506

### What's changed
Revert to previous perf targets

### Checklist
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20369205442)

(cherry picked from commit 385cfee75ce7f75d6af89da5b37b468ed7eca848)

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [Single card device perf](https://github.com/tenstorrent/tt-metal/actions/runs/20370700495)