### PR TITLE
topk: use multicore pad when appropriate

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -140,7 +140,9 @@ std::vector<Tensor> ExecuteTopK::invoke(
     const auto pad_val = largest ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max();
     if (pad_amount > 0) {
         ttnn::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
-        padded_tensor = ttnn::pad(transformed_tensor, padding, pad_val);
+        const bool pad_multicore = transformed_tensor.dtype() == DataType::BFLOAT16 &&
+                                   transformed_tensor.memory_config().buffer_type() != BufferType::L1;
+        padded_tensor = ttnn::pad(transformed_tensor, padding, pad_val, pad_multicore);
     }
 
     // fill implicit padding, if any


### PR DESCRIPTION

### Problem description
When running GPT-OSS-20B on batch=1 we were seeing the console flooded with the warning:
```
warning  |              Op | Only bfloat16 and non-L1 tiled tensors are currently supported for multicore tiled pad. Falling back to 1 core. #29295 (pad_device_operation.cpp:81)
```

When the router logits are in DRAM and bfloat16 it should be safe to use multicore pad according to the warnings.

### What's changed
Use multicore pad when logits are bfloat16 DRAM interleaved.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20372806322) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20372812782) CI with demo tests passes (if applicable)