### PR TITLE
Add cache validation utility for DeepSeekV3

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -90,6 +90,16 @@ def state_dict(model_path):
     yield load_state_dict(model_path, "")
 
 
+@pytest.fixture(scope="function", autouse=True)
+def clear_state_dict_cache(state_dict):
+    """
+    Clear the LazyStateDict cache after each test to prevent memory accumulation.
+    This preserves file handles (mmap benefits) while freeing tensor memory.
+    """
+    yield
+    state_dict.clear_cache()
+
+
 @pytest.fixture(scope="session")
 def hf_config_short(request, hf_config):
     hf_config_out = deepcopy(hf_config)

--- a/models/demos/deepseek_v3/scripts/validate_weight_cache.py
+++ b/models/demos/deepseek_v3/scripts/validate_weight_cache.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
+from models.demos.deepseek_v3.utils.weight_config import (
+    locked_file,
+    try_decode_saved_weight,
+    validate_weight_config_paths,
+)
+
+# Regex patterns for cache directory structure
+CACHE_DIR_PATTERN = re.compile(r"(\d+)_layers/mesh_(\d+)x(\d+)$")
+CACHE_CONFIG_PATTERN = re.compile(r"(\d+)_layers/mesh_(\d+)x(\d+)/config\.json$")
+
+
+def discover_cache_directories(root_path: Path) -> list[Path]:
+    """
+    Find all cache directories containing config.json.
+
+    Looks for directories matching the pattern: */{num_layers}_layers/mesh_{rows}x{cols}/config.json
+
+    Args:
+        root_path: Root directory to search recursively
+
+    Returns:
+        List of cache directory paths (parent of config.json)
+    """
+    cache_dirs = []
+
+    for config_file in root_path.rglob("config.json"):
+        # Check if path matches expected pattern
+        path_str = str(config_file)
+        if CACHE_CONFIG_PATTERN.search(path_str):
+            # Return the directory containing config.json (the cache directory)
+            cache_dirs.append(config_file.parent)
+
+    return sorted(cache_dirs)
+
+
+def extract_cache_info(cache_dir: Path) -> dict[str, Any] | None:
+    """
+    Extract cache information from directory path.
+
+    Args:
+        cache_dir: Cache directory path
+
+    Returns:
+        Dictionary with num_layers, mesh_rows, mesh_cols, or None if pattern doesn't match
+    """
+    path_str = str(cache_dir)
+    match = CACHE_DIR_PATTERN.search(path_str)
+    if match:
+        return {
+            "num_layers": int(match.group(1)),
+            "mesh_rows": int(match.group(2)),
+            "mesh_cols": int(match.group(3)),
+        }
+    return None
+
+
+def collect_saved_weights(weight_config: Any, path_prefix: str = "") -> list[tuple[str, SavedWeight]]:
+    """
+    Recursively collect all SavedWeight objects from a weight config.
+
+    Args:
+        weight_config: Weight configuration (dict, list, tuple, or nested structures)
+        path_prefix: Prefix for path identification
+
+    Returns:
+        List of (path_key, SavedWeight) tuples
+    """
+    saved_weights = []
+
+    if isinstance(weight_config, dict):
+        entries = weight_config.items()
+    elif isinstance(weight_config, (list, tuple)):
+        entries = enumerate(weight_config)
+    else:
+        return saved_weights
+
+    for key, entry in entries:
+        if entry is None:
+            continue
+        current_prefix = f"{path_prefix}.{key}" if path_prefix else str(key)
+
+        if isinstance(entry, SavedWeight):
+            saved_weights.append((current_prefix, entry))
+        else:
+            # Recursively collect from nested structures
+            saved_weights.extend(collect_saved_weights(entry, current_prefix))
+
+    return saved_weights
+
+
+def find_orphaned_files(cache_dir: Path, referenced_paths: set[Path]) -> list[Path]:
+    """
+    Find tensorbin files in cache directory that are not referenced in config.
+
+    Args:
+        cache_dir: Cache directory to search
+        referenced_paths: Set of absolute paths that are referenced in config
+
+    Returns:
+        List of orphaned file paths
+    """
+    orphaned = []
+    weights_dir = cache_dir / "weights"
+
+    if weights_dir.exists():
+        for file_path in weights_dir.rglob(f"*{TENSOR_CACHE_EXTENSION}"):
+            resolved_path = file_path.resolve()
+            if resolved_path not in referenced_paths:
+                orphaned.append(file_path)
+
+    return sorted(orphaned)
+
+
+def validate_cache_directory(cache_dir: Path, verbose: bool = False) -> dict[str, Any]:
+    """
+    Validate a single cache directory and return statistics.
+
+    Args:
+        cache_dir: Cache directory path
+        verbose: Whether to include detailed error information
+
+    Returns:
+        Dictionary with validation results and statistics
+    """
+    config_path = cache_dir / "config.json"
+    cache_info = extract_cache_info(cache_dir)
+
+    result = {
+        "cache_dir": cache_dir,
+        "cache_info": cache_info,
+        "config_exists": config_path.exists(),
+        "valid": False,
+        "errors": [],
+        "warnings": [],
+        "orphaned_files": [],
+        "stats": {
+            "total_files": 0,
+            "total_size": 0,
+            "absolute_paths": 0,
+            "missing_files": 0,
+            "invalid_extensions": 0,
+            "orphaned_files": 0,
+        },
+    }
+
+    if not result["config_exists"]:
+        result["errors"].append("config.json not found")
+        return result
+
+    # Load and decode config (with shared lock to prevent reading during writes)
+    try:
+        with locked_file(config_path, "r", exclusive=False) as f:
+            weight_config = json.load(f, object_hook=try_decode_saved_weight)
+    except Exception as e:
+        result["errors"].append(f"Failed to load config.json: {e}")
+        return result
+
+    # Collect all SavedWeight objects
+    saved_weights = collect_saved_weights(weight_config)
+    result["stats"]["total_files"] = len(saved_weights)
+
+    # Validate paths
+    validation_errors = []
+    referenced_paths = set()
+
+    for path_key, saved_weight in saved_weights:
+        # Check for absolute paths
+        if saved_weight.path.is_absolute():
+            result["stats"]["absolute_paths"] += 1
+            error_msg = f"Absolute path at '{path_key}': {saved_weight.path}"
+            validation_errors.append(error_msg)
+            if verbose:
+                result["errors"].append(error_msg)
+
+        # Check extension
+        if saved_weight.path.suffix != TENSOR_CACHE_EXTENSION:
+            result["stats"]["invalid_extensions"] += 1
+            error_msg = (
+                f"Invalid extension at '{path_key}': {saved_weight.path.suffix} (expected {TENSOR_CACHE_EXTENSION})"
+            )
+            validation_errors.append(error_msg)
+            if verbose:
+                result["errors"].append(error_msg)
+
+        # Resolve and check file existence
+        effective_path = cache_dir / saved_weight.path
+        referenced_paths.add(effective_path.resolve())
+
+        if not effective_path.exists():
+            result["stats"]["missing_files"] += 1
+            error_msg = f"Missing file at '{path_key}': {effective_path} (original: {saved_weight.path})"
+            validation_errors.append(error_msg)
+            if verbose:
+                result["errors"].append(error_msg)
+        else:
+            # Calculate file size
+            try:
+                result["stats"]["total_size"] += effective_path.stat().st_size
+            except OSError as e:
+                if verbose:
+                    result["warnings"].append(f"Could not stat '{path_key}' at {effective_path}: {e}")
+
+    # Use existing validation function to catch any additional issues
+    try:
+        validate_weight_config_paths(cache_dir, weight_config)
+    except ValueError as e:
+        # Only add if not already captured above
+        error_str = str(e)
+        if error_str not in validation_errors:
+            validation_errors.append(error_str)
+            if verbose:
+                result["errors"].append(error_str)
+
+    # Find orphaned files
+    orphaned = find_orphaned_files(cache_dir, referenced_paths)
+    result["stats"]["orphaned_files"] = len(orphaned)
+    result["orphaned_files"] = orphaned  # Store for later display
+    if orphaned and verbose:
+        result["warnings"].extend([f"Orphaned file: {f}" for f in orphaned])
+
+    # Determine if cache is valid
+    result["valid"] = (
+        len(validation_errors) == 0
+        and result["stats"]["missing_files"] == 0
+        and result["stats"]["absolute_paths"] == 0
+        and result["stats"]["invalid_extensions"] == 0
+    )
+
+    if not result["valid"] and not verbose:
+        # Collect error summaries even if not verbose
+        if result["stats"]["absolute_paths"] > 0:
+            result["errors"].append(f"{result['stats']['absolute_paths']} absolute path(s) found")
+        if result["stats"]["missing_files"] > 0:
+            result["errors"].append(f"{result['stats']['missing_files']} missing file(s)")
+        if result["stats"]["invalid_extensions"] > 0:
+            result["errors"].append(f"{result['stats']['invalid_extensions']} invalid extension(s)")
+
+    return result
+
+
+def collect_cache_statistics(cache_dirs: list[Path], verbose: bool = False) -> dict[str, Any]:
+    """
+    Collect comprehensive statistics across all caches.
+
+    Args:
+        cache_dirs: List of cache directory paths
+        verbose: Whether to include detailed error information
+
+    Returns:
+        Dictionary with aggregated statistics
+    """
+    results = []
+    total_stats = {
+        "total_caches": len(cache_dirs),
+        "valid_caches": 0,
+        "invalid_caches": 0,
+        "total_files": 0,
+        "total_size": 0,
+        "total_absolute_paths": 0,
+        "total_missing_files": 0,
+        "total_invalid_extensions": 0,
+        "total_orphaned_files": 0,
+    }
+
+    for cache_dir in cache_dirs:
+        result = validate_cache_directory(cache_dir, verbose)
+        results.append(result)
+
+        # Aggregate statistics
+        stats = result["stats"]
+        total_stats["total_files"] += stats["total_files"]
+        total_stats["total_size"] += stats["total_size"]
+        total_stats["total_absolute_paths"] += stats["absolute_paths"]
+        total_stats["total_missing_files"] += stats["missing_files"]
+        total_stats["total_invalid_extensions"] += stats["invalid_extensions"]
+        total_stats["total_orphaned_files"] += stats["orphaned_files"]
+
+        if result["valid"]:
+            total_stats["valid_caches"] += 1
+        else:
+            total_stats["invalid_caches"] += 1
+
+    return {
+        "summary": total_stats,
+        "results": results,
+    }
+
+
+def format_size(size_bytes: int) -> str:
+    """Format bytes as human-readable size."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"
+
+
+def print_summary(stats: dict[str, Any]) -> None:
+    """
+    Print detailed text summary.
+
+    Args:
+        stats: Statistics dictionary from collect_cache_statistics
+    """
+    summary = stats["summary"]
+    results = stats["results"]
+
+    print("=" * 80)
+    print("WEIGHT CACHE VALIDATION SUMMARY")
+    print("=" * 80)
+    print()
+
+    # Summary section
+    print("OVERALL STATISTICS")
+    print("-" * 80)
+    print(f"Total cache directories:     {summary['total_caches']}")
+    print(f"  Valid:                    {summary['valid_caches']}")
+    print(f"  Invalid:                  {summary['invalid_caches']}")
+    print(f"Total weight files:          {summary['total_files']}")
+    print(f"Total cache size:            {format_size(summary['total_size'])}")
+    print()
+
+    # Error summary
+    if (
+        summary["total_absolute_paths"] > 0
+        or summary["total_missing_files"] > 0
+        or summary["total_invalid_extensions"] > 0
+    ):
+        print("ERROR SUMMARY")
+        print("-" * 80)
+        if summary["total_absolute_paths"] > 0:
+            print(f"  Absolute paths found:      {summary['total_absolute_paths']}")
+        if summary["total_missing_files"] > 0:
+            print(f"  Missing files:             {summary['total_missing_files']}")
+        if summary["total_invalid_extensions"] > 0:
+            print(f"  Invalid extensions:        {summary['total_invalid_extensions']}")
+        print()
+
+    # Warnings
+    if summary["total_orphaned_files"] > 0:
+        print("WARNINGS")
+        print("-" * 80)
+        print(f"  Orphaned files:            {summary['total_orphaned_files']}")
+        print()
+
+    # Per-cache breakdown
+    print("PER-CACHE BREAKDOWN")
+    print("-" * 80)
+    for result in results:
+        cache_dir = result["cache_dir"]
+        cache_info = result["cache_info"]
+        stats = result["stats"]
+        status = "✓ VALID" if result["valid"] else "✗ INVALID"
+
+        if cache_info:
+            info_str = f"{cache_info['num_layers']} layers, mesh {cache_info['mesh_rows']}x{cache_info['mesh_cols']}"
+        else:
+            info_str = "unknown structure"
+
+        print(f"{status}  {cache_dir}")
+        print(f"      {info_str}")
+        print(f"      Files: {stats['total_files']}, Size: {format_size(stats['total_size'])}")
+
+        if not result["valid"]:
+            if result["errors"]:
+                print(f"      Errors:")
+                for error in result["errors"][:5]:  # Limit to 5 errors per cache
+                    print(f"        - {error}")
+                if len(result["errors"]) > 5:
+                    print(f"        ... and {len(result['errors']) - 5} more error(s)")
+
+        if result["warnings"]:
+            print(f"      Warnings:")
+            for warning in result["warnings"][:3]:  # Limit to 3 warnings per cache
+                print(f"        - {warning}")
+            if len(result["warnings"]) > 3:
+                print(f"        ... and {len(result['warnings']) - 3} more warning(s)")
+        print()
+
+    # Detailed error section
+    invalid_results = [r for r in results if not r["valid"]]
+    if invalid_results:
+        print("DETAILED ERROR INFORMATION")
+        print("-" * 80)
+        for result in invalid_results:
+            if result["errors"]:
+                print(f"\n{result['cache_dir']}:")
+                for error in result["errors"]:
+                    print(f"  ERROR: {error}")
+        print()
+
+    # Orphaned files section
+    results_with_orphans = [r for r in results if r["stats"]["orphaned_files"] > 0]
+    if results_with_orphans:
+        print("ORPHANED FILES")
+        print("-" * 80)
+        for result in results_with_orphans:
+            cache_dir = result["cache_dir"]
+            orphaned = result.get("orphaned_files", [])
+            if orphaned:
+                print(f"\n{cache_dir}:")
+                for orphan in orphaned:
+                    print(f"  {orphan}")
+        print()
+
+    print("=" * 80)
+
+
+def main():
+    """Main entry point with argparse."""
+    parser = argparse.ArgumentParser(description="Validate weight cache directories and print a comprehensive summary.")
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=None,
+        help="Root directory to search for cache directories (default: current directory or DEEPSEEK_V3_CACHE env var)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed error information for each cache",
+    )
+
+    args = parser.parse_args()
+
+    # Determine root path
+    if args.root:
+        root_path = Path(args.root)
+    else:
+        cache_env = os.getenv("DEEPSEEK_V3_CACHE")
+        if cache_env:
+            root_path = Path(cache_env)
+        else:
+            root_path = Path.cwd()
+
+    if not root_path.exists():
+        print(f"Error: Root path does not exist: {root_path}")
+        return 1
+
+    print(f"Searching for cache directories in: {root_path}")
+    print()
+
+    # Discover cache directories
+    cache_dirs = discover_cache_directories(root_path)
+
+    if not cache_dirs:
+        print("No cache directories found.")
+        return 0
+
+    print(f"Found {len(cache_dirs)} cache directory(ies)")
+    print()
+
+    # Collect statistics
+    stats = collect_cache_statistics(cache_dirs, verbose=args.verbose)
+
+    # Print summary
+    print_summary(stats)
+
+    # Return exit code based on validation results
+    if stats["summary"]["invalid_caches"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/models/demos/deepseek_v3/tests/test_get_weight_config.py
+++ b/models/demos/deepseek_v3/tests/test_get_weight_config.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import torch
+from transformers.configuration_utils import PretrainedConfig
+
+import ttnn
+from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
+from models.demos.deepseek_v3.utils.weight_config import (
+    WeightConfigEncoder,
+    get_weight_config,
+    normalize_weight_config_paths,
+    validate_weight_config_paths,
+)
+
+
+@dataclass(frozen=True)
+class _FakeMeshDevice:
+    # `get_weight_config()` only uses `.shape` for path construction and passes the object through.
+    shape: tuple[int, int]
+
+
+def _make_hf_config(num_hidden_layers: int = 2) -> PretrainedConfig:
+    hf_config = PretrainedConfig()
+    hf_config.num_hidden_layers = num_hidden_layers
+    return hf_config
+
+
+def test_get_weight_config_cache_hit_skips_convert(tmp_path: Path) -> None:
+    call_count = {"n": 0}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            call_count["n"] += 1
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w0{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w0": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(4, 8))
+    hf_config = _make_hf_config(num_hidden_layers=3)
+    base_cache = tmp_path / "weight_cache"
+
+    # First call: cache miss -> convert_weights is invoked and config.json is written.
+    cfg0 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+    assert isinstance(cfg0, dict) and "w0" in cfg0
+    assert isinstance(cfg0["w0"], SavedWeight)
+    assert cfg0["w0"].path.is_absolute()
+    assert cfg0["w0"].path.exists()
+
+    # Second call: cache hit -> convert_weights is skipped.
+    cfg1 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+    assert isinstance(cfg1["w0"], SavedWeight)
+    assert cfg1["w0"].path.is_absolute()
+    assert cfg1["w0"].path.exists()
+
+
+def test_get_weight_config_force_recalculate_bypasses_cache(tmp_path: Path) -> None:
+    call_count = {"n": 0}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            call_count["n"] += 1
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{call_count['n']}{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(f"unit-test-{call_count['n']}".encode("utf-8"))
+            return {f"w{call_count['n']}": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(1, 2))
+    hf_config = _make_hf_config(num_hidden_layers=1)
+    base_cache = tmp_path / "weight_cache"
+
+    cfg0 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+
+    cfg1 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=True,
+    )
+    assert call_count["n"] == 2
+
+    # When force_recalculate=True, we should get the newly produced config/weight path.
+    assert cfg0 != cfg1
+
+
+def test_get_weight_config_cache_miss_when_config_missing(tmp_path: Path) -> None:
+    """Test that cache miss occurs when config.json doesn't exist."""
+    call_count = {"n": 0}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            call_count["n"] += 1
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(2, 4))
+    hf_config = _make_hf_config(num_hidden_layers=5)
+    base_cache = tmp_path / "weight_cache"
+
+    # No cache exists, should call convert_weights
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+    assert cfg["w"].path.is_absolute()
+    assert cfg["w"].path.exists()
+
+
+def test_get_weight_config_cache_invalidation_missing_weight_file(tmp_path: Path) -> None:
+    """Test that cache is invalidated when weight file is missing."""
+    call_count = {"n": 0}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            call_count["n"] += 1
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(1, 1))
+    hf_config = _make_hf_config(num_hidden_layers=1)
+    base_cache = tmp_path / "weight_cache"
+
+    # First call: create cache
+    cfg0 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+
+    # Delete the weight file but keep config.json
+    # config.json has relative paths, so we should resolve them relative to weight_cache_path
+    # This simulates what validate_weight_config_paths does
+    weight_cache_path = (
+        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+    config_path = weight_cache_path / "config.json"
+
+    # Read the config.json to get the relative path (as it's actually stored)
+    with config_path.open() as f:
+        saved_config = json.load(f)
+    rel_path_str = saved_config["w"]["path"]
+    assert not Path(rel_path_str).is_absolute(), "Config should store relative paths"
+
+    # Resolve relative path to get the actual file location
+    weight_file = weight_cache_path / rel_path_str
+    assert weight_file.exists(), f"Weight file should exist: {weight_file}"
+    weight_file.unlink()
+    assert not weight_file.exists()
+
+    # Second call: cache validation should fail, triggering recalculation
+    cfg1 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 2
+    assert cfg1["w"].path.exists()
+
+
+def test_get_weight_config_cache_invalidation_wrong_suffix(tmp_path: Path) -> None:
+    """Test that cache is invalidated when weight file has wrong suffix."""
+    call_count = {"n": 0}
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            call_count["n"] += 1
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(2, 2))
+    hf_config = _make_hf_config(num_hidden_layers=2)
+    base_cache = tmp_path / "weight_cache"
+
+    # First call: create cache
+    cfg0 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 1
+
+    # Corrupt config.json to have wrong suffix
+    # Create a SavedWeight with wrong suffix - this will fail validation
+    weight_cache_path = (
+        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+    config_path = weight_cache_path / "config.json"
+    bad_weight = SavedWeight(path=Path("weights/w.bad"), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    bad_config = {"w": bad_weight}
+    with config_path.open("w") as f:
+        json.dump(bad_config, f, cls=WeightConfigEncoder)
+
+    # Second call: cache validation should fail, triggering recalculation
+    cfg1 = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert call_count["n"] == 2
+
+
+def test_get_weight_config_path_construction(tmp_path: Path) -> None:
+    """Test that weight_cache_path is correctly constructed with layers and mesh shape."""
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            # Verify the path structure
+            expected_suffix = f"{hf_config.num_hidden_layers}_layers/mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+            assert str(weight_cache_path).endswith(expected_suffix)
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(8, 16))
+    hf_config = _make_hf_config(num_hidden_layers=12)
+    base_cache = tmp_path / "weight_cache"
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+    assert cfg["w"].path.is_absolute()
+
+
+def test_get_weight_config_rejects_absolute_paths_from_module(tmp_path: Path) -> None:
+    """Test that get_weight_config rejects absolute paths returned by ModuleClass.convert_weights."""
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            # Return an absolute path (incorrect behavior)
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            abs_path = weight_cache_path / "weights" / f"w{TENSOR_CACHE_EXTENSION}"
+            abs_path.write_bytes(b"unit-test")
+            # Return absolute path instead of relative
+            return {"w": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(2, 2))
+    hf_config = _make_hf_config(num_hidden_layers=2)
+    base_cache = tmp_path / "weight_cache"
+
+    # get_weight_config should raise ValueError when convert_weights returns absolute paths
+    with pytest.raises(ValueError, match="absolute path.*Only relative paths are allowed"):
+        get_weight_config(
+            ModuleClass=FakeModule,
+            hf_config=hf_config,
+            state_dicts=({"dummy": torch.empty(1)},),
+            weight_cache_path=base_cache,
+            mesh_device=mesh_device,
+            force_recalculate=False,
+        )
+
+
+def test_get_weight_config_error_missing_weight_cache_path() -> None:
+    """Test that ValueError is raised when weight_cache_path is None."""
+    mesh_device = _FakeMeshDevice(shape=(1, 1))
+    hf_config = _make_hf_config()
+
+    with pytest.raises(ValueError, match="weight_cache_path must be provided"):
+        get_weight_config(
+            ModuleClass=None,  # Won't get this far
+            hf_config=hf_config,
+            weight_cache_path=None,
+            mesh_device=mesh_device,
+        )
+
+
+def test_get_weight_config_error_missing_mesh_device() -> None:
+    """Test that ValueError is raised when mesh_device is None."""
+    hf_config = _make_hf_config()
+
+    with pytest.raises(ValueError, match="mesh_device must be provided"):
+        get_weight_config(
+            ModuleClass=None,  # Won't get this far
+            hf_config=hf_config,
+            weight_cache_path=Path("/tmp"),
+            mesh_device=None,
+        )
+
+
+def test_validate_weight_config_paths_success(tmp_path: Path) -> None:
+    """Test successful validation of weight config paths."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_file1 = root_path / f"w1{TENSOR_CACHE_EXTENSION}"
+    weight_file2 = root_path / f"w2{TENSOR_CACHE_EXTENSION}"
+    weight_file1.write_bytes(b"test1")
+    weight_file2.write_bytes(b"test2")
+
+    weight_config = {
+        "layer1": SavedWeight(path=Path(f"w1{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        "layer2": SavedWeight(path=Path(f"w2{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    # Should not raise - both paths are relative
+    validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_missing_file(tmp_path: Path) -> None:
+    """Test validation raises ValueError when weight file is missing."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_config = {
+        "layer1": SavedWeight(path=Path(f"missing{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    with pytest.raises(ValueError, match="references missing file"):
+        validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_wrong_suffix(tmp_path: Path) -> None:
+    """Test validation raises ValueError when weight file has wrong suffix."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_file = root_path / "w.bad"
+    weight_file.write_bytes(b"test")
+
+    weight_config = {
+        "layer1": SavedWeight(path=Path("w.bad"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    with pytest.raises(ValueError, match="invalid suffix"):
+        validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_rejects_absolute_paths(tmp_path: Path) -> None:
+    """Test validation raises ValueError when SavedWeight has absolute path."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    abs_path = tmp_path / "other" / f"w{TENSOR_CACHE_EXTENSION}"
+    abs_path.parent.mkdir(parents=True)
+    abs_path.write_bytes(b"test")
+
+    weight_config = {
+        "layer1": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    with pytest.raises(ValueError, match="absolute path.*Only relative paths are allowed"):
+        validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_nested_structures(tmp_path: Path) -> None:
+    """Test validation works with nested dicts, lists, and tuples."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_file1 = root_path / f"w1{TENSOR_CACHE_EXTENSION}"
+    weight_file2 = root_path / f"w2{TENSOR_CACHE_EXTENSION}"
+    weight_file3 = root_path / f"w3{TENSOR_CACHE_EXTENSION}"
+    weight_file1.write_bytes(b"test1")
+    weight_file2.write_bytes(b"test2")
+    weight_file3.write_bytes(b"test3")
+
+    weight_config = {
+        "dict_nested": {
+            "w1": SavedWeight(path=Path(f"w1{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        },
+        "list_nested": [
+            SavedWeight(path=Path(f"w2{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        ],
+        "tuple_nested": (SavedWeight(path=Path(f"w3{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),),
+        "none_value": None,
+    }
+
+    # Should not raise
+    validate_weight_config_paths(root_path, weight_config)
+
+
+def test_validate_weight_config_paths_error_path_prefix(tmp_path: Path) -> None:
+    """Test that error messages include path prefix for nested structures."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    weight_config = {
+        "outer": {
+            "inner": SavedWeight(path=Path(f"missing{TENSOR_CACHE_EXTENSION}"), memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        },
+    }
+
+    with pytest.raises(ValueError, match="outer.inner"):
+        validate_weight_config_paths(root_path, weight_config)
+
+
+def test_normalize_weight_config_paths_relative_paths(tmp_path: Path) -> None:
+    """Test normalization converts relative paths to absolute."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    rel_path = Path(f"w{TENSOR_CACHE_EXTENSION}")
+    weight_config = {
+        "w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    normalized = normalize_weight_config_paths(root_path, weight_config)
+
+    assert normalized["w"].path.is_absolute()
+    assert normalized["w"].path == root_path / rel_path
+    # Original should be unchanged (no mutation)
+    assert not weight_config["w"].path.is_absolute()
+
+
+def test_normalize_weight_config_paths_absolute_paths(tmp_path: Path) -> None:
+    """Test normalization preserves absolute paths."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    abs_path = tmp_path / "other" / f"w{TENSOR_CACHE_EXTENSION}"
+    abs_path.parent.mkdir(parents=True)
+    abs_path.write_bytes(b"test")
+
+    weight_config = {
+        "w": SavedWeight(path=abs_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
+    }
+
+    normalized = normalize_weight_config_paths(root_path, weight_config)
+
+    assert normalized["w"].path.is_absolute()
+    assert normalized["w"].path == abs_path
+
+
+def test_normalize_weight_config_paths_nested_structures(tmp_path: Path) -> None:
+    """Test normalization works with nested dicts, lists, and tuples."""
+    root_path = tmp_path / "weights"
+    root_path.mkdir(parents=True)
+
+    rel_path = Path(f"w{TENSOR_CACHE_EXTENSION}")
+    weight_config = {
+        "dict_nested": {
+            "w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        },
+        "list_nested": [
+            SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),
+        ],
+        "tuple_nested": (SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG),),
+        "none_value": None,
+    }
+
+    normalized = normalize_weight_config_paths(root_path, weight_config)
+
+    assert normalized["dict_nested"]["w"].path.is_absolute()
+    assert normalized["list_nested"][0].path.is_absolute()
+    assert normalized["tuple_nested"][0].path.is_absolute()
+    assert normalized["none_value"] is None
+    # Verify tuple type is preserved
+    assert isinstance(normalized["tuple_nested"], tuple)
+    assert isinstance(normalized["list_nested"], list)
+
+
+def test_get_weight_config_returns_normalized_paths(tmp_path: Path) -> None:
+    """Test that get_weight_config returns config with absolute paths even though config.json has relative."""
+
+    class FakeModule:
+        @staticmethod
+        def convert_weights(hf_config, state_dicts, weight_cache_path: Path, mesh_device):
+            (weight_cache_path / "weights").mkdir(parents=True, exist_ok=True)
+            rel_path = Path("weights") / f"w{TENSOR_CACHE_EXTENSION}"
+            (weight_cache_path / rel_path).write_bytes(b"unit-test")
+            return {"w": SavedWeight(path=rel_path, memory_config=ttnn.DRAM_MEMORY_CONFIG)}
+
+    mesh_device = _FakeMeshDevice(shape=(1, 1))
+    hf_config = _make_hf_config(num_hidden_layers=1)
+    base_cache = tmp_path / "weight_cache"
+
+    cfg = get_weight_config(
+        ModuleClass=FakeModule,
+        hf_config=hf_config,
+        state_dicts=({"dummy": torch.empty(1)},),
+        weight_cache_path=base_cache,
+        mesh_device=mesh_device,
+        force_recalculate=False,
+    )
+
+    # Returned config should have absolute paths
+    assert cfg["w"].path.is_absolute()
+
+    # But config.json should have relative paths (check by reading it)
+    weight_cache_path = (
+        base_cache / f"{hf_config.num_hidden_layers}_layers" / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+    config_path = weight_cache_path / "config.json"
+    with config_path.open() as f:
+        saved_config = json.load(f)
+    # The saved path should be relative (as a string)
+    assert "weights" in saved_config["w"]["path"]
+    assert not Path(saved_config["w"]["path"]).is_absolute()

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -72,7 +72,6 @@ def test_forward_pass(
     # Pad input to SEQ_LEN_CHUNK_SIZE if necessary
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
-    # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
         LMHead, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -74,7 +74,7 @@ def test_forward_pass(
 
     # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
-        LMHead, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=True
+        LMHead, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )
     model_config = get_model_config(LMHead, mode, hf_config, mesh_device, 3)
     model_state = LMHead.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -14,11 +13,12 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.lm_head import LMHead
-from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert, sub_state_dict
+from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     assert_hidden_dim_pcc,
     get_model_config,
+    get_test_weight_config,
     pad_or_trim_seq_len,
     run_module_forward,
 )
@@ -72,17 +72,10 @@ def test_forward_pass(
     # Pad input to SEQ_LEN_CHUNK_SIZE if necessary
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
-    weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    # Setup: Get weight_config using the helper function
+    weight_config = get_test_weight_config(
+        LMHead, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=True
     )
-
-    # Setup: Convert weights and get weight_config
-    weight_config = LMHead.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)
-    _check_weights_exist_and_convert(weight_cache_path, weight_config)
     model_config = get_model_config(LMHead, mode, hf_config, mesh_device, 3)
     model_state = LMHead.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -68,7 +68,7 @@ def test_forward_pass(
 
     # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
-        LMHead1D, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=True
+        LMHead1D, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )
     model_config = get_model_config(LMHead1D, mode, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -66,7 +66,6 @@ def test_forward_pass(
     torch_input = torch.randn(1, 1, batch_size, hf_config.hidden_size)
     reference_output = reference_model(torch_input)
 
-    # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
         LMHead1D, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -32,7 +32,8 @@ def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_devic
         MLPClass=MLP,
         hf_config=hf_config,
         state_dict=reference_model.state_dict(),
-        tmp_path=tmp_path,
+        tmp_path=tmp_path
+        / "mesh_8x8",  # TODO: dummy mesh shape required until convert_weights no longer relies on this for parsing the absolutem filepaths
         mesh_device=mesh_device,
         reference_w1=reference_state_dict["gate_proj.weight"],
     )
@@ -49,7 +50,8 @@ def test_convert_weights_for_dequantized_mlps(MLPClass, module_path, hf_config, 
         MLPClass=MLPClass,
         hf_config=hf_config,
         state_dict=state_dict,
-        tmp_path=tmp_path,
+        tmp_path=tmp_path
+        / "mesh_8x8",  # TODO: dummy mesh shape required until convert_weights no longer relies on this for parsing the absolutem filepaths
         mesh_device=mesh_device,
         reference_w1=dequantize(
             state_dict["gate_proj.weight"],
@@ -79,6 +81,9 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     # assert Path(weight_config["w1"]["input_tensor_b"]).exists()
     # assert Path(weight_config["w2"]["input_tensor_b"]).exists()
     # assert Path(weight_config["w3"]["input_tensor_b"]).exists()
+
+    # Make the path absolute - this is required since load_weight expects an absolute path
+    weight_config["w1"]["input_tensor_b"].path = tmp_path / weight_config["w1"]["input_tensor_b"].path
 
     # Load and verify a weight
     w1_ttnn = load_weight(weight_config["w1"]["input_tensor_b"], device=mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -81,7 +81,7 @@ def test_forward_pass(
 
     # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
-        MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=True
+        MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )
 
     # Generate appropriate config using utility function

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -79,7 +79,6 @@ def test_forward_pass(
     with torch.no_grad():
         reference_output = reference_model(torch_input)
 
-    # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
         MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
     )

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import os
-
 import pytest
 import torch
 from loguru import logger
@@ -13,12 +11,12 @@ import ttnn
 # Import from local reference files instead of HuggingFace
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tt.moe import MoE
-from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
     add_inv_scale_to_state_dict,
     assert_hidden_dim_pcc,
     get_model_config,
+    get_test_weight_config,
     run_module_forward,
 )
 
@@ -81,16 +79,10 @@ def test_forward_pass(
     with torch.no_grad():
         reference_output = reference_model(torch_input)
 
-    weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    # Setup: Get weight_config using the helper function
+    weight_config = get_test_weight_config(
+        MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=True
     )
-    # Setup: Convert weights and get weight_config
-    weight_config = MoE.convert_weights(hf_config, (state_dict,), weight_cache_path, mesh_device)
-    _check_weights_exist_and_convert(weight_cache_path, weight_config)
 
     # Generate appropriate config using utility function
     model_config = get_model_config(MoE, mode, hf_config, mesh_device, topk_fallback=topk_fallback)

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -47,9 +47,8 @@ def test_forward_pass(
     reference_model = ReferenceMoEGate(hf_config, use_bitonic_sort).eval()
     hf_state_dict = reference_model.state_dict()
 
-    # Setup: Get weight_config using the helper function
     weight_config = get_test_weight_config(
-        MoEGate, hf_config, (hf_state_dict,), cache_path, mesh_device, force_recalculate=True
+        MoEGate, hf_config, (hf_state_dict,), cache_path, mesh_device, force_recalculate=False
     )
 
     # Generate appropriate config using utility function

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import os
-
 import pytest
 import torch
 from loguru import logger
@@ -13,9 +11,8 @@ import ttnn
 # Import from local reference files instead of HuggingFace
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate as ReferenceMoEGate
 from models.demos.deepseek_v3.tt.moe_gate import MoEGate
-from models.demos.deepseek_v3.utils.config_helpers import _check_weights_exist_and_convert
 from models.demos.deepseek_v3.utils.run_config import create_run_config
-from models.demos.deepseek_v3.utils.test_utils import get_model_config, run_module_forward
+from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, run_module_forward
 from tests.ttnn.utils_for_testing import comp_pcc
 
 
@@ -50,17 +47,10 @@ def test_forward_pass(
     reference_model = ReferenceMoEGate(hf_config, use_bitonic_sort).eval()
     hf_state_dict = reference_model.state_dict()
 
-    # Setup: Convert weights and get weight_config
-    weight_cache_path = (
-        cache_path
-        / "tests_cache"
-        / os.environ.get("PYTEST_CURRENT_TEST")
-        / f"{hf_config.num_hidden_layers}_layers"
-        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    # Setup: Get weight_config using the helper function
+    weight_config = get_test_weight_config(
+        MoEGate, hf_config, (hf_state_dict,), cache_path, mesh_device, force_recalculate=True
     )
-
-    weight_config = MoEGate.convert_weights(hf_config, (hf_state_dict,), weight_cache_path, mesh_device)
-    _check_weights_exist_and_convert(weight_cache_path, weight_config)
 
     # Generate appropriate config using utility function
     model_config = get_model_config(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -16,8 +16,9 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_weight_config
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 

--- a/models/demos/deepseek_v3/tt/generator_pp.py
+++ b/models/demos/deepseek_v3/tt/generator_pp.py
@@ -16,8 +16,9 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.model.row_pipelined_model import RowPipelinedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_weight_config
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -142,7 +142,6 @@ class MLP(AbstractModule):
                 per_device_out_features,
                 mesh_device.dram_grid_size(),
             ),
-            convert_meta=True,
         )
 
     @final

--- a/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_pipelined_model.py
@@ -58,7 +58,8 @@ class RowPipelinedModel(SharedStateAddOn, AbstractModule):
                 sub_state_dict(state_dict, f"model.layers.{layer_idx}.")
                 for layer_idx in range(hf_config.num_hidden_layers)
             ]
-            + [None]
+            + [None],
+            dtype=object,
         )
 
         return {

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -28,7 +28,6 @@ class RMSNorm(RMSNormBase):
         state_dicts: tuple[dict[str, torch.Tensor] | None, ...],
         output_path: Path,
         mesh_device: ttnn.Device,
-        convert_meta: bool = False,
     ) -> WeightConfig:
         torch_metaweight = get_state_dicts(state_dicts, "weight", dtype=torch.bfloat16)
         num_shards = torch_metaweight.shape[0]
@@ -47,7 +46,6 @@ class RMSNorm(RMSNormBase):
                 dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                convert_meta=convert_meta,
             ),
         }
 

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -584,7 +584,6 @@ def shard_and_save(
     layout: ttnn.Layout | None = None,
     memory_config: ttnn.MemoryConfig | None = None,
     _torch_impl: bool = False,
-    convert_meta=False,
 ) -> SavedWeight:
     """Shard a tensor and save it to a file."""
     assert all(isinstance(shard_dim, (int, NoneType)) for shard_dim in shard_dims)
@@ -656,7 +655,7 @@ def shard_and_save(
     ttnn.dump_tensor(path, ttnn_tensor)
 
     # Always convert absolute paths to relative paths for portability
-    # This ensures SavedWeight objects always have relative paths regardless of convert_meta flag
+    # This ensures SavedWeight objects always have relative paths
     if path.is_absolute():
         path_str = str(path)
         mesh_idx = path_str.find("mesh_")

--- a/models/demos/deepseek_v3/utils/lazy_state_dict.py
+++ b/models/demos/deepseek_v3/utils/lazy_state_dict.py
@@ -86,6 +86,15 @@ class LazyStateDict(Mapping[str, torch.Tensor]):
         self._file_handles[filename] = handle
         return handle
 
+    def clear_cache(self) -> None:
+        """
+        Clear cached tensors while keeping file handles open for reuse.
+        This allows memory to be freed while preserving the performance benefits
+        of keeping mmap'd file handles open across test cases.
+        """
+        if self._cache:
+            self._cache.clear()
+
     def close(self) -> None:
         """
         Close all cached shard handles and clear cached tensors and accounting.

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -19,7 +19,8 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.scripts.generate_test_inputs_outputs import __file__ as REFERENCE_IO_SCRIPT_NAME
 from models.demos.deepseek_v3.tt.rope import RotarySetup
 from models.demos.deepseek_v3.utils.abstract_module import AbstractModule
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, dequantize, even_int_div, get_weight_config
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, dequantize, even_int_div
+from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
 

--- a/models/demos/deepseek_v3/utils/weight_config.py
+++ b/models/demos/deepseek_v3/utils/weight_config.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from loguru import logger
+from transformers.configuration_utils import PretrainedConfig
+
+import ttnn
+from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+
+# Import TENSOR_CACHE_EXTENSION from config_helpers since it's also used by shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import TENSOR_CACHE_EXTENSION
+from models.demos.deepseek_v3.utils.run_config import WeightConfig
+
+
+# JSON serializer for the weight config
+class WeightConfigEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, SavedWeight):
+            obj = {
+                "path": str(obj.path),
+                "memory_config": None if obj.memory_config is None else json.loads(obj.memory_config.to_json()),
+            }
+        return obj
+
+
+def try_decode_saved_weight(obj: dict[str, Any]) -> Any:
+    path_str = obj.get("path", None)
+    if not isinstance(path_str, str):
+        return obj
+    memory_config_dict = obj.get("memory_config", None)
+    if not isinstance(memory_config_dict, dict) or not {
+        "buffer_type",
+        "memory_layout",
+        "created_with_nd_shard_spec",
+    }.issubset(memory_config_dict.keys()):
+        return obj
+    return SavedWeight(path=Path(path_str), memory_config=ttnn.MemoryConfig.from_json(json.dumps(memory_config_dict)))
+
+
+def get_weight_config(
+    ModuleClass: type["models.demos.deepseek_v3.utils.abstract_module.AbstractModule"],
+    hf_config: PretrainedConfig,
+    state_dicts: tuple[dict[str, torch.Tensor] | None, ...] | None = None,
+    weight_cache_path: Path | None = None,
+    mesh_device: ttnn.Device | None = None,
+    force_recalculate: bool = False,
+    random_weights: bool = False,
+    model_path: str | None = None,
+    single_layer: str | None = None,
+):
+    """
+    Get weight configuration, either from cache or by converting weights.
+
+    Args:
+        ModuleClass: The module class to convert weights for
+        hf_config: HuggingFace model configuration
+        state_dicts: Optional pre-loaded state dicts. If None, will be loaded based on random_weights/model_path.
+        weight_cache_path: Path to cache weights
+        mesh_device: TTNN mesh device
+        force_recalculate: Force recalculation even if cached weights exist
+        random_weights: If True, generate random weights from reference model
+        model_path: Path to HuggingFace model directory (required if random_weights=False and state_dicts=None)
+        single_layer: Optional single layer name (used for validation with random weights)
+
+    Returns:
+        Weight configuration dictionary
+    """
+    if weight_cache_path is None:
+        raise ValueError("weight_cache_path must be provided")
+    if mesh_device is None:
+        raise ValueError("mesh_device must be provided")
+
+    weight_cache_path = (
+        weight_cache_path
+        / f"{hf_config.num_hidden_layers}_layers"
+        / f"mesh_{mesh_device.shape[0]}x{mesh_device.shape[1]}"
+    )
+    config_path = weight_cache_path / "config.json"
+    weight_path = weight_cache_path / "weights"
+    for _ in range(1):
+        if force_recalculate:
+            logger.info(f"Forcing recalculating weights")
+            break
+        if not config_path.exists():
+            logger.info(f"Weight configuration file does not exist, forcing recalculating weights")
+            break
+        with config_path.open() as f:
+            weight_config = json.load(f, object_hook=try_decode_saved_weight)
+        try:
+            validate_weight_config_paths(weight_cache_path, weight_config)
+        except ValueError as e:
+            logger.warning(f"Cache validation failed, will recalculate weights: {e}")
+            break
+        logger.info(f"Using weights cached at {weight_cache_path}")
+        return normalize_weight_config_paths(weight_cache_path, weight_config)
+
+    # Only prepare state dicts if we need to convert weights
+    logger.info(f"Caching weights at {weight_cache_path}")
+    if state_dicts is None:
+        logger.info(f"State dict was not provided, preparing from random weights or model path")
+        from models.demos.deepseek_v3.utils.hf_model_utils import prepare_model_state_dict
+
+        model_state = prepare_model_state_dict(
+            hf_config=hf_config,
+            random_weights=random_weights,
+            model_path=model_path,
+            single_layer=single_layer,
+        )
+        state_dicts = (model_state,)
+
+    # Convert weights to TT tensors-on-disk and build weight_config
+    logger.info("Converting weights to TTNN SavedWeight format...")
+
+    weight_config = ModuleClass.convert_weights(hf_config, state_dicts, weight_cache_path, mesh_device)
+    breakpoint()
+
+    # Validate the converted weight config
+    validate_weight_config_paths(weight_cache_path, weight_config)
+
+    # Save config with relative paths for portability
+    with config_path.open("w") as f:
+        json.dump(weight_config, f, cls=WeightConfigEncoder)
+
+    # Return normalized config with absolute paths for runtime use
+    normalized_config = normalize_weight_config_paths(weight_cache_path, weight_config)
+    logger.info("Done converting weights to TTNN SavedWeight format")
+    return normalized_config
+
+
+def validate_weight_config_paths(root_path: Path, weight_config: WeightConfig, path_prefix: str = "") -> None:
+    """
+    Validate that all SavedWeight paths in the weight config exist and have the correct suffix.
+
+    Args:
+        root_path: Base path for resolving relative SavedWeight paths
+        weight_config: Weight configuration (dict, list, tuple, or nested structures)
+        path_prefix: Prefix for error messages to indicate location in nested structure
+
+    Raises:
+        ValueError: If any SavedWeight path is invalid (missing file, wrong suffix, etc.)
+    """
+    if isinstance(weight_config, dict):
+        entries = weight_config.items()
+    elif isinstance(weight_config, (list, tuple)):
+        entries = enumerate(weight_config)
+    else:
+        raise ValueError(f"Invalid weight config type: {type(weight_config)}")
+
+    for key, entry in entries:
+        if entry is None:
+            continue
+        current_prefix = f"{path_prefix}.{key}" if path_prefix else str(key)
+
+        if isinstance(entry, SavedWeight):
+            # Reject absolute paths - configs should only contain relative paths for portability
+            if entry.path.is_absolute():
+                raise ValueError(
+                    f"SavedWeight at '{current_prefix}' has absolute path '{entry.path}'. "
+                    f"Only relative paths are allowed in weight configs for portability."
+                )
+
+            # Resolve effective path
+            effective_path = root_path / entry.path
+
+            # Validate suffix
+            if entry.path.suffix != TENSOR_CACHE_EXTENSION:
+                raise ValueError(
+                    f"SavedWeight at '{current_prefix}' has invalid suffix '{entry.path.suffix}'. "
+                    f"Expected '{TENSOR_CACHE_EXTENSION}'. Path: {entry.path}"
+                )
+
+            # Validate file exists
+            if not effective_path.exists():
+                raise ValueError(
+                    f"SavedWeight at '{current_prefix}' references missing file. "
+                    f"Resolved path: {effective_path} (original: {entry.path})"
+                )
+        else:
+            # Recursively validate nested structures
+            validate_weight_config_paths(root_path, entry, current_prefix)
+
+
+def normalize_weight_config_paths(root_path: Path, weight_config: WeightConfig) -> WeightConfig:
+    """
+    Return a new weight config with all relative SavedWeight paths converted to absolute paths.
+
+    Args:
+        root_path: Base path for resolving relative SavedWeight paths
+        weight_config: Weight configuration (dict, list, tuple, or nested structures)
+
+    Returns:
+        New weight config with absolute paths (deep copy, no mutation of input)
+    """
+    if isinstance(weight_config, dict):
+        return {
+            key: normalize_weight_config_paths(root_path, value) if value is not None else None
+            for key, value in weight_config.items()
+        }
+    elif isinstance(weight_config, (list, tuple)):
+        normalized = [
+            normalize_weight_config_paths(root_path, item) if item is not None else None for item in weight_config
+        ]
+        # Preserve tuple type if input was a tuple
+        return tuple(normalized) if isinstance(weight_config, tuple) else normalized
+    elif isinstance(weight_config, SavedWeight):
+        # Create a new SavedWeight with absolute path
+        if weight_config.path.is_absolute():
+            normalized_path = weight_config.path
+        else:
+            normalized_path = root_path / weight_config.path
+        return SavedWeight(path=normalized_path, memory_config=weight_config.memory_config)
+    else:
+        # For other types (None, primitives, etc.), return as-is
+        return weight_config
+
+
+def _normalize_weight_config_paths_inplace(root_path: Path, weight_config: WeightConfig) -> None:
+    """
+    Internal helper that mutates weight_config in-place (for backward compatibility only).
+    New code should use normalize_weight_config_paths instead.
+    """
+    if isinstance(weight_config, dict):
+        entries = weight_config.values()
+    elif isinstance(weight_config, (list, tuple)):
+        entries = weight_config
+    else:
+        entries = []
+
+    for entry in entries:
+        if entry is None:
+            continue
+        if isinstance(entry, SavedWeight):
+            if not entry.path.is_absolute():
+                entry.path = root_path / entry.path
+        else:
+            _normalize_weight_config_paths_inplace(root_path, entry)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_deepseek_mla_ops.py
@@ -36,6 +36,7 @@ from transformers import AutoConfig
 from types import SimpleNamespace
 
 from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import get_test_weight_config
 
 TP = 8
 DP = 4
@@ -814,7 +815,7 @@ def run_rmsnorm_impl(
 
     # Setup: Convert weights and get weight_config
     state_dicts = ({"weight": rms_norm.weight.to(torch.bfloat16)},)  # Tuple of dictionaries
-    weight_config = RMSNorm.convert_weights(hf_config, state_dicts, temp_dir, device, convert_meta=True)
+    weight_config = get_test_weight_config(RMSNorm, hf_config, state_dicts, temp_dir, device, force_recalculate=True)
 
     # Generate appropriate config
     if mode == "prefill":


### PR DESCRIPTION
### Summary

This change adds a standalone cache validation utility for DeepSeek V3 weight caches that can be run to catch broken/partial caches early.

### What’s changed

- New utility script: `models/demos/deepseek_v3/scripts/validate_weight_cache.py`
  - Recursively finds caches containing config.json under the expected layout: `*/{num_layers}_layers/mesh_{rows}x{cols}/config.json`
  - Validation checks (per cache):
    - Config readability (JSON load + decode SavedWeight)
    - No absolute paths in SavedWeight.path (portability)
    - Correct tensor extension (.tensorbin)
    - Referenced files exist under the cache directory
    - Orphan detection: reports `weights/**/*.tensorbin` files that are not referenced by config.json
- Adds shared file locking when reading config.json to avoid racing when doing cache writes
  - In theory we can have tearing occur if two or more hosts write the config.json at the same time, this should prevent that. 
- Refactors cache invalidation logic in `get_weight_config` 
  - Provide more helpful logs to tell the user why the cache was invalid
  - Verify that the create weight config is correct and throw an exception if it is not
  - Decouple path normalization from config validation
- Clear `LazyStateDict` in-memory cache but retain virtual memory between test runs to avoid OOM while regenerating the caches
- Fixes current crash on main with pipeline parallel tests in `test_model.py::test_forward_pass` for prefill and decode: https://github.com/tenstorrent/tt-metal/actions/runs/20420920410/job/58672468324#step:6:13364

### Checklist
- [x] [Galaxy demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/20377903353
- [ ] Galaxy module tests: https://github.com/tenstorrent/tt-metal/actions/runs/20435810691
