### PR TITLE
#0: [skip ci] Don't upload skipped jobs to superset

### DIFF
--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -68,6 +68,11 @@ def create_cicd_json_for_data_analysis(
 
         logger.info(f"Processing raw GitHub job {github_job_id}")
 
+        # Ignore skipped jobs
+        if raw_job.get("conclusion") == "skipped":
+            logger.info(f"Job id:{github_job_id} is skipped. Skipping job upload.")
+            continue
+
         test_report_exists = github_job_id in github_job_id_to_test_reports
         if test_report_exists:
             tests = []

--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -69,6 +69,8 @@ def create_cicd_json_for_data_analysis(
         logger.info(f"Processing raw GitHub job {github_job_id}")
 
         # Ignore skipped jobs
+        # Reason: if an entire matrix is skipped then we can get duplicate skipped jobs with the same pydantic keys
+        # Which will fail pydantic model validation.
         if raw_job.get("conclusion") == "skipped":
             logger.info(f"Job id:{github_job_id} is skipped. Skipping job upload.")
             continue

--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -71,7 +71,7 @@ def create_cicd_json_for_data_analysis(
         # Ignore skipped jobs
         # Reason: if an entire matrix is skipped then we can get duplicate skipped jobs with the same pydantic keys
         # Which will fail pydantic model validation.
-        if raw_job.get("conclusion") == "skipped":
+        if raw_job.get("job_status") == "skipped":
             logger.info(f"Job id:{github_job_id} is skipped. Skipping job upload.")
             continue
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Skipped job matrices can generate skipped jobs with the same name which causes pydantic validation to fail 
https://github.com/tenstorrent/tt-metal/actions/runs/20374973988/job/58550939114#step:10:1523
```
Value error, Duplicate job combination found: ('blackhole-multi-card-demo-tests (DeskBox Demo tests, BH-DeskBox, pipeline-functional, 2) / matrix.test-group.name', datetime.datetime(2025, 12, 19, 14, 26, 19, tzinfo=TzInfo(0)), datetime.datetime(2025, 12, 19, 14, 26, 19, tzinfo=TzInfo(0)), datetime.datetime(2025, 12, 18, 21, 49, 54, tzinfo=TzInfo(0))) [type=value_error, input_value={'github_pipeline_id': 20..._smi_version='3.0.38')]}, input_type=dict]
```

E.g. the skipped deskbox demo jobs are duplicated
https://github.com/tenstorrent/tt-metal/actions/runs/20352140986/job/58543803159
https://github.com/tenstorrent/tt-metal/actions/runs/20352140986/job/58543803243

### What's changed
Ignore skipped jobs when analyzing jobs to upload

### Checklist
- [x] Produce data pipeline run passes on branch with fix: https://github.com/tenstorrent/tt-metal/actions/runs/20375895450/job/58554157985