### PR TITLE
#0: Fix noc assignment for deepseek_v3_b1 mcast unit tests

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/test_mcast.py
+++ b/models/demos/deepseek_v3_b1/tests/test_mcast.py
@@ -36,7 +36,7 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
                 ttnn.CoreCoord(0, 8),
                 ttnn.CoreCoord(8, 9),
             ),
-            ttnn.NOC.NOC_1,
+            ttnn.NOC.NOC_0,
         ),  # kv_a_proj input, 18 cores
         (
             1536,
@@ -45,7 +45,7 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
                 ttnn.CoreCoord(0, 0),
                 ttnn.CoreCoord(11, 7),
             ),
-            ttnn.NOC.NOC_0,
+            ttnn.NOC.NOC_1,
         ),  # q_b_proj input, 96 cores
         (
             8192,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Two of the mcast tests had noc assignment swapped, so they would get lower perf if measured.

### What's changed
Assign the appropriate nocs for the tests.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes