### PR TITLE
Matmul/Fused/Reduce - Add Deepseek Tests

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -47,7 +47,8 @@ def mesh_device(request, device_params):
     # Override mesh shape based on MESH_DEVICE environment variable
     requested_system_name = os.getenv("MESH_DEVICE")
     if requested_system_name is None:
-        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, or TG.")
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+
     mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
     logger.info(f"Selected MESH_DEVICE: '{requested_system_name}' - mesh shape will be set to: {mesh_shape}")
 

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -121,6 +121,7 @@ def run_test_matmul_dram_sharded(
     )
 
     # Create input tensors
+    torch.manual_seed(1234)
     in0 = torch.randn(in0_shape).bfloat16().float()
     in1 = torch.randn(in1_shape).bfloat16().float()
 

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI2,
+    COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+    COMPUTE_KERNEL_CONFIG_LOFI,
+    dram_sharded_weight_config,
+    get_activation_sharding_core_counts_for_dram_matmul,
+    get_dram_sharded_matmul_config,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+# =============================================================================
+# Reference tests for matmuls with no program config
+# (program_config: std::nullopt) - These use INTERLEAVED memory layout
+#
+# Test cases (see test_matmul_interleaved):
+#   - InputA: (1, 1, 32, 896),   InputB: (1, 1, 896, 1536)   - HiFi2, DRAM
+#   - InputA: (1, 1, 32, 1536),  InputB: (1, 1, 1536, 3072)  - HiFi2, DRAM
+#   - InputA: (1, 16, 32, 128),  InputB: (1, 16, 128, 512)   - HiFi2, DRAM, batched
+#   - InputA: (1, 1, 32, 896),   InputB: (1, 1, 896, 576)    - HiFi2, DRAM
+#   - InputA: (1, 16, 32, 512),  InputB: (1, 16, 512, 128)   - HiFi2, DRAM, batched
+#   - InputA: (1, 1, 32, 16384), InputB: (1, 1, 16384, 896)  - HiFi2, DRAM
+#   - InputA: (1, 1, 32, 7168),  InputB: (1, 1, 7168, 256)   - HiFi2, L1, fp32_acc
+#   - InputA: (1, 8, 128, 7168), InputB: (1, 8, 7168, 2048)  - LoFi, L1, batched
+#   - InputA: (1, 8, 128, 2048), InputB: (1, 8, 2048, 7168)  - LoFi, L1, batched
+# =============================================================================
+
+
+def run_test_matmul_dram_sharded(
+    device,
+    M,
+    K,
+    N,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+):
+    """
+    Test matmul with DRAM sharded weights using MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig.
+
+    This test mirrors the model's approach in MLP.decode_model_config:
+    - InputA (activation) is L1 width sharded
+    - InputB (weights) is DRAM width sharded
+    - Uses the same helper functions as the model
+    """
+    # Get device grid info (same as model does)
+    max_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    dram_grid_size = device.dram_grid_size()
+
+    # Calculate core counts using the same function as the model
+    # Input tensor shards across K dimension, output across N dimension
+    input_num_cores = max(get_activation_sharding_core_counts_for_dram_matmul(K, max_num_cores))
+    output_num_cores = max(get_activation_sharding_core_counts_for_dram_matmul(N, max_num_cores))
+
+    in0_shape = [1, 1, M, K]
+    in1_shape = [1, 1, K, N]
+
+    logger.info(f"Testing M={M}, K={K}, N={N}")
+    logger.info(
+        f"max_num_cores={max_num_cores}, input_num_cores={input_num_cores}, output_num_cores={output_num_cores}"
+    )
+
+    # Get program config using the model's helper function
+    program_config = get_dram_sharded_matmul_config(M, K, N, input_num_cores, output_num_cores)
+    logger.info(
+        f"Program config: in0_block_w={program_config.in0_block_w}, per_core_M={program_config.per_core_M}, per_core_N={program_config.per_core_N}"
+    )
+
+    # Get weight memory config using the model's helper function
+    in1_mem_config = dram_sharded_weight_config(K, N, dram_grid_size)
+    logger.info(f"Weight memory config: {in1_mem_config}")
+
+    # Create input activation memory config (L1 width sharded) - same as model
+    in0_shard_shape = (
+        ttnn.core.roundup(M, ttnn.TILE_SIZE),
+        ttnn.core.roundup(K // input_num_cores, ttnn.TILE_SIZE),
+    )
+    in0_mem_config = ttnn.create_sharded_memory_config_(
+        shape=in0_shard_shape,
+        core_grid=ttnn.num_cores_to_corerangeset(
+            input_num_cores,
+            ttnn.CoreCoord(device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y),
+            row_wise=True,
+        ),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    logger.info(f"Activation input memory config: {in0_mem_config}")
+
+    # Output memory config (L1 width sharded) - same as model
+    out_shard_shape = (
+        ttnn.core.roundup(M, ttnn.TILE_SIZE),
+        ttnn.core.roundup(N // output_num_cores, ttnn.TILE_SIZE),
+    )
+    out_mem_config = ttnn.create_sharded_memory_config_(
+        shape=out_shard_shape,
+        core_grid=ttnn.num_cores_to_corerangeset(
+            output_num_cores,
+            ttnn.CoreCoord(device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y),
+            row_wise=True,
+        ),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    # Interleaved config for initial tensor creation and final comparison
+    interleaved_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+
+    # Create input tensors
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in1 = torch.randn(in1_shape).bfloat16().float()
+
+    # Convert activation to TT tensor and shard to L1
+    in0_t = ttnn.from_torch(
+        in0, dtype=in0_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=interleaved_mem_config
+    )
+    in0_t = ttnn.to_memory_config(in0_t, in0_mem_config)
+
+    # Convert weight to TT tensor with DRAM sharding (using model's memory config)
+    in1_t = ttnn.from_torch(in1, dtype=in1_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in1_mem_config)
+
+    # Run linear (same as model uses ttnn.linear)
+    output_t = ttnn.linear(
+        in0_t,
+        in1_t,
+        program_config=program_config,
+        memory_config=out_mem_config,
+        dtype=out_dtype,
+        compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+    )
+
+    # Convert back to interleaved for comparison
+    output_t = ttnn.sharded_to_interleaved(output_t, interleaved_mem_config)
+
+    # Reference computation
+    pt_out = in0 @ in1
+
+    # Get output and compare
+    tt_out = ttnn.to_torch(output_t)
+
+    passing, output = comp_pcc(pt_out, tt_out)
+    logger.info(output)
+    assert passing
+
+
+# =============================================================================
+# Reference testcases the DRAM sharded matmuls
+# Uses L1 WIDTH_SHARDED for activations, DRAM WIDTH_SHARDED for weights
+#
+# Test cases (see test_matmul_dram_sharded):
+#   - InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 2304) - in0_block_w=4, per_core_M=1, per_core_N=1
+#   - InputA: (1, 1, 32, 2304), InputB: (1, 1, 2304, 7168) - in0_block_w=1, per_core_M=1, per_core_N=8
+#   - InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 256)  - in0_block_w=4, per_core_M=1, per_core_N=1
+#   - InputA: (1, 1, 32, 256),  InputB: (1, 1, 256, 7168)  - in0_block_w=1, per_core_M=1, per_core_N=8
+#   - InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 4064) - in0_block_w=4, per_core_M=1, per_core_N=127
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "M, K, N",
+    [
+        # InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 2304) - MLP w1/w3 style
+        (32, 7168, 2304),
+        # InputA: (1, 1, 32, 2304), InputB: (1, 1, 2304, 7168) - MLP w2 style
+        (32, 2304, 7168),
+        # InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 256) - smaller output
+        (32, 7168, 256),
+        # InputA: (1, 1, 32, 256), InputB: (1, 1, 256, 7168) - smaller input
+        (32, 256, 7168),
+        # InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 4064) - LM head style
+        (32, 7168, 4064),
+    ],
+    ids=[
+        "32x7168x2304_mlp_w1_style",
+        "32x2304x7168_mlp_w2_style",
+        "32x7168x256_small_output",
+        "32x256x7168_small_input",
+        "32x7168x4064_lm_head_style",
+    ],
+)
+@pytest.mark.parametrize(
+    "in0_dtype, in1_dtype, out_dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat16),
+    ],
+    ids=["bf16_bf4b_bf16"],
+)
+def test_matmul_dram_sharded(
+    device,
+    M,
+    K,
+    N,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+):
+    run_test_matmul_dram_sharded(
+        device,
+        M,
+        K,
+        N,
+        in0_dtype,
+        in1_dtype,
+        out_dtype,
+    )
+
+
+def run_test_matmul_interleaved(
+    device,
+    in0_shape,
+    in1_shape,
+    in0_dtype,
+    in1_dtype,
+    out_dtype,
+    in0_mem_config,
+    in1_mem_config,
+    out_mem_config,
+    compute_kernel_config,
+):
+    """
+    Test matmul with interleaved memory configs (no DRAM sharded program config).
+
+    Uses the same pre-defined compute kernel configs from config_helpers.py as the model.
+    """
+    logger.info(f"Testing in0_shape={in0_shape}, in1_shape={in1_shape}")
+    logger.info(f"in0_dtype={in0_dtype}, in1_dtype={in1_dtype}, out_dtype={out_dtype}")
+    logger.info(f"in0_mem={in0_mem_config}, in1_mem={in1_mem_config}, out_mem={out_mem_config}")
+    logger.info(f"compute_kernel_config={compute_kernel_config}")
+
+    # Create input tensors
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in1 = torch.randn(in1_shape).bfloat16().float()
+
+    # Convert to TT tensors
+    in0_t = ttnn.from_torch(in0, dtype=in0_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in0_mem_config)
+    in1_t = ttnn.from_torch(in1, dtype=in1_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in1_mem_config)
+
+    # Run matmul - no explicit program_config, let it auto-select
+    # Uses pre-defined compute kernel configs from config_helpers.py (same as model)
+    output_t = ttnn.matmul(
+        in0_t,
+        in1_t,
+        memory_config=out_mem_config,
+        dtype=out_dtype,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    # Reference computation
+    pt_out = in0 @ in1
+
+    # Get output and compare
+    tt_out = ttnn.to_torch(output_t)
+
+    passing, output = comp_pcc(pt_out, tt_out)
+    logger.info(output)
+    assert passing
+
+
+# Pre-defined memory configs for interleaved tests
+DRAM_INTERLEAVED = ttnn.MemoryConfig(
+    memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+    buffer_type=ttnn.BufferType.DRAM,
+)
+L1_INTERLEAVED = ttnn.MemoryConfig(
+    memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+    buffer_type=ttnn.BufferType.L1,
+)
+
+
+@pytest.mark.parametrize(
+    "in0_shape, in1_shape, in0_dtype, in1_dtype, in0_mem_config, in1_mem_config, out_mem_config, compute_kernel_config",
+    [
+        # HiFi2 FP16 cases with DRAM interleaved (uses COMPUTE_KERNEL_CONFIG_HIFI2_FP16)
+        # InputA: (1, 1, 32, 896), InputB: (1, 1, 896, 1536)
+        (
+            (1, 1, 32, 896),
+            (1, 1, 896, 1536),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # InputA: (1, 1, 32, 1536), InputB: (1, 1, 1536, 3072)
+        (
+            (1, 1, 32, 1536),
+            (1, 1, 1536, 3072),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # InputA: (1, 16, 32, 128), InputB: (1, 16, 128, 512) - batched
+        (
+            (1, 16, 32, 128),
+            (1, 16, 128, 512),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # InputA: (1, 1, 32, 896), InputB: (1, 1, 896, 576)
+        (
+            (1, 1, 32, 896),
+            (1, 1, 896, 576),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # InputA: (1, 16, 32, 512), InputB: (1, 16, 512, 128) - batched
+        (
+            (1, 16, 32, 512),
+            (1, 16, 512, 128),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # InputA: (1, 1, 32, 16384), InputB: (1, 1, 16384, 896)
+        (
+            (1, 1, 32, 16384),
+            (1, 1, 16384, 896),
+            ttnn.bfloat16,
+            ttnn.bfloat8_b,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2_FP16,
+        ),
+        # HiFi2 with L1 interleaved input and fp32_dest_acc_en (uses COMPUTE_KERNEL_CONFIG_HIFI2)
+        # InputA: (1, 1, 32, 7168), InputB: (1, 1, 7168, 256)
+        (
+            (1, 1, 32, 7168),
+            (1, 1, 7168, 256),
+            ttnn.bfloat16,
+            ttnn.bfloat16,
+            L1_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            L1_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_HIFI2,
+        ),
+        # LoFi cases with L1 interleaved - batched (uses COMPUTE_KERNEL_CONFIG_LOFI)
+        # InputA: (1, 8, 128, 7168), InputB: (1, 8, 7168, 2048)
+        (
+            (1, 8, 128, 7168),
+            (1, 8, 7168, 2048),
+            ttnn.bfloat16,
+            ttnn.bfloat4_b,
+            L1_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            L1_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_LOFI,
+        ),
+        # InputA: (1, 8, 128, 2048), InputB: (1, 8, 2048, 7168)
+        (
+            (1, 8, 128, 2048),
+            (1, 8, 2048, 7168),
+            ttnn.bfloat16,
+            ttnn.bfloat4_b,
+            L1_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            L1_INTERLEAVED,
+            COMPUTE_KERNEL_CONFIG_LOFI,
+        ),
+    ],
+    ids=[
+        "32x896x1536_HiFi2_FP16_DRAM",
+        "32x1536x3072_HiFi2_FP16_DRAM",
+        "16x32x128x512_HiFi2_FP16_DRAM_batched",
+        "32x896x576_HiFi2_FP16_DRAM",
+        "16x32x512x128_HiFi2_FP16_DRAM_batched",
+        "32x16384x896_HiFi2_FP16_DRAM",
+        "32x7168x256_HiFi2_L1_fp32acc",
+        "8x128x7168x2048_LoFi_L1_batched",
+        "8x128x2048x7168_LoFi_L1_batched",
+    ],
+)
+@pytest.mark.parametrize(
+    "out_dtype",
+    [ttnn.bfloat16],
+    ids=["out_bf16"],
+)
+def test_matmul_interleaved(
+    device,
+    in0_shape,
+    in1_shape,
+    in0_dtype,
+    in1_dtype,
+    in0_mem_config,
+    in1_mem_config,
+    out_mem_config,
+    compute_kernel_config,
+    out_dtype,
+):
+    run_test_matmul_interleaved(
+        device,
+        in0_shape,
+        in1_shape,
+        in0_dtype,
+        in1_dtype,
+        out_dtype,
+        in0_mem_config,
+        in1_mem_config,
+        out_mem_config,
+        compute_kernel_config,
+    )

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -383,6 +383,7 @@ def run_test_matmul_interleaved(
     logger.info(f"in0_mem={in0_mem_config}, in1_mem={in1_mem_config}, out_mem={out_mem_config}")
     logger.info(f"compute_kernel_config={compute_kernel_config}")
 
+    torch.manual_seed(1234)
     # Create input tensors
     in0 = torch.randn(in0_shape).bfloat16().float()
     in1 = torch.randn(in1_shape).bfloat16().float()

--- a/models/demos/deepseek_v3/tests/unit/test_reduce.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reduce.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import ttnn
+from models.demos.deepseek_v3.tests.unit.utils import random_torch_tensor, run_test
 from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_SDPA
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -58,3 +59,54 @@ def test_reduce_sum_single_device(device, shape):
     tt_output_torch = ttnn.to_torch(tt_output)
 
     assert_with_pcc(torch_output, tt_output_torch, pcc=0.99)
+
+
+@pytest.mark.parametrize("mesh_device", [(8, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 32, 8, 2),
+        (1, 1, 32, 8),
+    ],
+    ids=["32x8x2", "1x32x8"],
+)
+@pytest.mark.parametrize("enable_trace", [False, True])
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 10000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
+def test_reduce_sum_mesh_device(mesh_device, shape, enable_trace, device_params):
+    """
+    Mesh device sum reduction test.
+
+    Test configuration:
+    - Input: bfloat16, L1 INTERLEAVED, TILE layout
+    - Reduce dim: W (width, dim=-1)
+    - Output: bfloat16, L1 INTERLEAVED
+    - HiFi4 compute kernel (math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False)
+    """
+    torch_input = random_torch_tensor(ttnn.bfloat16, shape)
+    torch_output = torch_input.sum(dim=-1, keepdim=True)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    def run_op():
+        tt_output = ttnn.sum(
+            tt_input,
+            dim=-1,
+            keepdim=True,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_SDPA,
+        )
+        return tt_output
+
+    def check_op(tt_output):
+        assert_with_pcc(torch_output, tt_output, pcc=0.99)
+
+    run_test(mesh_device, run_op, check_op, enable_trace)

--- a/models/demos/deepseek_v3/tests/unit/test_reduce.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reduce.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_SDPA
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 32, 8, 2),
+        (1, 1, 32, 8),
+    ],
+    ids=["32x8x2", "1x32x8"],
+)
+def test_reduce_sum_single_device(device, shape):
+    """
+    Single device sum reduction test.
+
+    Test configuration:
+    - Input: bfloat16, L1 INTERLEAVED, TILE layout
+    - Reduce dim: W (width, dim=-1)
+    - Output: bfloat16, L1 INTERLEAVED
+    - HiFi4 compute kernel (math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False)
+    """
+    torch.manual_seed(1234)
+
+    # Create input tensor
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+
+    # Reference: sum along width dimension
+    torch_output = torch_input.sum(dim=-1, keepdim=True)
+
+    # Prepare input - L1 INTERLEAVED, TILE layout
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    # Run sum reduction along width dimension
+    tt_output = ttnn.sum(
+        tt_input,
+        dim=-1,
+        keepdim=True,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        compute_kernel_config=COMPUTE_KERNEL_CONFIG_SDPA,
+    )
+
+    # Get output and compare
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    assert_with_pcc(torch_output, tt_output_torch, pcc=0.99)

--- a/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
+++ b/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
@@ -1,0 +1,594 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+# =============================================================================
+# Reference tests for distributed RMSNorm operations
+#
+# The distributed RMSNorm is split into two phases:
+#   1. rms_norm_pre_all_gather: Computes local mean(x^2) statistics
+#   2. rms_norm_post_all_gather: Applies normalization using gathered stats
+#
+# Test cases based on model usage:
+#   - Input: (1, 1, 32, 896), L1 WIDTH_SHARDED, grid=(4,7)
+#   - HiFi4 compute kernel
+#   - LayerNormShardedMultiCoreProgramConfig
+# =============================================================================
+
+
+def reference_rmsnorm(x: torch.Tensor, gamma: torch.Tensor, epsilon: float) -> torch.Tensor:
+    """Reference RMSNorm implementation in PyTorch."""
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + epsilon) * gamma
+
+
+def run_test_rmsnorm_pre_all_gather(
+    device,
+    inp_shape,
+    n_devices,
+    dtype,
+    use_sharded,
+):
+    """
+    Test rms_norm_pre_all_gather operation.
+
+    This computes the local mean(x^2) statistics that will be gathered across devices.
+    The output is a stats tensor with shape [..., 32 * n_devices] containing the partial sums.
+    """
+    torch.manual_seed(1234)
+
+    logger.info(f"Testing rms_norm_pre_all_gather: shape={inp_shape}, n_devices={n_devices}, dtype={dtype}")
+
+    # Compute kernel config - HiFi4 for accuracy
+    kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Create input tensor
+    inp = torch.randn(inp_shape).bfloat16().float()
+
+    # Split input across simulated devices
+    inp_chunked = inp.chunk(n_devices, dim=-1)
+
+    # Compute expected partial sum(x^2) for each chunk
+    # Each device computes the sum of squares for its portion
+    expected_stats = []
+    for chunk in inp_chunked:
+        sum_x2 = chunk.pow(2).sum(dim=-1, keepdim=True)
+        expected_stats.append(sum_x2)
+
+    # Memory configs
+    if use_sharded:
+        # Create L1 width-sharded config similar to model usage
+        grid_x, grid_y = 4, 7
+        num_cores = grid_x * grid_y
+        shard_width = ttnn.core.roundup(inp_shape[-1] // n_devices // num_cores, ttnn.TILE_SIZE)
+        shard_height = ttnn.core.roundup(inp_shape[-2], ttnn.TILE_SIZE)
+
+        in_mem_config = ttnn.create_sharded_memory_config_(
+            shape=(shard_height, shard_width),
+            core_grid=ttnn.num_cores_to_corerangeset(
+                num_cores,
+                ttnn.CoreCoord(grid_x, grid_y),
+                row_wise=True,
+            ),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        # Program config for sharded input
+        program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=(grid_x, grid_y),
+            subblock_w=1,
+            block_h=ttnn.core.divup(shard_height, ttnn.TILE_SIZE),
+            block_w=ttnn.core.divup(shard_width, ttnn.TILE_SIZE),
+            inplace=False,
+        )
+    else:
+        in_mem_config = ttnn.DRAM_MEMORY_CONFIG
+        program_config = ttnn.LayerNormDefaultProgramConfig()
+
+    all_pass = True
+
+    # Test pre_all_gather for each simulated device's chunk
+    for d in range(n_devices):
+        chunk = inp_chunked[d]
+
+        # Convert to TT tensor
+        if use_sharded:
+            tt_inp = ttnn.from_torch(
+                chunk, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
+            tt_inp = ttnn.to_memory_config(tt_inp, in_mem_config)
+        else:
+            tt_inp = ttnn.from_torch(
+                chunk, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_mem_config
+            )
+
+        # Run pre_all_gather
+        tt_stats = ttnn.rms_norm_pre_all_gather(
+            tt_inp,
+            compute_kernel_config=kernel_config,
+            program_config=program_config,
+            dtype=ttnn.bfloat16,
+        )
+
+        # Get output
+        tt_stats_cpu = ttnn.to_torch(tt_stats)
+
+        # The output contains the partial sum(x^2) in specific positions
+        # Extract the first value which contains the sum
+        tt_sum_x2 = tt_stats_cpu[..., 0:1]
+
+        # Compare
+        passing, output_str = comp_pcc(expected_stats[d], tt_sum_x2, pcc=0.99)
+        logger.info(f"Device {d}: {output_str}")
+        all_pass = all_pass and passing
+
+    assert all_pass, "rms_norm_pre_all_gather test failed"
+
+
+def run_test_rmsnorm_post_all_gather(
+    device,
+    inp_shape,
+    n_devices,
+    input_dtype,
+    output_dtype,
+    use_sharded,
+):
+    """
+    Test rms_norm_post_all_gather operation.
+
+    This applies the RMSNorm using the gathered statistics from all devices.
+    It mirrors the distributed layernorm test pattern.
+    """
+    torch.manual_seed(1234)
+
+    logger.info(f"Testing rms_norm_post_all_gather: shape={inp_shape}, n_devices={n_devices}")
+    logger.info(f"input_dtype={input_dtype}, output_dtype={output_dtype}, use_sharded={use_sharded}")
+
+    # Compute kernel config - HiFi4 for accuracy
+    kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Create full input tensor and gamma weights
+    full_inp = torch.randn(inp_shape).bfloat16().float()
+    full_gamma = torch.rand(inp_shape[-1]).bfloat16().float() * 2 - 1
+
+    # Split across simulated devices
+    inp_chunked = full_inp.chunk(n_devices, dim=-1)
+    gamma_chunked = full_gamma.chunk(n_devices, dim=-1)
+
+    # Compute partial statistics for each chunk (sum of x^2)
+    partial_sum_x2 = [chunk.pow(2).sum(dim=-1, keepdim=True) for chunk in inp_chunked]
+
+    # Create the gathered stats tensor as the post_all_gather op expects
+    # Stats tensor contains sum(x^2) values from all devices, padded to tile width
+    stats_tiles = torch.zeros(inp_shape[:-1] + (32 * n_devices,))
+    for idx, sum_x2 in enumerate(partial_sum_x2):
+        stats_tiles[..., idx * 32 : idx * 32 + 1] = sum_x2
+
+    epsilon = 1e-6
+
+    # Reference output (full RMSNorm)
+    ref_out = reference_rmsnorm(full_inp, full_gamma, epsilon)
+    ref_chunks = ref_out.chunk(n_devices, dim=-1)
+
+    # Memory configs
+    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    if use_sharded:
+        grid_x, grid_y = 4, 7
+        num_cores = grid_x * grid_y
+        shard_width = ttnn.core.roundup(inp_shape[-1] // n_devices // num_cores, ttnn.TILE_SIZE)
+        shard_height = ttnn.core.roundup(inp_shape[-2], ttnn.TILE_SIZE)
+
+        in_mem_config = ttnn.create_sharded_memory_config_(
+            shape=(shard_height, shard_width),
+            core_grid=ttnn.num_cores_to_corerangeset(
+                num_cores,
+                ttnn.CoreCoord(grid_x, grid_y),
+                row_wise=True,
+            ),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=(grid_x, grid_y),
+            subblock_w=1,
+            block_h=ttnn.core.divup(shard_height, ttnn.TILE_SIZE),
+            block_w=ttnn.core.divup(shard_width, ttnn.TILE_SIZE),
+            inplace=False,
+        )
+    else:
+        in_mem_config = dram_memcfg
+        program_config = ttnn.LayerNormDefaultProgramConfig()
+
+    all_pass = True
+
+    # Test post_all_gather for each simulated device's chunk
+    for d in range(n_devices):
+        # Prepare input chunk
+        tt_inp = ttnn.from_torch(
+            inp_chunked[d],
+            dtype=input_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+        if use_sharded:
+            tt_inp = ttnn.to_memory_config(tt_inp, in_mem_config)
+
+        # Prepare gamma weights (ROW_MAJOR layout as per model)
+        tt_gamma = ttnn.from_torch(
+            gamma_chunked[d].reshape(1, 1, -1, 32),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+
+        # Prepare gathered stats
+        tt_stats = ttnn.from_torch(
+            stats_tiles,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+
+        # Run post_all_gather
+        tt_out = ttnn.rms_norm_post_all_gather(
+            tt_inp,
+            tt_stats,
+            epsilon=epsilon,
+            weight=tt_gamma,
+            compute_kernel_config=kernel_config,
+            program_config=program_config,
+            dtype=output_dtype,
+        )
+
+        # Get output and compare
+        tt_out_cpu = ttnn.to_torch(tt_out)
+
+        passing, output_str = comp_pcc(ref_chunks[d], tt_out_cpu, pcc=0.99)
+        logger.info(f"Device {d}: {output_str}")
+        all_pass = all_pass and passing
+
+    assert all_pass, "rms_norm_post_all_gather test failed"
+
+
+def run_test_rmsnorm_distributed_e2e(
+    device,
+    inp_shape,
+    n_devices,
+    input_dtype,
+    output_dtype,
+    use_sharded,
+):
+    """
+    End-to-end test of distributed RMSNorm (pre_all_gather + post_all_gather).
+
+    This simulates the full distributed RMSNorm flow as used in the model.
+    """
+    torch.manual_seed(1234)
+
+    logger.info(f"Testing distributed RMSNorm E2E: shape={inp_shape}, n_devices={n_devices}")
+
+    # Compute kernel config
+    kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    # Create full input tensor and gamma weights
+    full_inp = torch.randn(inp_shape).bfloat16().float()
+    full_gamma = torch.rand(inp_shape[-1]).bfloat16().float() * 2 - 1
+
+    # Split across simulated devices
+    inp_chunked = full_inp.chunk(n_devices, dim=-1)
+    gamma_chunked = full_gamma.chunk(n_devices, dim=-1)
+
+    epsilon = 1e-6
+
+    # Reference output
+    ref_out = reference_rmsnorm(full_inp, full_gamma, epsilon)
+    ref_chunks = ref_out.chunk(n_devices, dim=-1)
+
+    # Memory configs
+    dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    if use_sharded:
+        grid_x, grid_y = 4, 7
+        num_cores = grid_x * grid_y
+        shard_width = ttnn.core.roundup(inp_shape[-1] // n_devices // num_cores, ttnn.TILE_SIZE)
+        shard_height = ttnn.core.roundup(inp_shape[-2], ttnn.TILE_SIZE)
+
+        in_mem_config = ttnn.create_sharded_memory_config_(
+            shape=(shard_height, shard_width),
+            core_grid=ttnn.num_cores_to_corerangeset(
+                num_cores,
+                ttnn.CoreCoord(grid_x, grid_y),
+                row_wise=True,
+            ),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=(grid_x, grid_y),
+            subblock_w=1,
+            block_h=ttnn.core.divup(shard_height, ttnn.TILE_SIZE),
+            block_w=ttnn.core.divup(shard_width, ttnn.TILE_SIZE),
+            inplace=False,
+        )
+    else:
+        in_mem_config = dram_memcfg
+        program_config = ttnn.LayerNormDefaultProgramConfig()
+
+    # Step 1: Run pre_all_gather on each chunk and collect stats
+    all_stats = []
+    tt_inputs = []
+
+    for d in range(n_devices):
+        tt_inp = ttnn.from_torch(
+            inp_chunked[d],
+            dtype=input_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+        if use_sharded:
+            tt_inp = ttnn.to_memory_config(tt_inp, in_mem_config)
+        tt_inputs.append(tt_inp)
+
+        # Run pre_all_gather
+        tt_stats = ttnn.rms_norm_pre_all_gather(
+            tt_inp,
+            compute_kernel_config=kernel_config,
+            program_config=program_config,
+            dtype=ttnn.bfloat16,
+        )
+        all_stats.append(ttnn.to_torch(tt_stats))
+
+    # Step 2: Simulate all-gather by concatenating stats
+    # In real distributed setting, this would be done via CCL
+    gathered_stats = torch.cat(all_stats, dim=-1)
+
+    all_pass = True
+
+    # Step 3: Run post_all_gather on each chunk
+    for d in range(n_devices):
+        # Recreate input tensor (or reuse if still on device)
+        tt_inp = ttnn.from_torch(
+            inp_chunked[d],
+            dtype=input_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+        if use_sharded:
+            tt_inp = ttnn.to_memory_config(tt_inp, in_mem_config)
+
+        tt_gamma = ttnn.from_torch(
+            gamma_chunked[d].reshape(1, 1, -1, 32),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+
+        tt_gathered_stats = ttnn.from_torch(
+            gathered_stats,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=dram_memcfg,
+        )
+
+        # Run post_all_gather
+        tt_out = ttnn.rms_norm_post_all_gather(
+            tt_inp,
+            tt_gathered_stats,
+            epsilon=epsilon,
+            weight=tt_gamma,
+            compute_kernel_config=kernel_config,
+            program_config=program_config,
+            dtype=output_dtype,
+        )
+
+        tt_out_cpu = ttnn.to_torch(tt_out)
+
+        passing, output_str = comp_pcc(ref_chunks[d], tt_out_cpu, pcc=0.99)
+        logger.info(f"Device {d}: {output_str}")
+        all_pass = all_pass and passing
+
+    assert all_pass, "Distributed RMSNorm E2E test failed"
+
+
+# =============================================================================
+# Test: rms_norm_pre_all_gather
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "inp_shape",
+    [
+        (1, 1, 32, 896),  # From model spec - decode batch size
+        (1, 1, 32, 7168),  # Full hidden size (single device)
+        (1, 1, 128, 8192),  # Larger sequence
+    ],
+    ids=["32x896", "32x7168", "128x8192"],
+)
+@pytest.mark.parametrize(
+    "n_devices",
+    [1, 4, 8],
+    ids=["1dev", "4dev", "8dev"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.bfloat16],
+    ids=["bf16"],
+)
+@pytest.mark.parametrize(
+    "use_sharded",
+    [False, True],
+    ids=["interleaved", "sharded"],
+)
+def test_rmsnorm_pre_all_gather(
+    device,
+    inp_shape,
+    n_devices,
+    dtype,
+    use_sharded,
+):
+    # Skip if input can't be evenly divided
+    if inp_shape[-1] % n_devices != 0:
+        pytest.skip(f"Input width {inp_shape[-1]} not divisible by {n_devices} devices")
+
+    # Skip sharded tests for very small per-device widths
+    per_device_width = inp_shape[-1] // n_devices
+    if use_sharded and per_device_width < 32:
+        pytest.skip(f"Per-device width {per_device_width} too small for sharding")
+
+    run_test_rmsnorm_pre_all_gather(
+        device,
+        inp_shape,
+        n_devices,
+        dtype,
+        use_sharded,
+    )
+
+
+# =============================================================================
+# Test: rms_norm_post_all_gather
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "inp_shape",
+    [
+        (1, 1, 32, 896),  # From model spec
+        (1, 1, 32, 7168),  # Full hidden size
+        (1, 1, 128, 8192),  # Larger sequence
+    ],
+    ids=["32x896", "32x7168", "128x8192"],
+)
+@pytest.mark.parametrize(
+    "n_devices",
+    [1, 4, 8],
+    ids=["1dev", "4dev", "8dev"],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat16),
+    ],
+    ids=["bf16_bf16"],
+)
+@pytest.mark.parametrize(
+    "use_sharded",
+    [False, True],
+    ids=["interleaved", "sharded"],
+)
+def test_rmsnorm_post_all_gather(
+    device,
+    inp_shape,
+    n_devices,
+    input_dtype,
+    output_dtype,
+    use_sharded,
+):
+    # Skip if input can't be evenly divided
+    if inp_shape[-1] % n_devices != 0:
+        pytest.skip(f"Input width {inp_shape[-1]} not divisible by {n_devices} devices")
+
+    # Skip sharded tests for very small per-device widths
+    per_device_width = inp_shape[-1] // n_devices
+    if use_sharded and per_device_width < 32:
+        pytest.skip(f"Per-device width {per_device_width} too small for sharding")
+
+    run_test_rmsnorm_post_all_gather(
+        device,
+        inp_shape,
+        n_devices,
+        input_dtype,
+        output_dtype,
+        use_sharded,
+    )
+
+
+# =============================================================================
+# Test: Distributed RMSNorm End-to-End
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "inp_shape",
+    [
+        (1, 1, 32, 896),  # Model decode shape
+        (1, 1, 32, 7168),  # Full hidden size
+    ],
+    ids=["32x896", "32x7168"],
+)
+@pytest.mark.parametrize(
+    "n_devices",
+    [4, 8],
+    ids=["4dev", "8dev"],
+)
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (ttnn.bfloat16, ttnn.bfloat16),
+    ],
+    ids=["bf16_bf16"],
+)
+@pytest.mark.parametrize(
+    "use_sharded",
+    [False, True],
+    ids=["interleaved", "sharded"],
+)
+def test_rmsnorm_distributed_e2e(
+    device,
+    inp_shape,
+    n_devices,
+    input_dtype,
+    output_dtype,
+    use_sharded,
+):
+    # Skip if input can't be evenly divided
+    if inp_shape[-1] % n_devices != 0:
+        pytest.skip(f"Input width {inp_shape[-1]} not divisible by {n_devices} devices")
+
+    # Skip sharded tests for very small per-device widths
+    per_device_width = inp_shape[-1] // n_devices
+    if use_sharded and per_device_width < 32:
+        pytest.skip(f"Per-device width {per_device_width} too small for sharding")
+
+    run_test_rmsnorm_distributed_e2e(
+        device,
+        inp_shape,
+        n_devices,
+        input_dtype,
+        output_dtype,
+        use_sharded,
+    )

--- a/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
+++ b/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
@@ -387,7 +387,7 @@ def test_rmsnorm_distributed_mesh_device(mesh_device, enable_trace, device_param
     full_hidden_size = per_device_width * n_devices_row  # 7168
     inp_shape_per_device = (1, 1, 32, per_device_width)
     inp_shape_full = (1, 1, 32, full_hidden_size)
-    weight_shape_per_device = (1, 1, per_device_width // 32, 32)  # (1, 1, 28, 32)
+
     grid = ttnn.CoreGrid(x=4, y=7)
     epsilon = 1e-6
 

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -24,7 +24,7 @@ K_VALUE = 32
 @pytest.mark.parametrize(
     "shape",
     [
-        [1, 32, 32, 64],
+        [1, 32, 8, 64],  # Note: (1, 32, 32, 64) is the padded shape
         [1, 1, 32, 64],
         [1, 1, 32, 256],
     ],

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -1,0 +1,59 @@
+#  SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3.tests.unit.utils import random_torch_tensor, run_test
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+K_VALUE = 32
+TOPK_MEMORY_CONFIG = ttnn.L1_MEMORY_CONFIG
+SUB_CORE_GRIDS = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8, 9))])
+
+
+@pytest.mark.parametrize("mesh_device", [(8, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [32, 8, 64],
+        [1, 32, 64],
+        [1, 32, 256],
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("enable_trace", [False, True])
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 10000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
+)
+def test_topk(mesh_device, shape, dtype, enable_trace, device_params):
+    torch_input = random_torch_tensor(dtype, shape)
+    torch_values, _ = torch.topk(torch_input, k=K_VALUE, dim=-1, largest=True, sorted=True)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=TOPK_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    def run_op():
+        tt_values, _ = ttnn.topk(
+            tt_input,
+            k=K_VALUE,
+            dim=-1,
+            largest=True,
+            sorted=True,
+            memory_config=TOPK_MEMORY_CONFIG,
+            sub_core_grids=SUB_CORE_GRIDS,
+        )
+        return tt_values
+
+    def check_op(tt_output):
+        assert_with_pcc(torch_values, tt_output, 0.999)
+
+    run_test(mesh_device, run_op, check_op, enable_trace)

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -7,7 +7,6 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3.tests.unit.utils import random_torch_tensor, run_test
-from models.demos.deepseek_v3.utils.config_helpers import TOPK_MIN_WIDTH
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # Memory config matching model's decode mode (see MoEGate.model_config)
@@ -77,99 +76,13 @@ def test_topk_single_device(shape, dtype, device):
     assert cosine_sim > 0.99, f"Cosine similarity {cosine_sim} is less than 0.99"
 
 
-@pytest.mark.parametrize(
-    "shape, k",
-    [
-        # Width < TOPK_MIN_WIDTH (64) requires padding in model (see MoEGate.forward)
-        # Model pads with -inf: ttnn.pad(..., value=-float("inf"))
-        ([1, 1, 32, 32], 2),  # 32 < 64, needs padding
-        ([1, 1, 32, 16], 2),  # 16 < 64, needs padding
-        ([1, 1, 32, 48], 4),  # 48 < 64, needs padding
-    ],
-    ids=[
-        "width_32_needs_padding",
-        "width_16_needs_padding",
-        "width_48_needs_padding",
-    ],
-)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-def test_topk_with_padding(shape, k, dtype, device):
-    """
-    Test topk with padding for inputs smaller than TOPK_MIN_WIDTH.
-
-    The model pads inputs with width < TOPK_MIN_WIDTH (64) using -inf padding
-    before calling ttnn.topk (see MoEGate.forward):
-
-        if expert_scores_grouped.shape[3] < TOPK_MIN_WIDTH:
-            expert_scores_grouped = ttnn.pad(
-                expert_scores_grouped,
-                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_scores_grouped.shape[3])],
-                value=-float("inf"),
-            )
-
-    This test verifies the padding approach works correctly.
-    """
-    torch.manual_seed(1234)
-    original_width = shape[-1]
-    assert original_width < TOPK_MIN_WIDTH, f"Test expects width < {TOPK_MIN_WIDTH}"
-
-    torch_input = torch.rand(shape, dtype=torch.bfloat16)
-
-    # Reference: topk on original input
-    torch_values, _ = torch.topk(torch_input, k=k, dim=-1, largest=True, sorted=True)
-
-    # Pad input to TOPK_MIN_WIDTH (same as model does)
-    padded_shape = list(shape)
-    padded_shape[-1] = TOPK_MIN_WIDTH
-    torch_input_padded = torch.full(padded_shape, -float("inf"), dtype=torch.bfloat16)
-    torch_input_padded[..., :original_width] = torch_input
-
-    tt_input = ttnn.from_torch(
-        torch_input_padded,
-        dtype=dtype,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=TOPK_MEMORY_CONFIG,
-    )
-
-    tt_values, tt_indices = ttnn.topk(
-        tt_input,
-        k=k,
-        dim=-1,
-        largest=True,
-        sorted=True,
-        memory_config=TOPK_MEMORY_CONFIG,
-    )
-
-    tt_values_torch = ttnn.to_torch(tt_values)
-    tt_indices_torch = ttnn.to_torch(tt_indices).to(torch.int64)
-
-    # Check output shapes
-    expected_shape = list(padded_shape)
-    expected_shape[-1] = k
-    assert list(tt_values.shape) == expected_shape
-    assert list(tt_indices.shape) == expected_shape
-
-    # Values should match (padded -inf values shouldn't appear in top-k since k < original_width)
-    assert_with_pcc(torch_values, tt_values_torch, 0.999)
-
-    # Indices should be within original width (not pointing to padded region)
-    assert (tt_indices_torch < original_width).all(), "Indices should not point to padded region"
-
-
 @pytest.mark.parametrize("mesh_device", [(8, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "shape, k",
+    "shape",
     [
-        # Model-realistic shapes for mesh device tests
-        ([32, 8, 64], 8),  # batch=32, k=num_experts_per_tok
-        ([1, 32, 64], 4),  # k=topk_group
-        ([1, 32, 256], 8),  # larger width, k=num_experts_per_tok
-    ],
-    ids=[
-        "batch32_k8",
-        "batch1_k4",
-        "batch1_width256_k8",
+        [1, 32, 8, 64],  # Note: (1, 32, 32, 64) is the padded shape
+        [1, 1, 32, 64],
+        [1, 1, 32, 256],
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -177,14 +90,14 @@ def test_topk_with_padding(shape, k, dtype, device):
 @pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 10000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
-def test_topk_mesh_device(mesh_device, shape, k, dtype, enable_trace, device_params):
+def test_topk_mesh_device(mesh_device, shape, dtype, enable_trace, device_params):
     """
     Mesh device topk test with model-realistic shapes and k values.
 
     Uses SUB_CORE_GRIDS to limit the cores used, matching model usage patterns.
     """
     torch_input = random_torch_tensor(dtype, shape)
-    torch_values, _ = torch.topk(torch_input, k=k, dim=-1, largest=True, sorted=True)
+    torch_values, _ = torch.topk(torch_input, k=K_VALUE, dim=-1, largest=True, sorted=True)
 
     tt_input = ttnn.from_torch(
         torch_input,
@@ -198,7 +111,7 @@ def test_topk_mesh_device(mesh_device, shape, k, dtype, enable_trace, device_par
     def run_op():
         tt_values, _ = ttnn.topk(
             tt_input,
-            k=k,
+            k=K_VALUE,
             dim=-1,
             largest=True,
             sorted=True,

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -16,7 +16,7 @@ TOPK_MEMORY_CONFIG = ttnn.L1_MEMORY_CONFIG
 SUB_CORE_GRIDS = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8, 9))])
 
 
-# k=32 matches model usage patterns
+# k=32 matches the DeepSeek v3 MoE gating configuration, where the gate selects 32 experts per token.
 K_VALUE = 32
 
 

--- a/models/demos/deepseek_v3/tests/unit/test_topk.py
+++ b/models/demos/deepseek_v3/tests/unit/test_topk.py
@@ -7,20 +7,169 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3.tests.unit.utils import random_torch_tensor, run_test
+from models.demos.deepseek_v3.utils.config_helpers import TOPK_MIN_WIDTH
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-K_VALUE = 32
+# Memory config matching model's decode mode (see MoEGate.model_config)
 TOPK_MEMORY_CONFIG = ttnn.L1_MEMORY_CONFIG
+
+# Sub-core grids for mesh device tests
 SUB_CORE_GRIDS = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8, 9))])
+
+
+# k=32 matches model usage patterns
+K_VALUE = 32
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 32, 32, 64],
+        [1, 1, 32, 64],
+        [1, 1, 32, 256],
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_topk_single_device(shape, dtype, device):
+    """
+    Single device topk test.
+
+    The model uses L1_MEMORY_CONFIG for decode mode (see MoEGate.model_config).
+    """
+    torch.manual_seed(1234)
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+    torch_values, torch_indices = torch.topk(torch_input, k=K_VALUE, dim=-1, largest=True, sorted=True)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=TOPK_MEMORY_CONFIG,
+    )
+
+    tt_values, tt_indices = ttnn.topk(
+        tt_input,
+        k=K_VALUE,
+        dim=-1,
+        largest=True,
+        sorted=True,
+        memory_config=TOPK_MEMORY_CONFIG,
+    )
+
+    tt_values_torch = ttnn.to_torch(tt_values)
+    tt_indices_torch = ttnn.to_torch(tt_indices).to(torch.int64)
+
+    # Check output shapes
+    expected_shape = list(shape)
+    expected_shape[-1] = K_VALUE
+    assert list(tt_values.shape) == expected_shape
+    assert list(tt_indices.shape) == expected_shape
+
+    # Check values with PCC
+    assert_with_pcc(torch_values, tt_values_torch, 0.999)
+
+    # Check indices using cosine similarity on gathered values
+    # (PCC isn't ideal for indices since tied values can produce different orderings)
+    tt_gathered = torch.gather(torch_input, -1, tt_indices_torch)
+    cosine = torch.nn.CosineSimilarity(dim=-1)
+    cosine_sim = torch.mean(cosine(torch_values, tt_gathered))
+    assert cosine_sim > 0.99, f"Cosine similarity {cosine_sim} is less than 0.99"
+
+
+@pytest.mark.parametrize(
+    "shape, k",
+    [
+        # Width < TOPK_MIN_WIDTH (64) requires padding in model (see MoEGate.forward)
+        # Model pads with -inf: ttnn.pad(..., value=-float("inf"))
+        ([1, 1, 32, 32], 2),  # 32 < 64, needs padding
+        ([1, 1, 32, 16], 2),  # 16 < 64, needs padding
+        ([1, 1, 32, 48], 4),  # 48 < 64, needs padding
+    ],
+    ids=[
+        "width_32_needs_padding",
+        "width_16_needs_padding",
+        "width_48_needs_padding",
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_topk_with_padding(shape, k, dtype, device):
+    """
+    Test topk with padding for inputs smaller than TOPK_MIN_WIDTH.
+
+    The model pads inputs with width < TOPK_MIN_WIDTH (64) using -inf padding
+    before calling ttnn.topk (see MoEGate.forward):
+
+        if expert_scores_grouped.shape[3] < TOPK_MIN_WIDTH:
+            expert_scores_grouped = ttnn.pad(
+                expert_scores_grouped,
+                [(0, 0), (0, 0), (0, 0), (0, TOPK_MIN_WIDTH - expert_scores_grouped.shape[3])],
+                value=-float("inf"),
+            )
+
+    This test verifies the padding approach works correctly.
+    """
+    torch.manual_seed(1234)
+    original_width = shape[-1]
+    assert original_width < TOPK_MIN_WIDTH, f"Test expects width < {TOPK_MIN_WIDTH}"
+
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+
+    # Reference: topk on original input
+    torch_values, _ = torch.topk(torch_input, k=k, dim=-1, largest=True, sorted=True)
+
+    # Pad input to TOPK_MIN_WIDTH (same as model does)
+    padded_shape = list(shape)
+    padded_shape[-1] = TOPK_MIN_WIDTH
+    torch_input_padded = torch.full(padded_shape, -float("inf"), dtype=torch.bfloat16)
+    torch_input_padded[..., :original_width] = torch_input
+
+    tt_input = ttnn.from_torch(
+        torch_input_padded,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=TOPK_MEMORY_CONFIG,
+    )
+
+    tt_values, tt_indices = ttnn.topk(
+        tt_input,
+        k=k,
+        dim=-1,
+        largest=True,
+        sorted=True,
+        memory_config=TOPK_MEMORY_CONFIG,
+    )
+
+    tt_values_torch = ttnn.to_torch(tt_values)
+    tt_indices_torch = ttnn.to_torch(tt_indices).to(torch.int64)
+
+    # Check output shapes
+    expected_shape = list(padded_shape)
+    expected_shape[-1] = k
+    assert list(tt_values.shape) == expected_shape
+    assert list(tt_indices.shape) == expected_shape
+
+    # Values should match (padded -inf values shouldn't appear in top-k since k < original_width)
+    assert_with_pcc(torch_values, tt_values_torch, 0.999)
+
+    # Indices should be within original width (not pointing to padded region)
+    assert (tt_indices_torch < original_width).all(), "Indices should not point to padded region"
 
 
 @pytest.mark.parametrize("mesh_device", [(8, 8)], indirect=True)
 @pytest.mark.parametrize(
-    "shape",
+    "shape, k",
     [
-        [32, 8, 64],
-        [1, 32, 64],
-        [1, 32, 256],
+        # Model-realistic shapes for mesh device tests
+        ([32, 8, 64], 8),  # batch=32, k=num_experts_per_tok
+        ([1, 32, 64], 4),  # k=topk_group
+        ([1, 32, 256], 8),  # larger width, k=num_experts_per_tok
+    ],
+    ids=[
+        "batch32_k8",
+        "batch1_k4",
+        "batch1_width256_k8",
     ],
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -28,9 +177,14 @@ SUB_CORE_GRIDS = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.Co
 @pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 10000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
-def test_topk(mesh_device, shape, dtype, enable_trace, device_params):
+def test_topk_mesh_device(mesh_device, shape, k, dtype, enable_trace, device_params):
+    """
+    Mesh device topk test with model-realistic shapes and k values.
+
+    Uses SUB_CORE_GRIDS to limit the cores used, matching model usage patterns.
+    """
     torch_input = random_torch_tensor(dtype, shape)
-    torch_values, _ = torch.topk(torch_input, k=K_VALUE, dim=-1, largest=True, sorted=True)
+    torch_values, _ = torch.topk(torch_input, k=k, dim=-1, largest=True, sorted=True)
 
     tt_input = ttnn.from_torch(
         torch_input,
@@ -44,7 +198,7 @@ def test_topk(mesh_device, shape, dtype, enable_trace, device_params):
     def run_op():
         tt_values, _ = ttnn.topk(
             tt_input,
-            k=K_VALUE,
+            k=k,
             dim=-1,
             largest=True,
             sorted=True,

--- a/models/demos/deepseek_v3/tests/unit/utils.py
+++ b/models/demos/deepseek_v3/tests/unit/utils.py
@@ -57,7 +57,6 @@ def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
         ttnn.release_trace(mesh_device, trace_id)
 
         # Get results
-        # op_time = profiler.get("op_perf")
         profiler.print(units="us")
 
         # Every device executes the same op, check that each device returned the

--- a/models/demos/deepseek_v3/tests/unit/utils.py
+++ b/models/demos/deepseek_v3/tests/unit/utils.py
@@ -23,7 +23,6 @@ def random_torch_tensor(dtype, shape):
         return torch.rand(shape, dtype=torch.float32)
     if dtype == ttnn.bfloat16:
         return torch.rand(shape, dtype=torch.bfloat16)
-    # return torch.rand(shape).bfloat16().float()
     assert False, f"Unsupported dtype {dtype}"
 
 

--- a/models/demos/deepseek_v3/tests/unit/utils.py
+++ b/models/demos/deepseek_v3/tests/unit/utils.py
@@ -1,0 +1,68 @@
+#  SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.common.utility_functions import profiler
+
+
+# Generate tensor with random data
+def random_torch_tensor(dtype, shape):
+    torch.manual_seed(1234)
+    if dtype == ttnn.uint8:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.uint16:
+        return torch.randint(0, 100, shape).to(torch.int16)
+    if dtype == ttnn.int32:
+        return torch.randint(-(2**31), 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.uint32:
+        return torch.randint(0, 2**31, shape, dtype=torch.int32)
+    if dtype == ttnn.float32:
+        return torch.rand(shape, dtype=torch.float32)
+    if dtype == ttnn.bfloat16:
+        return torch.rand(shape, dtype=torch.bfloat16)
+    # return torch.rand(shape).bfloat16().float()
+    assert False, f"Unsupported dtype {dtype}"
+
+
+# This assumes all devices in the mesh contain identical output tensors.
+# Ex: this is true for all TM ops, not true for ReduceScatter CCL op.
+def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
+    if not enable_trace:
+        # Run the op
+        tt_outputs = run_op_proc()
+
+        # Every device executes the same op, check that each device returned the
+        # same result
+        for tt_output in ttnn.get_device_tensors(tt_outputs):
+            tt_output = ttnn.to_torch(tt_output)
+            check_op_proc(tt_output)
+    else:
+        profiler.clear()
+
+        # Compile the op
+        tt_outputs = run_op_proc()
+        tt_outputs.deallocate(True)
+
+        # Capture the trace
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        tt_outputs = run_op_proc()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+
+        # Execute trace
+        profiler.start("op_perf")
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        profiler.end("op_perf")
+        ttnn.release_trace(mesh_device, trace_id)
+
+        # Get results
+        # op_time = profiler.get("op_perf")
+        profiler.print(units="us")
+
+        # Every device executes the same op, check that each device returned the
+        # same result
+        for tt_output in ttnn.get_device_tensors(tt_outputs):
+            tt_output = ttnn.to_torch(tt_output)
+            check_op_proc(tt_output)

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -497,4 +497,6 @@ def system_name_to_mesh_shape(system_name: str) -> ttnn.MeshShape:
         return ttnn.MeshShape(8, 8)
     elif system_name == "QUAD":
         return ttnn.MeshShape(16, 8)
+    elif system_name == "T3K":
+        return ttnn.MeshShape(1, 8)
     raise ValueError(f"Unsupported system name: {system_name}. Supported values are DUAL, QUAD, and TG.")

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -499,4 +499,4 @@ def system_name_to_mesh_shape(system_name: str) -> ttnn.MeshShape:
         return ttnn.MeshShape(16, 8)
     elif system_name == "T3K":
         return ttnn.MeshShape(1, 8)
-    raise ValueError(f"Unsupported system name: {system_name}. Supported values are DUAL, QUAD, and TG.")
+    raise ValueError(f"Unsupported system name: {system_name}. Supported values are T3K, DUAL, QUAD, and TG.")


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/32463

### Problem description
Unit tests are needed to cover the fused/matmul/reduce ops used in Deepseek v3. 

### What's changed
Based on the Deepseek profiling results, unit tests were created to cover the ops used in it. This PR adds testing to cover:
- Matmul
- Reduce (sum)
- topk
- RMS norm
- Distributed RMS norm (pre/post all gather)

Single card versions are included (in case they are needed for development or debug) in addition to the mesh tests. 
The mesh tests run both with and without traces.
The conftest was edited to enable running these tests on a T3K as well.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20376992301)
- [x] New/Existing tests provide coverage for changes