### PR TITLE
Use module scoped device fixture to speed up ttnn pytests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -328,11 +328,11 @@ def device(request, device_params):
     ttnn.close_device(device)
 
 
-# Session-scoped device fixture for faster test execution
-# Use this for tests that don't require a fresh device state between runs
-# To use: replace `device` fixture with `device_session` in test function signature
-@pytest.fixture(scope="session")
-def device_session(request):
+# Module-scoped device fixture for faster test execution
+# Shares a single device across all tests in a module (file)
+# Use this for parameterized tests that don't need custom device_params
+@pytest.fixture(scope="module")
+def device_module(request):
     import ttnn
 
     device_id = request.config.getoption("device_id")

--- a/conftest.py
+++ b/conftest.py
@@ -940,7 +940,7 @@ def pytest_runtest_teardown(item, nextitem):
     if metal_timeout_enabled is not None or using_xdist:
         report = item.stash[phase_report_key]
         test_failed = report.get("call", None) and report["call"].failed
-        if test_failed:
+        if test_failed and hasattr(item, "pci_ids"):
             logger.info(f"In custom teardown, open device ids: {set(item.pci_ids)}")
             reset_tensix(set(item.pci_ids))
 

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -16,7 +16,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
 @pytest.mark.parametrize("layout", [ttnn.Layout.TILE, ttnn.Layout.ROW_MAJOR])
-def test_copy(shape, layout, dtype, device):
+def test_copy(shape, layout, dtype, device_module):
+    device = device_module
     torch.manual_seed(2005)
     torch_dtype = torch.int32
 
@@ -42,7 +43,8 @@ def test_copy(shape, layout, dtype, device):
         ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-def test_copy_block_sharded(device, layout, shape, shard_scheme, dtype):
+def test_copy_block_sharded(device_module, layout, shape, shard_scheme, dtype):
+    device = device_module
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)
@@ -97,7 +99,8 @@ def test_copy_block_sharded(device, layout, shape, shard_scheme, dtype):
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
     ],
 )
-def test_copy_width_sharded(device, layout, shape, shard_scheme, dtype):
+def test_copy_width_sharded(device_module, layout, shape, shard_scheme, dtype):
+    device = device_module
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)
@@ -156,7 +159,8 @@ def test_copy_width_sharded(device, layout, shape, shard_scheme, dtype):
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     ],
 )
-def test_copy_height_sharded(device, layout, shape, shard_scheme, dtype):
+def test_copy_height_sharded(device_module, layout, shape, shard_scheme, dtype):
+    device = device_module
     torch.manual_seed(1234)
     if dtype == ttnn.uint32:
         input_torch = torch.randint(1, 100, shape, dtype=torch.int32)

--- a/tests/ttnn/unit_tests/base_functionality/test_getitem.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_getitem.py
@@ -16,7 +16,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("width", [32, 96])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("on_device", [True, False])
-def test_getitem(device, batch_sizes, height, width, input_layout, on_device):
+def test_getitem(device_module, batch_sizes, height, width, input_layout, on_device):
+    device = device_module
     torch_input_tensor = torch.rand((*batch_sizes, height, width), dtype=torch.bfloat16)
 
     if batch_sizes:
@@ -51,7 +52,8 @@ def test_getitem(device, batch_sizes, height, width, input_layout, on_device):
 @pytest.mark.parametrize("width", [32, 96])
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("on_device", [True, False])
-def test_getitem_2d(device, height, width, input_layout, on_device):
+def test_getitem_2d(device_module, height, width, input_layout, on_device):
+    device = device_module
     torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
 
     torch_output_tensor = torch_input_tensor[:32]
@@ -80,7 +82,8 @@ def test_getitem_2d(device, height, width, input_layout, on_device):
 @pytest.mark.parametrize("height", [32, 64])
 @pytest.mark.parametrize("width", [32, 96])
 @pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT])
-def test_getitem_non_tile_boundary(device, batch_sizes, height, width, input_layout):
+def test_getitem_non_tile_boundary(device_module, batch_sizes, height, width, input_layout):
+    device = device_module
     torch_input_tensor = torch.rand((*batch_sizes, height, width), dtype=torch.bfloat16)
 
     if len(torch_input_tensor.shape) == 4:

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -20,8 +20,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize("enable_cache", [True])
-def test_ttnn_reshape_with_cache(device_module, enable_cache, input_shape, output_shape):
-    device = device_module
+def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape):
     if not enable_cache:
         device.disable_program_cache()
 
@@ -48,8 +47,7 @@ def test_ttnn_reshape_with_cache(device_module, enable_cache, input_shape, outpu
     ],
 )
 @pytest.mark.parametrize("enable_cache", [True])
-def test_tensor_reshape_with_cache(device_module, enable_cache, input_shape, output_shape):
-    device = device_module
+def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_shape):
     # respecting the parameters of the test, although cache should be active by default
     if not enable_cache:
         device.disable_and_clear_program_cache()
@@ -74,8 +72,7 @@ def test_tensor_reshape_with_cache(device_module, enable_cache, input_shape, out
 @pytest.mark.parametrize("c", [4])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [64])
-def test_reshape_sharded_rm(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_sharded_rm(device, n, c, h, w):
     pytest.skip("skipped to unblock P0 issue 16975 but needs to be fixed and removed for issue 17030")
 
     if device.core_grid.y < 8:
@@ -117,8 +114,7 @@ def test_reshape_sharded_rm(device_module, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_cw_div2_rm(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_cw_div2_rm(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c * 2, h, w // 2)
 
@@ -136,8 +132,7 @@ def test_reshape_cw_div2_rm(device_module, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_cw_mul2_rm(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_cw_mul2_rm(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c // 2, h, w * 2)
 
@@ -155,8 +150,7 @@ def test_reshape_cw_mul2_rm(device_module, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_hw_div2_rm(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_hw_div2_rm(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c, h * 2, w // 2)
 
@@ -174,8 +168,7 @@ def test_reshape_hw_div2_rm(device_module, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [8])
-def test_reshape_hw_mul2_rm(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_hw_mul2_rm(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c, h // 2, w * 2)
 
@@ -207,8 +200,7 @@ def run_reshape_hw_rm_with_program_cache(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [8])
-def test_reshape_hw_rm_with_program_cache(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_hw_rm_with_program_cache(device, n, c, h, w):
     for _ in range(2):
         run_reshape_hw_rm_with_program_cache(device, n, c, h, w)
         # dummy tensor to change tensor alloc
@@ -272,8 +264,7 @@ def test_reshape_in_4D(n, c, h, w):
 @pytest.mark.parametrize("c", [32, 64])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-def test_reshape_in_4D_on_device(device_module, n, c, h, w):
-    device = device_module
+def test_reshape_in_4D_on_device(device, n, c, h, w):
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(h, w, n, c)
 
@@ -287,8 +278,7 @@ def test_reshape_in_4D_on_device(device_module, n, c, h, w):
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
-def test_permute_reshape(device_module):
-    device = device_module
+def test_permute_reshape(device):
     input_shape = (1, 4, 64, 32)
     output_shape = (1, 64, 128)
 
@@ -307,8 +297,7 @@ def test_permute_reshape(device_module):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def test_reshape_with_negative_dim(device_module):
-    device = device_module
+def test_reshape_with_negative_dim(device):
     input_shape = (1, 4, 64, 32)
     output_shape = (1, -1, 2, 32)
     expected_output_shape = (1, 128, 2, 32)
@@ -327,8 +316,7 @@ def test_reshape_with_negative_dim(device_module):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-def test_reshape_tile_layout_mamba(device_module):
-    device = device_module
+def test_reshape_tile_layout_mamba(device):
     torch_input_tensor = torch.randn((1, 1, 2048, 64), dtype=torch.bfloat16)
     reshape_shape = (1, 2, 1024, 64)
     torch_result = torch_input_tensor.reshape(reshape_shape)
@@ -341,8 +329,7 @@ def test_reshape_tile_layout_mamba(device_module):
     assert_with_pcc(torch_result, output, 0.9999)
 
 
-def test_reshape_tile_layout_only_change_shape(device_module):
-    device = device_module
+def test_reshape_tile_layout_only_change_shape(device):
     torch_input_tensor = torch.randn((1, 64, 32, 4 * 32), dtype=torch.bfloat16)
     reshape_shape = (1, 32, 64, 4 * 32)
     torch_result = torch_input_tensor.reshape(reshape_shape)
@@ -386,8 +373,7 @@ def test_reshape_tile_layout_only_change_shape(device_module):
 @pytest.mark.parametrize(
     "dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.int32, ttnn.uint32), (torch.float32, ttnn.float32)]
 )
-def test_reshape_tile(device_module, input_shape, output_shape, layout, memory_config, dtype):
-    device = device_module
+def test_reshape_tile(device, input_shape, output_shape, layout, memory_config, dtype):
     if memory_config == ttnn.L1_MEMORY_CONFIG and input_shape in [(2888, 49, 96), (1, 1500, 1, 512)]:
         pytest.xfail("Test case is too big for L1")
 
@@ -435,8 +421,7 @@ def test_reshape_tile(device_module, input_shape, output_shape, layout, memory_c
         ),
     ),
 )
-def test_reshape_subgrid(device_module, input_shape, output_shape, layout, memory_config, dtype, sub_core_grids):
-    device = device_module
+def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_config, dtype, sub_core_grids):
     if memory_config == ttnn.L1_MEMORY_CONFIG and input_shape in [(2888, 49, 96), (1, 1500, 1, 512)]:
         pytest.xfail("Test case is too big for L1")
 
@@ -458,8 +443,7 @@ def test_reshape_subgrid(device_module, input_shape, output_shape, layout, memor
 
 
 @pytest.mark.parametrize("recreate_mapping_tensor", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
-def test_reshape_tile_program_cache(device_module, recreate_mapping_tensor):
-    device = device_module
+def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
     for input_shape, output_shape in ((1, 8, 8), (1, 16, 4)), ((16, 1, 5), (4, 2, 10)):
         for _ in range(3):
             torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
@@ -475,8 +459,7 @@ def test_reshape_tile_program_cache(device_module, recreate_mapping_tensor):
 
 
 # issue 15048
-def test_previously_failing_test(device_module):
-    device = device_module
+def test_previously_failing_test(device):
     src_shape = (1, 56, 56, 64)
     target_shape = (1, 1, 56 * 56, 64)
     torch_input_tensor = torch.randn(src_shape, dtype=torch.bfloat16)
@@ -505,8 +488,7 @@ def test_previously_failing_test(device_module):
         ((1, 128, 1), (1, 128)),
     ],
 )
-def test_reshape_host(input_shape, output_shape, device_module):
-    device = device_module
+def test_reshape_host(input_shape, output_shape, device):
     torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -527,8 +509,7 @@ def test_reshape_host(input_shape, output_shape, device_module):
         ((64, 32), (1, 1, 64, 32)),
     ],
 )
-def test_reshape_int(input_shape, output_shape, device_module):
-    device = device_module
+def test_reshape_int(input_shape, output_shape, device):
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -557,8 +538,7 @@ def test_reshape_int(input_shape, output_shape, device_module):
         ((16, 1, 32), (16, 1, 32)),
     ],
 )
-def test_fp32_support(input_shape, output_shape, device_module):
-    device = device_module
+def test_fp32_support(input_shape, output_shape, device):
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -589,8 +569,7 @@ def test_fp32_support(input_shape, output_shape, device_module):
         ((16, 1, 32), (16, 1, 32)),
     ],
 )
-def test_bf8_support(input_shape, output_shape, device_module):
-    device = device_module
+def test_bf8_support(input_shape, output_shape, device):
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -630,10 +609,7 @@ def test_bf8_support(input_shape, output_shape, device_module):
     "use_device, memory_config",
     [(True, None), (True, ttnn.L1_MEMORY_CONFIG), (False, None)],
 )
-def test_reshape_zero_element(
-    input_shape, output_shape, layout, ttnn_reshape, use_device, memory_config, device_module
-):
-    device = device_module
+def test_reshape_zero_element(input_shape, output_shape, layout, ttnn_reshape, use_device, memory_config, device):
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     if use_device:
         tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device, memory_config=memory_config)
@@ -670,12 +646,11 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
         assert tt_output_tensor.shape == torch.Size(output_shape)
 
 
-def test_reshape_oob(device_module):
+def test_reshape_oob(device):
     """
     Test proves that this reshape op writes data out of bounds, corrupting
     tensors at other memory locations.
     """
-    device = device_module
 
     def bf16_tensor(tensor):
         return ttnn.from_torch(tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -20,7 +20,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize("enable_cache", [True])
-def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape):
+def test_ttnn_reshape_with_cache(device_module, enable_cache, input_shape, output_shape):
+    device = device_module
     if not enable_cache:
         device.disable_program_cache()
 
@@ -47,7 +48,8 @@ def test_ttnn_reshape_with_cache(device, enable_cache, input_shape, output_shape
     ],
 )
 @pytest.mark.parametrize("enable_cache", [True])
-def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_shape):
+def test_tensor_reshape_with_cache(device_module, enable_cache, input_shape, output_shape):
+    device = device_module
     # respecting the parameters of the test, although cache should be active by default
     if not enable_cache:
         device.disable_and_clear_program_cache()
@@ -72,7 +74,8 @@ def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_sha
 @pytest.mark.parametrize("c", [4])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [64])
-def test_reshape_sharded_rm(device, n, c, h, w):
+def test_reshape_sharded_rm(device_module, n, c, h, w):
+    device = device_module
     pytest.skip("skipped to unblock P0 issue 16975 but needs to be fixed and removed for issue 17030")
 
     if device.core_grid.y < 8:
@@ -114,7 +117,8 @@ def test_reshape_sharded_rm(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_cw_div2_rm(device, n, c, h, w):
+def test_reshape_cw_div2_rm(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c * 2, h, w // 2)
 
@@ -132,7 +136,8 @@ def test_reshape_cw_div2_rm(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_cw_mul2_rm(device, n, c, h, w):
+def test_reshape_cw_mul2_rm(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c // 2, h, w * 2)
 
@@ -150,7 +155,8 @@ def test_reshape_cw_mul2_rm(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
-def test_reshape_hw_div2_rm(device, n, c, h, w):
+def test_reshape_hw_div2_rm(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c, h * 2, w // 2)
 
@@ -168,7 +174,8 @@ def test_reshape_hw_div2_rm(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [8])
-def test_reshape_hw_mul2_rm(device, n, c, h, w):
+def test_reshape_hw_mul2_rm(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(n, c, h // 2, w * 2)
 
@@ -200,7 +207,8 @@ def run_reshape_hw_rm_with_program_cache(device, n, c, h, w):
 @pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
 @pytest.mark.parametrize("w", [8])
-def test_reshape_hw_rm_with_program_cache(device, n, c, h, w):
+def test_reshape_hw_rm_with_program_cache(device_module, n, c, h, w):
+    device = device_module
     for _ in range(2):
         run_reshape_hw_rm_with_program_cache(device, n, c, h, w)
         # dummy tensor to change tensor alloc
@@ -264,7 +272,8 @@ def test_reshape_in_4D(n, c, h, w):
 @pytest.mark.parametrize("c", [32, 64])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-def test_reshape_in_4D_on_device(device, n, c, h, w):
+def test_reshape_in_4D_on_device(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor.reshape(h, w, n, c)
 
@@ -278,7 +287,8 @@ def test_reshape_in_4D_on_device(device, n, c, h, w):
     assert torch.allclose(torch_output_tensor, output_tensor)
 
 
-def test_permute_reshape(device):
+def test_permute_reshape(device_module):
+    device = device_module
     input_shape = (1, 4, 64, 32)
     output_shape = (1, 64, 128)
 
@@ -297,7 +307,8 @@ def test_permute_reshape(device):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def test_reshape_with_negative_dim(device):
+def test_reshape_with_negative_dim(device_module):
+    device = device_module
     input_shape = (1, 4, 64, 32)
     output_shape = (1, -1, 2, 32)
     expected_output_shape = (1, 128, 2, 32)
@@ -316,7 +327,8 @@ def test_reshape_with_negative_dim(device):
     assert_with_pcc(torch_output, tt_output, 0.9999)
 
 
-def test_reshape_tile_layout_mamba(device):
+def test_reshape_tile_layout_mamba(device_module):
+    device = device_module
     torch_input_tensor = torch.randn((1, 1, 2048, 64), dtype=torch.bfloat16)
     reshape_shape = (1, 2, 1024, 64)
     torch_result = torch_input_tensor.reshape(reshape_shape)
@@ -329,7 +341,8 @@ def test_reshape_tile_layout_mamba(device):
     assert_with_pcc(torch_result, output, 0.9999)
 
 
-def test_reshape_tile_layout_only_change_shape(device):
+def test_reshape_tile_layout_only_change_shape(device_module):
+    device = device_module
     torch_input_tensor = torch.randn((1, 64, 32, 4 * 32), dtype=torch.bfloat16)
     reshape_shape = (1, 32, 64, 4 * 32)
     torch_result = torch_input_tensor.reshape(reshape_shape)
@@ -373,7 +386,8 @@ def test_reshape_tile_layout_only_change_shape(device):
 @pytest.mark.parametrize(
     "dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.int32, ttnn.uint32), (torch.float32, ttnn.float32)]
 )
-def test_reshape_tile(device, input_shape, output_shape, layout, memory_config, dtype):
+def test_reshape_tile(device_module, input_shape, output_shape, layout, memory_config, dtype):
+    device = device_module
     if memory_config == ttnn.L1_MEMORY_CONFIG and input_shape in [(2888, 49, 96), (1, 1500, 1, 512)]:
         pytest.xfail("Test case is too big for L1")
 
@@ -421,7 +435,8 @@ def test_reshape_tile(device, input_shape, output_shape, layout, memory_config, 
         ),
     ),
 )
-def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_config, dtype, sub_core_grids):
+def test_reshape_subgrid(device_module, input_shape, output_shape, layout, memory_config, dtype, sub_core_grids):
+    device = device_module
     if memory_config == ttnn.L1_MEMORY_CONFIG and input_shape in [(2888, 49, 96), (1, 1500, 1, 512)]:
         pytest.xfail("Test case is too big for L1")
 
@@ -443,7 +458,8 @@ def test_reshape_subgrid(device, input_shape, output_shape, layout, memory_confi
 
 
 @pytest.mark.parametrize("recreate_mapping_tensor", (ttnn.TileReshapeMapMode.CACHE, ttnn.TileReshapeMapMode.RECREATE))
-def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
+def test_reshape_tile_program_cache(device_module, recreate_mapping_tensor):
+    device = device_module
     for input_shape, output_shape in ((1, 8, 8), (1, 16, 4)), ((16, 1, 5), (4, 2, 10)):
         for _ in range(3):
             torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
@@ -459,7 +475,8 @@ def test_reshape_tile_program_cache(device, recreate_mapping_tensor):
 
 
 # issue 15048
-def test_previously_failing_test(device):
+def test_previously_failing_test(device_module):
+    device = device_module
     src_shape = (1, 56, 56, 64)
     target_shape = (1, 1, 56 * 56, 64)
     torch_input_tensor = torch.randn(src_shape, dtype=torch.bfloat16)
@@ -488,7 +505,8 @@ def test_previously_failing_test(device):
         ((1, 128, 1), (1, 128)),
     ],
 )
-def test_reshape_host(input_shape, output_shape, device):
+def test_reshape_host(input_shape, output_shape, device_module):
+    device = device_module
     torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -509,7 +527,8 @@ def test_reshape_host(input_shape, output_shape, device):
         ((64, 32), (1, 1, 64, 32)),
     ],
 )
-def test_reshape_int(input_shape, output_shape, device):
+def test_reshape_int(input_shape, output_shape, device_module):
+    device = device_module
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -538,7 +557,8 @@ def test_reshape_int(input_shape, output_shape, device):
         ((16, 1, 32), (16, 1, 32)),
     ],
 )
-def test_fp32_support(input_shape, output_shape, device):
+def test_fp32_support(input_shape, output_shape, device_module):
+    device = device_module
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -569,7 +589,8 @@ def test_fp32_support(input_shape, output_shape, device):
         ((16, 1, 32), (16, 1, 32)),
     ],
 )
-def test_bf8_support(input_shape, output_shape, device):
+def test_bf8_support(input_shape, output_shape, device_module):
+    device = device_module
     torch_input_tensor = torch.randint(0, 100, input_shape)
     torch_result = torch_input_tensor.reshape(output_shape)
 
@@ -609,7 +630,10 @@ def test_bf8_support(input_shape, output_shape, device):
     "use_device, memory_config",
     [(True, None), (True, ttnn.L1_MEMORY_CONFIG), (False, None)],
 )
-def test_reshape_zero_element(input_shape, output_shape, layout, ttnn_reshape, use_device, memory_config, device):
+def test_reshape_zero_element(
+    input_shape, output_shape, layout, ttnn_reshape, use_device, memory_config, device_module
+):
+    device = device_module
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     if use_device:
         tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device, memory_config=memory_config)
@@ -646,11 +670,12 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
         assert tt_output_tensor.shape == torch.Size(output_shape)
 
 
-def test_reshape_oob(device):
+def test_reshape_oob(device_module):
     """
     Test proves that this reshape op writes data out of bounds, corrupting
     tensors at other memory locations.
     """
+    device = device_module
 
     def bf16_tensor(tensor):
         return ttnn.from_torch(tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)

--- a/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
@@ -31,7 +31,8 @@ dtypes = [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32, ttnn.uint16]
 @pytest.mark.parametrize("use_pack_untilize", [False, True])
 @pytest.mark.parametrize("H", [32, 512])
 @pytest.mark.parametrize("W", [1024, 256])
-def test_untilize_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
+def test_untilize_2D(device_module, in_dtype, use_multicore, use_pack_untilize, H, W):
+    device = device_module
     if in_dtype in [ttnn.uint32, ttnn.int32] and not use_pack_untilize:
         pytest.skip(f"Skipping: dtype {in_dtype} with use_pack_untilize=False is unsupported")
     torch_input_shape = [H, W]
@@ -52,7 +53,8 @@ def test_untilize_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("H", [128, 2048])
 @pytest.mark.parametrize("W", [32, 1056])
-def test_tilize_2D(device, in_dtype, use_multicore, H, W):
+def test_tilize_2D(device_module, in_dtype, use_multicore, H, W):
+    device = device_module
     torch_input_shape = [H, W]
 
     torch_input = random_torch_tensor(in_dtype, torch_input_shape)
@@ -73,7 +75,8 @@ def test_tilize_2D(device, in_dtype, use_multicore, H, W):
 @pytest.mark.parametrize("use_pack_untilize", [False, True])
 @pytest.mark.parametrize("H", [32, 43])
 @pytest.mark.parametrize("W", [64, 76])
-def test_untilize_with_unpadding_2D(device, in_dtype, use_multicore, use_pack_untilize, H, W):
+def test_untilize_with_unpadding_2D(device_module, in_dtype, use_multicore, use_pack_untilize, H, W):
+    device = device_module
     if in_dtype in [ttnn.uint32, ttnn.int32] and not use_pack_untilize:
         pytest.skip(f"Skipping: dtype {in_dtype} with use_pack_untilize=False is unsupported")
     torch_input_shape = [H, W]
@@ -97,7 +100,8 @@ def test_untilize_with_unpadding_2D(device, in_dtype, use_multicore, use_pack_un
 @pytest.mark.parametrize("pad_value", [2, 1.3])
 @pytest.mark.parametrize("H", [32, 43])
 @pytest.mark.parametrize("W", [64, 76])
-def test_tilize_with_val_padding_2D(device, in_dtype, use_multicore, H, W, pad_value):
+def test_tilize_with_val_padding_2D(device_module, in_dtype, use_multicore, H, W, pad_value):
+    device = device_module
     torch_input_shape = [H, W]
 
     torch_input = random_torch_tensor(in_dtype, torch_input_shape)
@@ -116,7 +120,8 @@ def test_tilize_with_val_padding_2D(device, in_dtype, use_multicore, H, W, pad_v
 @pytest.mark.parametrize("use_multicore", [False, True])
 @pytest.mark.parametrize("H", [128, 98])
 @pytest.mark.parametrize("W", [78, 1024])
-def test_tilize_with_zero_padding_2D(device, in_dtype, use_multicore, H, W):
+def test_tilize_with_zero_padding_2D(device_module, in_dtype, use_multicore, H, W):
+    device = device_module
     torch_input_shape = [H, W]
 
     torch_input = random_torch_tensor(in_dtype, torch_input_shape)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
@@ -22,7 +22,8 @@ import ttnn
         (2, 3, 4, 5, 6, 7, 8, 10),
     ],
 )
-def test_to_and_from(device, shape):
+def test_to_and_from(device_module, shape):
+    device = device_module
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_input_tensor, device=device)
     torch_output_tensor = ttnn.to_torch(tensor)
@@ -41,7 +42,8 @@ def test_to_and_from(device, shape):
         (2, 3, 4, 5, 6, 7, 8, 9),
     ],
 )
-def test_to_and_from_using_tile_layout(device, shape):
+def test_to_and_from_using_tile_layout(device_module, shape):
+    device = device_module
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
     torch_output_tensor = ttnn.to_torch(tensor)
@@ -50,7 +52,8 @@ def test_to_and_from_using_tile_layout(device, shape):
 
 @pytest.mark.parametrize("h", [7])
 @pytest.mark.parametrize("w", [4])
-def test_to_and_from_2D(device, h, w):
+def test_to_and_from_2D(device_module, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_input_tensor)
     # when w=3->size 40 & page size 6 (bad)
@@ -64,7 +67,8 @@ def test_to_and_from_2D(device, h, w):
 # fmt: off
 @pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.int32, ttnn.uint32), (torch.float32, ttnn.bfloat16)])
 # fmt: on
-def test_to_and_from_device(device, torch_dtype, ttnn_dtype):
+def test_to_and_from_device(device_module, torch_dtype, ttnn_dtype):
+    device = device_module
     # Notice that the width of these tensors are even!
     torch_input_tensor = torch.as_tensor([0, 1, 2, 3], dtype=torch_dtype)
     tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn_dtype)
@@ -79,7 +83,8 @@ def test_to_and_from_device(device, torch_dtype, ttnn_dtype):
 @pytest.mark.parametrize("c", [8])
 @pytest.mark.parametrize("h", [1500])
 @pytest.mark.parametrize("w", [64])
-def test_from_device_hang(device, b, c, h, w):
+def test_from_device_hang(device_module, b, c, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((b, c, h, w), dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor)
     input_tensor = ttnn.to_device(input_tensor, device)
@@ -92,7 +97,8 @@ def test_from_device_hang(device, b, c, h, w):
 @pytest.mark.parametrize("c", [8])
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_to_and_from_multiple_times(device, b, c, h, w):
+def test_to_and_from_multiple_times(device_module, b, c, h, w):
+    device = device_module
     tensor = torch.rand((b, c, h, w), dtype=torch.bfloat16)
     original_tensor = tensor
     for i in range(0, 50):

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -83,7 +83,8 @@ def test_to_and_from_2D(height, width, dtype, layout):
 
 
 @pytest.mark.skip(reason="GH Issue #15719")
-def test_from_torch_large(device):
+def test_from_torch_large(device_module):
+    device = device_module
     torch_x = torch.rand((2048, 1024, 32, 32), dtype=torch.bfloat16)
     x_tensor = ttnn.from_torch(torch_x, layout=ttnn.TILE_LAYOUT)
     x_tensor = ttnn.to_torch(x_tensor)
@@ -126,7 +127,8 @@ def test_to_for_01_rank(shape, layout, dtype, pad_value):
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("pad_value", [None, 1])
-def test_to_for_01_rank_on_device(device, shape, layout, dtype, pad_value):
+def test_to_for_01_rank_on_device(device_module, shape, layout, dtype, pad_value):
+    device = device_module
     if pad_value != None and layout != ttnn.TILE_LAYOUT:
         pytest.skip("Pad value is only supported for tile layout")
     torch_input_tensor = torch.rand(shape, dtype=dtype)

--- a/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
@@ -20,7 +20,8 @@ from models.common.utility_functions import is_grayskull, is_blackhole, torch_ra
 @pytest.mark.parametrize("C", [1, 2])
 @pytest.mark.parametrize("H", [32, 448])
 @pytest.mark.parametrize("W", [256, 672])
-def test_untilize(device, in_dtype, use_multicore, use_pack_untilize, N, C, H, W):
+def test_untilize(device_session, in_dtype, use_multicore, use_pack_untilize, N, C, H, W):
+    device = device_session  # Use session-scoped device
     torch_input_shape = [N, C, H, W]
 
     torch_input = torch.randn(torch_input_shape).bfloat16()
@@ -44,7 +45,8 @@ def test_untilize(device, in_dtype, use_multicore, use_pack_untilize, N, C, H, W
 @pytest.mark.parametrize("W", [32, 416])
 @pytest.mark.parametrize("i_h", [10, 20])
 @pytest.mark.parametrize("i_w", [2, 3])
-def test_untilize_with_unpadding(device, in_dtype, use_multicore, use_pack_untilize, N, C, H, W, i_h, i_w):
+def test_untilize_with_unpadding(device_session, in_dtype, use_multicore, use_pack_untilize, N, C, H, W, i_h, i_w):
+    device = device_session  # Use session-scoped device
     torch_input_shape = [N, C, H, W]
 
     torch_input = torch.randn(torch_input_shape).bfloat16()

--- a/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
@@ -20,8 +20,8 @@ from models.common.utility_functions import is_grayskull, is_blackhole, torch_ra
 @pytest.mark.parametrize("C", [1, 2])
 @pytest.mark.parametrize("H", [32, 448])
 @pytest.mark.parametrize("W", [256, 672])
-def test_untilize(device_session, in_dtype, use_multicore, use_pack_untilize, N, C, H, W):
-    device = device_session  # Use session-scoped device
+def test_untilize(device_module, in_dtype, use_multicore, use_pack_untilize, N, C, H, W):
+    device = device_module
     torch_input_shape = [N, C, H, W]
 
     torch_input = torch.randn(torch_input_shape).bfloat16()
@@ -45,8 +45,8 @@ def test_untilize(device_session, in_dtype, use_multicore, use_pack_untilize, N,
 @pytest.mark.parametrize("W", [32, 416])
 @pytest.mark.parametrize("i_h", [10, 20])
 @pytest.mark.parametrize("i_w", [2, 3])
-def test_untilize_with_unpadding(device_session, in_dtype, use_multicore, use_pack_untilize, N, C, H, W, i_h, i_w):
-    device = device_session  # Use session-scoped device
+def test_untilize_with_unpadding(device_module, in_dtype, use_multicore, use_pack_untilize, N, C, H, W, i_h, i_w):
+    device = device_module
     torch_input_shape = [N, C, H, W]
 
     torch_input = torch.randn(torch_input_shape).bfloat16()

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -28,43 +28,50 @@ def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardtanh(device, h, w):
+def test_hardtanh(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.hardtanh)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid_accurate(device, h, w):
+def test_sigmoid_accurate(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.sigmoid_accurate)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardswish(device, h, w):
+def test_hardswish(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.hardswish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log_sigmoid(device, h, w):
+def test_log_sigmoid(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.log_sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mish(device, h, w):
+def test_mish(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.mish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu6(device, h, w):
+def test_relu6(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.relu6)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device, h, w):
+def test_gelu(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.gelu)
 
 
@@ -85,7 +92,8 @@ def test_gelu(device, h, w):
         (3, 6, 1e-3, 1e-3),  # Positive saturation region
     ],
 )
-def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device):
+def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device_module):
+    device = device_module
     """Test GELU accuracy using allclose for different input regions matching analysis ranges"""
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
@@ -110,31 +118,36 @@ def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardsigmoid(device, h, w):
+def test_hardsigmoid(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.hardsigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid(device, h, w):
+def test_sigmoid(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sign(device, h, w):
+def test_sign(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.sign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_softsign(device, h, w):
+def test_softsign(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.softsign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_swish(device, h, w):
+def test_swish(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.swish)
 
 
@@ -161,13 +174,15 @@ def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, p
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("beta", [-1, 0.5, 1, 2])
 @pytest.mark.parametrize("threshold", [-20, 5, 10, 20, 40])
-def test_softplus(device, h, w, beta, threshold):
+def test_softplus(device_module, h, w, beta, threshold):
+    device = device_module
     run_activation_softplus_test(device, h, w, beta, threshold, ttnn.softplus)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanhshrink(device, h, w):
+def test_tanhshrink(device_module, h, w):
+    device = device_module
     run_activation_unary_test(device, h, w, ttnn.tanhshrink)
 
 
@@ -191,7 +206,8 @@ def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_glu(device, batch_size, h, w, dim):
+def test_glu(device_module, batch_size, h, w, dim):
+    device = device_module
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.glu)
 
 
@@ -199,7 +215,8 @@ def test_glu(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_reglu(device, batch_size, h, w, dim):
+def test_reglu(device_module, batch_size, h, w, dim):
+    device = device_module
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.reglu)
 
 
@@ -207,7 +224,8 @@ def test_reglu(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_swiglu(device, batch_size, h, w, dim):
+def test_swiglu(device_module, batch_size, h, w, dim):
+    device = device_module
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.swiglu)
 
 
@@ -215,7 +233,8 @@ def test_swiglu(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_geglu(device, batch_size, h, w, dim):
+def test_geglu(device_module, batch_size, h, w, dim):
+    device = device_module
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.geglu)
 
 
@@ -291,7 +310,8 @@ def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, pcc=0.99
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_elu(device, h, w, scalar):
+def test_scalarB_elu(device_module, h, w, scalar):
+    device = device_module
     run_activation_test_elu(device, h, w, scalar, ttnn.elu)
 
 
@@ -302,7 +322,8 @@ def test_scalarB_elu(device, h, w, scalar):
     "torch_dtype,ttnn_dtype",
     [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16), (torch.bfloat16, ttnn.bfloat4_b)],
 )
-def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
+def test_scalarB_celu(device_module, h, w, alpha, torch_dtype, ttnn_dtype):
+    device = device_module
     if alpha == 0:
         pytest.skip("alpha=0 is not supported")
 
@@ -327,7 +348,8 @@ def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
 @pytest.mark.parametrize("scalar", [0.5, 1.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_hardshrink(device, h, w, scalar):
+def test_scalarB_hardshrink(device_module, h, w, scalar):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -345,21 +367,24 @@ def test_scalarB_hardshrink(device, h, w, scalar):
 @pytest.mark.parametrize("value", [0.88])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_heaviside(device, h, w, value):
+def test_scalarB_heaviside(device_module, h, w, value):
+    device = device_module
     run_activation_test_scalarB_key(device, h, w, value, ttnn.heaviside)
 
 
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.1, 0.01, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_leaky_relu(device, h, w, scalar):
+def test_scalarB_leaky_relu(device_module, h, w, scalar):
+    device = device_module
     run_activation_test_leaky_relu(device, h, w, scalar, ttnn.leaky_relu)
 
 
 @pytest.mark.parametrize("weight", [-0.5, 1.0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_prelu(device, h, w, weight):
+def test_scalarB_prelu(device_module, h, w, weight):
+    device = device_module
     torch.manual_seed(0)
     ttnn_function = ttnn.prelu
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -377,7 +402,8 @@ def test_scalarB_prelu(device, h, w, weight):
 @pytest.mark.parametrize("scalar", [0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_softshrink(device, h, w, scalar):
+def test_scalarB_softshrink(device_module, h, w, scalar):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -413,7 +439,8 @@ def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_functi
 @pytest.mark.parametrize("max", [0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarBC_clip(device, h, w, min, max):
+def test_scalarBC_clip(device_module, h, w, min, max):
+    device = device_module
     run_activation_test_scalarBC_key(device, h, w, min, max, ttnn.clip)
 
 
@@ -438,12 +465,14 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("threshold", [-0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_threshold(device, h, w, value, threshold):
+def test_threshold(device_module, h, w, value, threshold):
+    device = device_module
     run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
 
 
 @pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
-def test_mish_golden_verification(ttnn_dtype, torch_dtype, device):
+def test_mish_golden_verification(ttnn_dtype, torch_dtype, device_module):
+    device = device_module
     input_data = torch.tensor(
         [
             [-1.1258, -1.1524, -0.2506, 1.5863, 0.9463, -0.8437],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -28,50 +28,43 @@ def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardtanh(device_module, h, w):
-    device = device_module
+def test_hardtanh(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.hardtanh)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid_accurate(device_module, h, w):
-    device = device_module
+def test_sigmoid_accurate(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.sigmoid_accurate)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardswish(device_module, h, w):
-    device = device_module
+def test_hardswish(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.hardswish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log_sigmoid(device_module, h, w):
-    device = device_module
+def test_log_sigmoid(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.log_sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mish(device_module, h, w):
-    device = device_module
+def test_mish(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.mish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu6(device_module, h, w):
-    device = device_module
+def test_relu6(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.relu6)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device_module, h, w):
-    device = device_module
+def test_gelu(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.gelu)
 
 
@@ -92,8 +85,7 @@ def test_gelu(device_module, h, w):
         (3, 6, 1e-3, 1e-3),  # Positive saturation region
     ],
 )
-def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device_module):
-    device = device_module
+def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device):
     """Test GELU accuracy using allclose for different input regions matching analysis ranges"""
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
@@ -118,36 +110,31 @@ def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device_modu
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardsigmoid(device_module, h, w):
-    device = device_module
+def test_hardsigmoid(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.hardsigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid(device_module, h, w):
-    device = device_module
+def test_sigmoid(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sign(device_module, h, w):
-    device = device_module
+def test_sign(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.sign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_softsign(device_module, h, w):
-    device = device_module
+def test_softsign(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.softsign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_swish(device_module, h, w):
-    device = device_module
+def test_swish(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.swish)
 
 
@@ -174,15 +161,13 @@ def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, p
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("beta", [-1, 0.5, 1, 2])
 @pytest.mark.parametrize("threshold", [-20, 5, 10, 20, 40])
-def test_softplus(device_module, h, w, beta, threshold):
-    device = device_module
+def test_softplus(device, h, w, beta, threshold):
     run_activation_softplus_test(device, h, w, beta, threshold, ttnn.softplus)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanhshrink(device_module, h, w):
-    device = device_module
+def test_tanhshrink(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.tanhshrink)
 
 
@@ -206,8 +191,7 @@ def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_glu(device_module, batch_size, h, w, dim):
-    device = device_module
+def test_glu(device, batch_size, h, w, dim):
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.glu)
 
 
@@ -215,8 +199,7 @@ def test_glu(device_module, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_reglu(device_module, batch_size, h, w, dim):
-    device = device_module
+def test_reglu(device, batch_size, h, w, dim):
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.reglu)
 
 
@@ -224,8 +207,7 @@ def test_reglu(device_module, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_swiglu(device_module, batch_size, h, w, dim):
-    device = device_module
+def test_swiglu(device, batch_size, h, w, dim):
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.swiglu)
 
 
@@ -233,8 +215,7 @@ def test_swiglu(device_module, batch_size, h, w, dim):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_geglu(device_module, batch_size, h, w, dim):
-    device = device_module
+def test_geglu(device, batch_size, h, w, dim):
     run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.geglu)
 
 
@@ -310,8 +291,7 @@ def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, pcc=0.99
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_elu(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_elu(device, h, w, scalar):
     run_activation_test_elu(device, h, w, scalar, ttnn.elu)
 
 
@@ -322,8 +302,7 @@ def test_scalarB_elu(device_module, h, w, scalar):
     "torch_dtype,ttnn_dtype",
     [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16), (torch.bfloat16, ttnn.bfloat4_b)],
 )
-def test_scalarB_celu(device_module, h, w, alpha, torch_dtype, ttnn_dtype):
-    device = device_module
+def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
     if alpha == 0:
         pytest.skip("alpha=0 is not supported")
 
@@ -348,8 +327,7 @@ def test_scalarB_celu(device_module, h, w, alpha, torch_dtype, ttnn_dtype):
 @pytest.mark.parametrize("scalar", [0.5, 1.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_hardshrink(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_hardshrink(device, h, w, scalar):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -367,24 +345,21 @@ def test_scalarB_hardshrink(device_module, h, w, scalar):
 @pytest.mark.parametrize("value", [0.88])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_heaviside(device_module, h, w, value):
-    device = device_module
+def test_scalarB_heaviside(device, h, w, value):
     run_activation_test_scalarB_key(device, h, w, value, ttnn.heaviside)
 
 
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.1, 0.01, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_leaky_relu(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_leaky_relu(device, h, w, scalar):
     run_activation_test_leaky_relu(device, h, w, scalar, ttnn.leaky_relu)
 
 
 @pytest.mark.parametrize("weight", [-0.5, 1.0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_prelu(device_module, h, w, weight):
-    device = device_module
+def test_scalarB_prelu(device, h, w, weight):
     torch.manual_seed(0)
     ttnn_function = ttnn.prelu
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -402,8 +377,7 @@ def test_scalarB_prelu(device_module, h, w, weight):
 @pytest.mark.parametrize("scalar", [0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_softshrink(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_softshrink(device, h, w, scalar):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -439,8 +413,7 @@ def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_functi
 @pytest.mark.parametrize("max", [0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarBC_clip(device_module, h, w, min, max):
-    device = device_module
+def test_scalarBC_clip(device, h, w, min, max):
     run_activation_test_scalarBC_key(device, h, w, min, max, ttnn.clip)
 
 
@@ -465,14 +438,12 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("threshold", [-0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_threshold(device_module, h, w, value, threshold):
-    device = device_module
+def test_threshold(device, h, w, value, threshold):
     run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
 
 
 @pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
-def test_mish_golden_verification(ttnn_dtype, torch_dtype, device_module):
-    device = device_module
+def test_mish_golden_verification(ttnn_dtype, torch_dtype, device):
     input_data = torch.tensor(
         [
             [-1.1258, -1.1524, -0.2506, 1.5863, 0.9463, -0.8437],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -28,44 +28,44 @@ def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardtanh(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.hardtanh)
+def test_hardtanh(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.hardtanh)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid_accurate(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.sigmoid_accurate)
+def test_sigmoid_accurate(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.sigmoid_accurate)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardswish(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.hardswish)
+def test_hardswish(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.hardswish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log_sigmoid(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.log_sigmoid)
+def test_log_sigmoid(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.log_sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mish(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.mish)
+def test_mish(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.mish)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu6(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.relu6)
+def test_relu6(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.relu6)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.gelu)
+def test_gelu(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.gelu)
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,8 @@ def test_gelu(device, h, w):
         (3, 6, 1e-3, 1e-3),  # Positive saturation region
     ],
 )
-def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device):
+def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device_module):
+    device = device_module
     """Test GELU accuracy using allclose for different input regions matching analysis ranges"""
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
@@ -110,32 +111,32 @@ def test_gelu_accurate_allclose(input_shapes, low, high, atol, rtol, device):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_hardsigmoid(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.hardsigmoid)
+def test_hardsigmoid(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.hardsigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sigmoid(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.sigmoid)
+def test_sigmoid(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.sigmoid)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sign(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.sign)
+def test_sign(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.sign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_softsign(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.softsign)
+def test_softsign(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.softsign)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_swish(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.swish)
+def test_swish(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.swish)
 
 
 def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, pcc=0.99):
@@ -161,14 +162,14 @@ def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, p
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("beta", [-1, 0.5, 1, 2])
 @pytest.mark.parametrize("threshold", [-20, 5, 10, 20, 40])
-def test_softplus(device, h, w, beta, threshold):
-    run_activation_softplus_test(device, h, w, beta, threshold, ttnn.softplus)
+def test_softplus(device_module, h, w, beta, threshold):
+    run_activation_softplus_test(device_module, h, w, beta, threshold, ttnn.softplus)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanhshrink(device, h, w):
-    run_activation_unary_test(device, h, w, ttnn.tanhshrink)
+def test_tanhshrink(device_module, h, w):
+    run_activation_unary_test(device_module, h, w, ttnn.tanhshrink)
 
 
 def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, pcc=0.99):
@@ -191,32 +192,32 @@ def run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn_function, 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_glu(device, batch_size, h, w, dim):
-    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.glu)
+def test_glu(device_module, batch_size, h, w, dim):
+    run_activation_unary_test_glu(device_module, batch_size, h, w, dim, ttnn.glu)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_reglu(device, batch_size, h, w, dim):
-    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.reglu)
+def test_reglu(device_module, batch_size, h, w, dim):
+    run_activation_unary_test_glu(device_module, batch_size, h, w, dim, ttnn.reglu)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_swiglu(device, batch_size, h, w, dim):
-    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.swiglu)
+def test_swiglu(device_module, batch_size, h, w, dim):
+    run_activation_unary_test_glu(device_module, batch_size, h, w, dim, ttnn.swiglu)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dim", [-1, 3])
-def test_geglu(device, batch_size, h, w, dim):
-    run_activation_unary_test_glu(device, batch_size, h, w, dim, ttnn.geglu)
+def test_geglu(device_module, batch_size, h, w, dim):
+    run_activation_unary_test_glu(device_module, batch_size, h, w, dim, ttnn.geglu)
 
 
 def torch_prelu(x, *args, weight, **kwargs):
@@ -291,8 +292,8 @@ def run_activation_test_scalarB_key(device, h, w, value, ttnn_function, pcc=0.99
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_elu(device, h, w, scalar):
-    run_activation_test_elu(device, h, w, scalar, ttnn.elu)
+def test_scalarB_elu(device_module, h, w, scalar):
+    run_activation_test_elu(device_module, h, w, scalar, ttnn.elu)
 
 
 @pytest.mark.parametrize("alpha", [1, 2.5, 5.0, -1, -5, 0])
@@ -302,7 +303,8 @@ def test_scalarB_elu(device, h, w, scalar):
     "torch_dtype,ttnn_dtype",
     [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16), (torch.bfloat16, ttnn.bfloat4_b)],
 )
-def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
+def test_scalarB_celu(device_module, h, w, alpha, torch_dtype, ttnn_dtype):
+    device = device_module
     if alpha == 0:
         pytest.skip("alpha=0 is not supported")
 
@@ -327,7 +329,8 @@ def test_scalarB_celu(device, h, w, alpha, torch_dtype, ttnn_dtype):
 @pytest.mark.parametrize("scalar", [0.5, 1.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_hardshrink(device, h, w, scalar):
+def test_scalarB_hardshrink(device_module, h, w, scalar):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -345,21 +348,22 @@ def test_scalarB_hardshrink(device, h, w, scalar):
 @pytest.mark.parametrize("value", [0.88])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_heaviside(device, h, w, value):
-    run_activation_test_scalarB_key(device, h, w, value, ttnn.heaviside)
+def test_scalarB_heaviside(device_module, h, w, value):
+    run_activation_test_scalarB_key(device_module, h, w, value, ttnn.heaviside)
 
 
 @pytest.mark.parametrize("scalar", [-0.5, 0, 0.1, 0.01, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_leaky_relu(device, h, w, scalar):
-    run_activation_test_leaky_relu(device, h, w, scalar, ttnn.leaky_relu)
+def test_scalarB_leaky_relu(device_module, h, w, scalar):
+    run_activation_test_leaky_relu(device_module, h, w, scalar, ttnn.leaky_relu)
 
 
 @pytest.mark.parametrize("weight", [-0.5, 1.0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_prelu(device, h, w, weight):
+def test_scalarB_prelu(device_module, h, w, weight):
+    device = device_module
     torch.manual_seed(0)
     ttnn_function = ttnn.prelu
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -377,7 +381,8 @@ def test_scalarB_prelu(device, h, w, weight):
 @pytest.mark.parametrize("scalar", [0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_softshrink(device, h, w, scalar):
+def test_scalarB_softshrink(device_module, h, w, scalar):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
@@ -413,8 +418,8 @@ def run_activation_test_scalarBC_key(device, h, w, scalar1, scalar2, ttnn_functi
 @pytest.mark.parametrize("max", [0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarBC_clip(device, h, w, min, max):
-    run_activation_test_scalarBC_key(device, h, w, min, max, ttnn.clip)
+def test_scalarBC_clip(device_module, h, w, min, max):
+    run_activation_test_scalarBC_key(device_module, h, w, min, max, ttnn.clip)
 
 
 def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function, pcc=0.99):
@@ -438,12 +443,13 @@ def run_activation_test_threshold(device, h, w, scalar1, scalar2, ttnn_function,
 @pytest.mark.parametrize("threshold", [-0.5, 1.5, 27.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_threshold(device, h, w, value, threshold):
-    run_activation_test_threshold(device, h, w, value, threshold, ttnn.threshold)
+def test_threshold(device_module, h, w, value, threshold):
+    run_activation_test_threshold(device_module, h, w, value, threshold, ttnn.threshold)
 
 
 @pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
-def test_mish_golden_verification(ttnn_dtype, torch_dtype, device):
+def test_mish_golden_verification(ttnn_dtype, torch_dtype, device_module):
+    device = device_module
     input_data = torch.tensor(
         [
             [-1.1258, -1.1524, -0.2506, 1.5863, 0.9463, -0.8437],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -20,7 +20,8 @@ from models.common.utility_functions import skip_for_slow_dispatch
         [[63, 1, 4], [1, 1, 1]],
     ],
 )
-def test_non_4D_channel_bcast(device, shapes):
+def test_non_4D_channel_bcast(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16)
@@ -42,7 +43,8 @@ def test_non_4D_channel_bcast(device, shapes):
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("size", [64, 1, 0])
-def test_add_1D_tensor_and_scalar(device, scalar, size):
+def test_add_1D_tensor_and_scalar(device_module, scalar, size):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
@@ -57,7 +59,8 @@ def test_add_1D_tensor_and_scalar(device, scalar, size):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_2D_tensors(device, hw):
+def test_add_2D_tensors(device_module, hw):
+    device = device_module
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -71,7 +74,8 @@ def test_add_2D_tensors(device, hw):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_2D_tensors_with_program_cache(device, hw):
+def test_add_2D_tensors_with_program_cache(device_module, hw):
+    device = device_module
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -86,7 +90,8 @@ def test_add_2D_tensors_with_program_cache(device, hw):
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
 @pytest.mark.parametrize("scalar", [0.42])
-def test_add_scalar(device, hw, scalar):
+def test_add_scalar(device_module, hw, scalar):
+    device = device_module
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = scalar + torch_input_tensor_a
 
@@ -99,7 +104,8 @@ def test_add_scalar(device, hw, scalar):
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
 @pytest.mark.parametrize("scalar", [0.42])
-def test_reverse_add_scalar(device, hw, scalar):
+def test_reverse_add_scalar(device_module, hw, scalar):
+    device = device_module
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = scalar + torch_input_tensor_a
 
@@ -111,7 +117,8 @@ def test_reverse_add_scalar(device, hw, scalar):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_4D_tensors(device, hw):
+def test_add_4D_tensors(device_module, hw):
+    device = device_module
     torch_input_tensor_a = torch.rand((5, 64, hw[0], hw[1]), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, hw[0], hw[1]), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -126,8 +133,9 @@ def test_add_4D_tensors(device, hw):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_with_broadcast(device, h, w):
+def test_add_with_broadcast(device_module, h, w):
     # See #4005, we basically are using ttnn.repeat to get this to pass.
+    device = device_module
     torch_input_tensor_a = torch.rand((2, 16, 1, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((2, 16, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -142,7 +150,8 @@ def test_add_with_broadcast(device, h, w):
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast(device, h, w):
+def test_expand_and_broadcast(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -157,7 +166,8 @@ def test_expand_and_broadcast(device, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_with_broadcast_on_batch(device, h, w):
+def test_add_with_broadcast_on_batch(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((1, 16, 1, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((2, 16, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -172,7 +182,8 @@ def test_add_with_broadcast_on_batch(device, h, w):
 
 @pytest.mark.parametrize("shape", [(8, 16, 384, 384)])
 @pytest.mark.parametrize("scalar", [0.125])
-def test_add_attention_scores_to_scalar(device, shape, scalar):
+def test_add_attention_scores_to_scalar(device_module, shape, scalar):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
@@ -190,7 +201,8 @@ def test_add_attention_scores_to_scalar(device, shape, scalar):
 
 @pytest.mark.parametrize("shape_a", [(8, 16, 128, 128)])
 @pytest.mark.parametrize("shape_b", [(1, 16, 128, 128)])
-def test_add_with_batch_broadcast(device, shape_a, shape_b):
+def test_add_with_batch_broadcast(device_module, shape_a, shape_b):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -212,7 +224,8 @@ def test_add_with_batch_broadcast(device, shape_a, shape_b):
 
 @pytest.mark.parametrize("shape_a", [(4096, 4096)])
 @pytest.mark.parametrize("shape_b", [(1, 4096)])
-def test_add_dram_and_l1_tensor(device, shape_a, shape_b):
+def test_add_dram_and_l1_tensor(device_module, shape_a, shape_b):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -234,7 +247,8 @@ def test_add_dram_and_l1_tensor(device, shape_a, shape_b):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("activations", [[], [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)]])
-def test_add_and_apply_activations(device, shape, activations):
+def test_add_and_apply_activations(device_module, shape, activations):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -255,7 +269,8 @@ def test_add_and_apply_activations(device, shape, activations):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("activations", [[], [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)]])
-def test_in_place_add_and_apply_activations(device, shape, activations):
+def test_in_place_add_and_apply_activations(device_module, shape, activations):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -275,7 +290,8 @@ def test_in_place_add_and_apply_activations(device, shape, activations):
 
 
 @pytest.mark.parametrize("shape", [(32, 32)])
-def test_prim_add(device, shape):
+def test_prim_add(device_module, shape):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -294,7 +310,8 @@ def test_prim_add(device, shape):
 @pytest.mark.skip(reason="#11002/#4005: Bcast does not appear to be doing what we expect.  Leaving test for reference.")
 @pytest.mark.parametrize("shape_a", [(1, 1, 8192, 320)])
 @pytest.mark.parametrize("shape_b", [(2, 1, 1, 320)])
-def test_add_with_different_batch(device, shape_a, shape_b):
+def test_add_with_different_batch(device_module, shape_a, shape_b):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -348,7 +365,8 @@ def test_add_with_different_batch(device, shape_a, shape_b):
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_height_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+def test_add_with_height_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+    device = device_module
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -398,7 +416,8 @@ def test_add_with_height_sharding(device, input_a_sharded, input_b_sharded, out_
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_width_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+def test_add_with_width_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+    device = device_module
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -448,7 +467,8 @@ def test_add_with_width_sharding(device, input_a_sharded, input_b_sharded, out_s
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_block_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+def test_add_with_block_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+    device = device_module
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -504,7 +524,8 @@ def test_add_with_block_sharding(device, input_a_sharded, input_b_sharded, out_s
     ],
 )
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_01_volume_tensors(device, data, memory_config):
+def test_01_volume_tensors(device_module, data, memory_config):
+    device = device_module
     (a, b, c_golden) = data
     a = torch.BFloat16Tensor(a)
     b = torch.BFloat16Tensor(b)
@@ -523,7 +544,8 @@ def test_01_volume_tensors(device, data, memory_config):
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_sub_devices(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+def test_add_with_sub_devices(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
+    device = device_module
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -20,8 +20,7 @@ from models.common.utility_functions import skip_for_slow_dispatch
         [[63, 1, 4], [1, 1, 1]],
     ],
 )
-def test_non_4D_channel_bcast(device_module, shapes):
-    device = device_module
+def test_non_4D_channel_bcast(device, shapes):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16)
@@ -43,8 +42,7 @@ def test_non_4D_channel_bcast(device_module, shapes):
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("size", [64, 1, 0])
-def test_add_1D_tensor_and_scalar(device_module, scalar, size):
-    device = device_module
+def test_add_1D_tensor_and_scalar(device, scalar, size):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
@@ -59,8 +57,7 @@ def test_add_1D_tensor_and_scalar(device_module, scalar, size):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_2D_tensors(device_module, hw):
-    device = device_module
+def test_add_2D_tensors(device, hw):
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -74,8 +71,7 @@ def test_add_2D_tensors(device_module, hw):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_2D_tensors_with_program_cache(device_module, hw):
-    device = device_module
+def test_add_2D_tensors_with_program_cache(device, hw):
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -90,8 +86,7 @@ def test_add_2D_tensors_with_program_cache(device_module, hw):
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
 @pytest.mark.parametrize("scalar", [0.42])
-def test_add_scalar(device_module, hw, scalar):
-    device = device_module
+def test_add_scalar(device, hw, scalar):
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = scalar + torch_input_tensor_a
 
@@ -104,8 +99,7 @@ def test_add_scalar(device_module, hw, scalar):
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
 @pytest.mark.parametrize("scalar", [0.42])
-def test_reverse_add_scalar(device_module, hw, scalar):
-    device = device_module
+def test_reverse_add_scalar(device, hw, scalar):
     torch_input_tensor_a = torch.rand(hw, dtype=torch.bfloat16)
     torch_output_tensor = scalar + torch_input_tensor_a
 
@@ -117,8 +111,7 @@ def test_reverse_add_scalar(device_module, hw, scalar):
 
 
 @pytest.mark.parametrize("hw", [(32, 64), (1, 1), (0, 0)])
-def test_add_4D_tensors(device_module, hw):
-    device = device_module
+def test_add_4D_tensors(device, hw):
     torch_input_tensor_a = torch.rand((5, 64, hw[0], hw[1]), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, hw[0], hw[1]), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -133,9 +126,8 @@ def test_add_4D_tensors(device_module, hw):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_with_broadcast(device_module, h, w):
+def test_add_with_broadcast(device, h, w):
     # See #4005, we basically are using ttnn.repeat to get this to pass.
-    device = device_module
     torch_input_tensor_a = torch.rand((2, 16, 1, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((2, 16, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -150,8 +142,7 @@ def test_add_with_broadcast(device_module, h, w):
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast(device_module, h, w):
-    device = device_module
+def test_expand_and_broadcast(device, h, w):
     torch_input_tensor_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -166,8 +157,7 @@ def test_expand_and_broadcast(device_module, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_with_broadcast_on_batch(device_module, h, w):
-    device = device_module
+def test_add_with_broadcast_on_batch(device, h, w):
     torch_input_tensor_a = torch.rand((1, 16, 1, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((2, 16, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -182,8 +172,7 @@ def test_add_with_broadcast_on_batch(device_module, h, w):
 
 @pytest.mark.parametrize("shape", [(8, 16, 384, 384)])
 @pytest.mark.parametrize("scalar", [0.125])
-def test_add_attention_scores_to_scalar(device_module, shape, scalar):
-    device = device_module
+def test_add_attention_scores_to_scalar(device, shape, scalar):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
@@ -201,8 +190,7 @@ def test_add_attention_scores_to_scalar(device_module, shape, scalar):
 
 @pytest.mark.parametrize("shape_a", [(8, 16, 128, 128)])
 @pytest.mark.parametrize("shape_b", [(1, 16, 128, 128)])
-def test_add_with_batch_broadcast(device_module, shape_a, shape_b):
-    device = device_module
+def test_add_with_batch_broadcast(device, shape_a, shape_b):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -224,8 +212,7 @@ def test_add_with_batch_broadcast(device_module, shape_a, shape_b):
 
 @pytest.mark.parametrize("shape_a", [(4096, 4096)])
 @pytest.mark.parametrize("shape_b", [(1, 4096)])
-def test_add_dram_and_l1_tensor(device_module, shape_a, shape_b):
-    device = device_module
+def test_add_dram_and_l1_tensor(device, shape_a, shape_b):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -247,8 +234,7 @@ def test_add_dram_and_l1_tensor(device_module, shape_a, shape_b):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("activations", [[], [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)]])
-def test_add_and_apply_activations(device_module, shape, activations):
-    device = device_module
+def test_add_and_apply_activations(device, shape, activations):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -269,8 +255,7 @@ def test_add_and_apply_activations(device_module, shape, activations):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("activations", [[], [ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)]])
-def test_in_place_add_and_apply_activations(device_module, shape, activations):
-    device = device_module
+def test_in_place_add_and_apply_activations(device, shape, activations):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -290,8 +275,7 @@ def test_in_place_add_and_apply_activations(device_module, shape, activations):
 
 
 @pytest.mark.parametrize("shape", [(32, 32)])
-def test_prim_add(device_module, shape):
-    device = device_module
+def test_prim_add(device, shape):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -310,8 +294,7 @@ def test_prim_add(device_module, shape):
 @pytest.mark.skip(reason="#11002/#4005: Bcast does not appear to be doing what we expect.  Leaving test for reference.")
 @pytest.mark.parametrize("shape_a", [(1, 1, 8192, 320)])
 @pytest.mark.parametrize("shape_b", [(2, 1, 1, 320)])
-def test_add_with_different_batch(device_module, shape_a, shape_b):
-    device = device_module
+def test_add_with_different_batch(device, shape_a, shape_b):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape_a, dtype=torch.bfloat16)
@@ -365,8 +348,7 @@ def test_add_with_different_batch(device_module, shape_a, shape_b):
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_height_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
-    device = device_module
+def test_add_with_height_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -416,8 +398,7 @@ def test_add_with_height_sharding(device_module, input_a_sharded, input_b_sharde
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_width_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
-    device = device_module
+def test_add_with_width_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -467,8 +448,7 @@ def test_add_with_width_sharding(device_module, input_a_sharded, input_b_sharded
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_block_sharding(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
-    device = device_module
+def test_add_with_block_sharding(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
@@ -524,8 +504,7 @@ def test_add_with_block_sharding(device_module, input_a_sharded, input_b_sharded
     ],
 )
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_01_volume_tensors(device_module, data, memory_config):
-    device = device_module
+def test_01_volume_tensors(device, data, memory_config):
     (a, b, c_golden) = data
     a = torch.BFloat16Tensor(a)
     b = torch.BFloat16Tensor(b)
@@ -544,8 +523,7 @@ def test_01_volume_tensors(device_module, data, memory_config):
 @pytest.mark.parametrize("input_b_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
-def test_add_with_sub_devices(device_module, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
-    device = device_module
+def test_add_with_sub_devices(device, input_a_sharded, input_b_sharded, out_sharded, shard_orientation):
     torch.manual_seed(0)
     shape = (1, 1, 1024, 1024)
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -43,8 +43,7 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
         [[5, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_unequal_ranks(a_shape, b_shape, device_module):
-    device = device_module
+def test_unequal_ranks(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -80,8 +79,7 @@ def test_unequal_ranks(a_shape, b_shape, device_module):
         (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
     ],
 )
-def test_01_volume_tensors(device_module, a, b, c_golden, memory_config_a, memory_config_b):
-    device = device_module
+def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_config_b):
     a = torch.BFloat16Tensor(a)
     b = torch.BFloat16Tensor(b)
     assert torch.add(a, b).tolist() == c_golden
@@ -101,8 +99,7 @@ def test_01_volume_tensors(device_module, a, b, c_golden, memory_config_a, memor
         [[1, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_binary_invalid_rank(device_module, a_shape, b_shape):
-    device = device_module
+def test_binary_invalid_rank(device, a_shape, b_shape):
     torch.manual_seed(0)
     pt_a, tt_a = rand_bf16_gen(a_shape, device)
     pt_b, tt_b = rand_bf16_gen(b_shape, device)
@@ -261,8 +258,7 @@ def test_binary_sharded_bcast_no_identical(
         ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (1, 6)), ttnn.CoreRange((3, 0), (3, 6))}),
     ),
 )
-def test_binary_sharded_row_major_layout(device_module, a_shape, b_shape, sharded_core_grid, memory_lay_out):
-    device = device_module
+def test_binary_sharded_row_major_layout(device, a_shape, b_shape, sharded_core_grid, memory_lay_out):
     torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         [160, 128],  # 14 cores
@@ -319,8 +315,7 @@ def test_binary_sharded_row_major_layout(device_module, a_shape, b_shape, sharde
     ),
 )
 @pytest.mark.parametrize("ttnn_fn", ["add", "sub", "mul", "add_", "sub_", "mul_"])
-def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device_module):
-    device = device_module
+def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device, min=-1e3, max=1e3)
@@ -361,8 +356,7 @@ def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device_module):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_height(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -426,8 +420,7 @@ def test_binary_sharded_bcast_w_height(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_c(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_height_c(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 1, 2 * 32, 1])
@@ -491,8 +484,7 @@ def test_binary_sharded_bcast_w_height_c(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_n(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_height_n(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 2 * 32, 1])
@@ -556,8 +548,7 @@ def test_binary_sharded_bcast_w_height_n(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_height(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -622,8 +613,7 @@ def test_binary_sharded_bcast_h_height(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_height(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -688,8 +678,7 @@ def test_binary_sharded_bcast_scalar_height(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_height(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_hw_mixed_height(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -751,8 +740,7 @@ def test_binary_sharded_bcast_hw_mixed_height(device_module, dtype_pt, dtype_tt)
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_width(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -817,8 +805,7 @@ def test_binary_sharded_bcast_w_width(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_width(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -883,8 +870,7 @@ def test_binary_sharded_bcast_h_width(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_width(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -961,8 +947,7 @@ def test_binary_sharded_bcast_scalar_width(device_module, dtype_pt, dtype_tt):
         ),
     ),
 )
-def test_binary_sharded_bcast_hw_mixed_width(device_module, dtype_pt, dtype_tt, sub_core_grids):
-    device = device_module
+def test_binary_sharded_bcast_hw_mixed_width(device, dtype_pt, dtype_tt, sub_core_grids):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 1, 7 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -1035,8 +1020,7 @@ def test_binary_sharded_bcast_hw_mixed_width(device_module, dtype_pt, dtype_tt, 
         (1, 1, 32, 128 * 1024),
     ),
 )
-def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
-    device = device_module
+def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
     """Test binary operations with sub_core_grids parameter"""
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
@@ -1133,8 +1117,7 @@ def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
         [ttnn.ShardStrategy.BLOCK, [32 * 5, 32], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 6))})],
     ),
 )
-def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
-    device = device_module
+def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device):
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1247,8 +1230,7 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
         ],
     ),
 )
-def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device_module):
-    device = device_module
+def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device):
     torch.manual_seed(0)
     golden_function = ttnn.get_golden_function(ttnn_fn)
 
@@ -1313,8 +1295,7 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
         [ttnn.ShardStrategy.BLOCK, ttnn.CoreGrid(x=2, y=5)],  # shard [32 * 7, 32],
     ),
 )
-def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device_module):
-    device = device_module
+def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1362,8 +1343,7 @@ def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device_mo
         [ttnn.ShardStrategy.BLOCK, [32 * 8, 64], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 4))})],
     ),
 )
-def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
-    device = device_module
+def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device):
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1632,8 +1612,7 @@ def test_binary_sharded_bcast_scalar_value_uneven(
         ],
     ),
 )
-def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
-    device = device_module
+def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1682,8 +1661,7 @@ def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, sh
         ],
     ),
 )
-def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
-    device = device_module
+def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1739,8 +1717,7 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
         ],
     ),
 )
-def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device_module):
-    device = device_module
+def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device):
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1943,8 +1920,7 @@ def test_binary_sharded_row_major_layout_mixed(
         [[256], [920, 1, 256]],
     ],
 )
-def test_binary_subtile_no_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_subtile_no_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -1974,8 +1950,7 @@ def test_binary_subtile_no_bcast(a_shape, b_shape, device_module):
         [[1, 8192], [8192, 8192]],
     ],
 )
-def test_binary_subtile_row_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_subtile_row_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2018,8 +1993,7 @@ def test_binary_subtile_row_bcast(a_shape, b_shape, device_module):
         [[4, 4, 320, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_col_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_subtile_col_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2055,8 +2029,7 @@ def test_binary_subtile_col_bcast(a_shape, b_shape, device_module):
         [[4, 4, 320, 320], [1, 1, 1, 1]],
     ],
 )
-def test_binary_subtile_scalar_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2098,8 +2071,7 @@ def test_binary_subtile_scalar_bcast(a_shape, b_shape, device_module):
         [[4, 4, 1, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2128,8 +2100,7 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device_module):
 )
 @pytest.mark.parametrize("bcast_dim", [ttnn.BcastOpDim.H, ttnn.BcastOpDim.W, ttnn.BcastOpDim.HW])
 @pytest.mark.parametrize("math_op", [ttnn.BcastOpMath.ADD, ttnn.BcastOpMath.SUB, ttnn.BcastOpMath.MUL])
-def test_bcast(input_shape_a, device_module, bcast_dim, math_op):
-    device = device_module
+def test_bcast(input_shape_a, device, bcast_dim, math_op):
     torch.manual_seed(0)
     input_shape_b = list(input_shape_a)
 
@@ -2168,8 +2139,7 @@ def test_bcast(input_shape_a, device_module, bcast_dim, math_op):
     assert comp_pass
 
 
-def test_yolov8_add_small(device_module):
-    device = device_module
+def test_yolov8_add_small(device):
     tor_a = torch.tensor(
         [
             [
@@ -2297,8 +2267,7 @@ def rand_gen(shape, device, *, dtype, tt_dtype, min=0, max=1, memory_config):
         [torch.float32, ttnn.float32, torch.bfloat16, ttnn.bfloat16],
     ),
 )
-def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device_module):
-    device = device_module
+def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device):
     torch.manual_seed(0)
     a_shape = torch.Size([1, 4, 2, 160])
     b_shape = torch.Size([1, 4, 1, 160])
@@ -2316,8 +2285,7 @@ def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device
     assert compare_pcc([out_tt], [out_pt])
 
 
-def test_add_1m(device_module):
-    device = device_module
+def test_add_1m(device):
     torch.manual_seed(0)
     a = torch.ones(1, 1) * 1_000_000
     b = torch.ones(32, 32)
@@ -2332,8 +2300,7 @@ def test_add_1m(device_module):
     assert_with_pcc(c, ttnn.to_torch(tc))
 
 
-def test_add_i32(device_module):
-    device = device_module
+def test_add_i32(device):
     torch.manual_seed(2024)
     a = torch.cat([torch.zeros(128, dtype=torch.int32), torch.ones(128, dtype=torch.int32)])
     a = torch.reshape(a, (1, 1, 1, 256))
@@ -2349,8 +2316,7 @@ def test_add_i32(device_module):
     assert torch.equal(torch_add, output_tensor)
 
 
-def test_add_error(device_module):
-    device = device_module
+def test_add_error(device):
     pytest.skip("Test is skipped because half mem config feature not supported yet")
     # Create input tensors with specified shapes
     input_shape = [1, 1, 1, 39576]
@@ -2375,8 +2341,7 @@ def test_add_error(device_module):
         [[8, 16, 32], [1, 1, 32]],
     ],
 )
-def test_sub_implicit_broadcast(device_module, shapes):
-    device = device_module
+def test_sub_implicit_broadcast(device, shapes):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
@@ -2406,8 +2371,7 @@ def test_sub_implicit_broadcast(device_module, shapes):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def test_small_fp32_multiply(device_module):
-    device = device_module
+def test_small_fp32_multiply(device):
     # Scaling with 0.01 to get realistic values that appear during training.
     a = ttnn.from_torch(0.01 * torch.randn((1, 1, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
     b = ttnn.from_torch(0.01 * torch.randn((4, 32, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
@@ -2437,8 +2401,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_block(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -2503,8 +2466,7 @@ def test_binary_sharded_bcast_w_block(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_block(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2569,8 +2531,7 @@ def test_binary_sharded_bcast_h_block(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_block(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -2635,8 +2596,7 @@ def test_binary_sharded_bcast_scalar_block(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_block(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_hw_mixed_block(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2754,8 +2714,7 @@ def test_binary_sharded_bcast_scalar_zero_dim(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
-    device = device_module
+def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2814,8 +2773,7 @@ def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_m
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device_module):
-    device = device_module
+def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device):
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2861,8 +2819,7 @@ def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device_module):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_height_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -2927,8 +2884,7 @@ def test_binary_sharded_bcast_w_height_uneven(device_module, dtype_pt, dtype_tt)
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_width_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -2994,8 +2950,7 @@ def test_binary_sharded_bcast_w_width_uneven(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_w_block_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 3 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -3061,8 +3016,7 @@ def test_binary_sharded_bcast_w_block_uneven(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_height_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3127,8 +3081,7 @@ def test_binary_sharded_bcast_h_height_uneven(device_module, dtype_pt, dtype_tt)
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_width_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -3193,8 +3146,7 @@ def test_binary_sharded_bcast_h_width_uneven(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_block_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 5 * 32])
@@ -3259,8 +3211,7 @@ def test_binary_sharded_bcast_h_block_uneven(device_module, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_height_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3325,8 +3276,7 @@ def test_binary_sharded_bcast_scalar_height_uneven(device_module, dtype_pt, dtyp
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_width_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -3391,8 +3341,7 @@ def test_binary_sharded_bcast_scalar_width_uneven(device_module, dtype_pt, dtype
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_scalar_block_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3471,8 +3420,7 @@ def rand_bf16_gen_dtype(shape, device, *, min=0, max=1, dtype, memory_config=ttn
         (torch.Size([5, 10, 1, 128]), torch.Size([5, 10, 640, 1])),
     ),
 )
-def test_binary_sfpu_row_bcast(a_shape, b_shape, device_module):
-    device = device_module
+def test_binary_sfpu_row_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
     # make 0 exclusive for rhs of div
     min, max = (1, 0)
@@ -3498,8 +3446,7 @@ def test_binary_sfpu_row_bcast(a_shape, b_shape, device_module):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3682,8 +3629,7 @@ def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven_
 
 @pytest.mark.parametrize("input_shape", [(1, 4096, 640)])
 @pytest.mark.parametrize("is_legacy", [True, False])
-def test_add_sharded(device_module, input_shape, is_legacy):
-    device = device_module
+def test_add_sharded(device, input_shape, is_legacy):
     torch_input_tensor_a = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -3711,8 +3657,7 @@ def test_add_sharded(device_module, input_shape, is_legacy):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_orientation_output(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 31 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 31])
@@ -3806,8 +3751,7 @@ def test_binary_sharded_bcast_hw_mixed_orientation_output(device_module, dtype_p
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3879,8 +3823,7 @@ def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device_module, dtype_pt,
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_identical_mixed_strategy(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_binary_sharded_bcast_identical_mixed_strategy(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -3957,8 +3900,7 @@ def test_binary_sharded_bcast_identical_mixed_strategy(device_module, dtype_pt, 
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 @pytest.mark.parametrize("scalar", [1.7, -0.25])
-def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device_module, dtype_pt, dtype_tt, scalar):
-    device = device_module
+def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device, dtype_pt, dtype_tt, scalar):
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     out_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -4049,8 +3991,7 @@ def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device_module, dty
         ttnn.logical_xor_,
     ],
 )
-def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module, ttnn_fn):
-    device = device_module
+def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device, ttnn_fn):
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4110,8 +4051,7 @@ def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, n
         None,
     ],
 )
-def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device_module):
-    device = device_module
+def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device):
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4180,8 +4120,7 @@ def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw
         (1, 1, 32, 32 * 1024),
     ),
 )
-def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
-    device = device_module
+def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -43,7 +43,8 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
         [[5, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_unequal_ranks(a_shape, b_shape, device):
+def test_unequal_ranks(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -79,7 +80,8 @@ def test_unequal_ranks(a_shape, b_shape, device):
         (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
     ],
 )
-def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_config_b):
+def test_01_volume_tensors(device_module, a, b, c_golden, memory_config_a, memory_config_b):
+    device = device_module
     a = torch.BFloat16Tensor(a)
     b = torch.BFloat16Tensor(b)
     assert torch.add(a, b).tolist() == c_golden
@@ -99,7 +101,8 @@ def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_confi
         [[1, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_binary_invalid_rank(device, a_shape, b_shape):
+def test_binary_invalid_rank(device_module, a_shape, b_shape):
+    device = device_module
     torch.manual_seed(0)
     pt_a, tt_a = rand_bf16_gen(a_shape, device)
     pt_b, tt_b = rand_bf16_gen(b_shape, device)
@@ -258,7 +261,8 @@ def test_binary_sharded_bcast_no_identical(
         ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (1, 6)), ttnn.CoreRange((3, 0), (3, 6))}),
     ),
 )
-def test_binary_sharded_row_major_layout(device, a_shape, b_shape, sharded_core_grid, memory_lay_out):
+def test_binary_sharded_row_major_layout(device_module, a_shape, b_shape, sharded_core_grid, memory_lay_out):
+    device = device_module
     torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         [160, 128],  # 14 cores
@@ -315,7 +319,8 @@ def test_binary_sharded_row_major_layout(device, a_shape, b_shape, sharded_core_
     ),
 )
 @pytest.mark.parametrize("ttnn_fn", ["add", "sub", "mul", "add_", "sub_", "mul_"])
-def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
+def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device, min=-1e3, max=1e3)
@@ -356,7 +361,8 @@ def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -420,7 +426,8 @@ def test_binary_sharded_bcast_w_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_c(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_c(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 1, 2 * 32, 1])
@@ -484,7 +491,8 @@ def test_binary_sharded_bcast_w_height_c(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_n(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_n(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 2 * 32, 1])
@@ -548,7 +556,8 @@ def test_binary_sharded_bcast_w_height_n(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -613,7 +622,8 @@ def test_binary_sharded_bcast_h_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -678,7 +688,8 @@ def test_binary_sharded_bcast_scalar_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -740,7 +751,8 @@ def test_binary_sharded_bcast_hw_mixed_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -805,7 +817,8 @@ def test_binary_sharded_bcast_w_width(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -870,7 +883,8 @@ def test_binary_sharded_bcast_h_width(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -947,7 +961,8 @@ def test_binary_sharded_bcast_scalar_width(device, dtype_pt, dtype_tt):
         ),
     ),
 )
-def test_binary_sharded_bcast_hw_mixed_width(device, dtype_pt, dtype_tt, sub_core_grids):
+def test_binary_sharded_bcast_hw_mixed_width(device_module, dtype_pt, dtype_tt, sub_core_grids):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 1, 7 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -1020,7 +1035,8 @@ def test_binary_sharded_bcast_hw_mixed_width(device, dtype_pt, dtype_tt, sub_cor
         (1, 1, 32, 128 * 1024),
     ),
 )
-def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
+def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
+    device = device_module
     """Test binary operations with sub_core_grids parameter"""
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
@@ -1117,7 +1133,8 @@ def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
         [ttnn.ShardStrategy.BLOCK, [32 * 5, 32], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 6))})],
     ),
 )
-def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1230,7 +1247,8 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
         ],
     ),
 )
-def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device):
+def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     golden_function = ttnn.get_golden_function(ttnn_fn)
 
@@ -1295,7 +1313,8 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
         [ttnn.ShardStrategy.BLOCK, ttnn.CoreGrid(x=2, y=5)],  # shard [32 * 7, 32],
     ),
 )
-def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
+def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1343,7 +1362,8 @@ def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
         [ttnn.ShardStrategy.BLOCK, [32 * 8, 64], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 4))})],
     ),
 )
-def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1612,7 +1632,8 @@ def test_binary_sharded_bcast_scalar_value_uneven(
         ],
     ),
 )
-def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1661,7 +1682,8 @@ def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, sh
         ],
     ),
 )
-def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1717,7 +1739,8 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
         ],
     ),
 )
-def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device):
+def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1920,7 +1943,8 @@ def test_binary_sharded_row_major_layout_mixed(
         [[256], [920, 1, 256]],
     ],
 )
-def test_binary_subtile_no_bcast(a_shape, b_shape, device):
+def test_binary_subtile_no_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -1950,7 +1974,8 @@ def test_binary_subtile_no_bcast(a_shape, b_shape, device):
         [[1, 8192], [8192, 8192]],
     ],
 )
-def test_binary_subtile_row_bcast(a_shape, b_shape, device):
+def test_binary_subtile_row_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -1993,7 +2018,8 @@ def test_binary_subtile_row_bcast(a_shape, b_shape, device):
         [[4, 4, 320, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_col_bcast(a_shape, b_shape, device):
+def test_binary_subtile_col_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2029,7 +2055,8 @@ def test_binary_subtile_col_bcast(a_shape, b_shape, device):
         [[4, 4, 320, 320], [1, 1, 1, 1]],
     ],
 )
-def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
+def test_binary_subtile_scalar_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2071,7 +2098,8 @@ def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
         [[4, 4, 1, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
+def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2100,7 +2128,8 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
 )
 @pytest.mark.parametrize("bcast_dim", [ttnn.BcastOpDim.H, ttnn.BcastOpDim.W, ttnn.BcastOpDim.HW])
 @pytest.mark.parametrize("math_op", [ttnn.BcastOpMath.ADD, ttnn.BcastOpMath.SUB, ttnn.BcastOpMath.MUL])
-def test_bcast(input_shape_a, device, bcast_dim, math_op):
+def test_bcast(input_shape_a, device_module, bcast_dim, math_op):
+    device = device_module
     torch.manual_seed(0)
     input_shape_b = list(input_shape_a)
 
@@ -2139,7 +2168,8 @@ def test_bcast(input_shape_a, device, bcast_dim, math_op):
     assert comp_pass
 
 
-def test_yolov8_add_small(device):
+def test_yolov8_add_small(device_module):
+    device = device_module
     tor_a = torch.tensor(
         [
             [
@@ -2267,7 +2297,8 @@ def rand_gen(shape, device, *, dtype, tt_dtype, min=0, max=1, memory_config):
         [torch.float32, ttnn.float32, torch.bfloat16, ttnn.bfloat16],
     ),
 )
-def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device):
+def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 4, 2, 160])
     b_shape = torch.Size([1, 4, 1, 160])
@@ -2285,7 +2316,8 @@ def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device
     assert compare_pcc([out_tt], [out_pt])
 
 
-def test_add_1m(device):
+def test_add_1m(device_module):
+    device = device_module
     torch.manual_seed(0)
     a = torch.ones(1, 1) * 1_000_000
     b = torch.ones(32, 32)
@@ -2300,7 +2332,8 @@ def test_add_1m(device):
     assert_with_pcc(c, ttnn.to_torch(tc))
 
 
-def test_add_i32(device):
+def test_add_i32(device_module):
+    device = device_module
     torch.manual_seed(2024)
     a = torch.cat([torch.zeros(128, dtype=torch.int32), torch.ones(128, dtype=torch.int32)])
     a = torch.reshape(a, (1, 1, 1, 256))
@@ -2316,7 +2349,8 @@ def test_add_i32(device):
     assert torch.equal(torch_add, output_tensor)
 
 
-def test_add_error(device):
+def test_add_error(device_module):
+    device = device_module
     pytest.skip("Test is skipped because half mem config feature not supported yet")
     # Create input tensors with specified shapes
     input_shape = [1, 1, 1, 39576]
@@ -2341,7 +2375,8 @@ def test_add_error(device):
         [[8, 16, 32], [1, 1, 32]],
     ],
 )
-def test_sub_implicit_broadcast(device, shapes):
+def test_sub_implicit_broadcast(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
@@ -2371,7 +2406,8 @@ def test_sub_implicit_broadcast(device, shapes):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def test_small_fp32_multiply(device):
+def test_small_fp32_multiply(device_module):
+    device = device_module
     # Scaling with 0.01 to get realistic values that appear during training.
     a = ttnn.from_torch(0.01 * torch.randn((1, 1, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
     b = ttnn.from_torch(0.01 * torch.randn((4, 32, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
@@ -2401,7 +2437,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -2466,7 +2503,8 @@ def test_binary_sharded_bcast_w_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2531,7 +2569,8 @@ def test_binary_sharded_bcast_h_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -2596,7 +2635,8 @@ def test_binary_sharded_bcast_scalar_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2714,7 +2754,8 @@ def test_binary_sharded_bcast_scalar_zero_dim(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
+def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2773,7 +2814,8 @@ def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device):
+def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2819,7 +2861,8 @@ def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -2884,7 +2927,8 @@ def test_binary_sharded_bcast_w_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -2950,7 +2994,8 @@ def test_binary_sharded_bcast_w_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 3 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -3016,7 +3061,8 @@ def test_binary_sharded_bcast_w_block_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3081,7 +3127,8 @@ def test_binary_sharded_bcast_h_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -3146,7 +3193,8 @@ def test_binary_sharded_bcast_h_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 5 * 32])
@@ -3211,7 +3259,8 @@ def test_binary_sharded_bcast_h_block_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3276,7 +3325,8 @@ def test_binary_sharded_bcast_scalar_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -3341,7 +3391,8 @@ def test_binary_sharded_bcast_scalar_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3420,7 +3471,8 @@ def rand_bf16_gen_dtype(shape, device, *, min=0, max=1, dtype, memory_config=ttn
         (torch.Size([5, 10, 1, 128]), torch.Size([5, 10, 640, 1])),
     ),
 )
-def test_binary_sfpu_row_bcast(a_shape, b_shape, device):
+def test_binary_sfpu_row_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
     # make 0 exclusive for rhs of div
     min, max = (1, 0)
@@ -3446,7 +3498,8 @@ def test_binary_sfpu_row_bcast(a_shape, b_shape, device):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3629,7 +3682,8 @@ def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven_
 
 @pytest.mark.parametrize("input_shape", [(1, 4096, 640)])
 @pytest.mark.parametrize("is_legacy", [True, False])
-def test_add_sharded(device, input_shape, is_legacy):
+def test_add_sharded(device_module, input_shape, is_legacy):
+    device = device_module
     torch_input_tensor_a = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -3657,7 +3711,8 @@ def test_add_sharded(device, input_shape, is_legacy):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_orientation_output(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 31 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 31])
@@ -3751,7 +3806,8 @@ def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtyp
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3823,7 +3879,8 @@ def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_identical_mixed_strategy(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_identical_mixed_strategy(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -3900,7 +3957,8 @@ def test_binary_sharded_bcast_identical_mixed_strategy(device, dtype_pt, dtype_t
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 @pytest.mark.parametrize("scalar", [1.7, -0.25])
-def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device, dtype_pt, dtype_tt, scalar):
+def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device_module, dtype_pt, dtype_tt, scalar):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     out_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -3991,7 +4049,8 @@ def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device, dtype_pt, 
         ttnn.logical_xor_,
     ],
 )
-def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device, ttnn_fn):
+def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module, ttnn_fn):
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4051,7 +4110,8 @@ def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, n
         None,
     ],
 )
-def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device):
+def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device_module):
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4120,7 +4180,8 @@ def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw
         (1, 1, 32, 32 * 1024),
     ),
 )
-def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
+def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -43,7 +43,8 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
         [[5, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_unequal_ranks(a_shape, b_shape, device):
+def test_unequal_ranks(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -79,7 +80,8 @@ def test_unequal_ranks(a_shape, b_shape, device):
         (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
     ],
 )
-def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_config_b):
+def test_01_volume_tensors(device_module, a, b, c_golden, memory_config_a, memory_config_b):
+    device = device_module
     a = torch.BFloat16Tensor(a)
     b = torch.BFloat16Tensor(b)
     assert torch.add(a, b).tolist() == c_golden
@@ -99,7 +101,8 @@ def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_confi
         [[1, 2, 3, 3, 4, 32], [5, 1, 3, 3, 4, 32]],
     ],
 )
-def test_binary_invalid_rank(device, a_shape, b_shape):
+def test_binary_invalid_rank(device_module, a_shape, b_shape):
+    device = device_module
     torch.manual_seed(0)
     pt_a, tt_a = rand_bf16_gen(a_shape, device)
     pt_b, tt_b = rand_bf16_gen(b_shape, device)
@@ -202,8 +205,9 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ),
 )
 def test_binary_sharded_bcast_no_identical(
-    a_shape, b_shape, a_config, b_config, out_config, dtype_pt, dtype_tt, device
+    a_shape, b_shape, a_config, b_config, out_config, dtype_pt, dtype_tt, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(b_shape)
@@ -258,7 +262,8 @@ def test_binary_sharded_bcast_no_identical(
         ttnn.CoreRangeSet({ttnn.CoreRange((1, 0), (1, 6)), ttnn.CoreRange((3, 0), (3, 6))}),
     ),
 )
-def test_binary_sharded_row_major_layout(device, a_shape, b_shape, sharded_core_grid, memory_lay_out):
+def test_binary_sharded_row_major_layout(device_module, a_shape, b_shape, sharded_core_grid, memory_lay_out):
+    device = device_module
     torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         [160, 128],  # 14 cores
@@ -315,11 +320,12 @@ def test_binary_sharded_row_major_layout(device, a_shape, b_shape, sharded_core_
     ),
 )
 @pytest.mark.parametrize("ttnn_fn", ["add", "sub", "mul", "add_", "sub_", "mul_"])
-def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
+def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
 
-    torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device, min=-1e3, max=1e3)
-    torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device, min=-1e3, max=1e3)
+    torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device_module, min=-1e3, max=1e3)
+    torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device_module, min=-1e3, max=1e3)
     ttnn_op = getattr(ttnn, ttnn_fn)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -356,7 +362,8 @@ def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -420,7 +427,8 @@ def test_binary_sharded_bcast_w_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_c(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_c(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 1, 2 * 32, 1])
@@ -484,7 +492,8 @@ def test_binary_sharded_bcast_w_height_c(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_height_n(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_n(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 2 * 32, 1])
@@ -548,7 +557,8 @@ def test_binary_sharded_bcast_w_height_n(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -613,7 +623,8 @@ def test_binary_sharded_bcast_h_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -678,7 +689,8 @@ def test_binary_sharded_bcast_scalar_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_height(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_height(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -740,7 +752,8 @@ def test_binary_sharded_bcast_hw_mixed_height(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -805,7 +818,8 @@ def test_binary_sharded_bcast_w_width(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -870,7 +884,8 @@ def test_binary_sharded_bcast_h_width(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_width(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -947,7 +962,8 @@ def test_binary_sharded_bcast_scalar_width(device, dtype_pt, dtype_tt):
         ),
     ),
 )
-def test_binary_sharded_bcast_hw_mixed_width(device, dtype_pt, dtype_tt, sub_core_grids):
+def test_binary_sharded_bcast_hw_mixed_width(device_module, dtype_pt, dtype_tt, sub_core_grids):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 1, 7 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -1020,7 +1036,8 @@ def test_binary_sharded_bcast_hw_mixed_width(device, dtype_pt, dtype_tt, sub_cor
         (1, 1, 32, 128 * 1024),
     ),
 )
-def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
+def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
+    device = device_module
     """Test binary operations with sub_core_grids parameter"""
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
@@ -1117,7 +1134,8 @@ def test_binary_subcoregrid(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
         [ttnn.ShardStrategy.BLOCK, [32 * 5, 32], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 6))})],
     ),
 )
-def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1230,7 +1248,8 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
         ],
     ),
 )
-def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device):
+def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core_range, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     golden_function = ttnn.get_golden_function(ttnn_fn)
 
@@ -1295,7 +1314,8 @@ def test_binary_sharded_col_major(a_shape, b_shape, shard_type, shard_size, core
         [ttnn.ShardStrategy.BLOCK, ttnn.CoreGrid(x=2, y=5)],  # shard [32 * 7, 32],
     ),
 )
-def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
+def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1343,7 +1363,8 @@ def test_binary_sharded_auto(a_shape, b_shape, shard_type, core_coord, device):
         [ttnn.ShardStrategy.BLOCK, [32 * 8, 64], ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (1, 4))})],
     ),
 )
-def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1491,8 +1512,9 @@ def test_binary_sharded_bcast_no_identical_uneven(a_shape, b_shape, shard_type, 
     ),
 )
 def test_binary_sharded_bcast_scalar_value(
-    dtype_pt, dtype_tt, scalar, a_shape, shard_type, shard_size, core_range, device
+    dtype_pt, dtype_tt, scalar, a_shape, shard_type, shard_size, core_range, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1563,8 +1585,9 @@ def test_binary_sharded_bcast_scalar_value(
     ),
 )
 def test_binary_sharded_bcast_scalar_value_uneven(
-    dtype_pt, dtype_tt, scalar, a_shape, shard_type, shard_size, core_range, device
+    dtype_pt, dtype_tt, scalar, a_shape, shard_type, shard_size, core_range, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1612,7 +1635,8 @@ def test_binary_sharded_bcast_scalar_value_uneven(
         ],
     ),
 )
-def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1661,7 +1685,8 @@ def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, sh
         ],
     ),
 )
-def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1717,7 +1742,8 @@ def test_binary_sharded_scalar_row_major(scalar, a_shape, shard_type, shard_size
         ],
     ),
 )
-def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device):
+def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_size, core_range, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.bfloat16), ttnn.bfloat16)(b_shape)
@@ -1793,8 +1819,9 @@ def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_siz
     ),
 )
 def test_binary_sharded_invalid_row_major_layout(
-    a_shape, b_shape, shard_type, shard_size, core_range, dtype_pt, dtype_tt, device
+    a_shape, b_shape, shard_type, shard_size, core_range, dtype_pt, dtype_tt, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1858,8 +1885,9 @@ def test_binary_sharded_invalid_row_major_layout(
     ),
 )
 def test_binary_sharded_row_major_layout_mixed(
-    dtype_pt, dtype_tt, a_shape, b_shape, shard_type, shard_size, core_range, device
+    dtype_pt, dtype_tt, a_shape, b_shape, shard_type, shard_size, core_range, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1920,7 +1948,8 @@ def test_binary_sharded_row_major_layout_mixed(
         [[256], [920, 1, 256]],
     ],
 )
-def test_binary_subtile_no_bcast(a_shape, b_shape, device):
+def test_binary_subtile_no_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -1950,7 +1979,8 @@ def test_binary_subtile_no_bcast(a_shape, b_shape, device):
         [[1, 8192], [8192, 8192]],
     ],
 )
-def test_binary_subtile_row_bcast(a_shape, b_shape, device):
+def test_binary_subtile_row_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -1993,7 +2023,8 @@ def test_binary_subtile_row_bcast(a_shape, b_shape, device):
         [[4, 4, 320, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_col_bcast(a_shape, b_shape, device):
+def test_binary_subtile_col_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2029,7 +2060,8 @@ def test_binary_subtile_col_bcast(a_shape, b_shape, device):
         [[4, 4, 320, 320], [1, 1, 1, 1]],
     ],
 )
-def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
+def test_binary_subtile_scalar_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2071,7 +2103,8 @@ def test_binary_subtile_scalar_bcast(a_shape, b_shape, device):
         [[4, 4, 1, 320], [4, 4, 320, 1]],
     ],
 )
-def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
+def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
@@ -2100,7 +2133,8 @@ def test_binary_subtile_row_b_col_a_bcast(a_shape, b_shape, device):
 )
 @pytest.mark.parametrize("bcast_dim", [ttnn.BcastOpDim.H, ttnn.BcastOpDim.W, ttnn.BcastOpDim.HW])
 @pytest.mark.parametrize("math_op", [ttnn.BcastOpMath.ADD, ttnn.BcastOpMath.SUB, ttnn.BcastOpMath.MUL])
-def test_bcast(input_shape_a, device, bcast_dim, math_op):
+def test_bcast(input_shape_a, device_module, bcast_dim, math_op):
+    device = device_module
     torch.manual_seed(0)
     input_shape_b = list(input_shape_a)
 
@@ -2139,7 +2173,8 @@ def test_bcast(input_shape_a, device, bcast_dim, math_op):
     assert comp_pass
 
 
-def test_yolov8_add_small(device):
+def test_yolov8_add_small(device_module):
+    device = device_module
     tor_a = torch.tensor(
         [
             [
@@ -2254,7 +2289,8 @@ def test_yolov8_add_small(device):
     assert pcc
 
 
-def rand_gen(shape, device, *, dtype, tt_dtype, min=0, max=1, memory_config):
+def rand_gen(shape, device_module, *, dtype, tt_dtype, min=0, max=1, memory_config):
+    device = device_module
     pt = torch.rand(shape, dtype=dtype) * (max - min) + min
     tt = ttnn.from_torch(pt, device=device, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, dtype=tt_dtype)
     return pt, tt
@@ -2267,15 +2303,16 @@ def rand_gen(shape, device, *, dtype, tt_dtype, min=0, max=1, memory_config):
         [torch.float32, ttnn.float32, torch.bfloat16, ttnn.bfloat16],
     ),
 )
-def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device):
+def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 4, 2, 160])
     b_shape = torch.Size([1, 4, 1, 160])
     mem = ttnn.MemoryConfig(
         memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED, buffer_type=ttnn.BufferType.L1, shard_spec=None
     )
-    a_pt, a_tt = rand_gen(a_shape, device, dtype=dtype_pt_a, tt_dtype=dtype_tt_a, memory_config=mem)
-    b_pt, b_tt = rand_gen(b_shape, device, dtype=dtype_pt_b, tt_dtype=dtype_tt_b, memory_config=mem)
+    a_pt, a_tt = rand_gen(a_shape, device_module, dtype=dtype_pt_a, tt_dtype=dtype_tt_a, memory_config=mem)
+    b_pt, b_tt = rand_gen(b_shape, device_module, dtype=dtype_pt_b, tt_dtype=dtype_tt_b, memory_config=mem)
 
     golden_fn = ttnn.get_golden_function(ttnn.add)
 
@@ -2285,7 +2322,8 @@ def test_binary_mixed_add(dtype_pt_a, dtype_tt_a, dtype_pt_b, dtype_tt_b, device
     assert compare_pcc([out_tt], [out_pt])
 
 
-def test_add_1m(device):
+def test_add_1m(device_module):
+    device = device_module
     torch.manual_seed(0)
     a = torch.ones(1, 1) * 1_000_000
     b = torch.ones(32, 32)
@@ -2300,7 +2338,8 @@ def test_add_1m(device):
     assert_with_pcc(c, ttnn.to_torch(tc))
 
 
-def test_add_i32(device):
+def test_add_i32(device_module):
+    device = device_module
     torch.manual_seed(2024)
     a = torch.cat([torch.zeros(128, dtype=torch.int32), torch.ones(128, dtype=torch.int32)])
     a = torch.reshape(a, (1, 1, 1, 256))
@@ -2316,7 +2355,8 @@ def test_add_i32(device):
     assert torch.equal(torch_add, output_tensor)
 
 
-def test_add_error(device):
+def test_add_error(device_module):
+    device = device_module
     pytest.skip("Test is skipped because half mem config feature not supported yet")
     # Create input tensors with specified shapes
     input_shape = [1, 1, 1, 39576]
@@ -2341,7 +2381,8 @@ def test_add_error(device):
         [[8, 16, 32], [1, 1, 32]],
     ],
 )
-def test_sub_implicit_broadcast(device, shapes):
+def test_sub_implicit_broadcast(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.float32)
@@ -2371,7 +2412,8 @@ def test_sub_implicit_broadcast(device, shapes):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
-def test_small_fp32_multiply(device):
+def test_small_fp32_multiply(device_module):
+    device = device_module
     # Scaling with 0.01 to get realistic values that appear during training.
     a = ttnn.from_torch(0.01 * torch.randn((1, 1, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
     b = ttnn.from_torch(0.01 * torch.randn((4, 32, 2048), dtype=torch.float32), layout=ttnn.TILE_LAYOUT, device=device)
@@ -2401,7 +2443,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -2466,7 +2509,8 @@ def test_binary_sharded_bcast_w_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2531,7 +2575,8 @@ def test_binary_sharded_bcast_h_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -2596,7 +2641,8 @@ def test_binary_sharded_bcast_scalar_block(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_block(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_block(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -2680,8 +2726,9 @@ height_sharded_memory_config = ttnn.create_sharded_memory_config(
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 def test_binary_sharded_bcast_scalar_zero_dim(
-    a_shape, b_shape, a_config, b_config, out_config, dtype_pt, dtype_tt, device
+    a_shape, b_shape, a_config, b_config, out_config, dtype_pt, dtype_tt, device_module
 ):
+    device = device_module
     torch.manual_seed(0)
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=dtype_pt), dtype_tt)(b_shape)
@@ -2714,7 +2761,8 @@ def test_binary_sharded_bcast_scalar_zero_dim(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
+def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2773,7 +2821,8 @@ def test_binary_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device):
+def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -2819,7 +2868,8 @@ def test_binary_sharded_shardspec_dram(dtype_pt, dtype_tt, device):
         # [torch.bfloat16, ttnn.bfloat8_b],
     ),
 )
-def test_binary_sharded_bcast_w_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([5, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([5, 7, 2 * 32, 1])
@@ -2884,7 +2934,8 @@ def test_binary_sharded_bcast_w_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([1, 2, 2 * 32, 40 * 32])
     b_shape = torch.Size([1, 1, 2 * 32, 1])
@@ -2950,7 +3001,8 @@ def test_binary_sharded_bcast_w_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_w_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_w_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 3 * 32])
     b_shape = torch.Size([1, 7, 32 * 2, 1])
@@ -3016,7 +3068,8 @@ def test_binary_sharded_bcast_w_block_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3081,7 +3134,8 @@ def test_binary_sharded_bcast_h_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 7 * 32])
@@ -3146,7 +3200,8 @@ def test_binary_sharded_bcast_h_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 5 * 32])
@@ -3211,7 +3266,8 @@ def test_binary_sharded_bcast_h_block_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_height_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_height_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 2 * 32, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3276,7 +3332,8 @@ def test_binary_sharded_bcast_scalar_height_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_width_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_width_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 1, 64, 7 * 32])
     b_shape = torch.Size([1, 1, 1, 1])
@@ -3341,7 +3398,8 @@ def test_binary_sharded_bcast_scalar_width_uneven(device, dtype_pt, dtype_tt):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_scalar_block_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_scalar_block_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 5 * 32])
     b_shape = torch.Size([1, 7, 1, 1])
@@ -3420,15 +3478,16 @@ def rand_bf16_gen_dtype(shape, device, *, min=0, max=1, dtype, memory_config=ttn
         (torch.Size([5, 10, 1, 128]), torch.Size([5, 10, 640, 1])),
     ),
 )
-def test_binary_sfpu_row_bcast(a_shape, b_shape, device):
+def test_binary_sfpu_row_bcast(a_shape, b_shape, device_module):
+    device = device_module
     torch.manual_seed(0)
     # make 0 exclusive for rhs of div
     min, max = (1, 0)
 
     ttnn_fn = ttnn.pow
     dtype = "bfloat16"
-    a_pt, a_tt = rand_bf16_gen_dtype(a_shape, device, dtype=dtype)
-    b_pt, b_tt = rand_bf16_gen_dtype(b_shape, device, min=min, max=max, dtype=dtype)
+    a_pt, a_tt = rand_bf16_gen_dtype(a_shape, device_module, dtype=dtype)
+    b_pt, b_tt = rand_bf16_gen_dtype(b_shape, device_module, min=min, max=max, dtype=dtype)
 
     out_tt = ttnn_fn(
         a_tt,
@@ -3446,7 +3505,8 @@ def test_binary_sfpu_row_bcast(a_shape, b_shape, device):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3536,8 +3596,9 @@ def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven(
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven_unaligned_shape(
-    device, dtype_pt, dtype_tt
+    device_module, dtype_pt, dtype_tt
 ):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 30 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 30])
@@ -3629,7 +3690,8 @@ def test_binary_sharded_bcast_hw_mixed_output_mixed_shard_strategy_mixed_uneven_
 
 @pytest.mark.parametrize("input_shape", [(1, 4096, 640)])
 @pytest.mark.parametrize("is_legacy", [True, False])
-def test_add_sharded(device, input_shape, is_legacy):
+def test_add_sharded(device_module, input_shape, is_legacy):
+    device = device_module
     torch_input_tensor_a = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
@@ -3657,7 +3719,8 @@ def test_add_sharded(device, input_shape, is_legacy):
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_hw_mixed_orientation_output(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 31 * 2, 1])
     b_shape = torch.Size([1, 7, 1, 4 * 31])
@@ -3751,7 +3814,8 @@ def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtyp
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([1, 7, 1, 4 * 32])
@@ -3823,7 +3887,8 @@ def test_binary_sharded_bcast_h_mixed_strategy_mixed_L1(device, dtype_pt, dtype_
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_binary_sharded_bcast_identical_mixed_strategy(device, dtype_pt, dtype_tt):
+def test_binary_sharded_bcast_identical_mixed_strategy(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     b_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -3900,7 +3965,8 @@ def test_binary_sharded_bcast_identical_mixed_strategy(device, dtype_pt, dtype_t
     ([torch.bfloat16, ttnn.bfloat16],),
 )
 @pytest.mark.parametrize("scalar", [1.7, -0.25])
-def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device, dtype_pt, dtype_tt, scalar):
+def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device_module, dtype_pt, dtype_tt, scalar):
+    device = device_module
     torch.manual_seed(0)
     a_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
     out_shape = torch.Size([2, 7, 32 * 2, 4 * 32])
@@ -3991,7 +4057,9 @@ def test_binary_sharded_bcast_scalar_value_mixed_shard_uneven(device, dtype_pt, 
         ttnn.logical_xor_,
     ],
 )
-def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device, ttnn_fn):
+def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module, ttnn_fn):
+    device = device_module
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4051,7 +4119,8 @@ def test_binary_inplace_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, n
         None,
     ],
 )
-def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device):
+def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, round_mode, device_module):
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)
@@ -4120,7 +4189,8 @@ def test_div_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw
         (1, 1, 32, 32 * 1024),
     ),
 )
-def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device):
+def test_remainder_composite_ops_with_subcore_grids(dtype_pt, dtype_tt, nb, nc, nh, nw, device_module):
+    device = device_module
     torch.manual_seed(10)
     shape = [nb, nc, nh, nw]
     inp_a = torch.rand(*shape).to(dtype_pt)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
@@ -26,7 +26,8 @@ from models.common.utility_functions import torch_random
     "dtype",
     ([ttnn.int32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat4_b]),
 )
-def test_binary_scalar_ops(input_shapes, dtype, device):
+def test_binary_scalar_ops(input_shapes, dtype, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
@@ -26,8 +26,7 @@ from models.common.utility_functions import torch_random
     "dtype",
     ([ttnn.int32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32, ttnn.bfloat4_b]),
 )
-def test_binary_scalar_ops(input_shapes, dtype, device_module):
-    device = device_module
+def test_binary_scalar_ops(input_shapes, dtype, device):
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
@@ -33,7 +33,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device):
+def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
 
@@ -76,7 +77,8 @@ def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, de
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device):
+def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
 
@@ -130,7 +132,8 @@ def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function
         ttnn.ne,
     ),
 )
-def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device):
+def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     cq_id = 0
@@ -172,7 +175,8 @@ def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, tt
     (ttnn.eq, ttnn.ne),
 )
 @pytest.mark.parametrize("use_legacy", (True, False))
-def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device, use_legacy):
+def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device_module, use_legacy):
+    device = device_module
     in_data = torch.randint(0, 100, input_shapes, dtype=torch.int32)
     in_data[-1] = 65535
     # Make a copy of in_data so 50% of values are the same

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
@@ -33,9 +33,10 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
+def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device_module, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device_module, True)
 
     cq_id = 0
     mem_cfg = mem_configs
@@ -76,13 +77,14 @@ def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, de
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
+def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device_module, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device_module, True)
 
     cq_id = 0
     mem_cfg = mem_configs
-    _, output_tensor = data_gen_with_range_dtype(input_shapes, -1, 1, device, False, False, out_dtype)
+    _, output_tensor = data_gen_with_range_dtype(input_shapes, -1, 1, device_module, False, False, out_dtype)
     ttnn_function(
         input_tensor, other_tensor, memory_config=mem_cfg, dtype=out_dtype, queue_id=cq_id, output_tensor=output_tensor
     )
@@ -130,8 +132,9 @@ def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function
         ttnn.ne,
     ),
 )
-def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device_module):
+    device = device_module
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device_module, True)
 
     cq_id = 0
     mem_cfg = mem_configs
@@ -172,7 +175,8 @@ def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, tt
     (ttnn.eq, ttnn.ne),
 )
 @pytest.mark.parametrize("use_legacy", (True, False))
-def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device, use_legacy):
+def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device_module, use_legacy):
+    device = device_module
     in_data = torch.randint(0, 100, input_shapes, dtype=torch.int32)
     in_data[-1] = 65535
     # Make a copy of in_data so 50% of values are the same

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
@@ -33,8 +33,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
-    device = device_module
+def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
 
@@ -77,8 +76,7 @@ def test_binary_comp_ops(input_shapes, out_dtype, mem_configs, ttnn_function, de
     "ttnn_function",
     (ttnn.lt, ttnn.gt, ttnn.eq, ttnn.le, ttnn.ge, ttnn.ne, ttnn.logical_and, ttnn.logical_or, ttnn.logical_xor),
 )
-def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device_module):
-    device = device_module
+def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
 
@@ -132,8 +130,7 @@ def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function
         ttnn.ne,
     ),
 )
-def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device_module):
-    device = device_module
+def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, ttnn_function, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     cq_id = 0
@@ -175,8 +172,7 @@ def test_binary_comp_ops_scalar(input_shapes, scalar, out_dtype, mem_configs, tt
     (ttnn.eq, ttnn.ne),
 )
 @pytest.mark.parametrize("use_legacy", (True, False))
-def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device_module, use_legacy):
-    device = device_module
+def test_binary_comp_uint16_ops(input_shapes, mem_configs, ttnn_function, device, use_legacy):
     in_data = torch.randint(0, 100, input_shapes, dtype=torch.int32)
     in_data[-1] = 65535
     # Make a copy of in_data so 50% of values are the same

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -26,7 +26,8 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nextafter_ttnn(input_shapes, device):
+def test_binary_nextafter_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -49,7 +50,8 @@ def test_binary_nextafter_ttnn(input_shapes, device):
 @pytest.mark.parametrize("atol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("rtol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("equal_nan", [True, False])
-def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
+def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device, seed=42)
 
@@ -70,7 +72,8 @@ def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_atan2_ttnn(input_shapes, device):
+def test_binary_atan2_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -90,7 +93,8 @@ def test_binary_atan2_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor_ttnn(input_shapes, device):
+def test_binary_logical_xor_ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -131,7 +135,8 @@ def test_binary_logical_xor_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -157,7 +162,8 @@ def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, -1, device)
@@ -184,7 +190,8 @@ def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -221,7 +228,8 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device):
+def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
@@ -243,7 +251,8 @@ def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, 
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device):
+def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -264,7 +273,8 @@ def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, val
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_no_nan_ttnn(input_shapes, device):
+def test_binary_div_no_nan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -285,7 +295,8 @@ def test_binary_div_no_nan_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
+def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div_no_nan(input_tensor1, value)
@@ -304,7 +315,8 @@ def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_floor_div_ttnn(input_shapes, device):
+def test_binary_floor_div_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.floor_div(input_tensor1, input_tensor2)
@@ -324,7 +336,8 @@ def test_binary_floor_div_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
+def test_binary_floor_div_overload_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.floor_div(input_tensor1, value)
@@ -343,7 +356,8 @@ def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_remainder_ttnn(input_shapes, device):
+def test_binary_remainder_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.remainder(input_tensor1, input_tensor2)
@@ -360,7 +374,8 @@ def test_binary_remainder_ttnn(input_shapes, device):
         [[1, 1, 3, 3], [1, 1, 3, 3]],
     ],
 )
-def test_shape_remainder(device, shapes):
+def test_shape_remainder(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
     high = 10
     low = -10
@@ -399,7 +414,8 @@ def test_shape_remainder(device, shapes):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_remainder_ttnn(input_shapes, scalar, device):
+def test_remainder_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     output_tensor = ttnn.remainder(input_tensor1, scalar)
     golden_function = ttnn.get_golden_function(ttnn.remainder)
@@ -417,7 +433,8 @@ def test_remainder_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_fmod_ttnn(input_shapes, device):
+def test_binary_fmod_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -438,7 +455,8 @@ def test_binary_fmod_ttnn(input_shapes, device):
     ),
 )
 # Input with more than two decimal places experience precision loss in bfloat16. use FP32 for better precision.
-def test_binary_fmod_decimal_ttnn(input_shapes, device):
+def test_binary_fmod_decimal_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.randn(input_shapes, dtype=torch.float32) * 9
     input_tensor1 = ttnn.Tensor(in_data1, ttnn.float32).to(ttnn.TILE_LAYOUT).to(device)
     in_data2 = torch.rand(input_shapes, dtype=torch.float32) - 2
@@ -463,7 +481,8 @@ def test_binary_fmod_decimal_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_fmod_ttnn(input_shapes, scalar, device):
+def test_fmod_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
 
     output_tensor = ttnn.fmod(input_tensor1, scalar)
@@ -482,7 +501,8 @@ def test_fmod_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_and__ttnn(input_shapes, device):
+def test_binary_logical_and__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -521,7 +541,8 @@ def test_binary_logical_and__ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_or__ttnn(input_shapes, device):
+def test_binary_logical_or__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -560,7 +581,8 @@ def test_binary_logical_or__ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor__ttnn(input_shapes, device):
+def test_binary_logical_xor__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -600,7 +622,8 @@ def test_binary_logical_xor__ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("coeffs", [[0.0], [-5.0, 2.0], [-3.0, 0.0, 10.0], [-100.0, -25.0, 0.0, 15.0, 100.0]])
-def test_binary_polyval_ttnn(input_shapes, coeffs, device):
+def test_binary_polyval_ttnn(input_shapes, coeffs, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.polyval(input_tensor1, coeffs)
@@ -619,7 +642,8 @@ def test_binary_polyval_ttnn(input_shapes, coeffs, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gti_ttnn(input_shapes, device):
+def test_binary_gti_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.gt_(input_tensor1, input_tensor2)
@@ -642,7 +666,8 @@ def test_binary_gti_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gti_ttnn(input_shapes, scalar, device):
+def test_gti_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.gt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.gt_)
@@ -660,7 +685,8 @@ def test_gti_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gei_ttnn(input_shapes, device):
+def test_binary_gei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ge_(input_tensor1, input_tensor2)
@@ -683,7 +709,8 @@ def test_binary_gei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gei_ttnn(input_shapes, scalar, device):
+def test_gei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ge_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ge_)
@@ -701,7 +728,8 @@ def test_gei_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lti_ttnn(input_shapes, device):
+def test_binary_lti_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.lt_(input_tensor1, input_tensor2)
@@ -724,7 +752,8 @@ def test_binary_lti_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lti_ttnn(input_shapes, scalar, device):
+def test_lti_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.lt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.lt_)
@@ -742,7 +771,8 @@ def test_lti_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lei_ttnn(input_shapes, device):
+def test_binary_lei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.le_(input_tensor1, input_tensor2)
@@ -765,7 +795,8 @@ def test_binary_lei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lei_ttnn(input_shapes, scalar, device):
+def test_lei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.le_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.le_)
@@ -783,7 +814,8 @@ def test_lei_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_eqi_ttnn(input_shapes, device):
+def test_binary_eqi_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.eq_(input_tensor1, input_tensor2)
@@ -806,7 +838,8 @@ def test_binary_eqi_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_eqi_ttnn(input_shapes, scalar, device):
+def test_eqi_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.eq_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.eq_)
@@ -824,7 +857,8 @@ def test_eqi_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nei_ttnn(input_shapes, device):
+def test_binary_nei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ne_(input_tensor1, input_tensor2)
@@ -847,7 +881,8 @@ def test_binary_nei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_nei_ttnn(input_shapes, scalar, device):
+def test_nei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ne_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ne_)
@@ -870,7 +905,8 @@ def test_nei_ttnn(input_shapes, scalar, device):
         (torch.Size([49, 321])),
     ),
 )
-def test_binary_prelu_ttnn(input_shapes, device):
+def test_binary_prelu_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     channels = input_shapes[1]
     in_data2 = torch.rand((channels,), dtype=torch.bfloat16) * 200 - 100
@@ -903,7 +939,8 @@ def test_binary_prelu_ttnn(input_shapes, device):
     "scalar",
     {-0.25, -2.7, 0.45, 6.4},
 )
-def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
+def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -939,7 +976,8 @@ def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
         [-1],
     ],
 )
-def test_binary_prelu_1D_weight(input_shapes, weight, device):
+def test_binary_prelu_1D_weight(input_shapes, weight, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -960,7 +998,8 @@ def test_binary_prelu_1D_weight(input_shapes, weight, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_left_shift(input_shapes, device):
+def test_binary_left_shift(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-20, 50, input_shapes, dtype=torch.int32)
@@ -985,7 +1024,8 @@ def test_binary_left_shift(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_right_shift(input_shapes, device):
+def test_binary_right_shift(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(0, 31, input_shapes, dtype=torch.int32)
@@ -1014,7 +1054,8 @@ def test_binary_right_shift(input_shapes, device):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_left_shift(input_shapes, device, scalar):
+def test_unary_left_shift(input_shapes, device_module, scalar):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1041,7 +1082,8 @@ def test_unary_left_shift(input_shapes, device, scalar):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_right_shift(input_shapes, device, scalar):
+def test_unary_right_shift(input_shapes, device_module, scalar):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -26,7 +26,8 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nextafter_ttnn(input_shapes, device):
+def test_binary_nextafter_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -49,9 +50,10 @@ def test_binary_nextafter_ttnn(input_shapes, device):
 @pytest.mark.parametrize("atol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("rtol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("equal_nan", [True, False])
-def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
-    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device, seed=42)
+def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device_module):
+    device = device_module
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device_module, seed=0)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device_module, seed=42)
 
     output_tensor = ttnn.isclose(input_tensor1, input_tensor2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
@@ -70,7 +72,8 @@ def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_atan2_ttnn(input_shapes, device):
+def test_binary_atan2_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -90,7 +93,8 @@ def test_binary_atan2_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor_ttnn(input_shapes, device):
+def test_binary_logical_xor_ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -131,7 +135,8 @@ def test_binary_logical_xor_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -157,7 +162,8 @@ def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, -1, device)
@@ -184,7 +190,8 @@ def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
+def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device_module):
+    device = device_module
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -221,7 +228,8 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device):
+def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
@@ -243,7 +251,8 @@ def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, 
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device):
+def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -264,7 +273,8 @@ def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, val
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_no_nan_ttnn(input_shapes, device):
+def test_binary_div_no_nan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -285,7 +295,8 @@ def test_binary_div_no_nan_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
+def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div_no_nan(input_tensor1, value)
@@ -304,7 +315,8 @@ def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_floor_div_ttnn(input_shapes, device):
+def test_binary_floor_div_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.floor_div(input_tensor1, input_tensor2)
@@ -324,7 +336,8 @@ def test_binary_floor_div_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
+def test_binary_floor_div_overload_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.floor_div(input_tensor1, value)
@@ -343,7 +356,8 @@ def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_remainder_ttnn(input_shapes, device):
+def test_binary_remainder_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.remainder(input_tensor1, input_tensor2)
@@ -360,7 +374,8 @@ def test_binary_remainder_ttnn(input_shapes, device):
         [[1, 1, 3, 3], [1, 1, 3, 3]],
     ],
 )
-def test_shape_remainder(device, shapes):
+def test_shape_remainder(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
     high = 10
     low = -10
@@ -399,7 +414,8 @@ def test_shape_remainder(device, shapes):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_remainder_ttnn(input_shapes, scalar, device):
+def test_remainder_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     output_tensor = ttnn.remainder(input_tensor1, scalar)
     golden_function = ttnn.get_golden_function(ttnn.remainder)
@@ -417,7 +433,8 @@ def test_remainder_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_fmod_ttnn(input_shapes, device):
+def test_binary_fmod_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -438,7 +455,8 @@ def test_binary_fmod_ttnn(input_shapes, device):
     ),
 )
 # Input with more than two decimal places experience precision loss in bfloat16. use FP32 for better precision.
-def test_binary_fmod_decimal_ttnn(input_shapes, device):
+def test_binary_fmod_decimal_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.randn(input_shapes, dtype=torch.float32) * 9
     input_tensor1 = ttnn.Tensor(in_data1, ttnn.float32).to(ttnn.TILE_LAYOUT).to(device)
     in_data2 = torch.rand(input_shapes, dtype=torch.float32) - 2
@@ -463,7 +481,8 @@ def test_binary_fmod_decimal_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_fmod_ttnn(input_shapes, scalar, device):
+def test_fmod_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
 
     output_tensor = ttnn.fmod(input_tensor1, scalar)
@@ -482,7 +501,8 @@ def test_fmod_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_and__ttnn(input_shapes, device):
+def test_binary_logical_and__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -521,7 +541,8 @@ def test_binary_logical_and__ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_or__ttnn(input_shapes, device):
+def test_binary_logical_or__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -560,7 +581,8 @@ def test_binary_logical_or__ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor__ttnn(input_shapes, device):
+def test_binary_logical_xor__ttnn(input_shapes, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -600,7 +622,8 @@ def test_binary_logical_xor__ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("coeffs", [[0.0], [-5.0, 2.0], [-3.0, 0.0, 10.0], [-100.0, -25.0, 0.0, 15.0, 100.0]])
-def test_binary_polyval_ttnn(input_shapes, coeffs, device):
+def test_binary_polyval_ttnn(input_shapes, coeffs, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.polyval(input_tensor1, coeffs)
@@ -619,7 +642,8 @@ def test_binary_polyval_ttnn(input_shapes, coeffs, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gti_ttnn(input_shapes, device):
+def test_binary_gti_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.gt_(input_tensor1, input_tensor2)
@@ -642,7 +666,8 @@ def test_binary_gti_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gti_ttnn(input_shapes, scalar, device):
+def test_gti_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.gt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.gt_)
@@ -660,7 +685,8 @@ def test_gti_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gei_ttnn(input_shapes, device):
+def test_binary_gei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ge_(input_tensor1, input_tensor2)
@@ -683,7 +709,8 @@ def test_binary_gei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gei_ttnn(input_shapes, scalar, device):
+def test_gei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ge_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ge_)
@@ -701,7 +728,8 @@ def test_gei_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lti_ttnn(input_shapes, device):
+def test_binary_lti_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.lt_(input_tensor1, input_tensor2)
@@ -724,7 +752,8 @@ def test_binary_lti_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lti_ttnn(input_shapes, scalar, device):
+def test_lti_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.lt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.lt_)
@@ -742,7 +771,8 @@ def test_lti_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lei_ttnn(input_shapes, device):
+def test_binary_lei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.le_(input_tensor1, input_tensor2)
@@ -765,7 +795,8 @@ def test_binary_lei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lei_ttnn(input_shapes, scalar, device):
+def test_lei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.le_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.le_)
@@ -783,7 +814,8 @@ def test_lei_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_eqi_ttnn(input_shapes, device):
+def test_binary_eqi_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.eq_(input_tensor1, input_tensor2)
@@ -806,7 +838,8 @@ def test_binary_eqi_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_eqi_ttnn(input_shapes, scalar, device):
+def test_eqi_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.eq_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.eq_)
@@ -824,7 +857,8 @@ def test_eqi_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nei_ttnn(input_shapes, device):
+def test_binary_nei_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ne_(input_tensor1, input_tensor2)
@@ -847,7 +881,8 @@ def test_binary_nei_ttnn(input_shapes, device):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_nei_ttnn(input_shapes, scalar, device):
+def test_nei_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ne_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ne_)
@@ -870,7 +905,8 @@ def test_nei_ttnn(input_shapes, scalar, device):
         (torch.Size([49, 321])),
     ),
 )
-def test_binary_prelu_ttnn(input_shapes, device):
+def test_binary_prelu_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     channels = input_shapes[1]
     in_data2 = torch.rand((channels,), dtype=torch.bfloat16) * 200 - 100
@@ -903,7 +939,8 @@ def test_binary_prelu_ttnn(input_shapes, device):
     "scalar",
     {-0.25, -2.7, 0.45, 6.4},
 )
-def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
+def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -939,7 +976,8 @@ def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
         [-1],
     ],
 )
-def test_binary_prelu_1D_weight(input_shapes, weight, device):
+def test_binary_prelu_1D_weight(input_shapes, weight, device_module):
+    device = device_module
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -960,7 +998,8 @@ def test_binary_prelu_1D_weight(input_shapes, weight, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_left_shift(input_shapes, device):
+def test_binary_left_shift(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-20, 50, input_shapes, dtype=torch.int32)
@@ -985,7 +1024,8 @@ def test_binary_left_shift(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_right_shift(input_shapes, device):
+def test_binary_right_shift(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(0, 31, input_shapes, dtype=torch.int32)
@@ -1014,7 +1054,9 @@ def test_binary_right_shift(input_shapes, device):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_left_shift(input_shapes, device, scalar):
+def test_unary_left_shift(input_shapes, device_module, scalar):
+    device = device_module
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1041,7 +1083,9 @@ def test_unary_left_shift(input_shapes, device, scalar):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_right_shift(input_shapes, device, scalar):
+def test_unary_right_shift(input_shapes, device_module, scalar):
+    device = device_module
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -26,8 +26,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nextafter_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_nextafter_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -50,8 +49,7 @@ def test_binary_nextafter_ttnn(input_shapes, device_module):
 @pytest.mark.parametrize("atol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("rtol", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("equal_nan", [True, False])
-def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device_module):
-    device = device_module
+def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device, seed=42)
 
@@ -72,8 +70,7 @@ def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device_module)
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_atan2_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_atan2_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -93,8 +90,7 @@ def test_binary_atan2_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_logical_xor_ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-100, 100, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -135,8 +131,7 @@ def test_binary_logical_xor_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device_module):
-    device = device_module
+def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -162,8 +157,7 @@ def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device_module)
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device_module):
-    device = device_module
+def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, -1, device)
@@ -190,8 +184,7 @@ def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device_modu
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device_module):
-    device = device_module
+def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -228,8 +221,7 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device_mod
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device_module):
-    device = device_module
+def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
@@ -251,8 +243,7 @@ def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, 
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device_module):
-    device = device_module
+def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -273,8 +264,7 @@ def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, val
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_div_no_nan_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_div_no_nan_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -295,8 +285,7 @@ def test_binary_div_no_nan_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div_no_nan(input_tensor1, value)
@@ -315,8 +304,7 @@ def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_floor_div_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_floor_div_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.floor_div(input_tensor1, input_tensor2)
@@ -336,8 +324,7 @@ def test_binary_floor_div_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-def test_binary_floor_div_overload_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.floor_div(input_tensor1, value)
@@ -356,8 +343,7 @@ def test_binary_floor_div_overload_ttnn(input_shapes, value, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_remainder_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_remainder_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.remainder(input_tensor1, input_tensor2)
@@ -374,8 +360,7 @@ def test_binary_remainder_ttnn(input_shapes, device_module):
         [[1, 1, 3, 3], [1, 1, 3, 3]],
     ],
 )
-def test_shape_remainder(device_module, shapes):
-    device = device_module
+def test_shape_remainder(device, shapes):
     torch.manual_seed(0)
     high = 10
     low = -10
@@ -414,8 +399,7 @@ def test_shape_remainder(device_module, shapes):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_remainder_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_remainder_ttnn(input_shapes, scalar, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     output_tensor = ttnn.remainder(input_tensor1, scalar)
     golden_function = ttnn.get_golden_function(ttnn.remainder)
@@ -433,8 +417,7 @@ def test_remainder_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_fmod_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_fmod_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -455,8 +438,7 @@ def test_binary_fmod_ttnn(input_shapes, device_module):
     ),
 )
 # Input with more than two decimal places experience precision loss in bfloat16. use FP32 for better precision.
-def test_binary_fmod_decimal_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_fmod_decimal_ttnn(input_shapes, device):
     in_data1 = torch.randn(input_shapes, dtype=torch.float32) * 9
     input_tensor1 = ttnn.Tensor(in_data1, ttnn.float32).to(ttnn.TILE_LAYOUT).to(device)
     in_data2 = torch.rand(input_shapes, dtype=torch.float32) - 2
@@ -481,8 +463,7 @@ def test_binary_fmod_decimal_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_fmod_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_fmod_ttnn(input_shapes, scalar, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
 
     output_tensor = ttnn.fmod(input_tensor1, scalar)
@@ -501,8 +482,7 @@ def test_fmod_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_and__ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_logical_and__ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -541,8 +521,7 @@ def test_binary_logical_and__ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_or__ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_logical_or__ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -581,8 +560,7 @@ def test_binary_logical_or__ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_xor__ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_logical_xor__ttnn(input_shapes, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data1 = torch.linspace(-150, 150, num_elements, dtype=torch.bfloat16)
     in_data1 = in_data1[:num_elements].reshape(input_shapes)
@@ -622,8 +600,7 @@ def test_binary_logical_xor__ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("coeffs", [[0.0], [-5.0, 2.0], [-3.0, 0.0, 10.0], [-100.0, -25.0, 0.0, 15.0, 100.0]])
-def test_binary_polyval_ttnn(input_shapes, coeffs, device_module):
-    device = device_module
+def test_binary_polyval_ttnn(input_shapes, coeffs, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.polyval(input_tensor1, coeffs)
@@ -642,8 +619,7 @@ def test_binary_polyval_ttnn(input_shapes, coeffs, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gti_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_gti_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.gt_(input_tensor1, input_tensor2)
@@ -666,8 +642,7 @@ def test_binary_gti_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gti_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_gti_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.gt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.gt_)
@@ -685,8 +660,7 @@ def test_gti_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gei_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_gei_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ge_(input_tensor1, input_tensor2)
@@ -709,8 +683,7 @@ def test_binary_gei_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_gei_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_gei_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ge_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ge_)
@@ -728,8 +701,7 @@ def test_gei_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lti_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_lti_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.lt_(input_tensor1, input_tensor2)
@@ -752,8 +724,7 @@ def test_binary_lti_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lti_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_lti_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.lt_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.lt_)
@@ -771,8 +742,7 @@ def test_lti_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_lei_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_lei_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.le_(input_tensor1, input_tensor2)
@@ -795,8 +765,7 @@ def test_binary_lei_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_lei_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_lei_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.le_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.le_)
@@ -814,8 +783,7 @@ def test_lei_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_eqi_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_eqi_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.eq_(input_tensor1, input_tensor2)
@@ -838,8 +806,7 @@ def test_binary_eqi_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_eqi_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_eqi_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.eq_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.eq_)
@@ -857,8 +824,7 @@ def test_eqi_ttnn(input_shapes, scalar, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_nei_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_nei_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
     ttnn.ne_(input_tensor1, input_tensor2)
@@ -881,8 +847,7 @@ def test_binary_nei_ttnn(input_shapes, device_module):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-def test_nei_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_nei_ttnn(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.ne_(input_tensor, scalar)
     golden_function = ttnn.get_golden_function(ttnn.ne_)
@@ -905,8 +870,7 @@ def test_nei_ttnn(input_shapes, scalar, device_module):
         (torch.Size([49, 321])),
     ),
 )
-def test_binary_prelu_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_prelu_ttnn(input_shapes, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     channels = input_shapes[1]
     in_data2 = torch.rand((channels,), dtype=torch.bfloat16) * 200 - 100
@@ -939,8 +903,7 @@ def test_binary_prelu_ttnn(input_shapes, device_module):
     "scalar",
     {-0.25, -2.7, 0.45, 6.4},
 )
-def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device_module):
-    device = device_module
+def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -976,8 +939,7 @@ def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device_module):
         [-1],
     ],
 )
-def test_binary_prelu_1D_weight(input_shapes, weight, device_module):
-    device = device_module
+def test_binary_prelu_1D_weight(input_shapes, weight, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -998,8 +960,7 @@ def test_binary_prelu_1D_weight(input_shapes, weight, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_left_shift(input_shapes, device_module):
-    device = device_module
+def test_binary_left_shift(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-20, 50, input_shapes, dtype=torch.int32)
@@ -1024,8 +985,7 @@ def test_binary_left_shift(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_right_shift(input_shapes, device_module):
-    device = device_module
+def test_binary_right_shift(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(0, 31, input_shapes, dtype=torch.int32)
@@ -1054,8 +1014,7 @@ def test_binary_right_shift(input_shapes, device_module):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_left_shift(input_shapes, device_module, scalar):
-    device = device_module
+def test_unary_left_shift(input_shapes, device, scalar):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1082,8 +1041,7 @@ def test_unary_left_shift(input_shapes, device_module, scalar):
     "scalar",
     {random.randint(0, 31)},
 )
-def test_unary_right_shift(input_shapes, device_module, scalar):
-    device = device_module
+def test_unary_right_shift(input_shapes, device, scalar):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -21,8 +21,7 @@ from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
         ttnn.add,
     ],
 )
-def test_fp32(device_module, ttnn_function):
-    device = device_module
+def test_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -43,8 +42,7 @@ def test_fp32(device_module, ttnn_function):
         ttnn.sub,
     ],
 )
-def test_int32(device_module, ttnn_function):
-    device = device_module
+def test_int32(device, ttnn_function):
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -64,8 +62,7 @@ def test_int32(device_module, ttnn_function):
         ttnn.mul,
     ],
 )
-def test_mul_fp32(device_module, ttnn_function):
-    device = device_module
+def test_mul_fp32(device, ttnn_function):
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -87,8 +84,7 @@ def test_mul_fp32(device_module, ttnn_function):
 )
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device_module, ttnn_function):
-    device = device_module
+def test_div_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -112,8 +108,7 @@ def test_div_fp32(device_module, ttnn_function):
     ],
 )
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device_module, ttnn_function):
-    device = device_module
+def test_div_bf16_nonzero(device, ttnn_function):
     x_torch = torch.tensor(
         [
             [
@@ -160,8 +155,7 @@ def test_div_bf16_nonzero(device_module, ttnn_function):
         ttnn.pow,
     ],
 )
-def test_pow_fp32(device_module, ttnn_function):
-    device = device_module
+def test_pow_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -175,8 +169,7 @@ def test_pow_fp32(device_module, ttnn_function):
     assert status
 
 
-def test_squared_sum_fp32_activ(device_module):
-    device = device_module
+def test_squared_sum_fp32_activ(device):
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -204,8 +197,7 @@ def test_squared_sum_fp32_activ(device_module):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device_module, ttnn_function, shape):
-    device = device_module
+def test_add_fp32_input_activ(device, ttnn_function, shape):
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -229,8 +221,7 @@ def test_add_fp32_input_activ(device_module, ttnn_function, shape):
         ttnn.logaddexp,
     ],
 )
-def test_logaddexp_fp32(device_module, ttnn_function):
-    device = device_module
+def test_logaddexp_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -250,8 +241,7 @@ def test_logaddexp_fp32(device_module, ttnn_function):
         ttnn.logaddexp2,
     ],
 )
-def test_logaddexp2_fp32(device_module, ttnn_function):
-    device = device_module
+def test_logaddexp2_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -271,8 +261,7 @@ def test_logaddexp2_fp32(device_module, ttnn_function):
         ttnn.ldexp,
     ],
 )
-def test_ldexp_fp32(device_module, ttnn_function):
-    device = device_module
+def test_ldexp_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -292,8 +281,7 @@ def test_ldexp_fp32(device_module, ttnn_function):
         ttnn.bias_gelu,
     ],
 )
-def test_bias_gelu_fp32(device_module, ttnn_function):
-    device = device_module
+def test_bias_gelu_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -313,8 +301,7 @@ def test_bias_gelu_fp32(device_module, ttnn_function):
         ttnn.squared_difference,
     ],
 )
-def test_squared_difference_fp32(device_module, ttnn_function):
-    device = device_module
+def test_squared_difference_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -336,8 +323,7 @@ def test_squared_difference_fp32(device_module, ttnn_function):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device_module, ttnn_function):
-    device = device_module
+def test_logical_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -362,8 +348,7 @@ def test_logical_fp32(device_module, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device_module, ttnn_function):
-    device = device_module
+def test_relational_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -385,8 +370,7 @@ def test_relational_fp32(device_module, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device_module, ttnn_function):
-    device = device_module
+def test_bitwise(device, ttnn_function):
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -409,8 +393,7 @@ def test_bitwise(device_module, ttnn_function):
     ),
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_xlogy_ttnn(input_shapes, device_module, use_legacy):
-    device = device_module
+def test_binary_xlogy_ttnn(input_shapes, device, use_legacy):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -425,8 +408,7 @@ def test_binary_xlogy_ttnn(input_shapes, device_module, use_legacy):
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16)])
-def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device_module, torch_dtype, ttnn_dtype):
-    device = device_module
+def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device, torch_dtype, ttnn_dtype):
     if torch_dtype == torch.bfloat16 and round_mode is None and accurate_mode is False:
         pytest.skip(
             "Skipping test case due to division by zero not being handled properly in bfloat16 with round_mode=None and accurate_mode=False"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -21,7 +21,8 @@ from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
         ttnn.add,
     ],
 )
-def test_fp32(device, ttnn_function):
+def test_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -42,7 +43,8 @@ def test_fp32(device, ttnn_function):
         ttnn.sub,
     ],
 )
-def test_int32(device, ttnn_function):
+def test_int32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -62,7 +64,8 @@ def test_int32(device, ttnn_function):
         ttnn.mul,
     ],
 )
-def test_mul_fp32(device, ttnn_function):
+def test_mul_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -84,7 +87,8 @@ def test_mul_fp32(device, ttnn_function):
 )
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device, ttnn_function):
+def test_div_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -108,7 +112,8 @@ def test_div_fp32(device, ttnn_function):
     ],
 )
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device, ttnn_function):
+def test_div_bf16_nonzero(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -155,7 +160,8 @@ def test_div_bf16_nonzero(device, ttnn_function):
         ttnn.pow,
     ],
 )
-def test_pow_fp32(device, ttnn_function):
+def test_pow_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -169,7 +175,8 @@ def test_pow_fp32(device, ttnn_function):
     assert status
 
 
-def test_squared_sum_fp32_activ(device):
+def test_squared_sum_fp32_activ(device_module):
+    device = device_module
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -197,7 +204,8 @@ def test_squared_sum_fp32_activ(device):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device, ttnn_function, shape):
+def test_add_fp32_input_activ(device_module, ttnn_function, shape):
+    device = device_module
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -221,7 +229,8 @@ def test_add_fp32_input_activ(device, ttnn_function, shape):
         ttnn.logaddexp,
     ],
 )
-def test_logaddexp_fp32(device, ttnn_function):
+def test_logaddexp_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -241,7 +250,8 @@ def test_logaddexp_fp32(device, ttnn_function):
         ttnn.logaddexp2,
     ],
 )
-def test_logaddexp2_fp32(device, ttnn_function):
+def test_logaddexp2_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -261,7 +271,8 @@ def test_logaddexp2_fp32(device, ttnn_function):
         ttnn.ldexp,
     ],
 )
-def test_ldexp_fp32(device, ttnn_function):
+def test_ldexp_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -281,7 +292,8 @@ def test_ldexp_fp32(device, ttnn_function):
         ttnn.bias_gelu,
     ],
 )
-def test_bias_gelu_fp32(device, ttnn_function):
+def test_bias_gelu_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -301,7 +313,8 @@ def test_bias_gelu_fp32(device, ttnn_function):
         ttnn.squared_difference,
     ],
 )
-def test_squared_difference_fp32(device, ttnn_function):
+def test_squared_difference_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -323,7 +336,8 @@ def test_squared_difference_fp32(device, ttnn_function):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device, ttnn_function):
+def test_logical_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -348,7 +362,8 @@ def test_logical_fp32(device, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device, ttnn_function):
+def test_relational_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -370,7 +385,8 @@ def test_relational_fp32(device, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device, ttnn_function):
+def test_bitwise(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -393,7 +409,8 @@ def test_bitwise(device, ttnn_function):
     ),
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_xlogy_ttnn(input_shapes, device, use_legacy):
+def test_binary_xlogy_ttnn(input_shapes, device_module, use_legacy):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -408,7 +425,8 @@ def test_binary_xlogy_ttnn(input_shapes, device, use_legacy):
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16)])
-def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device, torch_dtype, ttnn_dtype):
+def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device_module, torch_dtype, ttnn_dtype):
+    device = device_module
     if torch_dtype == torch.bfloat16 and round_mode is None and accurate_mode is False:
         pytest.skip(
             "Skipping test case due to division by zero not being handled properly in bfloat16 with round_mode=None and accurate_mode=False"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -21,7 +21,8 @@ from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
         ttnn.add,
     ],
 )
-def test_fp32(device, ttnn_function):
+def test_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -42,7 +43,8 @@ def test_fp32(device, ttnn_function):
         ttnn.sub,
     ],
 )
-def test_int32(device, ttnn_function):
+def test_int32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -62,7 +64,8 @@ def test_int32(device, ttnn_function):
         ttnn.mul,
     ],
 )
-def test_mul_fp32(device, ttnn_function):
+def test_mul_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -84,7 +87,8 @@ def test_mul_fp32(device, ttnn_function):
 )
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device, ttnn_function):
+def test_div_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -108,7 +112,8 @@ def test_div_fp32(device, ttnn_function):
     ],
 )
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device, ttnn_function):
+def test_div_bf16_nonzero(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -155,7 +160,8 @@ def test_div_bf16_nonzero(device, ttnn_function):
         ttnn.pow,
     ],
 )
-def test_pow_fp32(device, ttnn_function):
+def test_pow_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -169,7 +175,8 @@ def test_pow_fp32(device, ttnn_function):
     assert status
 
 
-def test_squared_sum_fp32_activ(device):
+def test_squared_sum_fp32_activ(device_module):
+    device = device_module
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -197,7 +204,8 @@ def test_squared_sum_fp32_activ(device):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device, ttnn_function, shape):
+def test_add_fp32_input_activ(device_module, ttnn_function, shape):
+    device = device_module
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -221,7 +229,8 @@ def test_add_fp32_input_activ(device, ttnn_function, shape):
         ttnn.logaddexp,
     ],
 )
-def test_logaddexp_fp32(device, ttnn_function):
+def test_logaddexp_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -241,7 +250,8 @@ def test_logaddexp_fp32(device, ttnn_function):
         ttnn.logaddexp2,
     ],
 )
-def test_logaddexp2_fp32(device, ttnn_function):
+def test_logaddexp2_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -261,7 +271,8 @@ def test_logaddexp2_fp32(device, ttnn_function):
         ttnn.ldexp,
     ],
 )
-def test_ldexp_fp32(device, ttnn_function):
+def test_ldexp_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -281,7 +292,8 @@ def test_ldexp_fp32(device, ttnn_function):
         ttnn.bias_gelu,
     ],
 )
-def test_bias_gelu_fp32(device, ttnn_function):
+def test_bias_gelu_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -301,7 +313,8 @@ def test_bias_gelu_fp32(device, ttnn_function):
         ttnn.squared_difference,
     ],
 )
-def test_squared_difference_fp32(device, ttnn_function):
+def test_squared_difference_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -323,7 +336,8 @@ def test_squared_difference_fp32(device, ttnn_function):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device, ttnn_function):
+def test_logical_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -348,7 +362,8 @@ def test_logical_fp32(device, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device, ttnn_function):
+def test_relational_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -370,7 +385,8 @@ def test_relational_fp32(device, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device, ttnn_function):
+def test_bitwise(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -393,7 +409,9 @@ def test_bitwise(device, ttnn_function):
     ),
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_xlogy_ttnn(input_shapes, device, use_legacy):
+def test_binary_xlogy_ttnn(input_shapes, device_module, use_legacy):
+    device = device_module
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
 
@@ -408,7 +426,9 @@ def test_binary_xlogy_ttnn(input_shapes, device, use_legacy):
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize("torch_dtype, ttnn_dtype", [(torch.float32, ttnn.float32), (torch.bfloat16, ttnn.bfloat16)])
-def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device, torch_dtype, ttnn_dtype):
+def test_binary_div_edge_case_ttnn(accurate_mode, round_mode, device_module, torch_dtype, ttnn_dtype):
+    device = device_module
+    device = device_module
     if torch_dtype == torch.bfloat16 and round_mode is None and accurate_mode is False:
         pytest.skip(
             "Skipping test case due to division by zero not being handled properly in bfloat16 with round_mode=None and accurate_mode=False"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -62,7 +62,8 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device):
+def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
@@ -130,7 +131,8 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_l
         ttnn.rsub,
     ],
 )
-def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape)
@@ -203,7 +205,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
 @pytest.mark.parametrize(
     "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference", "rsub")
 )
-def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
+def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_module):
+    device = device_module
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
@@ -247,7 +250,8 @@ def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device)
         ttnn.logical_and,
     ],
 )
-def test_binary_logical_int32_edge_cases(logical_op, device):
+def test_binary_logical_int32_edge_cases(logical_op, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 1, -1, 2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896]
     )
@@ -293,8 +297,9 @@ def test_binary_logical_int32_edge_cases(logical_op, device):
         ttnn.uint32,
     ],
 )
-def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
+def test_binary_left_shift(device_module, ttnn_function, ttnn_dtype):
     # Test with regular values and extreme values for both int32 and uint32
+    device = device_module
     if ttnn_dtype == ttnn.int32:
         x_torch = torch.tensor(
             [[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000, 2147483647, -2147483648, -1, 1]], dtype=torch.int32
@@ -338,7 +343,8 @@ def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
         ttnn.uint32,
     ],
 )
-def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
+def test_bitwise_right_shift(device_module, ttnn_function, ttnn_dtype):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -396,7 +402,8 @@ def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_logical_right_shift(device, ttnn_function, ttnn_dtype, use_legacy):
+def test_logical_right_shift(device_module, ttnn_function, ttnn_dtype, use_legacy):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -464,7 +471,8 @@ def test_logical_right_shift(device, ttnn_function, ttnn_dtype, use_legacy):
         (-1, 1, -2147483648, -1073741823),
     ],
 )
-def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     if high_a in (3, 2, 1):
         values_a = torch.arange(low_a, high_a + 1, dtype=torch.int32)
@@ -507,7 +515,8 @@ def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device):
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_mul_int32_edge_cases(use_legacy, device):
+def test_binary_mul_int32_edge_cases(use_legacy, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [
             0,
@@ -600,7 +609,8 @@ def test_binary_mul_int32_edge_cases(use_legacy, device):
         ttnn.div,
     ],
 )
-def test_binary_implicit_broadcast(device, shapes, ttnn_op):
+def test_binary_implicit_broadcast(device_module, shapes, ttnn_op):
+    device = device_module
     torch.manual_seed(0)
 
     min_int = torch.iinfo(torch.int32).min
@@ -644,7 +654,8 @@ def test_binary_implicit_broadcast(device, shapes, ttnn_op):
         ttnn.le,
     ],
 )
-def test_comp_ops_edge_cases(ttnn_op, device):
+def test_comp_ops_edge_cases(ttnn_op, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 0, 1254, 43, 2147483647, -2147483648, 2147483647, 0, -123456789, -56738943, 2147483647, -2147483648]
     )
@@ -680,7 +691,8 @@ def test_comp_ops_edge_cases(ttnn_op, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_div_int32_full_range(input_shapes, device):
+def test_binary_div_int32_full_range(input_shapes, device_module):
+    device = device_module
     value_ranges_a = [
         (-300, 300),
         (-500, 500),
@@ -746,7 +758,8 @@ def test_binary_div_int32_full_range(input_shapes, device):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
 
 
-def test_div_int32_optional_output(device):
+def test_div_int32_optional_output(device_module):
+    device = device_module
     torch_input_tensor_a = torch.arange(-(2**23), 2**23, 1024, dtype=torch.int32)
     torch_input_tensor_b = torch.arange(-(2**23) - 1, 2**23 - 1, 1024, dtype=torch.int32)
     torch_input_tensor_b[torch_input_tensor_b == 0] = 1
@@ -790,7 +803,8 @@ def test_div_int32_optional_output(device):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device):
+def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device_module):
+    device = device_module
     # Skip some cases for rounding_mode==None that aren't supported due to:
     # https://github.com/tenstorrent/tt-metal/issues/33334
     if round_mode is None and low_a == -2147483648:
@@ -838,7 +852,8 @@ def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round
 
 
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_edge_cases(round_mode, device):
+def test_div_edge_cases(round_mode, device_module):
+    device = device_module
     pairs = [
         (16777215, 1),
         (16777216, 2),
@@ -893,7 +908,8 @@ def test_div_edge_cases(round_mode, device):
         assert torch.equal(torch_output_tensor, output_tensor)
 
 
-def test_div_inf_nan_cases(device):
+def test_div_inf_nan_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -925,7 +941,8 @@ def test_div_inf_nan_cases(device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_divide_int32_full_range(input_shapes, device):
+def test_binary_divide_int32_full_range(input_shapes, device_module):
+    device = device_module
     value_ranges_a = [
         (-300, 300),
         (-750, 500),
@@ -993,7 +1010,8 @@ def test_binary_divide_int32_full_range(input_shapes, device):
         assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_edge_cases(device):
+def test_divide_edge_cases(device_module):
+    device = device_module
     pairs = [
         (3, 2),
         (2, 2),
@@ -1037,7 +1055,8 @@ def test_divide_edge_cases(device):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_inf_nan_cases(device):
+def test_divide_inf_nan_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -62,7 +62,8 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device):
+def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
@@ -130,7 +131,8 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_l
         ttnn.rsub,
     ],
 )
-def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
+def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape)
@@ -203,7 +205,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
 @pytest.mark.parametrize(
     "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference", "rsub")
 )
-def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
+def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_module):
+    device = device_module
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
@@ -247,7 +250,8 @@ def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device)
         ttnn.logical_and,
     ],
 )
-def test_binary_logical_int32_edge_cases(logical_op, device):
+def test_binary_logical_int32_edge_cases(logical_op, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 1, -1, 2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896]
     )
@@ -293,7 +297,8 @@ def test_binary_logical_int32_edge_cases(logical_op, device):
         ttnn.uint32,
     ],
 )
-def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
+def test_binary_left_shift(device_module, ttnn_function, ttnn_dtype):
+    device = device_module
     # Test with regular values and extreme values for both int32 and uint32
     if ttnn_dtype == ttnn.int32:
         x_torch = torch.tensor(
@@ -338,7 +343,8 @@ def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
         ttnn.uint32,
     ],
 )
-def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
+def test_bitwise_right_shift(device_module, ttnn_function, ttnn_dtype):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -396,7 +402,8 @@ def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_logical_right_shift(device, ttnn_function, ttnn_dtype, use_legacy):
+def test_logical_right_shift(device_module, ttnn_function, ttnn_dtype, use_legacy):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -464,7 +471,8 @@ def test_logical_right_shift(device, ttnn_function, ttnn_dtype, use_legacy):
         (-1, 1, -2147483648, -1073741823),
     ],
 )
-def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     if high_a in (3, 2, 1):
         values_a = torch.arange(low_a, high_a + 1, dtype=torch.int32)
@@ -507,7 +515,8 @@ def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device):
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_mul_int32_edge_cases(use_legacy, device):
+def test_binary_mul_int32_edge_cases(use_legacy, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [
             0,
@@ -600,7 +609,8 @@ def test_binary_mul_int32_edge_cases(use_legacy, device):
         ttnn.div,
     ],
 )
-def test_binary_implicit_broadcast(device, shapes, ttnn_op):
+def test_binary_implicit_broadcast(device_module, shapes, ttnn_op):
+    device = device_module
     torch.manual_seed(0)
 
     min_int = torch.iinfo(torch.int32).min
@@ -644,7 +654,8 @@ def test_binary_implicit_broadcast(device, shapes, ttnn_op):
         ttnn.le,
     ],
 )
-def test_comp_ops_edge_cases(ttnn_op, device):
+def test_comp_ops_edge_cases(ttnn_op, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 0, 1254, 43, 2147483647, -2147483648, 2147483647, 0, -123456789, -56738943, 2147483647, -2147483648]
     )
@@ -680,7 +691,8 @@ def test_comp_ops_edge_cases(ttnn_op, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_div_int32_full_range(input_shapes, device):
+def test_binary_div_int32_full_range(input_shapes, device_module):
+    device = device_module
     value_ranges_a = [
         (-300, 300),
         (-500, 500),
@@ -746,7 +758,8 @@ def test_binary_div_int32_full_range(input_shapes, device):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
 
 
-def test_div_int32_optional_output(device):
+def test_div_int32_optional_output(device_module):
+    device = device_module
     torch_input_tensor_a = torch.arange(-(2**23), 2**23, 1024, dtype=torch.int32)
     torch_input_tensor_b = torch.arange(-(2**23) - 1, 2**23 - 1, 1024, dtype=torch.int32)
     torch_input_tensor_b[torch_input_tensor_b == 0] = 1
@@ -790,7 +803,8 @@ def test_div_int32_optional_output(device):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device):
+def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device_module):
+    device = device_module
     # Skip some cases for rounding_mode==None that aren't supported due to:
     # https://github.com/tenstorrent/tt-metal/issues/33334
     if round_mode is None and low_a == -2147483648:
@@ -838,7 +852,8 @@ def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round
 
 
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_edge_cases(round_mode, device):
+def test_div_edge_cases(round_mode, device_module):
+    device = device_module
     pairs = [
         (16777215, 1),
         (16777216, 2),
@@ -893,7 +908,8 @@ def test_div_edge_cases(round_mode, device):
         assert torch.equal(torch_output_tensor, output_tensor)
 
 
-def test_div_inf_nan_cases(device):
+def test_div_inf_nan_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -925,7 +941,8 @@ def test_div_inf_nan_cases(device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_divide_int32_full_range(input_shapes, device):
+def test_binary_divide_int32_full_range(input_shapes, device_module):
+    device = device_module
     value_ranges_a = [
         (-300, 300),
         (-750, 500),
@@ -993,7 +1010,8 @@ def test_binary_divide_int32_full_range(input_shapes, device):
         assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_edge_cases(device):
+def test_divide_edge_cases(device_module):
+    device = device_module
     pairs = [
         (3, 2),
         (2, 2),
@@ -1037,7 +1055,8 @@ def test_divide_edge_cases(device):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_inf_nan_cases(device):
+def test_divide_inf_nan_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -62,8 +62,7 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device_module):
-    device = device_module
+def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_legacy, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
@@ -131,8 +130,7 @@ def test_binary_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_op, use_l
         ttnn.rsub,
     ],
 )
-def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device_module):
-    device = device_module
+def test_binary_int32_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, ttnn_op, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape)
@@ -205,8 +203,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
 @pytest.mark.parametrize(
     "ttnn_fn", ("logical_or", "logical_xor", "logical_and", "add", "sub", "mul", "squared_difference", "rsub")
 )
-def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_module):
-    device = device_module
+def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
@@ -250,8 +247,7 @@ def test_binary_int32_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_
         ttnn.logical_and,
     ],
 )
-def test_binary_logical_int32_edge_cases(logical_op, device_module):
-    device = device_module
+def test_binary_logical_int32_edge_cases(logical_op, device):
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 1, -1, 2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896]
     )
@@ -297,9 +293,8 @@ def test_binary_logical_int32_edge_cases(logical_op, device_module):
         ttnn.uint32,
     ],
 )
-def test_binary_left_shift(device_module, ttnn_function, ttnn_dtype):
+def test_binary_left_shift(device, ttnn_function, ttnn_dtype):
     # Test with regular values and extreme values for both int32 and uint32
-    device = device_module
     if ttnn_dtype == ttnn.int32:
         x_torch = torch.tensor(
             [[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000, 2147483647, -2147483648, -1, 1]], dtype=torch.int32
@@ -343,8 +338,7 @@ def test_binary_left_shift(device_module, ttnn_function, ttnn_dtype):
         ttnn.uint32,
     ],
 )
-def test_bitwise_right_shift(device_module, ttnn_function, ttnn_dtype):
-    device = device_module
+def test_bitwise_right_shift(device, ttnn_function, ttnn_dtype):
     x_torch = torch.tensor(
         [
             [
@@ -402,8 +396,7 @@ def test_bitwise_right_shift(device_module, ttnn_function, ttnn_dtype):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_logical_right_shift(device_module, ttnn_function, ttnn_dtype, use_legacy):
-    device = device_module
+def test_logical_right_shift(device, ttnn_function, ttnn_dtype, use_legacy):
     x_torch = torch.tensor(
         [
             [
@@ -471,8 +464,7 @@ def test_logical_right_shift(device_module, ttnn_function, ttnn_dtype, use_legac
         (-1, 1, -2147483648, -1073741823),
     ],
 )
-def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     if high_a in (3, 2, 1):
         values_a = torch.arange(low_a, high_a + 1, dtype=torch.int32)
@@ -515,8 +507,7 @@ def test_binary_mul_int32(input_shapes, low_a, high_a, low_b, high_b, device_mod
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_mul_int32_edge_cases(use_legacy, device_module):
-    device = device_module
+def test_binary_mul_int32_edge_cases(use_legacy, device):
     torch_input_tensor_a = torch.tensor(
         [
             0,
@@ -609,8 +600,7 @@ def test_binary_mul_int32_edge_cases(use_legacy, device_module):
         ttnn.div,
     ],
 )
-def test_binary_implicit_broadcast(device_module, shapes, ttnn_op):
-    device = device_module
+def test_binary_implicit_broadcast(device, shapes, ttnn_op):
     torch.manual_seed(0)
 
     min_int = torch.iinfo(torch.int32).min
@@ -654,8 +644,7 @@ def test_binary_implicit_broadcast(device_module, shapes, ttnn_op):
         ttnn.le,
     ],
 )
-def test_comp_ops_edge_cases(ttnn_op, device_module):
-    device = device_module
+def test_comp_ops_edge_cases(ttnn_op, device):
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 0, 1254, 43, 2147483647, -2147483648, 2147483647, 0, -123456789, -56738943, 2147483647, -2147483648]
     )
@@ -691,8 +680,7 @@ def test_comp_ops_edge_cases(ttnn_op, device_module):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_div_int32_full_range(input_shapes, device_module):
-    device = device_module
+def test_binary_div_int32_full_range(input_shapes, device):
     value_ranges_a = [
         (-300, 300),
         (-500, 500),
@@ -758,8 +746,7 @@ def test_binary_div_int32_full_range(input_shapes, device_module):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=2.0)
 
 
-def test_div_int32_optional_output(device_module):
-    device = device_module
+def test_div_int32_optional_output(device):
     torch_input_tensor_a = torch.arange(-(2**23), 2**23, 1024, dtype=torch.int32)
     torch_input_tensor_b = torch.arange(-(2**23) - 1, 2**23 - 1, 1024, dtype=torch.int32)
     torch_input_tensor_b[torch_input_tensor_b == 0] = 1
@@ -803,8 +790,7 @@ def test_div_int32_optional_output(device_module):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device_module):
-    device = device_module
+def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round_mode, device):
     # Skip some cases for rounding_mode==None that aren't supported due to:
     # https://github.com/tenstorrent/tt-metal/issues/33334
     if round_mode is None and low_a == -2147483648:
@@ -852,8 +838,7 @@ def test_div_int32_round_modes(input_shapes, low_a, high_a, low_b, high_b, round
 
 
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_div_edge_cases(round_mode, device_module):
-    device = device_module
+def test_div_edge_cases(round_mode, device):
     pairs = [
         (16777215, 1),
         (16777216, 2),
@@ -908,8 +893,7 @@ def test_div_edge_cases(round_mode, device_module):
         assert torch.equal(torch_output_tensor, output_tensor)
 
 
-def test_div_inf_nan_cases(device_module):
-    device = device_module
+def test_div_inf_nan_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -941,8 +925,7 @@ def test_div_inf_nan_cases(device_module):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_divide_int32_full_range(input_shapes, device_module):
-    device = device_module
+def test_binary_divide_int32_full_range(input_shapes, device):
     value_ranges_a = [
         (-300, 300),
         (-750, 500),
@@ -1010,8 +993,7 @@ def test_binary_divide_int32_full_range(input_shapes, device_module):
         assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_edge_cases(device_module):
-    device = device_module
+def test_divide_edge_cases(device):
     pairs = [
         (3, 2),
         (2, 2),
@@ -1055,8 +1037,7 @@ def test_divide_edge_cases(device_module):
     assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=1.0)
 
 
-def test_divide_inf_nan_cases(device_module):
-    device = device_module
+def test_divide_inf_nan_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, -1, 0, 0, 1, -1, -1, 1, 2147483647, 0], dtype=torch.int32)
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -22,8 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -65,8 +64,7 @@ def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device_mod
         (11, 53),
     ],
 )
-def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -111,8 +109,7 @@ def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -157,8 +154,7 @@ def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -215,8 +211,7 @@ def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -265,8 +260,7 @@ def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device_modu
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.float32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.float32) * input_b_val
 
@@ -316,8 +310,7 @@ def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device
         (11, 1),
     ],
 )
-def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.bfloat16) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.bfloat16) * input_b_val
 
@@ -361,8 +354,7 @@ def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device
         (-3.0 * 10**38, 3.0 * 10**38, -3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -408,8 +400,7 @@ def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device_modu
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -457,8 +448,7 @@ def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -504,8 +494,7 @@ def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_max_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -22,7 +22,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -64,7 +65,8 @@ def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device):
         (11, 53),
     ],
 )
-def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
+def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -109,7 +111,8 @@ def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -154,7 +157,8 @@ def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -211,7 +215,8 @@ def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -260,7 +265,8 @@ def test_binary_max_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device):
+def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.float32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.float32) * input_b_val
 
@@ -310,7 +316,8 @@ def test_binary_max_fill_val_fp32(input_shapes, input_a_val, input_b_val, device
         (11, 1),
     ],
 )
-def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device):
+def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.bfloat16) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.bfloat16) * input_b_val
 
@@ -354,7 +361,8 @@ def test_binary_max_fill_val_bf16(input_shapes, input_a_val, input_b_val, device
         (-3.0 * 10**38, 3.0 * 10**38, -3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -400,7 +408,8 @@ def test_binary_max_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -448,7 +457,8 @@ def test_binary_max_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -494,7 +504,8 @@ def test_binary_max_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_max_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_max_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -22,8 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -65,8 +64,7 @@ def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device_mod
         (11, 53),
     ],
 )
-def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -109,8 +107,7 @@ def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -156,8 +153,7 @@ def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -214,8 +210,7 @@ def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -265,8 +260,7 @@ def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device_modu
         (11, 1),
     ],
 )
-def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.float32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.float32) * input_b_val
 
@@ -316,8 +310,7 @@ def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device
         (11, 1),
     ],
 )
-def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.bfloat16) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.bfloat16) * input_b_val
 
@@ -361,8 +354,7 @@ def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device
         (-3.0 * 10**38, 3.0 * 10**38, -3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes).nan_to_num(0.0)
@@ -410,8 +402,7 @@ def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device_modu
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -460,8 +451,7 @@ def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a).nan_to_num(0.0)
@@ -507,8 +497,7 @@ def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_min_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -22,7 +22,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -64,7 +65,8 @@ def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device):
         (11, 53),
     ],
 )
-def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
+def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -107,7 +109,8 @@ def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -153,7 +156,8 @@ def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -210,7 +214,8 @@ def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -260,7 +265,8 @@ def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
         (11, 1),
     ],
 )
-def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device):
+def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.float32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.float32) * input_b_val
 
@@ -310,7 +316,8 @@ def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device
         (11, 1),
     ],
 )
-def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device):
+def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.bfloat16) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.bfloat16) * input_b_val
 
@@ -354,7 +361,8 @@ def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device
         (-3.0 * 10**38, 3.0 * 10**38, -3.3 * 10**38, 3.3 * 10**38),
     ],
 )
-def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes).nan_to_num(0.0)
@@ -402,7 +410,8 @@ def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -451,7 +460,8 @@ def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a).nan_to_num(0.0)
@@ -497,7 +507,8 @@ def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],
 )
-def test_binary_min_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_min_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -56,7 +56,8 @@ binary_fns = {
     ([ttnn.TILE_LAYOUT]),
 )
 # No typecast on inputs and optional output
-def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device):
+def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -104,7 +105,8 @@ def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device):
     ([ttnn.bfloat8_b]),
 )
 # Typecast on both inputs and optional output
-def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
+def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -146,7 +148,8 @@ def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
     ),
 )
 # Typecast on both inputs
-def test_sub_typecast(input_shapes, device):
+def test_sub_typecast(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -190,7 +193,8 @@ def test_sub_typecast(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_sub_typecast_a(input_shapes, device):
+def test_sub_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -234,7 +238,8 @@ def test_sub_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_sub_typecast_b(input_shapes, device):
+def test_sub_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -278,7 +283,8 @@ def test_sub_typecast_b(input_shapes, device):
     ),
 )
 # Typecast on both inputs
-def test_sub_opt_output_typecast_inputs(input_shapes, device):
+def test_sub_opt_output_typecast_inputs(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -328,7 +334,8 @@ def test_sub_opt_output_typecast_inputs(input_shapes, device):
     ),
 )
 # Typecast on output
-def test_sub_opt_output_typecast_out(input_shapes, device):
+def test_sub_opt_output_typecast_out(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -376,7 +383,8 @@ def test_sub_opt_output_typecast_out(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_sub_opt_output_typecast_a(input_shapes, device):
+def test_sub_opt_output_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -424,7 +432,8 @@ def test_sub_opt_output_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_sub_opt_output_typecast_b(input_shapes, device):
+def test_sub_opt_output_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -472,7 +481,8 @@ def test_sub_opt_output_typecast_b(input_shapes, device):
     ),
 )
 # Typecast on both inputs
-def test_inplace_sub_typecast(input_shapes, device):
+def test_inplace_sub_typecast(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -516,7 +526,8 @@ def test_inplace_sub_typecast(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_inplace_sub_typecast_a(input_shapes, device):
+def test_inplace_sub_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -560,7 +571,8 @@ def test_inplace_sub_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_inplace_sub_typecast_b(input_shapes, device):
+def test_inplace_sub_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -622,7 +634,8 @@ def test_inplace_sub_typecast_b(input_shapes, device):
 )
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
 # Typecast on both input and optional tensor
-def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
+def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -675,7 +688,8 @@ def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -720,7 +734,8 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -776,7 +791,8 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
@@ -839,7 +855,8 @@ def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
@@ -890,7 +907,7 @@ def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_c
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("output_dtype", [ttnn.float32, ttnn.bfloat16])
 def test_binary_div(
-    device,
+    device_module,
     input_shape,
     input_layout,
     input_shard_grid,
@@ -899,6 +916,7 @@ def test_binary_div(
     input_dtype,
     output_dtype,
 ):
+    device = device_module
     memory_config = ttnn.create_sharded_memory_config(
         input_shape,
         core_grid=input_shard_grid,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -56,8 +56,7 @@ binary_fns = {
     ([ttnn.TILE_LAYOUT]),
 )
 # No typecast on inputs and optional output
-def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device_module):
-    device = device_module
+def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device):
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -105,8 +104,7 @@ def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device_mod
     ([ttnn.bfloat8_b]),
 )
 # Typecast on both inputs and optional output
-def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device_module):
-    device = device_module
+def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -148,8 +146,7 @@ def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device_module):
     ),
 )
 # Typecast on both inputs
-def test_sub_typecast(input_shapes, device_module):
-    device = device_module
+def test_sub_typecast(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -193,8 +190,7 @@ def test_sub_typecast(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor a
-def test_sub_typecast_a(input_shapes, device_module):
-    device = device_module
+def test_sub_typecast_a(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -238,8 +234,7 @@ def test_sub_typecast_a(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor b
-def test_sub_typecast_b(input_shapes, device_module):
-    device = device_module
+def test_sub_typecast_b(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -283,8 +278,7 @@ def test_sub_typecast_b(input_shapes, device_module):
     ),
 )
 # Typecast on both inputs
-def test_sub_opt_output_typecast_inputs(input_shapes, device_module):
-    device = device_module
+def test_sub_opt_output_typecast_inputs(input_shapes, device):
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -334,8 +328,7 @@ def test_sub_opt_output_typecast_inputs(input_shapes, device_module):
     ),
 )
 # Typecast on output
-def test_sub_opt_output_typecast_out(input_shapes, device_module):
-    device = device_module
+def test_sub_opt_output_typecast_out(input_shapes, device):
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -383,8 +376,7 @@ def test_sub_opt_output_typecast_out(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor a
-def test_sub_opt_output_typecast_a(input_shapes, device_module):
-    device = device_module
+def test_sub_opt_output_typecast_a(input_shapes, device):
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -432,8 +424,7 @@ def test_sub_opt_output_typecast_a(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor b
-def test_sub_opt_output_typecast_b(input_shapes, device_module):
-    device = device_module
+def test_sub_opt_output_typecast_b(input_shapes, device):
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -481,8 +472,7 @@ def test_sub_opt_output_typecast_b(input_shapes, device_module):
     ),
 )
 # Typecast on both inputs
-def test_inplace_sub_typecast(input_shapes, device_module):
-    device = device_module
+def test_inplace_sub_typecast(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -526,8 +516,7 @@ def test_inplace_sub_typecast(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor a
-def test_inplace_sub_typecast_a(input_shapes, device_module):
-    device = device_module
+def test_inplace_sub_typecast_a(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -571,8 +560,7 @@ def test_inplace_sub_typecast_a(input_shapes, device_module):
     ),
 )
 # Typecast on input tensor b
-def test_inplace_sub_typecast_b(input_shapes, device_module):
-    device = device_module
+def test_inplace_sub_typecast_b(input_shapes, device):
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -634,8 +622,7 @@ def test_inplace_sub_typecast_b(input_shapes, device_module):
 )
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
 # Typecast on both input and optional tensor
-def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device_module):
-    device = device_module
+def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
     torch.manual_seed(0)
     a_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -688,8 +675,7 @@ def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device_module):
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
-    device = device_module
+def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device):
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -734,8 +720,7 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
-    device = device_module
+def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device):
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -791,8 +776,7 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device_module):
-    device = device_module
+def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device):
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
@@ -855,8 +839,7 @@ def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device_module):
-    device = device_module
+def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device):
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -56,7 +56,8 @@ binary_fns = {
     ([ttnn.TILE_LAYOUT]),
 )
 # No typecast on inputs and optional output
-def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device):
+def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -104,7 +105,8 @@ def test_opt_output_no_typecast(input_shapes, dtype, layout, ttnn_fn, device):
     ([ttnn.bfloat8_b]),
 )
 # Typecast on both inputs and optional output
-def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
+def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -146,7 +148,8 @@ def test_opt_output_bf8b(input_shapes, dtype, ttnn_fn, device):
     ),
 )
 # Typecast on both inputs
-def test_sub_typecast(input_shapes, device):
+def test_sub_typecast(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -190,7 +193,8 @@ def test_sub_typecast(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_sub_typecast_a(input_shapes, device):
+def test_sub_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -234,7 +238,8 @@ def test_sub_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_sub_typecast_b(input_shapes, device):
+def test_sub_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -278,7 +283,8 @@ def test_sub_typecast_b(input_shapes, device):
     ),
 )
 # Typecast on both inputs
-def test_sub_opt_output_typecast_inputs(input_shapes, device):
+def test_sub_opt_output_typecast_inputs(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -328,7 +334,8 @@ def test_sub_opt_output_typecast_inputs(input_shapes, device):
     ),
 )
 # Typecast on output
-def test_sub_opt_output_typecast_out(input_shapes, device):
+def test_sub_opt_output_typecast_out(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -376,7 +383,8 @@ def test_sub_opt_output_typecast_out(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_sub_opt_output_typecast_a(input_shapes, device):
+def test_sub_opt_output_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -424,7 +432,8 @@ def test_sub_opt_output_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_sub_opt_output_typecast_b(input_shapes, device):
+def test_sub_opt_output_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape, out_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -472,7 +481,8 @@ def test_sub_opt_output_typecast_b(input_shapes, device):
     ),
 )
 # Typecast on both inputs
-def test_inplace_sub_typecast(input_shapes, device):
+def test_inplace_sub_typecast(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -516,7 +526,8 @@ def test_inplace_sub_typecast(input_shapes, device):
     ),
 )
 # Typecast on input tensor a
-def test_inplace_sub_typecast_a(input_shapes, device):
+def test_inplace_sub_typecast_a(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -560,7 +571,8 @@ def test_inplace_sub_typecast_a(input_shapes, device):
     ),
 )
 # Typecast on input tensor b
-def test_inplace_sub_typecast_b(input_shapes, device):
+def test_inplace_sub_typecast_b(input_shapes, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     torch_input_tensor_a = gen_func_with_cast_tt(
@@ -622,7 +634,8 @@ def test_inplace_sub_typecast_b(input_shapes, device):
 )
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
 # Typecast on both input and optional tensor
-def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
+def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, out_shape = input_shapes
     ttnn_op = getattr(ttnn, ttnn_fn)
@@ -675,7 +688,8 @@ def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -720,7 +734,8 @@ def test_edgecase_dims_eltwise_scalar_matrix_math(input_shape, scalar, ttnn_fn, 
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape = input_shape
 
@@ -776,7 +791,8 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 
@@ -839,7 +855,8 @@ def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memo
     "layout",
     ([ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT]),
 )
-def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device):
+def test_edgecase_dims_eltwise_broadcast_logical(input_shapes, ttnn_fn, memory_config, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
     a_shape, b_shape = input_shapes
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
@@ -29,7 +29,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
         (ttnn.bias_gelu),
     ),
 )
-def test_binary_scalar_ops(input_shapes, device, ttnn_fn):
+def test_binary_scalar_ops(input_shapes, device_module, ttnn_fn):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     cq_id = 0

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
@@ -29,8 +29,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
         (ttnn.bias_gelu),
     ),
 )
-def test_binary_scalar_ops(input_shapes, device_module, ttnn_fn):
-    device = device_module
+def test_binary_scalar_ops(input_shapes, device, ttnn_fn):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     cq_id = 0

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -27,8 +27,7 @@ import ttnn
         (0, 32000, 0, 32000),
     ],
 )
-def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -64,8 +63,7 @@ def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_add_uint16_edge_cases(device_module):
-    device = device_module
+def test_binary_add_uint16_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 11, 500, 32767, 30000, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -132,8 +130,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", ("add", "mul", "logical_and", "logical_or", "logical_xor"))
-def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_module):
-    device = device_module
+def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(0, 100, num_elements, dtype=torch.int32)
@@ -190,8 +187,7 @@ def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device
         (32001, 65000, 0, 32000),
     ],
 )
-def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -225,8 +221,7 @@ def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_sub_uint16_edge_cases(device_module):
-    device = device_module
+def test_binary_sub_uint16_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 11, 7727, 65535, 65535, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -267,8 +262,7 @@ def test_binary_sub_uint16_edge_cases(device_module):
         block_sharded_memory_config,
     ],
 )
-def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device_module):
-    device = device_module
+def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(151, 300, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -331,8 +325,7 @@ def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device_modu
         ttnn.bitwise_xor,
     ],
 )
-def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b, bitwise_op, device_module):
-    device = device_module
+def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b, bitwise_op, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 65535, 0, 65535, 1], dtype=torch.int32)
@@ -392,8 +385,7 @@ def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op, device_module):
-    device = device_module
+def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(0, 100, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 65535, 0, 65535, 1], dtype=torch.int32)
@@ -455,8 +447,7 @@ def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op,
         (0, 1, 32767, 65535),
     ],
 )
-def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     if high_a in (32, 4, 2, 1):
         values_a = torch.arange(low_a, high_a + 1, dtype=torch.int32)
@@ -494,8 +485,7 @@ def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_mul_uint16_edge_cases(device_module):
-    device = device_module
+def test_binary_mul_uint16_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 32767, 65535, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -552,8 +542,7 @@ def test_binary_mul_uint16_edge_cases(device_module):
         (0, 32000, 0, 32000),
     ],
 )
-def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(low_a, high_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a[::5] = 0  # every 5th element is zero
@@ -600,8 +589,7 @@ def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, l
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device_module):
-    device = device_module
+def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 32767, 65534, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -646,8 +634,7 @@ def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device_module):
         (305, 400, 150, 300),
     ],
 )
-def test_binary_squared_difference_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_squared_difference_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements_a, dtype=torch.int32)
     num_elements_b = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -27,7 +27,8 @@ import ttnn
         (0, 32000, 0, 32000),
     ],
 )
-def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
+def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -63,7 +64,8 @@ def test_binary_add_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_add_uint16_edge_cases(device):
+def test_binary_add_uint16_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 11, 500, 32767, 30000, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -130,7 +132,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", ("add", "mul", "logical_and", "logical_or", "logical_xor"))
-def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device):
+def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device_module):
+    device = device_module
     ttnn_op = getattr(ttnn, ttnn_fn)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(0, 100, num_elements, dtype=torch.int32)
@@ -187,7 +190,8 @@ def test_binary_uint16_sharded(a_shape, b_shape, sharded_config, ttnn_fn, device
         (32001, 65000, 0, 32000),
     ],
 )
-def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
+def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -221,7 +225,8 @@ def test_binary_sub_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_sub_uint16_edge_cases(device):
+def test_binary_sub_uint16_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 11, 7727, 65535, 65535, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -262,7 +267,8 @@ def test_binary_sub_uint16_edge_cases(device):
         block_sharded_memory_config,
     ],
 )
-def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device):
+def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(151, 300, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -325,7 +331,8 @@ def test_binary_sub_uint16_sharded(a_shape, b_shape, sharded_config, device):
         ttnn.bitwise_xor,
     ],
 )
-def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b, bitwise_op, device):
+def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b, bitwise_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 65535, 0, 65535, 1], dtype=torch.int32)
@@ -385,7 +392,8 @@ def test_binary_bitwise_op_uint16(a_shape, b_shape, low_a, high_a, low_b, high_b
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op, device):
+def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(0, 100, num_elements, dtype=torch.int32)
     corner_cases = torch.tensor([0, 1, 65535, 0, 65535, 1], dtype=torch.int32)
@@ -447,7 +455,8 @@ def test_bitwise_op_uint16_sharded(a_shape, b_shape, sharded_config, bitwise_op,
         (0, 1, 32767, 65535),
     ],
 )
-def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
+def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     if high_a in (32, 4, 2, 1):
         values_a = torch.arange(low_a, high_a + 1, dtype=torch.int32)
@@ -485,7 +494,8 @@ def test_binary_mul_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b,
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_binary_mul_uint16_edge_cases(device):
+def test_binary_mul_uint16_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 32767, 65535, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -542,7 +552,8 @@ def test_binary_mul_uint16_edge_cases(device):
         (0, 32000, 0, 32000),
     ],
 )
-def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, low_b, high_b, device):
+def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(low_a, high_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a[::5] = 0  # every 5th element is zero
@@ -589,7 +600,8 @@ def test_binary_logical_uint16_bcast(a_shape, b_shape, ttnn_op, low_a, high_a, l
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device):
+def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 32767, 65534, 65535])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -634,7 +646,8 @@ def test_binary_logical_uint16_edge_cases(ttnn_op, use_legacy, device):
         (305, 400, 150, 300),
     ],
 )
-def test_binary_squared_difference_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
+def test_binary_squared_difference_uint16_bcast(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements_a, dtype=torch.int32)
     num_elements_b = max(int(torch.prod(torch.tensor(b_shape)).item()), 1)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -67,7 +67,8 @@ BINARY_OP_TEST_CASES = [
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input_shapes, device):
+def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input_shapes, device_module):
+    device = device_module
     torch_input_tensor_a = create_full_range_tensor(
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
     )
@@ -123,7 +124,8 @@ def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input
         pytest.param([(1, 16, 1), (8, 1, 32)], id="broadcast_both_5"),  # mixed bcast
     ],
 )
-def test_binary_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     a_shape, b_shape = input_shapes
 
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
@@ -209,7 +211,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         block_sharded_memory_config,
     ],
 )
-def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b_shape, sharded_config, device):
+def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b_shape, sharded_config, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -258,7 +261,8 @@ def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b
         (0, 70000, 80000, 200000),
     ],
 )
-def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
+def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     """Test uint32 subtraction with underflow cases (wrap-around behavior)"""
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
@@ -293,7 +297,8 @@ def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, hig
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_sub_uint32_edge_cases(use_legacy, device):
+def test_binary_sub_uint32_edge_cases(use_legacy, device_module):
+    device = device_module
     """Test uint32 subtraction with edge cases including underflow"""
     torch_input_tensor_a = torch.tensor(
         [4294967295, 2147483647, 1000000000, 500, 0, 100, 1, 0]  # uint32 max, int32 max, large, medium, min
@@ -340,7 +345,8 @@ def test_binary_sub_uint32_edge_cases(use_legacy, device):
 
 
 # For inputs within int32 range [0, 2147483647]
-def test_binary_add_uint32_lower_edge_cases(device):
+def test_binary_add_uint32_lower_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 1147482, 2147483647, 1])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -369,7 +375,8 @@ def test_binary_add_uint32_lower_edge_cases(device):
 
 
 # For inputs outside int32 range [2147483648, 4294967295]
-def test_binary_add_uint32_upper_edge_cases(device):
+def test_binary_add_uint32_upper_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([3000000000, 2750000000, 2147483648, 4294967292, 1, 4294967295, 0])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -420,7 +427,8 @@ def test_binary_add_uint32_upper_edge_cases(device):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_bitwise_uint32(device, ttnn_function, use_legacy):
+def test_bitwise_uint32(device_module, ttnn_function, use_legacy):
+    device = device_module
     x_torch = torch.tensor(
         [
             [1, 2, 3, 4, 5, 0],
@@ -454,7 +462,8 @@ def test_bitwise_uint32(device, ttnn_function, use_legacy):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_bitwise_uint32_full_range(device, ttnn_function, use_legacy):
+def test_bitwise_uint32_full_range(device_module, ttnn_function, use_legacy):
+    device = device_module
     x_values = torch.linspace(0, 4294967295, 1024, dtype=torch.float64)
     x_torch = x_values.to(dtype=torch.uint32)
 
@@ -482,7 +491,8 @@ def test_bitwise_uint32_full_range(device, ttnn_function, use_legacy):
         ttnn.logical_xor,
     ],
 )
-def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device):
+def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 2147483647, 2147483647, 2147483647, 1073741823, 1073741823, 4294967295, 4294967294, 4294967295]
     )
@@ -515,7 +525,8 @@ def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device):
 
 
 # For inputs within int32 range [0, 2147483647]
-def test_binary_mul_uint32_lower_edge_cases(device):
+def test_binary_mul_uint32_lower_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 2147483647, 1, 1073741823, 715827882, 46340])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -544,7 +555,8 @@ def test_binary_mul_uint32_lower_edge_cases(device):
 
 
 # For inputs outside int32 range [2147483648, 4294967295]
-def test_binary_mul_uint32_upper_edge_cases(device):
+def test_binary_mul_uint32_upper_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [4294967295, 1, 4294967295, 4294967294, 2147483647, 1431655765, 16777215, 65535]
     )
@@ -588,7 +600,8 @@ def test_binary_mul_uint32_upper_edge_cases(device):
     #               shape=Shape([8]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
-def test_binary_squared_difference_uint32_edge_cases(device):
+def test_binary_squared_difference_uint32_edge_cases(device_module):
+    device = device_module
     torch_input_tensor_a = torch.tensor([0, 1, 0, 5, 10, 65535, 0, 4294967295, 4294901760, 4294967295])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -67,8 +67,7 @@ BINARY_OP_TEST_CASES = [
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input_shapes, device_module):
-    device = device_module
+def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input_shapes, device):
     torch_input_tensor_a = create_full_range_tensor(
         input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
     )
@@ -124,8 +123,7 @@ def test_binary_uint32_full_range(ttnn_op, value_ranges_a, value_ranges_b, input
         pytest.param([(1, 16, 1), (8, 1, 32)], id="broadcast_both_5"),  # mixed bcast
     ],
 )
-def test_binary_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_uint32_bcast(ttnn_op, input_shapes, low_a, high_a, low_b, high_b, device):
     a_shape, b_shape = input_shapes
 
     num_elements_a = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
@@ -211,8 +209,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         block_sharded_memory_config,
     ],
 )
-def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b_shape, sharded_config, device_module):
-    device = device_module
+def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b_shape, sharded_config, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a = torch_input_tensor_a[:num_elements].reshape(a_shape).nan_to_num(0.0)
@@ -261,8 +258,7 @@ def test_binary_uint32_sharded(ttnn_op, low_a, high_a, low_b, high_b, a_shape, b
         (0, 70000, 80000, 200000),
     ],
 )
-def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, high_b, device):
     """Test uint32 subtraction with underflow cases (wrap-around behavior)"""
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
@@ -297,8 +293,7 @@ def test_binary_sub_uint32_underflow(a_shape, b_shape, low_a, high_a, low_b, hig
 
 
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_binary_sub_uint32_edge_cases(use_legacy, device_module):
-    device = device_module
+def test_binary_sub_uint32_edge_cases(use_legacy, device):
     """Test uint32 subtraction with edge cases including underflow"""
     torch_input_tensor_a = torch.tensor(
         [4294967295, 2147483647, 1000000000, 500, 0, 100, 1, 0]  # uint32 max, int32 max, large, medium, min
@@ -345,8 +340,7 @@ def test_binary_sub_uint32_edge_cases(use_legacy, device_module):
 
 
 # For inputs within int32 range [0, 2147483647]
-def test_binary_add_uint32_lower_edge_cases(device_module):
-    device = device_module
+def test_binary_add_uint32_lower_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 1147482, 2147483647, 1])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -375,8 +369,7 @@ def test_binary_add_uint32_lower_edge_cases(device_module):
 
 
 # For inputs outside int32 range [2147483648, 4294967295]
-def test_binary_add_uint32_upper_edge_cases(device_module):
-    device = device_module
+def test_binary_add_uint32_upper_edge_cases(device):
     torch_input_tensor_a = torch.tensor([3000000000, 2750000000, 2147483648, 4294967292, 1, 4294967295, 0])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -427,8 +420,7 @@ def test_binary_add_uint32_upper_edge_cases(device_module):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_bitwise_uint32(device_module, ttnn_function, use_legacy):
-    device = device_module
+def test_bitwise_uint32(device, ttnn_function, use_legacy):
     x_torch = torch.tensor(
         [
             [1, 2, 3, 4, 5, 0],
@@ -462,8 +454,7 @@ def test_bitwise_uint32(device_module, ttnn_function, use_legacy):
     ],
 )
 @pytest.mark.parametrize("use_legacy", [True, False])
-def test_bitwise_uint32_full_range(device_module, ttnn_function, use_legacy):
-    device = device_module
+def test_bitwise_uint32_full_range(device, ttnn_function, use_legacy):
     x_values = torch.linspace(0, 4294967295, 1024, dtype=torch.float64)
     x_torch = x_values.to(dtype=torch.uint32)
 
@@ -491,8 +482,7 @@ def test_bitwise_uint32_full_range(device_module, ttnn_function, use_legacy):
         ttnn.logical_xor,
     ],
 )
-def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device_module):
-    device = device_module
+def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device):
     torch_input_tensor_a = torch.tensor(
         [0, 1, 0, 2147483647, 2147483647, 2147483647, 1073741823, 1073741823, 4294967295, 4294967294, 4294967295]
     )
@@ -525,8 +515,7 @@ def test_binary_comp_logical_ops_uint32_edge_cases(ttnn_op, device_module):
 
 
 # For inputs within int32 range [0, 2147483647]
-def test_binary_mul_uint32_lower_edge_cases(device_module):
-    device = device_module
+def test_binary_mul_uint32_lower_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 2147483647, 1, 1073741823, 715827882, 46340])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -555,8 +544,7 @@ def test_binary_mul_uint32_lower_edge_cases(device_module):
 
 
 # For inputs outside int32 range [2147483648, 4294967295]
-def test_binary_mul_uint32_upper_edge_cases(device_module):
-    device = device_module
+def test_binary_mul_uint32_upper_edge_cases(device):
     torch_input_tensor_a = torch.tensor(
         [4294967295, 1, 4294967295, 4294967294, 2147483647, 1431655765, 16777215, 65535]
     )
@@ -600,8 +588,7 @@ def test_binary_mul_uint32_upper_edge_cases(device_module):
     #               shape=Shape([8]), dtype=DataType::UINT32, layout=Layout::TILE)
 
 
-def test_binary_squared_difference_uint32_edge_cases(device_module):
-    device = device_module
+def test_binary_squared_difference_uint32_edge_cases(device):
     torch_input_tensor_a = torch.tensor([0, 1, 0, 5, 10, 65535, 0, 4294967295, 4294901760, 4294967295])
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -67,8 +67,7 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
         ttnn.hypot,
     ],
 )
-def test_ND_subtile_bcast(device_module, shapes, ttnn_fn):
-    device = device_module
+def test_ND_subtile_bcast(device, shapes, ttnn_fn):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16) * 100 - 50
@@ -137,8 +136,7 @@ def test_ND_subtile_bcast(device_module, shapes, ttnn_fn):
         ttnn.bias_gelu,
     ],
 )
-def test_ND_scalar_bcast(device_module, shapes, ttnn_fn):
-    device = device_module
+def test_ND_scalar_bcast(device, shapes, ttnn_fn):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16) * 220 - 100

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -67,7 +67,8 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
         ttnn.hypot,
     ],
 )
-def test_ND_subtile_bcast(device, shapes, ttnn_fn):
+def test_ND_subtile_bcast(device_module, shapes, ttnn_fn):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16) * 100 - 50
@@ -136,7 +137,8 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
         ttnn.bias_gelu,
     ],
 )
-def test_ND_scalar_bcast(device, shapes, ttnn_fn):
+def test_ND_scalar_bcast(device_module, shapes, ttnn_fn):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16) * 220 - 100

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -9,8 +9,7 @@ import pytest
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
 
-def test_sub_fp32(device_module):
-    device = device_module
+def test_sub_fp32(device):
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.sub)
@@ -24,8 +23,7 @@ def test_sub_fp32(device_module):
     assert status
 
 
-def test_rsub_fp32(device_module):
-    device = device_module
+def test_rsub_fp32(device):
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.rsub)
@@ -39,8 +37,7 @@ def test_rsub_fp32(device_module):
     assert status
 
 
-def test_add_fp32(device_module):
-    device = device_module
+def test_add_fp32(device):
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -54,8 +51,7 @@ def test_add_fp32(device_module):
     assert status
 
 
-def test_add_int32(device_module):
-    device = device_module
+def test_add_int32(device):
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -69,8 +65,7 @@ def test_add_int32(device_module):
     assert status
 
 
-def test_mul_fp32(device_module):
-    device = device_module
+def test_mul_fp32(device):
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.multiply)
@@ -86,8 +81,7 @@ def test_mul_fp32(device_module):
 
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device_module):
-    device = device_module
+def test_div_fp32(device):
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -105,8 +99,7 @@ def test_div_fp32(device_module):
 
 
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device_module):
-    device = device_module
+def test_div_bf16_nonzero(device):
     x_torch = torch.tensor(
         [
             [
@@ -147,8 +140,7 @@ def test_div_bf16_nonzero(device_module):
     assert_with_ulp(z_torch, tt_out, ulp_threshold=1, allow_nonfinite=True)
 
 
-def test_pow_fp32(device_module):
-    device = device_module
+def test_pow_fp32(device):
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -163,9 +155,8 @@ def test_pow_fp32(device_module):
 
 
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
-def test_hypot_multi_dtype(device_module, dtype):
+def test_hypot_multi_dtype(device, dtype):
     # Map ttnn dtypes to torch dtypes
-    device = device_module
     torch_dtype_map = {ttnn.float32: torch.float32, ttnn.bfloat16: torch.bfloat16}
     torch_dtype = torch_dtype_map[dtype]
 
@@ -183,8 +174,7 @@ def test_hypot_multi_dtype(device_module, dtype):
         assert_with_ulp(z_torch, z_tt_hypot, ulp_threshold=1)
 
 
-def test_add_fp32_activ(device_module):
-    device = device_module
+def test_add_fp32_activ(device):
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -206,8 +196,7 @@ def test_add_fp32_activ(device_module):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device_module, shape):
-    device = device_module
+def test_add_fp32_input_activ(device, shape):
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -226,8 +215,7 @@ def test_add_fp32_input_activ(device_module, shape):
     assert status
 
 
-def test_logaddexp_fp32(device_module):
-    device = device_module
+def test_logaddexp_fp32(device):
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp)
@@ -241,8 +229,7 @@ def test_logaddexp_fp32(device_module):
     assert status
 
 
-def test_logaddexp2_fp32(device_module):
-    device = device_module
+def test_logaddexp2_fp32(device):
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp2)
@@ -256,8 +243,7 @@ def test_logaddexp2_fp32(device_module):
     assert status
 
 
-def test_ldexp_fp32(device_module):
-    device = device_module
+def test_ldexp_fp32(device):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.ldexp)
@@ -271,8 +257,7 @@ def test_ldexp_fp32(device_module):
     assert status
 
 
-def test_bias_gelu_fp32(device_module):
-    device = device_module
+def test_bias_gelu_fp32(device):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.bias_gelu)
@@ -286,8 +271,7 @@ def test_bias_gelu_fp32(device_module):
     assert status
 
 
-def test_squared_difference_fp32(device_module):
-    device = device_module
+def test_squared_difference_fp32(device):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.squared_difference)
@@ -309,8 +293,7 @@ def test_squared_difference_fp32(device_module):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device_module, ttnn_function):
-    device = device_module
+def test_logical_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -335,8 +318,7 @@ def test_logical_fp32(device_module, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device_module, ttnn_function):
-    device = device_module
+def test_relational_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -358,8 +340,7 @@ def test_relational_fp32(device_module, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device_module, ttnn_function):
-    device = device_module
+def test_bitwise(device, ttnn_function):
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -373,8 +354,7 @@ def test_bitwise(device_module, ttnn_function):
     assert status
 
 
-def test_bitwise_left_shift(device_module):
-    device = device_module
+def test_bitwise_left_shift(device):
     x_torch = torch.tensor([[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000]], dtype=torch.int32)
     y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
@@ -388,8 +368,7 @@ def test_bitwise_left_shift(device_module):
     assert status
 
 
-def test_bitwise_right_shift(device_module):
-    device = device_module
+def test_bitwise_right_shift(device):
     x_torch = torch.tensor([[19, 3, 101, 21, 47, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[5, 2, 31, 4, 5, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
@@ -413,8 +392,7 @@ def test_bitwise_right_shift(device_module):
         ttnn.divide,
     ],
 )
-def test_ng_scalar_fp32(device_module, ttnn_function):
-    device = device_module
+def test_ng_scalar_fp32(device, ttnn_function):
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = 0.00030171126
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -429,8 +407,7 @@ def test_ng_scalar_fp32(device_module, ttnn_function):
 
 
 @pytest.mark.parametrize("alpha", [-10.0, -5.0, 1.0, 2.0, 5.0, 10.0])
-def test_addalpha_fp32(alpha, device_module):
-    device = device_module
+def test_addalpha_fp32(alpha, device):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.addalpha)
@@ -443,8 +420,7 @@ def test_addalpha_fp32(alpha, device_module):
 
 
 @pytest.mark.parametrize("alpha", [-100.0, -20.0, 0.0, 2.0, 5.0, 10.0, 50.0])
-def test_subalpha_fp32(alpha, device_module):
-    device = device_module
+def test_subalpha_fp32(alpha, device):
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.subalpha)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -9,7 +9,8 @@ import pytest
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
 
-def test_sub_fp32(device):
+def test_sub_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.sub)
@@ -23,7 +24,8 @@ def test_sub_fp32(device):
     assert status
 
 
-def test_rsub_fp32(device):
+def test_rsub_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.rsub)
@@ -37,7 +39,8 @@ def test_rsub_fp32(device):
     assert status
 
 
-def test_add_fp32(device):
+def test_add_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -51,7 +54,8 @@ def test_add_fp32(device):
     assert status
 
 
-def test_add_int32(device):
+def test_add_int32(device_module):
+    device = device_module
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -65,7 +69,8 @@ def test_add_int32(device):
     assert status
 
 
-def test_mul_fp32(device):
+def test_mul_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.multiply)
@@ -81,7 +86,8 @@ def test_mul_fp32(device):
 
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device):
+def test_div_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -99,7 +105,8 @@ def test_div_fp32(device):
 
 
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device):
+def test_div_bf16_nonzero(device_module):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -140,7 +147,8 @@ def test_div_bf16_nonzero(device):
     assert_with_ulp(z_torch, tt_out, ulp_threshold=1, allow_nonfinite=True)
 
 
-def test_pow_fp32(device):
+def test_pow_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -155,8 +163,9 @@ def test_pow_fp32(device):
 
 
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
-def test_hypot_multi_dtype(device, dtype):
+def test_hypot_multi_dtype(device_module, dtype):
     # Map ttnn dtypes to torch dtypes
+    device = device_module
     torch_dtype_map = {ttnn.float32: torch.float32, ttnn.bfloat16: torch.bfloat16}
     torch_dtype = torch_dtype_map[dtype]
 
@@ -174,7 +183,8 @@ def test_hypot_multi_dtype(device, dtype):
         assert_with_ulp(z_torch, z_tt_hypot, ulp_threshold=1)
 
 
-def test_add_fp32_activ(device):
+def test_add_fp32_activ(device_module):
+    device = device_module
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -196,7 +206,8 @@ def test_add_fp32_activ(device):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device, shape):
+def test_add_fp32_input_activ(device_module, shape):
+    device = device_module
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -215,7 +226,8 @@ def test_add_fp32_input_activ(device, shape):
     assert status
 
 
-def test_logaddexp_fp32(device):
+def test_logaddexp_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp)
@@ -229,7 +241,8 @@ def test_logaddexp_fp32(device):
     assert status
 
 
-def test_logaddexp2_fp32(device):
+def test_logaddexp2_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp2)
@@ -243,7 +256,8 @@ def test_logaddexp2_fp32(device):
     assert status
 
 
-def test_ldexp_fp32(device):
+def test_ldexp_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.ldexp)
@@ -257,7 +271,8 @@ def test_ldexp_fp32(device):
     assert status
 
 
-def test_bias_gelu_fp32(device):
+def test_bias_gelu_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.bias_gelu)
@@ -271,7 +286,8 @@ def test_bias_gelu_fp32(device):
     assert status
 
 
-def test_squared_difference_fp32(device):
+def test_squared_difference_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.squared_difference)
@@ -293,7 +309,8 @@ def test_squared_difference_fp32(device):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device, ttnn_function):
+def test_logical_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -318,7 +335,8 @@ def test_logical_fp32(device, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device, ttnn_function):
+def test_relational_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -340,7 +358,8 @@ def test_relational_fp32(device, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device, ttnn_function):
+def test_bitwise(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -354,7 +373,8 @@ def test_bitwise(device, ttnn_function):
     assert status
 
 
-def test_bitwise_left_shift(device):
+def test_bitwise_left_shift(device_module):
+    device = device_module
     x_torch = torch.tensor([[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000]], dtype=torch.int32)
     y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
@@ -368,7 +388,8 @@ def test_bitwise_left_shift(device):
     assert status
 
 
-def test_bitwise_right_shift(device):
+def test_bitwise_right_shift(device_module):
+    device = device_module
     x_torch = torch.tensor([[19, 3, 101, 21, 47, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[5, 2, 31, 4, 5, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
@@ -392,7 +413,8 @@ def test_bitwise_right_shift(device):
         ttnn.divide,
     ],
 )
-def test_ng_scalar_fp32(device, ttnn_function):
+def test_ng_scalar_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = 0.00030171126
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -407,7 +429,8 @@ def test_ng_scalar_fp32(device, ttnn_function):
 
 
 @pytest.mark.parametrize("alpha", [-10.0, -5.0, 1.0, 2.0, 5.0, 10.0])
-def test_addalpha_fp32(alpha, device):
+def test_addalpha_fp32(alpha, device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.addalpha)
@@ -420,7 +443,8 @@ def test_addalpha_fp32(alpha, device):
 
 
 @pytest.mark.parametrize("alpha", [-100.0, -20.0, 0.0, 2.0, 5.0, 10.0, 50.0])
-def test_subalpha_fp32(alpha, device):
+def test_subalpha_fp32(alpha, device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.subalpha)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -9,7 +9,8 @@ import pytest
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
 
-def test_sub_fp32(device):
+def test_sub_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.sub)
@@ -23,7 +24,8 @@ def test_sub_fp32(device):
     assert status
 
 
-def test_rsub_fp32(device):
+def test_rsub_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.rsub)
@@ -37,7 +39,8 @@ def test_rsub_fp32(device):
     assert status
 
 
-def test_add_fp32(device):
+def test_add_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -51,7 +54,8 @@ def test_add_fp32(device):
     assert status
 
 
-def test_add_int32(device):
+def test_add_int32(device_module):
+    device = device_module
     x_torch = torch.tensor([[11, 23, 0, -23, -1, -100]], dtype=torch.int32)
     y_torch = torch.tensor([[78, 99, 34, -33, -1, 100]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.add)
@@ -65,7 +69,8 @@ def test_add_int32(device):
     assert status
 
 
-def test_mul_fp32(device):
+def test_mul_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[2]], dtype=torch.float32)
     y_torch = torch.tensor([[0.00030171126]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.multiply)
@@ -81,7 +86,8 @@ def test_mul_fp32(device):
 
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=nan; in fp32  tile
 # Torch num/ 0 = inf and 0/0  nan; TT num/ 0 = inf and 0/0=0; in chained (mul * recip) div op
-def test_div_fp32(device):
+def test_div_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.00030171126, -3, 16, -5, 14, -12, 0, 0, 1, 15]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -4, -5, 0, 0, 0, 1, 0, 10]], dtype=torch.float32)
     # torch out in ttnn TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
@@ -99,7 +105,8 @@ def test_div_fp32(device):
 
 
 # Test division when input_b is non-zero
-def test_div_bf16_nonzero(device):
+def test_div_bf16_nonzero(device_module):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -140,7 +147,8 @@ def test_div_bf16_nonzero(device):
     assert_with_ulp(z_torch, tt_out, ulp_threshold=1, allow_nonfinite=True)
 
 
-def test_pow_fp32(device):
+def test_pow_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.55, 2.25, -3.6]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, -2.2]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -155,7 +163,8 @@ def test_pow_fp32(device):
 
 
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
-def test_hypot_multi_dtype(device, dtype):
+def test_hypot_multi_dtype(device_module, dtype):
+    device = device_module
     # Map ttnn dtypes to torch dtypes
     torch_dtype_map = {ttnn.float32: torch.float32, ttnn.bfloat16: torch.bfloat16}
     torch_dtype = torch_dtype_map[dtype]
@@ -174,7 +183,8 @@ def test_hypot_multi_dtype(device, dtype):
         assert_with_ulp(z_torch, z_tt_hypot, ulp_threshold=1)
 
 
-def test_add_fp32_activ(device):
+def test_add_fp32_activ(device_module):
+    device = device_module
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
     z_torch = torch.square(x_torch + y_torch)
@@ -196,7 +206,8 @@ def test_add_fp32_activ(device):
         [1, 3, 320, 384],
     ],
 )
-def test_add_fp32_input_activ(device, shape):
+def test_add_fp32_input_activ(device_module, shape):
+    device = device_module
     x_torch = torch.ones(shape, dtype=torch.float32) * 2
     y_torch = torch.ones(shape, dtype=torch.float32) * 4
     z_torch = torch.square(torch.nn.functional.silu(x_torch) + y_torch)
@@ -215,7 +226,8 @@ def test_add_fp32_input_activ(device, shape):
     assert status
 
 
-def test_logaddexp_fp32(device):
+def test_logaddexp_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp)
@@ -229,7 +241,8 @@ def test_logaddexp_fp32(device):
     assert status
 
 
-def test_logaddexp2_fp32(device):
+def test_logaddexp2_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.logaddexp2)
@@ -243,7 +256,8 @@ def test_logaddexp2_fp32(device):
     assert status
 
 
-def test_ldexp_fp32(device):
+def test_ldexp_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.ldexp)
@@ -257,7 +271,8 @@ def test_ldexp_fp32(device):
     assert status
 
 
-def test_bias_gelu_fp32(device):
+def test_bias_gelu_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2, 3, 4, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.bias_gelu)
@@ -271,7 +286,8 @@ def test_bias_gelu_fp32(device):
     assert status
 
 
-def test_squared_difference_fp32(device):
+def test_squared_difference_fp32(device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.squared_difference)
@@ -293,7 +309,8 @@ def test_squared_difference_fp32(device):
         ttnn.logical_and,
     ],
 )
-def test_logical_fp32(device, ttnn_function):
+def test_logical_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.509009, 2, 3.33, 4, 0, -11]], dtype=torch.float32)
     y_torch = torch.tensor([[0, 3, 4, 5, 0, -9999]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -318,7 +335,8 @@ def test_logical_fp32(device, ttnn_function):
         ttnn.le,
     ],
 )
-def test_relational_fp32(device, ttnn_function):
+def test_relational_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1.99999999991, 0, 345.1234568999130, -1]], dtype=torch.float32)
     y_torch = torch.tensor([[1.99999999990, 0, 345.1234568999131, -1]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -340,7 +358,8 @@ def test_relational_fp32(device, ttnn_function):
         ttnn.bitwise_xor,
     ],
 )
-def test_bitwise(device, ttnn_function):
+def test_bitwise(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1, 2, 3, 4, 5, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[9, 3, 0, 1, 7, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -354,7 +373,8 @@ def test_bitwise(device, ttnn_function):
     assert status
 
 
-def test_bitwise_left_shift(device):
+def test_bitwise_left_shift(device_module):
+    device = device_module
     x_torch = torch.tensor([[99, 3, 100, 1, 72, 0, -100, 22, 12, 1000]], dtype=torch.int32)
     y_torch = torch.tensor([[1, 2, 31, 4, 5, 0, -20, 1, -3, -25]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
@@ -368,7 +388,8 @@ def test_bitwise_left_shift(device):
     assert status
 
 
-def test_bitwise_right_shift(device):
+def test_bitwise_right_shift(device_module):
+    device = device_module
     x_torch = torch.tensor([[19, 3, 101, 21, 47, 0]], dtype=torch.int32)
     y_torch = torch.tensor([[5, 2, 31, 4, 5, 0]], dtype=torch.int32)
     golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
@@ -392,7 +413,8 @@ def test_bitwise_right_shift(device):
         ttnn.divide,
     ],
 )
-def test_ng_scalar_fp32(device, ttnn_function):
+def test_ng_scalar_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[1]], dtype=torch.float32)
     y_torch = 0.00030171126
     golden_fn = ttnn.get_golden_function(ttnn_function)
@@ -407,7 +429,8 @@ def test_ng_scalar_fp32(device, ttnn_function):
 
 
 @pytest.mark.parametrize("alpha", [-10.0, -5.0, 1.0, 2.0, 5.0, 10.0])
-def test_addalpha_fp32(alpha, device):
+def test_addalpha_fp32(alpha, device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.addalpha)
@@ -420,7 +443,8 @@ def test_addalpha_fp32(alpha, device):
 
 
 @pytest.mark.parametrize("alpha", [-100.0, -20.0, 0.0, 2.0, 5.0, 10.0, 50.0])
-def test_subalpha_fp32(alpha, device):
+def test_subalpha_fp32(alpha, device_module):
+    device = device_module
     x_torch = torch.tensor([[1.5, 2, 3.33, 4]], dtype=torch.float32)
     y_torch = torch.tensor([[2.009, 3.11, 4.22, 5]], dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.subalpha)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
@@ -43,7 +43,8 @@ input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+def test_broadcast_to(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+    device = device_module
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(shape)
     torch_result = torch_input_tensor.broadcast_to(broadcast_shape)
@@ -88,7 +89,8 @@ input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to_out(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+def test_broadcast_to_out(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+    device = device_module
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(shape)
     torch_output_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(
@@ -138,7 +140,8 @@ profile_input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", profile_input_bcast_shape_pairs)
-def test_broadcast_to_profile(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+def test_broadcast_to_profile(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
+    device = device_module
     torch.manual_seed(0)
     shape, broadcast_shape = shape_and_broadcast_spec
     if dtype_pt == torch.bfloat16 and shape[-1] < 2 and broadcast_shape[-1] < 2:
@@ -175,7 +178,8 @@ input_bcast_shape_pairs = [
 
 @pytest.mark.parametrize("dtype_pt, dtype_tt", ((torch.bfloat16, ttnn.bfloat16),))
 @pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device):
+def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(input)
@@ -196,7 +200,8 @@ input_bcast_shape_pairs = [
 
 
 @pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_invalid_broadcast_to_sharding(input, bcast, device):
+def test_invalid_broadcast_to_sharding(input, bcast, device_module):
+    device = device_module
     torch.manual_seed(0)
     dtype_pt, dtype_tt = [torch.bfloat16, ttnn.bfloat16]
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype_tt)(input)
@@ -229,7 +234,8 @@ input_bcast_shape_pairs = [
 
 
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to_bf8_b(device, shape_and_broadcast_spec):
+def test_broadcast_to_bf8_b(device_module, shape_and_broadcast_spec):
+    device = device_module
     pytest.skip("Skip for now, as it is not stable. Need to investigate.")
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
@@ -43,8 +43,7 @@ input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
-    device = device_module
+def test_broadcast_to(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(shape)
     torch_result = torch_input_tensor.broadcast_to(broadcast_shape)
@@ -89,8 +88,7 @@ input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to_out(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
-    device = device_module
+def test_broadcast_to_out(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(shape)
     torch_output_tensor = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(
@@ -140,8 +138,7 @@ profile_input_bcast_shape_pairs = [
     [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
 )
 @pytest.mark.parametrize("shape_and_broadcast_spec", profile_input_bcast_shape_pairs)
-def test_broadcast_to_profile(device_module, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
-    device = device_module
+def test_broadcast_to_profile(device, dtype_pt, dtype_tt, shape_and_broadcast_spec, memory_config_input):
     torch.manual_seed(0)
     shape, broadcast_shape = shape_and_broadcast_spec
     if dtype_pt == torch.bfloat16 and shape[-1] < 2 and broadcast_shape[-1] < 2:
@@ -178,8 +175,7 @@ input_bcast_shape_pairs = [
 
 @pytest.mark.parametrize("dtype_pt, dtype_tt", ((torch.bfloat16, ttnn.bfloat16),))
 @pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device_module):
-    device = device_module
+def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device):
     torch.manual_seed(0)
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(input)
@@ -200,8 +196,7 @@ input_bcast_shape_pairs = [
 
 
 @pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_invalid_broadcast_to_sharding(input, bcast, device_module):
-    device = device_module
+def test_invalid_broadcast_to_sharding(input, bcast, device):
     torch.manual_seed(0)
     dtype_pt, dtype_tt = [torch.bfloat16, ttnn.bfloat16]
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype_tt)(input)
@@ -234,8 +229,7 @@ input_bcast_shape_pairs = [
 
 
 @pytest.mark.parametrize("shape_and_broadcast_spec", input_bcast_shape_pairs)
-def test_broadcast_to_bf8_b(device_module, shape_and_broadcast_spec):
-    device = device_module
+def test_broadcast_to_bf8_b(device, shape_and_broadcast_spec):
     pytest.skip("Skip for now, as it is not stable. Need to investigate.")
     shape, broadcast_shape = shape_and_broadcast_spec
     torch_input_tensor = gen_func_with_cast_tt(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
@@ -8,7 +8,8 @@ import math
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_celu_arange(device):
+def test_celu_arange(device_module):
+    device = device_module
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -42,7 +43,8 @@ def test_celu_arange(device):
         (1.1663108012064884e-38, 1.6 * 10**38, 1e-6, 1e-6),
     ],
 )
-def test_celu_allclose(low, high, expected_Atol, expected_rtol, device):
+def test_celu_allclose(low, high, expected_Atol, expected_rtol, device_module):
+    device = device_module
     num_elements = math.prod([1, 3, 320, 320])
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_celu_21f.py
@@ -8,8 +8,7 @@ import math
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_celu_arange(device_module):
-    device = device_module
+def test_celu_arange(device):
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -43,8 +42,7 @@ def test_celu_arange(device_module):
         (1.1663108012064884e-38, 1.6 * 10**38, 1e-6, 1e-6),
     ],
 )
-def test_celu_allclose(low, high, expected_Atol, expected_rtol, device_module):
-    device = device_module
+def test_celu_allclose(low, high, expected_Atol, expected_rtol, device):
     num_elements = math.prod([1, 3, 320, 320])
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -43,7 +43,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ("tensor", "tensor"),
     ],
 )
-def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device):
+def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     if min_val == "tensor":
@@ -100,7 +101,8 @@ def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device):
         ("tensor", "tensor"),
     ],
 )
-def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device):
+def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     if min_val == "tensor":
@@ -136,7 +138,8 @@ def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_digamma_ttnn(input_shapes, device):
+def test_unary_composite_digamma_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1, 100, device)
 
     output_tensor = ttnn.digamma(input_tensor1)
@@ -155,7 +158,8 @@ def test_unary_composite_digamma_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_lgamma_ttnn(input_shapes, device):
+def test_unary_composite_lgamma_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 0.1, 100, device)
 
     output_tensor = ttnn.lgamma(input_tensor1)
@@ -174,7 +178,8 @@ def test_unary_composite_lgamma_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_mish_ttnn(input_shapes, device):
+def test_unary_composite_mish_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.mish(input_tensor1)
@@ -189,7 +194,8 @@ def test_unary_composite_mish_ttnn(input_shapes, device):
     "input_shapes",
     (torch.Size([1, 1, 89600, 32]),),
 )
-def test_unary_composite_mish_sharded_ttnn(input_shapes, device):
+def test_unary_composite_mish_sharded_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
     shard_grid = ttnn.CoreRangeSet(
         {
@@ -228,7 +234,8 @@ def test_unary_composite_mish_sharded_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_multigammaln_ttnn(input_shapes, device):
+def test_unary_composite_multigammaln_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1.6, 100, device)
 
     output_tensor = ttnn.multigammaln(input_tensor1)
@@ -247,7 +254,8 @@ def test_unary_composite_multigammaln_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_polygamma_ttnn(input_shapes, device):
+def test_unary_composite_polygamma_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1, 10, device)
     k = 5
     output_tensor = ttnn.polygamma(input_tensor1, k)
@@ -266,7 +274,8 @@ def test_unary_composite_polygamma_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_tril_ttnn(input_shapes, device):
+def test_unary_composite_tril_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.tril(input_tensor1)
@@ -285,7 +294,8 @@ def test_unary_composite_tril_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_triu_ttnn(input_shapes, device):
+def test_unary_composite_triu_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.triu(input_tensor1)
@@ -308,7 +318,8 @@ def test_unary_composite_triu_ttnn(input_shapes, device):
     "dim",
     [-1, 3],
 )
-def test_unary_glu_ttnn(input_shapes, dim, device):
+def test_unary_glu_ttnn(input_shapes, dim, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.glu)
 
@@ -331,7 +342,8 @@ def test_unary_glu_ttnn(input_shapes, dim, device):
     "dim",
     [-1, 3],
 )
-def test_unary_reglu_ttnn(input_shapes, dim, device):
+def test_unary_reglu_ttnn(input_shapes, dim, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.reglu)
 
@@ -354,7 +366,8 @@ def test_unary_reglu_ttnn(input_shapes, dim, device):
     "dim",
     [-1, 3],
 )
-def test_unary_geglu_ttnn(input_shapes, dim, device):
+def test_unary_geglu_ttnn(input_shapes, dim, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.geglu)
 
@@ -376,7 +389,8 @@ def test_unary_geglu_ttnn(input_shapes, dim, device):
     "dim",
     [-1, 3],
 )
-def test_unary_swiglu_ttnn(input_shapes, dim, device):
+def test_unary_swiglu_ttnn(input_shapes, dim, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.swiglu)
 
@@ -413,7 +427,8 @@ def test_unary_swiglu_ttnn(input_shapes, dim, device):
         (0, 1),
     ],
 )
-def test_unary_composite_clamp_int_ttnn(input_shapes, min_val, max_val, device):
+def test_unary_composite_clamp_int_ttnn(input_shapes, min_val, max_val, device_module):
+    device = device_module
     in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     if min_val is None:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -43,8 +43,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ("tensor", "tensor"),
     ],
 )
-def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device_module):
-    device = device_module
+def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     if min_val == "tensor":
@@ -101,8 +100,7 @@ def test_unary_composite_clamp_ttnn(input_shapes, min_val, max_val, device_modul
         ("tensor", "tensor"),
     ],
 )
-def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device_module):
-    device = device_module
+def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     if min_val == "tensor":
@@ -138,8 +136,7 @@ def test_unary_composite_clip_ttnn(input_shapes, min_val, max_val, device_module
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_digamma_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_digamma_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1, 100, device)
 
     output_tensor = ttnn.digamma(input_tensor1)
@@ -158,8 +155,7 @@ def test_unary_composite_digamma_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_lgamma_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_lgamma_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 0.1, 100, device)
 
     output_tensor = ttnn.lgamma(input_tensor1)
@@ -178,8 +174,7 @@ def test_unary_composite_lgamma_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_mish_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_mish_ttnn(input_shapes, device):
     in_data1 = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.mish(input_tensor1)
@@ -194,8 +189,7 @@ def test_unary_composite_mish_ttnn(input_shapes, device_module):
     "input_shapes",
     (torch.Size([1, 1, 89600, 32]),),
 )
-def test_unary_composite_mish_sharded_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_mish_sharded_ttnn(input_shapes, device):
     in_data = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
     shard_grid = ttnn.CoreRangeSet(
         {
@@ -234,8 +228,7 @@ def test_unary_composite_mish_sharded_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_multigammaln_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_multigammaln_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1.6, 100, device)
 
     output_tensor = ttnn.multigammaln(input_tensor1)
@@ -254,8 +247,7 @@ def test_unary_composite_multigammaln_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_polygamma_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_polygamma_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, 1, 10, device)
     k = 5
     output_tensor = ttnn.polygamma(input_tensor1, k)
@@ -274,8 +266,7 @@ def test_unary_composite_polygamma_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_tril_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_tril_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.tril(input_tensor1)
@@ -294,8 +285,7 @@ def test_unary_composite_tril_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_composite_triu_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_composite_triu_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.triu(input_tensor1)
@@ -318,8 +308,7 @@ def test_unary_composite_triu_ttnn(input_shapes, device_module):
     "dim",
     [-1, 3],
 )
-def test_unary_glu_ttnn(input_shapes, dim, device_module):
-    device = device_module
+def test_unary_glu_ttnn(input_shapes, dim, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.glu)
 
@@ -342,8 +331,7 @@ def test_unary_glu_ttnn(input_shapes, dim, device_module):
     "dim",
     [-1, 3],
 )
-def test_unary_reglu_ttnn(input_shapes, dim, device_module):
-    device = device_module
+def test_unary_reglu_ttnn(input_shapes, dim, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.reglu)
 
@@ -366,8 +354,7 @@ def test_unary_reglu_ttnn(input_shapes, dim, device_module):
     "dim",
     [-1, 3],
 )
-def test_unary_geglu_ttnn(input_shapes, dim, device_module):
-    device = device_module
+def test_unary_geglu_ttnn(input_shapes, dim, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.geglu)
 
@@ -389,8 +376,7 @@ def test_unary_geglu_ttnn(input_shapes, dim, device_module):
     "dim",
     [-1, 3],
 )
-def test_unary_swiglu_ttnn(input_shapes, dim, device_module):
-    device = device_module
+def test_unary_swiglu_ttnn(input_shapes, dim, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
     golden_fn = ttnn.get_golden_function(ttnn.swiglu)
 
@@ -427,8 +413,7 @@ def test_unary_swiglu_ttnn(input_shapes, dim, device_module):
         (0, 1),
     ],
 )
-def test_unary_composite_clamp_int_ttnn(input_shapes, min_val, max_val, device_module):
-    device = device_module
+def test_unary_composite_clamp_int_ttnn(input_shapes, min_val, max_val, device):
     in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     if min_val is None:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -17,8 +17,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         ttnn.remainder,
     ],
 )
-def test_remainder_fp32(device_module, ttnn_function):
-    device = device_module
+def test_remainder_fp32(device, ttnn_function):
     torch.manual_seed(213919)
     x_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
     y_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
@@ -39,8 +38,7 @@ def test_remainder_fp32(device_module, ttnn_function):
         ttnn.div_no_nan,
     ],
 )
-def test_div_no_nan_fp32(device_module, ttnn_function):
-    device = device_module
+def test_div_no_nan_fp32(device, ttnn_function):
     x_torch = torch.tensor(
         [
             [
@@ -88,8 +86,7 @@ def test_div_no_nan_fp32(device_module, ttnn_function):
         ttnn.remainder,
     ],
 )
-def test_remainder_forge(device_module, ttnn_function):
-    device = device_module
+def test_remainder_forge(device, ttnn_function):
     torch.manual_seed(213919)
     input1 = torch.randn(2, 32, 32)
     input2 = torch.randn(2, 32, 32)
@@ -162,8 +159,7 @@ def test_binary_fmod_bf16(
     ),
 )
 @pytest.mark.parametrize("scalar", [-0.0029, -0.002, -0.0005, 0.0, 0.0007, 0.001, 0.0025])
-def test_unary_fmod(input_shapes, scalar, device_module):
-    device = device_module
+def test_unary_fmod(input_shapes, scalar, device):
     torch.manual_seed(0)
     if len(input_shapes) == 0:
         torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -17,7 +17,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         ttnn.remainder,
     ],
 )
-def test_remainder_fp32(device, ttnn_function):
+def test_remainder_fp32(device_module, ttnn_function):
+    device = device_module
     torch.manual_seed(213919)
     x_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
     y_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
@@ -38,7 +39,8 @@ def test_remainder_fp32(device, ttnn_function):
         ttnn.div_no_nan,
     ],
 )
-def test_div_no_nan_fp32(device, ttnn_function):
+def test_div_no_nan_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -86,7 +88,8 @@ def test_div_no_nan_fp32(device, ttnn_function):
         ttnn.remainder,
     ],
 )
-def test_remainder_forge(device, ttnn_function):
+def test_remainder_forge(device_module, ttnn_function):
+    device = device_module
     torch.manual_seed(213919)
     input1 = torch.randn(2, 32, 32)
     input2 = torch.randn(2, 32, 32)
@@ -97,8 +100,8 @@ def test_remainder_forge(device, ttnn_function):
     input1 = ttnn.from_torch(input1, dtype=ttnn.float32)
     input2 = ttnn.from_torch(input2, dtype=ttnn.float32)
 
-    input1 = ttnn.to_device(input1, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-    input2 = ttnn.to_device(input2, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    input1 = ttnn.to_device(input1, device_module, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    input2 = ttnn.to_device(input2, device_module, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
     input1 = ttnn.to_layout(input1, ttnn.TILE_LAYOUT)
     input2 = ttnn.to_layout(input2, ttnn.TILE_LAYOUT)
@@ -126,9 +129,10 @@ def generate_torch_tensor(shape, low, high, step=0.0025, dtype=torch.float32):
     [[64, 640], [2, 32, 320], [2, 1, 1024, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 64]],
 )
 def test_binary_fmod_bf16(
-    device,
+    device_module,
     input_shapes,
 ):
+    device = device_module
     torch_input_tensor_a = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-100, 100)
     torch_input_tensor_b = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-80, 120)
     torch_output_tensor = torch.fmod(torch_input_tensor_a, torch_input_tensor_b)
@@ -159,7 +163,8 @@ def test_binary_fmod_bf16(
     ),
 )
 @pytest.mark.parametrize("scalar", [-0.0029, -0.002, -0.0005, 0.0, 0.0007, 0.001, 0.0025])
-def test_unary_fmod(input_shapes, scalar, device):
+def test_unary_fmod(input_shapes, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     if len(input_shapes) == 0:
         torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -17,7 +17,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         ttnn.remainder,
     ],
 )
-def test_remainder_fp32(device, ttnn_function):
+def test_remainder_fp32(device_module, ttnn_function):
+    device = device_module
     torch.manual_seed(213919)
     x_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
     y_torch = torch.rand([2, 3, 64, 64], dtype=torch.float32)
@@ -38,7 +39,8 @@ def test_remainder_fp32(device, ttnn_function):
         ttnn.div_no_nan,
     ],
 )
-def test_div_no_nan_fp32(device, ttnn_function):
+def test_div_no_nan_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor(
         [
             [
@@ -86,7 +88,8 @@ def test_div_no_nan_fp32(device, ttnn_function):
         ttnn.remainder,
     ],
 )
-def test_remainder_forge(device, ttnn_function):
+def test_remainder_forge(device_module, ttnn_function):
+    device = device_module
     torch.manual_seed(213919)
     input1 = torch.randn(2, 32, 32)
     input2 = torch.randn(2, 32, 32)
@@ -159,7 +162,8 @@ def test_binary_fmod_bf16(
     ),
 )
 @pytest.mark.parametrize("scalar", [-0.0029, -0.002, -0.0005, 0.0, 0.0007, 0.001, 0.0025])
-def test_unary_fmod(input_shapes, scalar, device):
+def test_unary_fmod(input_shapes, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     if len(input_shapes) == 0:
         torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
@@ -12,7 +12,8 @@ import pytest
 @pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 @pytest.mark.parametrize("approx", [True, False])
-def test_div_zero(device, val_a, val_b, dtype, approx):
+def test_div_zero(device_module, val_a, val_b, dtype, approx):
+    device = device_module
     torch_dtype = getattr(torch, dtype)
     tt_dtype = getattr(ttnn, dtype)
 
@@ -43,7 +44,8 @@ def test_div_zero(device, val_a, val_b, dtype, approx):
 @pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 @pytest.mark.parametrize("approx", [True, False])
-def test_divide_inplace_zero(device, val_a, val_b, dtype, approx):
+def test_divide_inplace_zero(device_module, val_a, val_b, dtype, approx):
+    device = device_module
     torch_dtype = getattr(torch, dtype)
     tt_dtype = getattr(ttnn, dtype)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
@@ -12,8 +12,7 @@ import pytest
 @pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 @pytest.mark.parametrize("approx", [True, False])
-def test_div_zero(device_module, val_a, val_b, dtype, approx):
-    device = device_module
+def test_div_zero(device, val_a, val_b, dtype, approx):
     torch_dtype = getattr(torch, dtype)
     tt_dtype = getattr(ttnn, dtype)
 
@@ -44,8 +43,7 @@ def test_div_zero(device_module, val_a, val_b, dtype, approx):
 @pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 @pytest.mark.parametrize("approx", [True, False])
-def test_divide_inplace_zero(device_module, val_a, val_b, dtype, approx):
-    device = device_module
+def test_divide_inplace_zero(device, val_a, val_b, dtype, approx):
     torch_dtype = getattr(torch, dtype)
     tt_dtype = getattr(ttnn, dtype)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
@@ -36,57 +36,49 @@ def run_elt_binary_test_range(device, h, w, ttnn_function, low, high, pcc=0.9999
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ldexp(device_module, h, w):
-    device = device_module
+def test_ldexp(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.ldexp, -60, 60, pcc=0.9995)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logaddexp(device_module, h, w):
-    device = device_module
+def test_logaddexp(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.logaddexp, -80, 80)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logaddexp2(device_module, h, w):
-    device = device_module
+def test_logaddexp2(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.logaddexp2, -60, 100, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_and(device_module, h, w):
-    device = device_module
+def test_logical_and(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.logical_and, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_or(device_module, h, w):
-    device = device_module
+def test_logical_or(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.logical_or, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_xor(device_module, h, w):
-    device = device_module
+def test_logical_xor(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.logical_xor, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_xlogy(device_module, h, w):
-    device = device_module
+def test_xlogy(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.xlogy, 1e-6, 1e6)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_bias_gelu(device_module, h, w):
-    device = device_module
+def test_bias_gelu(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.bias_gelu, -100, 100)
 
 
@@ -114,20 +106,17 @@ def run_elt_binary_test_min_max(device, h, w, ttnn_function, low, high, pcc=0.99
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_maximum(device_module, h, w):
-    device = device_module
+def test_maximum(device, h, w):
     run_elt_binary_test_min_max(device, h, w, ttnn.maximum, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_minimum(device_module, h, w):
-    device = device_module
+def test_minimum(device, h, w):
     run_elt_binary_test_min_max(device, h, w, ttnn.minimum, -100, 100)
 
 
-def test_arithmetic_operators(device_module):
-    device = device_module
+def test_arithmetic_operators(device):
     """Test basic arithmetic operators (+, -, *, /) on ttnn tensors"""
 
     # Create test tensors with different values

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
@@ -36,49 +36,57 @@ def run_elt_binary_test_range(device, h, w, ttnn_function, low, high, pcc=0.9999
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ldexp(device, h, w):
+def test_ldexp(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.ldexp, -60, 60, pcc=0.9995)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logaddexp(device, h, w):
+def test_logaddexp(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.logaddexp, -80, 80)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logaddexp2(device, h, w):
+def test_logaddexp2(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.logaddexp2, -60, 100, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_and(device, h, w):
+def test_logical_and(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.logical_and, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_or(device, h, w):
+def test_logical_or(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.logical_or, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_xor(device, h, w):
+def test_logical_xor(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.logical_xor, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_xlogy(device, h, w):
+def test_xlogy(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.xlogy, 1e-6, 1e6)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_bias_gelu(device, h, w):
+def test_bias_gelu(device_module, h, w):
+    device = device_module
     run_elt_binary_test_range(device, h, w, ttnn.bias_gelu, -100, 100)
 
 
@@ -106,17 +114,20 @@ def run_elt_binary_test_min_max(device, h, w, ttnn_function, low, high, pcc=0.99
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_maximum(device, h, w):
+def test_maximum(device_module, h, w):
+    device = device_module
     run_elt_binary_test_min_max(device, h, w, ttnn.maximum, -100, 100)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_minimum(device, h, w):
+def test_minimum(device_module, h, w):
+    device = device_module
     run_elt_binary_test_min_max(device, h, w, ttnn.minimum, -100, 100)
 
 
-def test_arithmetic_operators(device):
+def test_arithmetic_operators(device_module):
+    device = device_module
     """Test basic arithmetic operators (+, -, *, /) on ttnn tensors"""
 
     # Create test tensors with different values

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py
@@ -82,8 +82,9 @@ def test_eltwise_logical_andi_test(
     in_mem_config,
     out_mem_config,
     data_seed,
-    device,
+    device_module,
 ):
+    device = device_module
     run_eltwise_logical_andi_tests(
         input_shape,
         dtype,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
@@ -68,5 +68,6 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_pow(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
+def test_pow(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device_module):
+    device = device_module
     run_pow_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_pow_float.py
@@ -68,6 +68,5 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_pow(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device_module):
-    device = device_module
+def test_pow(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
     run_pow_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_rsqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_rsqrt.py
@@ -76,6 +76,5 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_rsqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
-    device = device_module
+def test_eltwise_rsqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_eltwise_rsqrt_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_rsqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_rsqrt.py
@@ -76,5 +76,6 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_rsqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+def test_eltwise_rsqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
+    device = device_module
     run_eltwise_rsqrt_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
@@ -83,11 +83,13 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_selu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+def test_eltwise_selu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
+    device = device_module
     run_eltwise_selu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)
 
 
-def test_selu_arange(device):
+def test_selu_arange(device_module):
+    device = device_module
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -124,7 +126,8 @@ def test_selu_arange(device):
         (-1.6 * 10**38, 1.6 * 10**38, 0),  # bf16 range
     ],
 )
-def test_selu_atol(low, high, expected_Atol, device):
+def test_selu_atol(low, high, expected_Atol, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(torch.Size([1, 3, 320, 320]))).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_selu.py
@@ -83,13 +83,11 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_selu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
-    device = device_module
+def test_eltwise_selu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_eltwise_selu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)
 
 
-def test_selu_arange(device_module):
-    device = device_module
+def test_selu_arange(device):
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -126,8 +124,7 @@ def test_selu_arange(device_module):
         (-1.6 * 10**38, 1.6 * 10**38, 0),  # bf16 range
     ],
 )
-def test_selu_atol(low, high, expected_Atol, device_module):
-    device = device_module
+def test_selu_atol(low, high, expected_Atol, device):
     num_elements = torch.prod(torch.tensor(torch.Size([1, 3, 320, 320]))).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
@@ -71,6 +71,5 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_sin(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
-    device = device_module
+def test_eltwise_sin(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_eltwise_sin_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
@@ -71,5 +71,6 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_sin(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+def test_eltwise_sin(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
+    device = device_module
     run_eltwise_sin_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
@@ -71,8 +71,9 @@ test_sweep_args = [
     (test_sweep_args),
 )
 def test_eltwise_softplus(
-    input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed, device
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed, device_module
 ):
+    device = device_module
     run_eltwise_softplus_tests(
         input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed, device
     )

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sqrt.py
@@ -68,5 +68,6 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_sqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+def test_eltwise_sqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
+    device = device_module
     run_eltwise_sqrt_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sqrt.py
@@ -68,6 +68,5 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_sqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device_module):
-    device = device_module
+def test_eltwise_sqrt(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_eltwise_sqrt_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -126,8 +126,7 @@ class TestTypecast:
 
 
 @pytest.mark.skip("Issue #17237: Does not work with new mantissa rounding")
-def test_typecast_bf16_to_bfp8_b(device_module):
-    device = device_module
+def test_typecast_bf16_to_bfp8_b(device):
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -161,8 +160,7 @@ def print_mismatches(cpu, npu, num_max_print):
 @pytest.mark.parametrize("seed", [0, 2, 4, 6, 8])
 @pytest.mark.parametrize("scale", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("bias", [0, 1, 2, 4, 8, 16, 32, 64, 128])
-def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device_module):
-    device = device_module
+def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -195,8 +193,7 @@ def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device_module)
 @pytest.mark.parametrize("bias", [2])
 # NaN becomes -Inf when converted to bfloat8_b format, skip testing
 @pytest.mark.parametrize("insert_inf, insert_nan", [[True, False]])  # , [False, True], [True, True]])
-def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device_module):
-    device = device_module
+def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device):
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -231,8 +228,7 @@ def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, ins
     assert passed
 
 
-def test_typecast_bfp8_b_to_bf16(device_module):
-    device = device_module
+def test_typecast_bfp8_b_to_bf16(device):
     torch.manual_seed(0)
     shape = [1024, 1024]
 
@@ -251,8 +247,7 @@ def test_typecast_bfp8_b_to_bf16(device_module):
     assert passed
 
 
-def test_typecast_fp32_to_bfp8_b(device_module):
-    device = device_module
+def test_typecast_fp32_to_bfp8_b(device):
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -272,8 +267,7 @@ def test_typecast_fp32_to_bfp8_b(device_module):
     assert passed
 
 
-def test_typecast_bfp8_b_to_fp32(device_module):
-    device = device_module
+def test_typecast_bfp8_b_to_fp32(device):
     torch.manual_seed(0)
     shape = [1024, 1024]
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -126,7 +126,8 @@ class TestTypecast:
 
 
 @pytest.mark.skip("Issue #17237: Does not work with new mantissa rounding")
-def test_typecast_bf16_to_bfp8_b(device):
+def test_typecast_bf16_to_bfp8_b(device_module):
+    device = device_module
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -160,7 +161,8 @@ def print_mismatches(cpu, npu, num_max_print):
 @pytest.mark.parametrize("seed", [0, 2, 4, 6, 8])
 @pytest.mark.parametrize("scale", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("bias", [0, 1, 2, 4, 8, 16, 32, 64, 128])
-def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
+def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device_module):
+    device = device_module
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -193,7 +195,8 @@ def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
 @pytest.mark.parametrize("bias", [2])
 # NaN becomes -Inf when converted to bfloat8_b format, skip testing
 @pytest.mark.parametrize("insert_inf, insert_nan", [[True, False]])  # , [False, True], [True, True]])
-def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device):
+def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device_module):
+    device = device_module
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -228,7 +231,8 @@ def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, ins
     assert passed
 
 
-def test_typecast_bfp8_b_to_bf16(device):
+def test_typecast_bfp8_b_to_bf16(device_module):
+    device = device_module
     torch.manual_seed(0)
     shape = [1024, 1024]
 
@@ -247,7 +251,8 @@ def test_typecast_bfp8_b_to_bf16(device):
     assert passed
 
 
-def test_typecast_fp32_to_bfp8_b(device):
+def test_typecast_fp32_to_bfp8_b(device_module):
+    device = device_module
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -267,7 +272,8 @@ def test_typecast_fp32_to_bfp8_b(device):
     assert passed
 
 
-def test_typecast_bfp8_b_to_fp32(device):
+def test_typecast_bfp8_b_to_fp32(device_module):
+    device = device_module
     torch.manual_seed(0)
     shape = [1024, 1024]
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -98,9 +98,10 @@ class TestTypecast:
         input_shapes,
         input_mem_config,
         dst_mem_config,
-        device,
+        device_module,
         function_level_defaults,
     ):
+        device = device_module
         if tt_input_dtype == tt_output_dtype:
             pytest.skip("Same I/O data types. Skip.")
         datagen_func = [
@@ -126,7 +127,8 @@ class TestTypecast:
 
 
 @pytest.mark.skip("Issue #17237: Does not work with new mantissa rounding")
-def test_typecast_bf16_to_bfp8_b(device):
+def test_typecast_bf16_to_bfp8_b(device_module):
+    device = device_module
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -160,7 +162,8 @@ def print_mismatches(cpu, npu, num_max_print):
 @pytest.mark.parametrize("seed", [0, 2, 4, 6, 8])
 @pytest.mark.parametrize("scale", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("bias", [0, 1, 2, 4, 8, 16, 32, 64, 128])
-def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
+def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device_module):
+    device = device_module
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -193,7 +196,8 @@ def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
 @pytest.mark.parametrize("bias", [2])
 # NaN becomes -Inf when converted to bfloat8_b format, skip testing
 @pytest.mark.parametrize("insert_inf, insert_nan", [[True, False]])  # , [False, True], [True, True]])
-def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device):
+def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device_module):
+    device = device_module
     torch.manual_seed(seed)
     shape = [1024, 1024]
 
@@ -228,7 +232,9 @@ def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, ins
     assert passed
 
 
-def test_typecast_bfp8_b_to_bf16(device):
+def test_typecast_bfp8_b_to_bf16(device_module):
+    device = device_module
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
     shape = [1024, 1024]
 
@@ -247,7 +253,9 @@ def test_typecast_bfp8_b_to_bf16(device):
     assert passed
 
 
-def test_typecast_fp32_to_bfp8_b(device):
+def test_typecast_fp32_to_bfp8_b(device_module):
+    device = device_module
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
     shape = [32, 32]
 
@@ -267,7 +275,9 @@ def test_typecast_fp32_to_bfp8_b(device):
     assert passed
 
 
-def test_typecast_bfp8_b_to_fp32(device):
+def test_typecast_bfp8_b_to_fp32(device_module):
+    device = device_module
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
     shape = [1024, 1024]
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
@@ -9,8 +9,7 @@ import math
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_elu_arange_masking(device_module):
-    device = device_module
+def test_elu_arange_masking(device):
     # elu Working range - Underflow after -88(<0) as in exp
     high = math.inf
     low = -88.0
@@ -54,8 +53,7 @@ def test_elu_arange_masking(device_module):
         (-88.0, 1.6 * 10**38, 0.0, 0.0),  # bf16 working range for elu
     ],
 )
-def test_elu_allclose(low, high, expected_atol, expected_rtol, device_module):
-    device = device_module
+def test_elu_allclose(low, high, expected_atol, expected_rtol, device):
     num_elements = math.prod(torch.Size([1, 3, 320, 320]))
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elu.py
@@ -9,7 +9,8 @@ import math
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_elu_arange_masking(device):
+def test_elu_arange_masking(device_module):
+    device = device_module
     # elu Working range - Underflow after -88(<0) as in exp
     high = math.inf
     low = -88.0
@@ -53,7 +54,8 @@ def test_elu_arange_masking(device):
         (-88.0, 1.6 * 10**38, 0.0, 0.0),  # bf16 working range for elu
     ],
 )
-def test_elu_allclose(low, high, expected_atol, expected_rtol, device):
+def test_elu_allclose(low, high, expected_atol, expected_rtol, device_module):
+    device = device_module
     num_elements = math.prod(torch.Size([1, 3, 320, 320]))
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -9,8 +9,7 @@ import numpy as np
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
-def test_exp2_arange_masking(device_module):
-    device = device_module
+def test_exp2_arange_masking(device):
     # Exp2 Working range - Overflow from 128(inf), Underflow till -127(<0)
     low = -126.0
     high = 127.0
@@ -55,8 +54,7 @@ def test_exp2_arange_masking(device_module):
         (-126, 127),
     ],
 )
-def test_exp2_ULP(input_shapes, low, high, device_module):
-    device = device_module
+def test_exp2_ULP(input_shapes, low, high, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -91,8 +89,7 @@ def test_exp2_ULP(input_shapes, low, high, device_module):
         (-127, -126),
     ],
 )
-def test_exp2_atol(input_shapes, low, high, device_module):
-    device = device_module
+def test_exp2_atol(input_shapes, low, high, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -9,7 +9,8 @@ import numpy as np
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
-def test_exp2_arange_masking(device):
+def test_exp2_arange_masking(device_module):
+    device = device_module
     # Exp2 Working range - Overflow from 128(inf), Underflow till -127(<0)
     low = -126.0
     high = 127.0
@@ -54,7 +55,8 @@ def test_exp2_arange_masking(device):
         (-126, 127),
     ],
 )
-def test_exp2_ULP(input_shapes, low, high, device):
+def test_exp2_ULP(input_shapes, low, high, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -89,7 +91,8 @@ def test_exp2_ULP(input_shapes, low, high, device):
         (-127, -126),
     ],
 )
-def test_exp2_atol(input_shapes, low, high, device):
+def test_exp2_atol(input_shapes, low, high, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -9,7 +9,8 @@ import numpy as np
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
-def test_exp_arange_masking(device):
+def test_exp_arange_masking(device_module):
+    device = device_module
     # Exp Working range - Overflow from 88.5(inf), Underflow till -87(<0)
     low = -87.0
     high = 88.5
@@ -93,7 +94,8 @@ def test_exp_arange_masking(device):
         (-87.0, 88.5),
     ],
 )
-def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device):
+def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -129,7 +131,8 @@ def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device):
         (-87.3, 88.7, "float32", 1e-2, 1e-3),
     ],
 )
-def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expected_atol, device):
+def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expected_atol, device_module):
+    device = device_module
     torch_dtype = getattr(torch, testing_dtype)
     ttnn_dtype = getattr(ttnn, testing_dtype)
 
@@ -152,7 +155,8 @@ def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expecte
     assert_allclose(tt_result, golden, rtol=expected_rtol, atol=expected_atol)
 
 
-def test_exp_fp32(device):
+def test_exp_fp32(device_module):
+    device = device_module
     # Exp Working range for fp32 - Overflow from 88.7(inf), Underflow till -87.3(<0)
     low = -87.3
     high = 88.7

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -9,8 +9,7 @@ import numpy as np
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
 
-def test_exp_arange_masking(device_module):
-    device = device_module
+def test_exp_arange_masking(device):
     # Exp Working range - Overflow from 88.5(inf), Underflow till -87(<0)
     low = -87.0
     high = 88.5
@@ -94,8 +93,7 @@ def test_exp_arange_masking(device_module):
         (-87.0, 88.5),
     ],
 )
-def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device_module):
-    device = device_module
+def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -131,8 +129,7 @@ def test_exp_ULP_subcoregrid(input_shapes, sub_core_grid, low, high, device_modu
         (-87.3, 88.7, "float32", 1e-2, 1e-3),
     ],
 )
-def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expected_atol, device_module):
-    device = device_module
+def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expected_atol, device):
     torch_dtype = getattr(torch, testing_dtype)
     ttnn_dtype = getattr(ttnn, testing_dtype)
 
@@ -155,8 +152,7 @@ def test_exp_atol(input_shapes, low, high, testing_dtype, expected_rtol, expecte
     assert_allclose(tt_result, golden, rtol=expected_rtol, atol=expected_atol)
 
 
-def test_exp_fp32(device_module):
-    device = device_module
+def test_exp_fp32(device):
     # Exp Working range for fp32 - Overflow from 88.7(inf), Underflow till -87.3(<0)
     low = -87.3
     high = 88.7

--- a/tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
@@ -55,21 +55,18 @@ def _ttt_where_test_impl(
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-def test_ttt_where_0d(device_module):
-    device = device_module
+def test_ttt_where_0d(device):
     _ttt_where_test_impl(device, ())
 
 
 @pytest.mark.parametrize("h", [16, 32, 64, 65, 1024])
-def test_ttt_where_1d(device_module, h):
-    device = device_module
+def test_ttt_where_1d(device, h):
     _ttt_where_test_impl(device, (h))
 
 
 @pytest.mark.parametrize("h", [0, 16, 32, 64, 65, 1024])
 @pytest.mark.parametrize("w", [0, 16, 32, 64, 65, 1024])
-def test_ttt_where_2d(device_module, h, w):
-    device = device_module
+def test_ttt_where_2d(device, h, w):
     _ttt_where_test_impl(device, (h, w))
 
 
@@ -77,8 +74,7 @@ def test_ttt_where_2d(device_module, h, w):
 @pytest.mark.parametrize("d3", [16])
 @pytest.mark.parametrize("h", [16])
 @pytest.mark.parametrize("w", [16])
-def test_ttt_where_4d(device_module, d4, d3, h, w):
-    device = device_module
+def test_ttt_where_4d(device, d4, d3, h, w):
     _ttt_where_test_impl(device, (d4, d3, h, w))
 
 
@@ -87,34 +83,29 @@ def test_ttt_where_4d(device_module, d4, d3, h, w):
 @pytest.mark.parametrize("d3", [16])
 @pytest.mark.parametrize("h", [16])
 @pytest.mark.parametrize("w", [16])
-def test_ttt_where_5d(device_module, d5, d4, d3, h, w):
-    device = device_module
+def test_ttt_where_5d(device, d5, d4, d3, h, w):
     _ttt_where_test_impl(device, (d5, d4, d3, h, w))
 
 
 @pytest.mark.parametrize("shape", [tuple([32] * i) for i in range(6)])
-def test_ttt_where_shapes(device_module, shape):
-    device = device_module
+def test_ttt_where_shapes(device, shape):
     _ttt_where_test_impl(device, shape)
 
 
 @pytest.mark.xfail(reason="Integer data types are not yet supported.")
 @pytest.mark.parametrize("tt_dtype", [ttnn.uint8, ttnn.uint16, ttnn.int32, ttnn.uint32])
-def test_ttt_where_int_types(device_module, tt_dtype):
-    device = device_module
+def test_ttt_where_int_types(device, tt_dtype):
     _ttt_where_test_impl(device, DEFAULT_SHAPE, tt_dtype=tt_dtype)
 
 
 @pytest.mark.xfail(reason="ttnn.bfloat4_b data type is not yet supported.")
 @pytest.mark.parametrize("tt_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_ttt_where_float_types(device_module, tt_dtype):
-    device = device_module
+def test_ttt_where_float_types(device, tt_dtype):
     _ttt_where_test_impl(device, DEFAULT_SHAPE, tt_dtype=tt_dtype)
 
 
 @pytest.mark.xfail(reason="ROW_MAJOR_LAYOUT is not yet supported.")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_ttt_where_layouts(device_module, layout):
+def test_ttt_where_layouts(device, layout):
     # Missing parameters in from_torch() for layout test coverage: tile, pad_value
-    device = device_module
     _ttt_where_test_impl(device, DEFAULT_SHAPE, layout=layout)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_experimental_where.py
@@ -55,18 +55,21 @@ def _ttt_where_test_impl(
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-def test_ttt_where_0d(device):
+def test_ttt_where_0d(device_module):
+    device = device_module
     _ttt_where_test_impl(device, ())
 
 
 @pytest.mark.parametrize("h", [16, 32, 64, 65, 1024])
-def test_ttt_where_1d(device, h):
+def test_ttt_where_1d(device_module, h):
+    device = device_module
     _ttt_where_test_impl(device, (h))
 
 
 @pytest.mark.parametrize("h", [0, 16, 32, 64, 65, 1024])
 @pytest.mark.parametrize("w", [0, 16, 32, 64, 65, 1024])
-def test_ttt_where_2d(device, h, w):
+def test_ttt_where_2d(device_module, h, w):
+    device = device_module
     _ttt_where_test_impl(device, (h, w))
 
 
@@ -74,7 +77,8 @@ def test_ttt_where_2d(device, h, w):
 @pytest.mark.parametrize("d3", [16])
 @pytest.mark.parametrize("h", [16])
 @pytest.mark.parametrize("w", [16])
-def test_ttt_where_4d(device, d4, d3, h, w):
+def test_ttt_where_4d(device_module, d4, d3, h, w):
+    device = device_module
     _ttt_where_test_impl(device, (d4, d3, h, w))
 
 
@@ -83,29 +87,34 @@ def test_ttt_where_4d(device, d4, d3, h, w):
 @pytest.mark.parametrize("d3", [16])
 @pytest.mark.parametrize("h", [16])
 @pytest.mark.parametrize("w", [16])
-def test_ttt_where_5d(device, d5, d4, d3, h, w):
+def test_ttt_where_5d(device_module, d5, d4, d3, h, w):
+    device = device_module
     _ttt_where_test_impl(device, (d5, d4, d3, h, w))
 
 
 @pytest.mark.parametrize("shape", [tuple([32] * i) for i in range(6)])
-def test_ttt_where_shapes(device, shape):
+def test_ttt_where_shapes(device_module, shape):
+    device = device_module
     _ttt_where_test_impl(device, shape)
 
 
 @pytest.mark.xfail(reason="Integer data types are not yet supported.")
 @pytest.mark.parametrize("tt_dtype", [ttnn.uint8, ttnn.uint16, ttnn.int32, ttnn.uint32])
-def test_ttt_where_int_types(device, tt_dtype):
+def test_ttt_where_int_types(device_module, tt_dtype):
+    device = device_module
     _ttt_where_test_impl(device, DEFAULT_SHAPE, tt_dtype=tt_dtype)
 
 
 @pytest.mark.xfail(reason="ttnn.bfloat4_b data type is not yet supported.")
 @pytest.mark.parametrize("tt_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_ttt_where_float_types(device, tt_dtype):
+def test_ttt_where_float_types(device_module, tt_dtype):
+    device = device_module
     _ttt_where_test_impl(device, DEFAULT_SHAPE, tt_dtype=tt_dtype)
 
 
 @pytest.mark.xfail(reason="ROW_MAJOR_LAYOUT is not yet supported.")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_ttt_where_layouts(device, layout):
+def test_ttt_where_layouts(device_module, layout):
     # Missing parameters in from_torch() for layout test coverage: tile, pad_value
+    device = device_module
     _ttt_where_test_impl(device, DEFAULT_SHAPE, layout=layout)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
@@ -18,8 +18,7 @@ def flush_subnormal_values(tensor):
     return tensor
 
 
-def test_expm1_arange_masking(device_module):
-    device = device_module
+def test_expm1_arange_masking(device):
     # Expm1 Working range - Overflow from 88.5(inf) as in exp
     low = -math.inf
     high = 88.5
@@ -64,8 +63,7 @@ def test_expm1_arange_masking(device_module):
         (0.69140625, 88.5, 0.001, 0.01),
     ],
 )
-def test_expm1_allclose(low, high, expected_atol, expected_rtol, device_module):
-    device = device_module
+def test_expm1_allclose(low, high, expected_atol, expected_rtol, device):
     num_elements = math.prod([1, 3, 320, 320])
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_expm1.py
@@ -18,7 +18,8 @@ def flush_subnormal_values(tensor):
     return tensor
 
 
-def test_expm1_arange_masking(device):
+def test_expm1_arange_masking(device_module):
+    device = device_module
     # Expm1 Working range - Overflow from 88.5(inf) as in exp
     low = -math.inf
     high = 88.5
@@ -63,7 +64,8 @@ def test_expm1_arange_masking(device):
         (0.69140625, 88.5, 0.001, 0.01),
     ],
 )
-def test_expm1_allclose(low, high, expected_atol, expected_rtol, device):
+def test_expm1_allclose(low, high, expected_atol, expected_rtol, device_module):
+    device = device_module
     num_elements = math.prod([1, 3, 320, 320])
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 3, 320, 320]))

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
@@ -19,8 +19,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     ),
 )
 @pytest.mark.parametrize("fill_value", [1, 0, 5.5, -2.235])
-def test_fill(device_module, input_shapes, fill_value):
-    device = device_module
+def test_fill(device, input_shapes, fill_value):
     torch_input_tensor = torch.randn((input_shapes), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -40,8 +39,7 @@ def test_fill(device_module, input_shapes, fill_value):
     ),
 )
 @pytest.mark.parametrize("fill_value", [5.88958, -9.76145])
-def test_fill_fp32(device_module, input_shapes, fill_value):
-    device = device_module
+def test_fill_fp32(device, input_shapes, fill_value):
     torch_input_tensor = torch.randn((input_shapes), dtype=torch.float32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -54,8 +52,7 @@ def test_fill_fp32(device_module, input_shapes, fill_value):
 
 
 @pytest.mark.parametrize("fill_value", [2147483647, -2147483648, 15.5])
-def test_fill_int32(device_module, fill_value):
-    device = device_module
+def test_fill_int32(device, fill_value):
     torch_input_tensor = torch.zeros((1, 2), dtype=torch.int32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -69,8 +66,7 @@ def test_fill_int32(device_module, fill_value):
 
 
 @pytest.mark.parametrize("fill_value", [2147483647, 25.5, 4294967293, 1000000000, 4294967295])
-def test_fill_uint32(device_module, fill_value):
-    device = device_module
+def test_fill_uint32(device, fill_value):
     torch_input_tensor = torch.ones((1, 2), dtype=torch.uint32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
@@ -19,7 +19,8 @@ from tests.ttnn.utils_for_testing import assert_equal
     ),
 )
 @pytest.mark.parametrize("fill_value", [1, 0, 5.5, -2.235])
-def test_fill(device, input_shapes, fill_value):
+def test_fill(device_module, input_shapes, fill_value):
+    device = device_module
     torch_input_tensor = torch.randn((input_shapes), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -39,7 +40,8 @@ def test_fill(device, input_shapes, fill_value):
     ),
 )
 @pytest.mark.parametrize("fill_value", [5.88958, -9.76145])
-def test_fill_fp32(device, input_shapes, fill_value):
+def test_fill_fp32(device_module, input_shapes, fill_value):
+    device = device_module
     torch_input_tensor = torch.randn((input_shapes), dtype=torch.float32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -52,7 +54,8 @@ def test_fill_fp32(device, input_shapes, fill_value):
 
 
 @pytest.mark.parametrize("fill_value", [2147483647, -2147483648, 15.5])
-def test_fill_int32(device, fill_value):
+def test_fill_int32(device_module, fill_value):
+    device = device_module
     torch_input_tensor = torch.zeros((1, 2), dtype=torch.int32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)
@@ -66,7 +69,8 @@ def test_fill_int32(device, fill_value):
 
 
 @pytest.mark.parametrize("fill_value", [2147483647, 25.5, 4294967293, 1000000000, 4294967295])
-def test_fill_uint32(device, fill_value):
+def test_fill_uint32(device_module, fill_value):
+    device = device_module
     torch_input_tensor = torch.ones((1, 2), dtype=torch.uint32)
     golden_function = ttnn.get_golden_function(ttnn.fill)
     torch_output_tensor = golden_function(torch_input_tensor, fill_value)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
@@ -12,7 +12,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     "testing_dtype",
     ["bfloat16", "float32"],
 )
-def test_fmod_nan(testing_dtype, device):
+def test_fmod_nan(testing_dtype, device_module):
+    device = device_module
     torch_dtype = getattr(torch, testing_dtype)
     ttnn_dtype = getattr(ttnn, testing_dtype)
     if testing_dtype == "bfloat16":

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod.py
@@ -12,8 +12,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     "testing_dtype",
     ["bfloat16", "float32"],
 )
-def test_fmod_nan(testing_dtype, device_module):
-    device = device_module
+def test_fmod_nan(testing_dtype, device):
     torch_dtype = getattr(torch, testing_dtype)
     ttnn_dtype = getattr(ttnn, testing_dtype)
     if testing_dtype == "bfloat16":

--- a/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
@@ -18,8 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gcd_int32(input_shapes, device_module):
-    device = device_module
+def test_binary_gcd_int32(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
@@ -43,8 +42,7 @@ def test_binary_gcd_int32(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gcd_ttnn(input_shapes, device_module):
-    device = device_module
+def test_binary_gcd_ttnn(input_shapes, device):
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -73,8 +71,7 @@ def test_binary_gcd_ttnn(input_shapes, device_module):
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -118,8 +115,7 @@ def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device_mod
         (11, 53),
     ],
 )
-def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
-    device = device_module
+def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -164,8 +160,7 @@ def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -211,8 +206,7 @@ def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
-    device = device_module
+def test_binary_gcd_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
@@ -18,7 +18,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gcd_int32(input_shapes, device):
+def test_binary_gcd_int32(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
@@ -42,7 +43,8 @@ def test_binary_gcd_int32(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_gcd_ttnn(input_shapes, device):
+def test_binary_gcd_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -71,7 +73,8 @@ def test_binary_gcd_ttnn(input_shapes, device):
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
@@ -115,7 +118,8 @@ def test_binary_gcd_int32(input_shapes, low_a, high_a, low_b, high_b, device):
         (11, 53),
     ],
 )
-def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
+def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, device_module):
+    device = device_module
     torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
     torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
 
@@ -160,7 +164,8 @@ def test_binary_gcd_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
@@ -206,7 +211,8 @@ def test_binary_gcd_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         (-2147483647, 2147483647, -21474, 21474),
     ],
 )
-def test_binary_gcd_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+def test_binary_gcd_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "shapes",
     [[1, 1, 32, 32], [64, 64], [2, 2, 3, 256, 256]],
 )
-def test_hardtanh_default(device_module, shapes):
-    device = device_module
+def test_hardtanh_default(device, shapes):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn(shapes[0], dtype=torch.bfloat16) * 10
@@ -45,8 +44,7 @@ def test_hardtanh_default(device_module, shapes):
     "max",
     [1, 2.5, 3, 6.6],
 )
-def test_hardtanh_args(device_module, shapes, min, max):
-    device = device_module
+def test_hardtanh_args(device, shapes, min, max):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn(shapes[0], dtype=torch.bfloat16) * 10

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "shapes",
     [[1, 1, 32, 32], [64, 64], [2, 2, 3, 256, 256]],
 )
-def test_hardtanh_default(device, shapes):
+def test_hardtanh_default(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn(shapes[0], dtype=torch.bfloat16) * 10
@@ -44,7 +45,8 @@ def test_hardtanh_default(device, shapes):
     "max",
     [1, 2.5, 3, 6.6],
 )
-def test_hardtanh_args(device, shapes, min, max):
+def test_hardtanh_args(device_module, shapes, min, max):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn(shapes[0], dtype=torch.bfloat16) * 10

--- a/tests/ttnn/unit_tests/operations/eltwise/test_inplace.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_inplace.py
@@ -14,8 +14,7 @@ from torch.nn import functional as F
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_mul_inplace(device_module, h, w):
-    device = device_module
+def test_mul_inplace(device, h, w):
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.mul_)
@@ -31,8 +30,7 @@ def test_mul_inplace(device_module, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_inplace(device_module, h, w):
-    device = device_module
+def test_add_inplace(device, h, w):
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.add_)
@@ -48,8 +46,7 @@ def test_add_inplace(device_module, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_sub_inplace(device_module, h, w):
-    device = device_module
+def test_sub_inplace(device, h, w):
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.sub_)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_inplace.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_inplace.py
@@ -14,7 +14,8 @@ from torch.nn import functional as F
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_mul_inplace(device, h, w):
+def test_mul_inplace(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.mul_)
@@ -30,7 +31,8 @@ def test_mul_inplace(device, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_add_inplace(device, h, w):
+def test_add_inplace(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.add_)
@@ -46,7 +48,8 @@ def test_add_inplace(device, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_sub_inplace(device, h, w):
+def test_sub_inplace(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.sub_)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -35,23 +35,20 @@ def run_math_unary_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_i0(device_module, h, w):
-    device = device_module
+def test_i0(device, h, w):
     run_math_unary_test(device, h, w, ttnn.i0, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [5])
 @pytest.mark.parametrize("w", [5])
-def test_lgamma(device_module, h, w):
-    device = device_module
+def test_lgamma(device, h, w):
     run_math_unary_test(device, h, w, ttnn.lgamma, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.uint16, ttnn.uint32])
-def test_eq(device_module, h, w, output_dtype):
-    device = device_module
+def test_eq(device, h, w, output_dtype):
     torch.manual_seed(0)
 
     same = 50
@@ -102,127 +99,109 @@ def test_eq(device_module, h, w, output_dtype):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log10(device_module, h, w):
-    device = device_module
+def test_log10(device, h, w):
     run_math_unary_test(device, h, w, ttnn.log10)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log1p(device_module, h, w):
-    device = device_module
+def test_log1p(device, h, w):
     run_math_unary_test(device, h, w, ttnn.log1p, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log2(device_module, h, w):
-    device = device_module
+def test_log2(device, h, w):
     run_math_unary_test(device, h, w, ttnn.log2, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_neg(device_module, h, w):
-    device = device_module
+def test_neg(device, h, w):
     run_math_unary_test(device, h, w, ttnn.neg)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_abs(device_module, h, w):
-    device = device_module
+def test_abs(device, h, w):
     run_math_unary_test(device, h, w, ttnn.abs)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rad2deg(device_module, h, w):
-    device = device_module
+def test_rad2deg(device, h, w):
     run_math_unary_test(device, h, w, ttnn.rad2deg)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cbrt(device_module, h, w):
-    device = device_module
+def test_cbrt(device, h, w):
     run_math_unary_test(device, h, w, ttnn.cbrt, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tril(device_module, h, w):
-    device = device_module
+def test_tril(device, h, w):
     run_math_unary_test(device, h, w, ttnn.tril)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_deg2rad(device_module, h, w):
-    device = device_module
+def test_deg2rad(device, h, w):
     run_math_unary_test(device, h, w, ttnn.deg2rad)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sqrt(device_module, h, w):
-    device = device_module
+def test_sqrt(device, h, w):
     run_math_unary_test(device, h, w, ttnn.sqrt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_digamma(device_module, h, w):
-    device = device_module
+def test_digamma(device, h, w):
     run_math_unary_test(device, h, w, ttnn.digamma)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_erf(device_module, h, w):
-    device = device_module
+def test_erf(device, h, w):
     run_math_unary_test(device, h, w, ttnn.erf)
 
 
 @pytest.mark.parametrize("h", [2])
 @pytest.mark.parametrize("w", [3])
-def test_erfc(device_module, h, w):
-    device = device_module
+def test_erfc(device, h, w):
     run_math_unary_test(device, h, w, ttnn.erfc)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_erfinv(device_module, h, w):
-    device = device_module
+def test_erfinv(device, h, w):
     run_math_unary_test(device, h, w, ttnn.erfinv, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_square(device_module, h, w):
-    device = device_module
+def test_square(device, h, w):
     run_math_unary_test(device, h, w, ttnn.square)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp2(device_module, h, w):
-    device = device_module
+def test_exp2(device, h, w):
     run_math_unary_test(device, h, w, ttnn.exp2, pcc=0.98)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_expm1(device_module, h, w):
-    device = device_module
+def test_expm1(device, h, w):
     run_math_unary_test(device, h, w, ttnn.expm1, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_triu(device_module, h, w):
-    device = device_module
+def test_triu(device, h, w):
     run_math_unary_test(device, h, w, ttnn.triu)
 
 
@@ -256,8 +235,7 @@ def run_math_unary_test_fixed_val(device, h, w, fill_value, ttnn_function, pcc=0
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_recip(device_module, h, w):
-    device = device_module
+def test_recip(device, h, w):
     run_math_unary_test_recip(device, h, w, ttnn.reciprocal, pcc=0.999)
 
 
@@ -279,8 +257,7 @@ def run_math_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [5])
 @pytest.mark.parametrize("w", [5])
-def test_multigammaln(device_module, h, w):
-    device = device_module
+def test_multigammaln(device, h, w):
     run_math_unary_test_range(device, h, w, ttnn.multigammaln, pcc=0.999)
 
 
@@ -304,13 +281,11 @@ def run_math_test_polygamma(device, h, w, scalar, ttnn_function, pcc=0.9999):
 @pytest.mark.parametrize("scalar", [1, 2, 5, 10])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_polygamma(device_module, h, w, scalar):
-    device = device_module
+def test_polygamma(device, h, w, scalar):
     run_math_test_polygamma(device, h, w, scalar, ttnn.polygamma, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_recip_fixed(device_module, h, w):
-    device = device_module
+def test_recip_fixed(device, h, w):
     run_math_unary_test_fixed_val(device, h, w, 0, ttnn.reciprocal, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -35,20 +35,23 @@ def run_math_unary_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_i0(device, h, w):
+def test_i0(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.i0, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [5])
 @pytest.mark.parametrize("w", [5])
-def test_lgamma(device, h, w):
+def test_lgamma(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.lgamma, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.uint16, ttnn.uint32])
-def test_eq(device, h, w, output_dtype):
+def test_eq(device_module, h, w, output_dtype):
+    device = device_module
     torch.manual_seed(0)
 
     same = 50
@@ -99,109 +102,127 @@ def test_eq(device, h, w, output_dtype):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log10(device, h, w):
+def test_log10(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.log10)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log1p(device, h, w):
+def test_log1p(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.log1p, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log2(device, h, w):
+def test_log2(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.log2, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_neg(device, h, w):
+def test_neg(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.neg)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_abs(device, h, w):
+def test_abs(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.abs)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rad2deg(device, h, w):
+def test_rad2deg(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.rad2deg)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cbrt(device, h, w):
+def test_cbrt(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.cbrt, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tril(device, h, w):
+def test_tril(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.tril)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_deg2rad(device, h, w):
+def test_deg2rad(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.deg2rad)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sqrt(device, h, w):
+def test_sqrt(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.sqrt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_digamma(device, h, w):
+def test_digamma(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.digamma)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_erf(device, h, w):
+def test_erf(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.erf)
 
 
 @pytest.mark.parametrize("h", [2])
 @pytest.mark.parametrize("w", [3])
-def test_erfc(device, h, w):
+def test_erfc(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.erfc)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_erfinv(device, h, w):
+def test_erfinv(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.erfinv, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_square(device, h, w):
+def test_square(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.square)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp2(device, h, w):
+def test_exp2(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.exp2, pcc=0.98)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_expm1(device, h, w):
+def test_expm1(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.expm1, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_triu(device, h, w):
+def test_triu(device_module, h, w):
+    device = device_module
     run_math_unary_test(device, h, w, ttnn.triu)
 
 
@@ -235,7 +256,8 @@ def run_math_unary_test_fixed_val(device, h, w, fill_value, ttnn_function, pcc=0
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_recip(device, h, w):
+def test_recip(device_module, h, w):
+    device = device_module
     run_math_unary_test_recip(device, h, w, ttnn.reciprocal, pcc=0.999)
 
 
@@ -257,7 +279,8 @@ def run_math_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [5])
 @pytest.mark.parametrize("w", [5])
-def test_multigammaln(device, h, w):
+def test_multigammaln(device_module, h, w):
+    device = device_module
     run_math_unary_test_range(device, h, w, ttnn.multigammaln, pcc=0.999)
 
 
@@ -281,11 +304,13 @@ def run_math_test_polygamma(device, h, w, scalar, ttnn_function, pcc=0.9999):
 @pytest.mark.parametrize("scalar", [1, 2, 5, 10])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_polygamma(device, h, w, scalar):
+def test_polygamma(device_module, h, w, scalar):
+    device = device_module
     run_math_test_polygamma(device, h, w, scalar, ttnn.polygamma, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_recip_fixed(device, h, w):
+def test_recip_fixed(device_module, h, w):
+    device = device_module
     run_math_unary_test_fixed_val(device, h, w, 0, ttnn.reciprocal, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 # fmt: off
 @pytest.mark.parametrize("scalar", [3.0])
 # fmt: on
-def test_multiply_not_4D(device_module, scalar):
-    device = device_module
+def test_multiply_not_4D(device, scalar):
     torch_input_tensor_a = torch.arange(32).to(dtype=torch.bfloat16)
     torch_input_tensor_b = torch.arange(32).to(dtype=torch.bfloat16)
 
@@ -32,8 +31,7 @@ def test_multiply_not_4D(device_module, scalar):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_mul_4D(device_module, h, w):
-    device = device_module
+def test_mul_4D(device, h, w):
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
@@ -49,8 +47,7 @@ def test_mul_4D(device_module, h, w):
 # fmt: off
 @pytest.mark.parametrize("scalar", [3.0, 0.125])
 # fmt: on
-def test_multiply_with_scalar(device_module, scalar):
-    device = device_module
+def test_multiply_with_scalar(device, scalar):
     torch_input_tensor_a = torch.arange(1024).reshape(32, 32).to(dtype=torch.bfloat16)
     torch_output_tensor = scalar * torch_input_tensor_a
 
@@ -64,8 +61,7 @@ def test_multiply_with_scalar(device_module, scalar):
 @pytest.mark.parametrize("output_memory_config", [ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("scalar", [3.0, 0.125])
-def test_multiply_with_scalar_sharded(device_module, scalar, input_shard_orientation, output_memory_config):
-    device = device_module
+def test_multiply_with_scalar_sharded(device, scalar, input_shard_orientation, output_memory_config):
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand(1024 * 32, dtype=torch.bfloat16).reshape(32, 32, 32)
     torch_output_tensor = scalar * torch_input_tensor_a
@@ -92,8 +88,7 @@ def test_multiply_with_scalar_sharded(device_module, scalar, input_shard_orienta
         ([13, 16, 42, 42], 0.125)
     ])
 # fmt: on
-def test_multiply_int32_with_scalar(device_module, input_a, scalar):
-    device = device_module
+def test_multiply_int32_with_scalar(device, input_a, scalar):
     torch_input_tensor_a = torch.as_tensor(input_a, dtype=torch.int32)
     torch_output_tensor = scalar * torch_input_tensor_a
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
@@ -107,8 +102,7 @@ def test_multiply_int32_with_scalar(device_module, input_a, scalar):
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("scalar", [0.125])
 @pytest.mark.parametrize("batch_size", [6, 7, 8])
-def test_multiply_float32_with_scalar_sharded(device_module, scalar, batch_size, output_memory_config):
-    device = device_module
+def test_multiply_float32_with_scalar_sharded(device, scalar, batch_size, output_memory_config):
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand((batch_size, 16, 384, 384), dtype=torch.float32)
     torch_output_tensor = scalar * torch_input_tensor_a

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 # fmt: off
 @pytest.mark.parametrize("scalar", [3.0])
 # fmt: on
-def test_multiply_not_4D(device, scalar):
+def test_multiply_not_4D(device_module, scalar):
+    device = device_module
     torch_input_tensor_a = torch.arange(32).to(dtype=torch.bfloat16)
     torch_input_tensor_b = torch.arange(32).to(dtype=torch.bfloat16)
 
@@ -31,7 +32,8 @@ def test_multiply_not_4D(device, scalar):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_mul_4D(device, h, w):
+def test_mul_4D(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((5, 64, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
@@ -47,7 +49,8 @@ def test_mul_4D(device, h, w):
 # fmt: off
 @pytest.mark.parametrize("scalar", [3.0, 0.125])
 # fmt: on
-def test_multiply_with_scalar(device, scalar):
+def test_multiply_with_scalar(device_module, scalar):
+    device = device_module
     torch_input_tensor_a = torch.arange(1024).reshape(32, 32).to(dtype=torch.bfloat16)
     torch_output_tensor = scalar * torch_input_tensor_a
 
@@ -61,7 +64,8 @@ def test_multiply_with_scalar(device, scalar):
 @pytest.mark.parametrize("output_memory_config", [ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("input_shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("scalar", [3.0, 0.125])
-def test_multiply_with_scalar_sharded(device, scalar, input_shard_orientation, output_memory_config):
+def test_multiply_with_scalar_sharded(device_module, scalar, input_shard_orientation, output_memory_config):
+    device = device_module
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand(1024 * 32, dtype=torch.bfloat16).reshape(32, 32, 32)
     torch_output_tensor = scalar * torch_input_tensor_a
@@ -88,7 +92,8 @@ def test_multiply_with_scalar_sharded(device, scalar, input_shard_orientation, o
         ([13, 16, 42, 42], 0.125)
     ])
 # fmt: on
-def test_multiply_int32_with_scalar(device, input_a, scalar):
+def test_multiply_int32_with_scalar(device_module, input_a, scalar):
+    device = device_module
     torch_input_tensor_a = torch.as_tensor(input_a, dtype=torch.int32)
     torch_output_tensor = scalar * torch_input_tensor_a
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
@@ -102,7 +107,8 @@ def test_multiply_int32_with_scalar(device, input_a, scalar):
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("scalar", [0.125])
 @pytest.mark.parametrize("batch_size", [6, 7, 8])
-def test_multiply_float32_with_scalar_sharded(device, scalar, batch_size, output_memory_config):
+def test_multiply_float32_with_scalar_sharded(device_module, scalar, batch_size, output_memory_config):
+    device = device_module
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand((batch_size, 16, 384, 384), dtype=torch.float32)
     torch_output_tensor = scalar * torch_input_tensor_a

--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
@@ -12,8 +12,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
-def test_nextafter(device_module, shape):
-    device = device_module
+def test_nextafter(device, shape):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
@@ -12,7 +12,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
-def test_nextafter(device, shape):
+def test_nextafter(device_module, shape):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
@@ -20,7 +20,8 @@ def torch_polyval(input_tensor, coeff):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("coeff", [(1.5, 2.4, 6.7, 9.1)])
-def test_polyval(device, shape, coeff):
+def test_polyval(device_module, shape, coeff):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_polyval.py
@@ -20,8 +20,7 @@ def torch_polyval(input_tensor, coeff):
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize("coeff", [(1.5, 2.4, 6.7, 9.1)])
-def test_polyval(device_module, shape, coeff):
-    device = device_module
+def test_polyval(device, shape, coeff):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -18,7 +18,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, asser
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 2.0, 4])
-def test_unary_pow_ttnn(input_shapes, exponent, device):
+def test_unary_pow_ttnn(input_shapes, exponent, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -40,7 +41,8 @@ def test_unary_pow_ttnn(input_shapes, exponent, device):
 # Both input and exponent are -ve and exponent is a non-integer, TT and Torch output = nan
 # input = non-zero and exponent = 0, TT and Torch output = 1
 # Both input and exponent are 0, TT = 1 and Torch output = 0
-def test_binary_pow_scalar_input(input_shapes, input, exponent, device):
+def test_binary_pow_scalar_input(input_shapes, input, exponent, device_module):
+    device = device_module
     torch_input_tensor_b = torch.full(input_shapes, exponent, dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
     torch_output_tensor = golden_fn(input, torch_input_tensor_b)
@@ -67,7 +69,8 @@ def generate_torch_tensor(shape, low, high, step=0.0025, dtype=torch.float32):
     "input_shapes",
     [[64, 640], [2, 32, 320], [2, 1, 32, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 128]],
 )
-def test_binary_sfpu_pow(device, input_shapes):
+def test_binary_sfpu_pow(device_module, input_shapes):
+    device = device_module
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 30, step=0.0022)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -87,7 +90,8 @@ def test_binary_sfpu_pow(device, input_shapes):
     "input_shapes",
     [[64, 640], [2, 32, 320], [2, 1, 1024, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 64]],
 )
-def test_binary_sfpu_pow_bf16(device, input_shapes):
+def test_binary_sfpu_pow_bf16(device_module, input_shapes):
+    device = device_module
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 30, step=0.0021, dtype=torch.bfloat16)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20, dtype=torch.bfloat16)
     torch_output_tensor = torch.pow(torch_input_tensor_a, torch_input_tensor_b)
@@ -106,7 +110,8 @@ def test_binary_sfpu_pow_bf16(device, input_shapes):
     "input_shapes",
     [[2, 1, 32, 1024], [1, 3, 320, 384], [1, 2, 32, 64, 128], [1, 1, 32, 64]],
 )
-def test_binary_sfpu_pow_pos(device, input_shapes):
+def test_binary_sfpu_pow_pos(device_module, input_shapes):
+    device = device_module
     torch_input_tensor_a = generate_torch_tensor(input_shapes, 0, 30, step=0.0111)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -126,7 +131,8 @@ def test_binary_sfpu_pow_pos(device, input_shapes):
     "input_shapes",
     [[2, 1, 32, 1024], [1, 3, 320, 384], [1, 2, 32, 64, 128]],
 )
-def test_binary_sfpu_pow_neg(device, input_shapes):
+def test_binary_sfpu_pow_neg(device_module, input_shapes):
+    device = device_module
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 0, step=0.0111)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, 0, 10)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -156,7 +162,8 @@ def test_binary_sfpu_pow_neg(device, input_shapes):
         "bfloat16",
     ],
 )
-def test_binary_pow(device, dtype_a, dtype_b):
+def test_binary_pow(device_module, dtype_a, dtype_b):
+    device = device_module
     torch_dtype_a = getattr(torch, dtype_a)
     ttnn_dtype_a = getattr(ttnn, dtype_a)
     torch_dtype_b = getattr(torch, dtype_b)
@@ -190,7 +197,8 @@ def test_binary_pow(device, dtype_a, dtype_b):
     ),
 )
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_pow_bug(device, input_shapes, dtype):
+def test_binary_sfpu_pow_bug(device_module, input_shapes, dtype):
+    device = device_module
     torch.manual_seed(0)
     torch_dtype = getattr(torch, dtype)
     ttnn_dtype = getattr(ttnn, dtype)
@@ -210,7 +218,8 @@ def test_binary_sfpu_pow_bug(device, input_shapes, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_accuracy(device, dtype):
+def test_binary_sfpu_accuracy(device_module, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -233,7 +242,8 @@ def test_binary_sfpu_accuracy(device, dtype):
         assert_allclose(torch_output_tensor, output, rtol=0.005, atol=1e-3)  # Ensures > 99.5% accuracy
 
 
-def test_special_input_fp32(device):
+def test_special_input_fp32(device_module):
+    device = device_module
     a = torch.tensor(
         [[1.0, 0.999, 0.999, 0.999, 0.999, 0.234, 0.985, 1.456, 0.0, -1.0, 1.2, -5.3, 6.7, 9.8, -10.9, 5.999]],
         dtype=torch.float32,
@@ -255,7 +265,8 @@ def test_special_input_fp32(device):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_pow_determinism(device, dtype):
+def test_pow_determinism(device_module, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -285,7 +296,8 @@ def test_pow_determinism(device, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_accuracy_pos(device, dtype):
+def test_binary_sfpu_accuracy_pos(device_module, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -325,7 +337,8 @@ def test_binary_sfpu_accuracy_pos(device, dtype):
     ],
 )
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_ng_pow(device, input_a, input_b, dtype):
+def test_binary_ng_pow(device_module, input_a, input_b, dtype):
+    device = device_module
     torch.manual_seed(0)
     torch_dtype = getattr(torch, dtype)
     ttnn_dtype = getattr(ttnn, dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -18,8 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, asser
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 2.0, 4])
-def test_unary_pow_ttnn(input_shapes, exponent, device_module):
-    device = device_module
+def test_unary_pow_ttnn(input_shapes, exponent, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -41,8 +40,7 @@ def test_unary_pow_ttnn(input_shapes, exponent, device_module):
 # Both input and exponent are -ve and exponent is a non-integer, TT and Torch output = nan
 # input = non-zero and exponent = 0, TT and Torch output = 1
 # Both input and exponent are 0, TT = 1 and Torch output = 0
-def test_binary_pow_scalar_input(input_shapes, input, exponent, device_module):
-    device = device_module
+def test_binary_pow_scalar_input(input_shapes, input, exponent, device):
     torch_input_tensor_b = torch.full(input_shapes, exponent, dtype=torch.float32)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
     torch_output_tensor = golden_fn(input, torch_input_tensor_b)
@@ -69,8 +67,7 @@ def generate_torch_tensor(shape, low, high, step=0.0025, dtype=torch.float32):
     "input_shapes",
     [[64, 640], [2, 32, 320], [2, 1, 32, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 128]],
 )
-def test_binary_sfpu_pow(device_module, input_shapes):
-    device = device_module
+def test_binary_sfpu_pow(device, input_shapes):
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 30, step=0.0022)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -90,8 +87,7 @@ def test_binary_sfpu_pow(device_module, input_shapes):
     "input_shapes",
     [[64, 640], [2, 32, 320], [2, 1, 1024, 1024], [1, 1, 32, 32], [1, 3, 320, 384], [1, 2, 32, 64, 64]],
 )
-def test_binary_sfpu_pow_bf16(device_module, input_shapes):
-    device = device_module
+def test_binary_sfpu_pow_bf16(device, input_shapes):
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 30, step=0.0021, dtype=torch.bfloat16)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20, dtype=torch.bfloat16)
     torch_output_tensor = torch.pow(torch_input_tensor_a, torch_input_tensor_b)
@@ -110,8 +106,7 @@ def test_binary_sfpu_pow_bf16(device_module, input_shapes):
     "input_shapes",
     [[2, 1, 32, 1024], [1, 3, 320, 384], [1, 2, 32, 64, 128], [1, 1, 32, 64]],
 )
-def test_binary_sfpu_pow_pos(device_module, input_shapes):
-    device = device_module
+def test_binary_sfpu_pow_pos(device, input_shapes):
     torch_input_tensor_a = generate_torch_tensor(input_shapes, 0, 30, step=0.0111)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, -20, 20)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -131,8 +126,7 @@ def test_binary_sfpu_pow_pos(device_module, input_shapes):
     "input_shapes",
     [[2, 1, 32, 1024], [1, 3, 320, 384], [1, 2, 32, 64, 128]],
 )
-def test_binary_sfpu_pow_neg(device_module, input_shapes):
-    device = device_module
+def test_binary_sfpu_pow_neg(device, input_shapes):
     torch_input_tensor_a = generate_torch_tensor(input_shapes, -30, 0, step=0.0111)
     torch_input_tensor_b = generate_torch_tensor(input_shapes, 0, 10)
     golden_fn = ttnn.get_golden_function(ttnn.pow)
@@ -162,8 +156,7 @@ def test_binary_sfpu_pow_neg(device_module, input_shapes):
         "bfloat16",
     ],
 )
-def test_binary_pow(device_module, dtype_a, dtype_b):
-    device = device_module
+def test_binary_pow(device, dtype_a, dtype_b):
     torch_dtype_a = getattr(torch, dtype_a)
     ttnn_dtype_a = getattr(ttnn, dtype_a)
     torch_dtype_b = getattr(torch, dtype_b)
@@ -197,8 +190,7 @@ def test_binary_pow(device_module, dtype_a, dtype_b):
     ),
 )
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_pow_bug(device_module, input_shapes, dtype):
-    device = device_module
+def test_binary_sfpu_pow_bug(device, input_shapes, dtype):
     torch.manual_seed(0)
     torch_dtype = getattr(torch, dtype)
     ttnn_dtype = getattr(ttnn, dtype)
@@ -218,8 +210,7 @@ def test_binary_sfpu_pow_bug(device_module, input_shapes, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_accuracy(device_module, dtype):
-    device = device_module
+def test_binary_sfpu_accuracy(device, dtype):
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -242,8 +233,7 @@ def test_binary_sfpu_accuracy(device_module, dtype):
         assert_allclose(torch_output_tensor, output, rtol=0.005, atol=1e-3)  # Ensures > 99.5% accuracy
 
 
-def test_special_input_fp32(device_module):
-    device = device_module
+def test_special_input_fp32(device):
     a = torch.tensor(
         [[1.0, 0.999, 0.999, 0.999, 0.999, 0.234, 0.985, 1.456, 0.0, -1.0, 1.2, -5.3, 6.7, 9.8, -10.9, 5.999]],
         dtype=torch.float32,
@@ -265,8 +255,7 @@ def test_special_input_fp32(device_module):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_pow_determinism(device_module, dtype):
-    device = device_module
+def test_pow_determinism(device, dtype):
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -296,8 +285,7 @@ def test_pow_determinism(device_module, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_sfpu_accuracy_pos(device_module, dtype):
-    device = device_module
+def test_binary_sfpu_accuracy_pos(device, dtype):
     torch.manual_seed(0)
 
     torch_dtype = getattr(torch, dtype)
@@ -337,8 +325,7 @@ def test_binary_sfpu_accuracy_pos(device_module, dtype):
     ],
 )
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
-def test_binary_ng_pow(device_module, input_a, input_b, dtype):
-    device = device_module
+def test_binary_ng_pow(device, input_a, input_b, dtype):
     torch.manual_seed(0)
     torch_dtype = getattr(torch, dtype)
     ttnn_dtype = getattr(ttnn, dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -49,73 +49,85 @@ def run_relational_z_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gtz(device, h, w):
+def test_gtz(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.gtz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gt(device, h, w):
+def test_gt(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.gt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ltz(device, h, w):
+def test_ltz(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.ltz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ge(device, h, w):
+def test_ge(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.ge)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gez(device, h, w):
+def test_gez(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.gez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_lt(device, h, w):
+def test_lt(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.lt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_lez(device, h, w):
+def test_lez(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.lez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_le(device, h, w):
+def test_le(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.le)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_eqz(device, h, w):
+def test_eqz(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.eqz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_eq(device, h, w):
+def test_eq(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.eq)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nez(device, h, w):
+def test_nez(device_module, h, w):
+    device = device_module
     run_relational_z_test(device, h, w, ttnn.nez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ne(device, h, w):
+def test_ne(device_module, h, w):
+    device = device_module
     run_relational_test(device, h, w, ttnn.ne)
 
 
@@ -140,90 +152,103 @@ def run_relational_test_with_scalar(device, h, w, scalar, ttnn_function, pcc=0.9
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_gt(device, h, w, scalar):
+def test_scalarB_gt(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.gt)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_ge(device, h, w, scalar):
+def test_scalarB_ge(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ge)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_lt(device, h, w, scalar):
+def test_scalarB_lt(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.lt)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_le(device, h, w, scalar):
+def test_scalarB_le(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.le)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_eq(device, h, w, scalar):
+def test_scalarB_eq(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.eq)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_ne(device, h, w, scalar):
+def test_scalarB_ne(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ne)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_gt(device, h, w, scalar):
+def test_nscalarB_gt(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.gt)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_ge(device, h, w, scalar):
+def test_nscalarB_ge(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ge)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_lt(device, h, w, scalar):
+def test_nscalarB_lt(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.lt)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_le(device, h, w, scalar):
+def test_nscalarB_le(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.le)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_eq(device, h, w, scalar):
+def test_nscalarB_eq(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.eq)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_ne(device, h, w, scalar):
+def test_nscalarB_ne(device_module, h, w, scalar):
+    device = device_module
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ne)
 
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast(device, h, w):
+def test_expand_and_broadcast(device_module, h, w):
+    device = device_module
     torch_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_b = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.lt)
@@ -239,7 +264,8 @@ def test_expand_and_broadcast(device, h, w):
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast_reversed(device, h, w):
+def test_expand_and_broadcast_reversed(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.lt)
@@ -257,7 +283,8 @@ def test_expand_and_broadcast_reversed(device, h, w):
 @pytest.mark.parametrize("rtol", [1e-5, 1e-9])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_isclose(device, h, w, atol, rtol):
+def test_isclose(device_module, h, w, atol, rtol):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((1, 1, h, w), dtype=torch.bfloat16)
@@ -309,7 +336,8 @@ def test_isclose(device, h, w, atol, rtol):
     "use_legacy",
     [False, True],
 )
-def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use_legacy, device):
+def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use_legacy, device_module):
+    device = device_module
     low1, high1 = range1
     low2, high2 = range2
     in_data1 = torch.randint(low1, high1, input_shapes, dtype=torch.int32)
@@ -348,7 +376,8 @@ def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use
     "use_legacy",
     [False, True],
 )
-def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legacy, device):
+def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legacy, device_module):
+    device = device_module
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -395,7 +424,8 @@ def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legac
     ],
 )
 @pytest.mark.parametrize("scalar", [-2, -1, 0, 1, 2])
-def test_binary_relational_scalar_ttnn(device, input_shapes, scalar, ttnn_function):
+def test_binary_relational_scalar_ttnn(device_module, input_shapes, scalar, ttnn_function):
+    device = device_module
     in_data = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -49,85 +49,73 @@ def run_relational_z_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gtz(device_module, h, w):
-    device = device_module
+def test_gtz(device, h, w):
     run_relational_z_test(device, h, w, ttnn.gtz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gt(device_module, h, w):
-    device = device_module
+def test_gt(device, h, w):
     run_relational_test(device, h, w, ttnn.gt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ltz(device_module, h, w):
-    device = device_module
+def test_ltz(device, h, w):
     run_relational_z_test(device, h, w, ttnn.ltz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ge(device_module, h, w):
-    device = device_module
+def test_ge(device, h, w):
     run_relational_test(device, h, w, ttnn.ge)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gez(device_module, h, w):
-    device = device_module
+def test_gez(device, h, w):
     run_relational_z_test(device, h, w, ttnn.gez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_lt(device_module, h, w):
-    device = device_module
+def test_lt(device, h, w):
     run_relational_test(device, h, w, ttnn.lt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_lez(device_module, h, w):
-    device = device_module
+def test_lez(device, h, w):
     run_relational_z_test(device, h, w, ttnn.lez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_le(device_module, h, w):
-    device = device_module
+def test_le(device, h, w):
     run_relational_test(device, h, w, ttnn.le)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_eqz(device_module, h, w):
-    device = device_module
+def test_eqz(device, h, w):
     run_relational_z_test(device, h, w, ttnn.eqz)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_eq(device_module, h, w):
-    device = device_module
+def test_eq(device, h, w):
     run_relational_test(device, h, w, ttnn.eq)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nez(device_module, h, w):
-    device = device_module
+def test_nez(device, h, w):
     run_relational_z_test(device, h, w, ttnn.nez)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ne(device_module, h, w):
-    device = device_module
+def test_ne(device, h, w):
     run_relational_test(device, h, w, ttnn.ne)
 
 
@@ -152,103 +140,90 @@ def run_relational_test_with_scalar(device, h, w, scalar, ttnn_function, pcc=0.9
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_gt(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_gt(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.gt)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_ge(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_ge(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ge)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_lt(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_lt(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.lt)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_le(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_le(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.le)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_eq(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_eq(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.eq)
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_scalarB_ne(device_module, h, w, scalar):
-    device = device_module
+def test_scalarB_ne(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ne)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_gt(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_gt(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.gt)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_ge(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_ge(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ge)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_lt(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_lt(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.lt)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_le(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_le(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.le)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_eq(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_eq(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.eq)
 
 
 @pytest.mark.parametrize("scalar", [-1])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_nscalarB_ne(device_module, h, w, scalar):
-    device = device_module
+def test_nscalarB_ne(device, h, w, scalar):
     run_relational_test_with_scalar(device, h, w, scalar, ttnn.ne)
 
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast(device_module, h, w):
-    device = device_module
+def test_expand_and_broadcast(device, h, w):
     torch_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_b = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.lt)
@@ -264,8 +239,7 @@ def test_expand_and_broadcast(device_module, h, w):
 
 @pytest.mark.parametrize("h", [500])
 @pytest.mark.parametrize("w", [512])
-def test_expand_and_broadcast_reversed(device_module, h, w):
-    device = device_module
+def test_expand_and_broadcast_reversed(device, h, w):
     torch_input_tensor_a = torch.rand((1, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     golden_function = ttnn.get_golden_function(ttnn.lt)
@@ -283,8 +257,7 @@ def test_expand_and_broadcast_reversed(device_module, h, w):
 @pytest.mark.parametrize("rtol", [1e-5, 1e-9])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_isclose(device_module, h, w, atol, rtol):
-    device = device_module
+def test_isclose(device, h, w, atol, rtol):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((1, 1, h, w), dtype=torch.bfloat16)
@@ -336,8 +309,7 @@ def test_isclose(device_module, h, w, atol, rtol):
     "use_legacy",
     [False, True],
 )
-def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use_legacy, device_module):
-    device = device_module
+def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use_legacy, device):
     low1, high1 = range1
     low2, high2 = range2
     in_data1 = torch.randint(low1, high1, input_shapes, dtype=torch.int32)
@@ -376,8 +348,7 @@ def test_binary_relational_ttnn(input_shapes, ttnn_function, range1, range2, use
     "use_legacy",
     [False, True],
 )
-def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legacy, device_module):
-    device = device_module
+def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legacy, device):
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -424,8 +395,7 @@ def test_binary_relational_edge_case_ttnn(input_shapes, ttnn_function, use_legac
     ],
 )
 @pytest.mark.parametrize("scalar", [-2, -1, 0, 1, 2])
-def test_binary_relational_scalar_ttnn(device_module, input_shapes, scalar, ttnn_function):
-    device = device_module
+def test_binary_relational_scalar_ttnn(device, input_shapes, scalar, ttnn_function):
     in_data = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -14,7 +14,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_broken_remainder(input_shapes, device):
+def test_broken_remainder(input_shapes, device_module):
+    device = device_module
     torch_lhs = torch.ones(32, 32, dtype=torch.bfloat16)
     torch_rhs = torch.zeros(32, 32, dtype=torch.bfloat16)
 
@@ -35,7 +36,8 @@ def test_broken_remainder(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_broken_remainder1(input_shapes, device):
+def test_broken_remainder1(input_shapes, device_module):
+    device = device_module
     torch_lhs = torch.ones(32, 32, dtype=torch.bfloat16) * 95
     torch_rhs = torch.ones(32, 32, dtype=torch.bfloat16) * (-94.5)
 
@@ -67,7 +69,8 @@ def test_broken_remainder1(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("scalar", [-0.002, -0.001, -0.0006, -0.0003, 0.0, 0.0005, 0.0007, 0.001, 0.002])
-def test_remainder_scalar(input_shapes, scalar, device):
+def test_remainder_scalar(input_shapes, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     if len(input_shapes) == 0:
         torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -14,8 +14,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_broken_remainder(input_shapes, device_module):
-    device = device_module
+def test_broken_remainder(input_shapes, device):
     torch_lhs = torch.ones(32, 32, dtype=torch.bfloat16)
     torch_rhs = torch.zeros(32, 32, dtype=torch.bfloat16)
 
@@ -36,8 +35,7 @@ def test_broken_remainder(input_shapes, device_module):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_broken_remainder1(input_shapes, device_module):
-    device = device_module
+def test_broken_remainder1(input_shapes, device):
     torch_lhs = torch.ones(32, 32, dtype=torch.bfloat16) * 95
     torch_rhs = torch.ones(32, 32, dtype=torch.bfloat16) * (-94.5)
 
@@ -69,8 +67,7 @@ def test_broken_remainder1(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("scalar", [-0.002, -0.001, -0.0006, -0.0003, 0.0, 0.0005, 0.0007, 0.001, 0.002])
-def test_remainder_scalar(input_shapes, scalar, device_module):
-    device = device_module
+def test_remainder_scalar(input_shapes, scalar, device):
     torch.manual_seed(0)
     if len(input_shapes) == 0:
         torch_input_tensor = torch.tensor(5.0, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -27,7 +27,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_round_new(shape, dtypes, decimal, device):
+def test_round_new(shape, dtypes, decimal, device_module):
+    device = device_module
     torch.manual_seed(0)
     torch_dtype, tt_dtype = dtypes
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch_dtype), tt_dtype)(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -27,8 +27,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_round_new(shape, dtypes, decimal, device_module):
-    device = device_module
+def test_round_new(shape, dtypes, decimal, device):
     torch.manual_seed(0)
     torch_dtype, tt_dtype = dtypes
     torch_input_tensor = gen_func_with_cast_tt(partial(torch_random, low=-100, high=100, dtype=torch_dtype), tt_dtype)(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
@@ -190,7 +190,8 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
 @pytest.mark.parametrize("k", [[10, 15, 20, 25, 30] * 6 + [10, 20]])  # Example of per-user k
 @pytest.mark.parametrize("p", [[0.0, 0.3, 0.5, 0.7, 0.9] * 6 + [0.1, 0.8]])  # Example of per-user p
 @pytest.mark.parametrize("seed", [2024, 11, 123])
-def test_sampling_callback(shape, k, p, seed, device):
+def test_sampling_callback(shape, k, p, seed, device_module):
+    device = device_module
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):
@@ -216,7 +217,8 @@ def test_sampling_callback(shape, k, p, seed, device):
 @pytest.mark.parametrize(
     "sub_core_grids", [ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8 - 1, 4 - 1))})]
 )
-def test_sampling_subcores_callback(shape, k, p, seed, device, sub_core_grids):
+def test_sampling_subcores_callback(shape, k, p, seed, device_module, sub_core_grids):
+    device = device_module
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
@@ -190,8 +190,7 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
 @pytest.mark.parametrize("k", [[10, 15, 20, 25, 30] * 6 + [10, 20]])  # Example of per-user k
 @pytest.mark.parametrize("p", [[0.0, 0.3, 0.5, 0.7, 0.9] * 6 + [0.1, 0.8]])  # Example of per-user p
 @pytest.mark.parametrize("seed", [2024, 11, 123])
-def test_sampling_callback(shape, k, p, seed, device_module):
-    device = device_module
+def test_sampling_callback(shape, k, p, seed, device):
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):
@@ -217,8 +216,7 @@ def test_sampling_callback(shape, k, p, seed, device_module):
 @pytest.mark.parametrize(
     "sub_core_grids", [ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8 - 1, 4 - 1))})]
 )
-def test_sampling_subcores_callback(shape, k, p, seed, device_module, sub_core_grids):
-    device = device_module
+def test_sampling_subcores_callback(shape, k, p, seed, device, sub_core_grids):
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
@@ -7,7 +7,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_sigmoid_accurate_arange(device):
+def test_sigmoid_accurate_arange(device_module):
+    device = device_module
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_accurate_21f.py
@@ -7,8 +7,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def test_sigmoid_accurate_arange(device_module):
-    device = device_module
+def test_sigmoid_accurate_arange(device):
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
@@ -32,6 +32,7 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
 @pytest.mark.parametrize("out_channels", [2])
 @pytest.mark.parametrize("vector_mode", [2, 4])
 @pytest.mark.parametrize("approx_mode", [True, False])
-def test_sigmoid_two_out_channels(device, h, w, out_channels, vector_mode, approx_mode):
+def test_sigmoid_two_out_channels(device_module, h, w, out_channels, vector_mode, approx_mode):
+    device = device_module
     torch.manual_seed(0)
     run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, pcc=0.991)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sigmoid_vector_modes.py
@@ -32,7 +32,6 @@ def run_unary_test_sharded(device, hw, out_channels, vector_mode, approx_mode, t
 @pytest.mark.parametrize("out_channels", [2])
 @pytest.mark.parametrize("vector_mode", [2, 4])
 @pytest.mark.parametrize("approx_mode", [True, False])
-def test_sigmoid_two_out_channels(device_module, h, w, out_channels, vector_mode, approx_mode):
-    device = device_module
+def test_sigmoid_two_out_channels(device, h, w, out_channels, vector_mode, approx_mode):
     torch.manual_seed(0)
     run_unary_test_sharded(device, h * w, out_channels, vector_mode, approx_mode, ttnn.sigmoid, pcc=0.991)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_signbit.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_signbit.py
@@ -39,8 +39,9 @@ class TestSignbit:
         self,
         input_shapes,
         dst_mem_config,
-        device,
+        device_module,
     ):
+        device = device_module
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
         ]
@@ -61,8 +62,9 @@ class TestSignbit:
         self,
         input_shapes,
         dst_mem_config,
-        device,
+        device_module,
     ):
+        device = device_module
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_constant, constant=-0.0), torch.bfloat16)
         ]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_silu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_silu.py
@@ -134,7 +134,7 @@ def run_elt_silu_relu(
 @pytest.mark.parametrize("op", ["silu", "relu"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_gs_silu_relu(
-    device,
+    device_module,
     batch_size,
     input_channels,
     input_height,
@@ -146,6 +146,7 @@ def test_gs_silu_relu(
     op,
     dtype,
 ):
+    device = device_module
     run_elt_silu_relu(
         device,
         batch_size,
@@ -177,7 +178,7 @@ def test_gs_silu_relu(
 @pytest.mark.parametrize("op", ["silu", "relu"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_wh_silu_relu(
-    device,
+    device_module,
     batch_size,
     input_channels,
     input_height,
@@ -189,6 +190,7 @@ def test_wh_silu_relu(
     op,
     dtype,
 ):
+    device = device_module
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         if shard_strategy == ttnn.ShardStrategy.BLOCK:
             grid_size = (grid_size[0], 4) if grid_size[1] == 8 else grid_size  # reduce #f core used for N300
@@ -214,7 +216,7 @@ def test_wh_silu_relu(
 )
 @pytest.mark.parametrize("op", ["silu", "relu"])
 def test_silu_llm(
-    device,
+    device_module,
     batch_size,
     input_channels,
     input_height,
@@ -225,6 +227,7 @@ def test_silu_llm(
     shard_orientation,
     op,
 ):
+    device = device_module
     run_elt_silu_relu(
         device,
         batch_size,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
@@ -30,7 +30,8 @@ TILE_WIDTH = 32
     ],
 )
 @pytest.mark.parametrize("shard_strategy", [ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.BLOCK])
-def test_silu_multi_core(device, input_shape, shard_strategy):
+def test_silu_multi_core(device_module, input_shape, shard_strategy):
+    device = device_module
     ## input shape is N C H W
     batch_size, num_channels, height, width = input_shape
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
@@ -30,9 +30,8 @@ TILE_WIDTH = 32
     ],
 )
 @pytest.mark.parametrize("shard_strategy", [ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.BLOCK])
-def test_silu_multi_core(device_module, input_shape, shard_strategy):
+def test_silu_multi_core(device, input_shape, shard_strategy):
     ## input shape is N C H W
-    device = device_module
     batch_size, num_channels, height, width = input_shape
     torch.manual_seed(0)
     input = torch.rand(input_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
@@ -30,8 +30,9 @@ TILE_WIDTH = 32
     ],
 )
 @pytest.mark.parametrize("shard_strategy", [ttnn.ShardStrategy.HEIGHT, ttnn.ShardStrategy.BLOCK])
-def test_silu_multi_core(device, input_shape, shard_strategy):
+def test_silu_multi_core(device_module, input_shape, shard_strategy):
     ## input shape is N C H W
+    device = device_module
     batch_size, num_channels, height, width = input_shape
     torch.manual_seed(0)
     input = torch.rand(input_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("s", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sub_scalar(device, s, h, w):
+def test_sub_scalar(device_module, s, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor - s
 
@@ -29,7 +30,8 @@ def test_sub_scalar(device, s, h, w):
 @pytest.mark.parametrize("s", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rsub_scalar(device, s, h, w):
+def test_rsub_scalar(device_module, s, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = s - torch_input_tensor
 
@@ -46,7 +48,8 @@ def test_rsub_scalar(device, s, h, w):
 @pytest.mark.parametrize("scalar_input_tensor_b", [0.5])
 @pytest.mark.parametrize("h", [1])
 @pytest.mark.parametrize("w", [4])
-def test_sub_scalar_and_alpha(device, scalar_input_tensor_b, h, w):
+def test_sub_scalar_and_alpha(device_module, scalar_input_tensor_b, h, w):
+    device = device_module
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor, scalar_input_tensor_b)
 
@@ -59,7 +62,8 @@ def test_sub_scalar_and_alpha(device, scalar_input_tensor_b, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_sub(device, h, w):
+def test_sub(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
@@ -74,7 +78,8 @@ def test_sub(device, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_rsub(device, h, w):
+def test_rsub(device_module, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_b, torch_input_tensor_a)
@@ -91,7 +96,8 @@ def test_rsub(device, h, w):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [128])
-def test_sub_4D(device, n, c, h, w):
+def test_sub_4D(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
@@ -109,7 +115,8 @@ def test_sub_4D(device, n, c, h, w):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [128])
-def test_rsub_4D(device, n, c, h, w):
+def test_rsub_4D(device_module, n, c, h, w):
+    device = device_module
     torch_input_tensor_a = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_b, torch_input_tensor_a)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sub.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("s", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sub_scalar(device_module, s, h, w):
-    device = device_module
+def test_sub_scalar(device, s, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor - s
 
@@ -30,8 +29,7 @@ def test_sub_scalar(device_module, s, h, w):
 @pytest.mark.parametrize("s", [3])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rsub_scalar(device_module, s, h, w):
-    device = device_module
+def test_rsub_scalar(device, s, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = s - torch_input_tensor
 
@@ -48,8 +46,7 @@ def test_rsub_scalar(device_module, s, h, w):
 @pytest.mark.parametrize("scalar_input_tensor_b", [0.5])
 @pytest.mark.parametrize("h", [1])
 @pytest.mark.parametrize("w", [4])
-def test_sub_scalar_and_alpha(device_module, scalar_input_tensor_b, h, w):
-    device = device_module
+def test_sub_scalar_and_alpha(device, scalar_input_tensor_b, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor, scalar_input_tensor_b)
 
@@ -62,8 +59,7 @@ def test_sub_scalar_and_alpha(device_module, scalar_input_tensor_b, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_sub(device_module, h, w):
-    device = device_module
+def test_sub(device, h, w):
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
@@ -78,8 +74,7 @@ def test_sub(device_module, h, w):
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
-def test_rsub(device_module, h, w):
-    device = device_module
+def test_rsub(device, h, w):
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_b, torch_input_tensor_a)
@@ -96,8 +91,7 @@ def test_rsub(device_module, h, w):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [128])
-def test_sub_4D(device_module, n, c, h, w):
-    device = device_module
+def test_sub_4D(device, n, c, h, w):
     torch_input_tensor_a = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
@@ -115,8 +109,7 @@ def test_sub_4D(device_module, n, c, h, w):
 @pytest.mark.parametrize("c", [3])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [128])
-def test_rsub_4D(device_module, n, c, h, w):
-    device = device_module
+def test_rsub_4D(device, n, c, h, w):
     torch_input_tensor_a = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((n, c, h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.sub(torch_input_tensor_b, torch_input_tensor_a)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -11,7 +11,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype, atol", [(torch.bfloat16, ttnn.bfloat16, 0.008), (torch.float32, ttnn.float32, 0.003)]
 )
-def test_tanh_range(device, torch_dtype, ttnn_dtype, atol):
+def test_tanh_range(device_module, torch_dtype, ttnn_dtype, atol):
+    device = device_module
     torch_input_tensor_a = torch.tensor(
         [
             [
@@ -87,7 +88,8 @@ def test_tanh_range(device, torch_dtype, ttnn_dtype, atol):
         (4, -4),
     ],
 )
-def test_tanh_inplace(device, high, low, torch_dtype, ttnn_dtype, atol):
+def test_tanh_inplace(device_module, high, low, torch_dtype, ttnn_dtype, atol):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand([1, 9, 8192], dtype=torch_dtype) * (high - low) + low
@@ -128,7 +130,8 @@ def test_tanh_inplace(device, high, low, torch_dtype, ttnn_dtype, atol):
         (4, -4),  # pcc_msg 0.9999948671754642
     ],
 )
-def test_tanh_accuracy(device, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
+def test_tanh_accuracy(device_module, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((input_shapes), dtype=torch_dtype) * (high - low) + low
@@ -159,7 +162,8 @@ def test_tanh_accuracy(device, input_shapes, high, low, torch_dtype, ttnn_dtype,
         (4, -4),
     ],
 )
-def test_tanh_height_sharded(device, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
+def test_tanh_height_sharded(device_module, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
+    device = device_module
     torch.manual_seed(0)
 
     in_data = torch.rand((input_shapes), dtype=torch_dtype) * (high - low) + low
@@ -269,7 +273,8 @@ def return_mem_config(mem_config_string):
         "l1_block_sharded_cm",
     ],
 )
-def test_tanh_sharded(device, high, low, input_mem_config, torch_dtype, ttnn_dtype, atol):
+def test_tanh_sharded(device_module, high, low, input_mem_config, torch_dtype, ttnn_dtype, atol):
+    device = device_module
     torch.manual_seed(0)
 
     in_data = torch.rand([1, 1, 512, 512], dtype=torch_dtype) * (high - low) + low

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -11,8 +11,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype, atol", [(torch.bfloat16, ttnn.bfloat16, 0.008), (torch.float32, ttnn.float32, 0.003)]
 )
-def test_tanh_range(device_module, torch_dtype, ttnn_dtype, atol):
-    device = device_module
+def test_tanh_range(device, torch_dtype, ttnn_dtype, atol):
     torch_input_tensor_a = torch.tensor(
         [
             [
@@ -88,8 +87,7 @@ def test_tanh_range(device_module, torch_dtype, ttnn_dtype, atol):
         (4, -4),
     ],
 )
-def test_tanh_inplace(device_module, high, low, torch_dtype, ttnn_dtype, atol):
-    device = device_module
+def test_tanh_inplace(device, high, low, torch_dtype, ttnn_dtype, atol):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand([1, 9, 8192], dtype=torch_dtype) * (high - low) + low
@@ -130,8 +128,7 @@ def test_tanh_inplace(device_module, high, low, torch_dtype, ttnn_dtype, atol):
         (4, -4),  # pcc_msg 0.9999948671754642
     ],
 )
-def test_tanh_accuracy(device_module, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
-    device = device_module
+def test_tanh_accuracy(device, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((input_shapes), dtype=torch_dtype) * (high - low) + low
@@ -162,8 +159,7 @@ def test_tanh_accuracy(device_module, input_shapes, high, low, torch_dtype, ttnn
         (4, -4),
     ],
 )
-def test_tanh_height_sharded(device_module, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
-    device = device_module
+def test_tanh_height_sharded(device, input_shapes, high, low, torch_dtype, ttnn_dtype, atol):
     torch.manual_seed(0)
 
     in_data = torch.rand((input_shapes), dtype=torch_dtype) * (high - low) + low
@@ -273,8 +269,7 @@ def return_mem_config(mem_config_string):
         "l1_block_sharded_cm",
     ],
 )
-def test_tanh_sharded(device_module, high, low, input_mem_config, torch_dtype, ttnn_dtype, atol):
-    device = device_module
+def test_tanh_sharded(device, high, low, input_mem_config, torch_dtype, ttnn_dtype, atol):
     torch.manual_seed(0)
 
     in_data = torch.rand([1, 1, 512, 512], dtype=torch_dtype) * (high - low) + low

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mac_all_tensors(device, h, w):
+def test_mac_all_tensors(device_module, h, w):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -42,7 +43,8 @@ def test_mac_all_tensors(device, h, w):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("scalar1", [5.5])
 @pytest.mark.parametrize("scalar2", [-13.2])
-def test_mac_tensor_with_2_scalaras(device, h, w, scalar1, scalar2):
+def test_mac_tensor_with_2_scalaras(device_module, h, w, scalar1, scalar2):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -100,7 +102,8 @@ def assert_where_with_pcc(torch_input_tensor, torch_input1, torch_input2, device
         [64, 1, 64, 1, 1, 128],
     ],
 )
-def test_where_bcast(device, dtype, hc, ht, hf, wc, wt, wf):
+def test_where_bcast(device_module, dtype, hc, ht, hf, wc, wt, wf):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=dtype).uniform_(-100, 100)
@@ -137,7 +140,8 @@ def run_ternary_test_value(device, h, w, value, ttnn_function, pcc=0.9999):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("value", [15.5])
-def test_addcdiv(device, h, w, value):
+def test_addcdiv(device_module, h, w, value):
+    device = device_module
     run_ternary_test_value(device, h, w, value, ttnn.addcdiv)
 
 
@@ -165,7 +169,8 @@ def test_addcdiv(device, h, w, value):
         [1, 64, 64, 1, 128, 128],
     ],
 )
-def test_addcmul_with_bcast(device, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
+def test_addcmul_with_bcast(device_module, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=tor_dtype).uniform_(-100, 500)
@@ -208,10 +213,11 @@ def test_addcmul_with_bcast(device, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, w
         ((4, 2, 1088, 1024), (1, 2, 1088, 1024), (1, 1, 1088, 1024)),  # HLK
     ],
 )
-def test_addcmul_with_bcast_bf8b(device, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
+def test_addcmul_with_bcast_bf8b(device_module, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
     """
     Test addcmul: Block format datatype inputs with subtile broadcast use composite Addcmul implementation.
     """
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(a_shape, dtype=torch_dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mac_all_tensors(device, h, w):
+def test_mac_all_tensors(device_module, h, w):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -42,7 +43,8 @@ def test_mac_all_tensors(device, h, w):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("scalar1", [5.5])
 @pytest.mark.parametrize("scalar2", [-13.2])
-def test_mac_tensor_with_2_scalaras(device, h, w, scalar1, scalar2):
+def test_mac_tensor_with_2_scalaras(device_module, h, w, scalar1, scalar2):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -100,7 +102,10 @@ def assert_where_with_pcc(torch_input_tensor, torch_input1, torch_input2, device
         [64, 1, 64, 1, 1, 128],
     ],
 )
-def test_where_bcast(device, dtype, hc, ht, hf, wc, wt, wf):
+def test_where_bcast(device_module, dtype, hc, ht, hf, wc, wt, wf):
+    device = device_module
+    # Clear program cache to ensure correct handling of broadcast shapes
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=dtype).uniform_(-100, 100)
@@ -137,7 +142,8 @@ def run_ternary_test_value(device, h, w, value, ttnn_function, pcc=0.9999):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("value", [15.5])
-def test_addcdiv(device, h, w, value):
+def test_addcdiv(device_module, h, w, value):
+    device = device_module
     run_ternary_test_value(device, h, w, value, ttnn.addcdiv)
 
 
@@ -165,7 +171,10 @@ def test_addcdiv(device, h, w, value):
         [1, 64, 64, 1, 128, 128],
     ],
 )
-def test_addcmul_with_bcast(device, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
+def test_addcmul_with_bcast(device_module, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
+    device = device_module
+    # Clear program cache to ensure correct handling of broadcast shapes
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=tor_dtype).uniform_(-100, 500)
@@ -208,7 +217,8 @@ def test_addcmul_with_bcast(device, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, w
         ((4, 2, 1088, 1024), (1, 2, 1088, 1024), (1, 1, 1088, 1024)),  # HLK
     ],
 )
-def test_addcmul_with_bcast_bf8b(device, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
+def test_addcmul_with_bcast_bf8b(device_module, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
+    device = device_module
     """
     Test addcmul: Block format datatype inputs with subtile broadcast use composite Addcmul implementation.
     """

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_mac_all_tensors(device_module, h, w):
-    device = device_module
+def test_mac_all_tensors(device, h, w):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -43,8 +42,7 @@ def test_mac_all_tensors(device_module, h, w):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("scalar1", [5.5])
 @pytest.mark.parametrize("scalar2", [-13.2])
-def test_mac_tensor_with_2_scalaras(device_module, h, w, scalar1, scalar2):
-    device = device_module
+def test_mac_tensor_with_2_scalaras(device, h, w, scalar1, scalar2):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -102,8 +100,7 @@ def assert_where_with_pcc(torch_input_tensor, torch_input1, torch_input2, device
         [64, 1, 64, 1, 1, 128],
     ],
 )
-def test_where_bcast(device_module, dtype, hc, ht, hf, wc, wt, wf):
-    device = device_module
+def test_where_bcast(device, dtype, hc, ht, hf, wc, wt, wf):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=dtype).uniform_(-100, 100)
@@ -140,8 +137,7 @@ def run_ternary_test_value(device, h, w, value, ttnn_function, pcc=0.9999):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("value", [15.5])
-def test_addcdiv(device_module, h, w, value):
-    device = device_module
+def test_addcdiv(device, h, w, value):
     run_ternary_test_value(device, h, w, value, ttnn.addcdiv)
 
 
@@ -169,8 +165,7 @@ def test_addcdiv(device_module, h, w, value):
         [1, 64, 64, 1, 128, 128],
     ],
 )
-def test_addcmul_with_bcast(device_module, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
-    device = device_module
+def test_addcmul_with_bcast(device, tor_dtype, ttnn_dtype, hc, ht, hf, wc, wt, wf, value):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((hc, wc), dtype=tor_dtype).uniform_(-100, 500)
@@ -213,11 +208,10 @@ def test_addcmul_with_bcast(device_module, tor_dtype, ttnn_dtype, hc, ht, hf, wc
         ((4, 2, 1088, 1024), (1, 2, 1088, 1024), (1, 1, 1088, 1024)),  # HLK
     ],
 )
-def test_addcmul_with_bcast_bf8b(device_module, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
+def test_addcmul_with_bcast_bf8b(device, torch_dtype, ttnn_dtype, a_shape, b_shape, c_shape, value):
     """
     Test addcmul: Block format datatype inputs with subtile broadcast use composite Addcmul implementation.
     """
-    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(a_shape, dtype=torch_dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -21,8 +21,7 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_ternary_addcmul_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_ternary_addcmul_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -80, 80, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -90, 90, device)
@@ -44,8 +43,7 @@ def test_ternary_addcmul_ttnn(input_shapes, value, device_module):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_ternary_addcdiv_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_ternary_addcdiv_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -67,8 +65,7 @@ def test_ternary_addcdiv_ttnn(input_shapes, value, device_module):
     ),
 )
 @pytest.mark.parametrize("predicate", [0, 1])
-def test_ternary_where_opt_output(input_shapes, predicate, device_module):
-    device = device_module
+def test_ternary_where_opt_output(input_shapes, predicate, device):
     in_data1, input_tensor1 = data_gen_with_val(input_shapes, device, val=predicate)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -90, 90, device)
@@ -91,8 +88,7 @@ def test_ternary_where_opt_output(input_shapes, predicate, device_module):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_lerp_overload_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_lerp_overload_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -112,8 +108,7 @@ def test_lerp_overload_ttnn(input_shapes, value, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_lerp_ttnn(input_shapes, device_module):
-    device = device_module
+def test_lerp_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -136,8 +131,7 @@ def test_lerp_ttnn(input_shapes, device_module):
 )
 @pytest.mark.parametrize("value1", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("value2", [1.0, 5.0, 10.0])
-def test_mac_overload_ttnn(input_shapes, value1, value2, device_module):
-    device = device_module
+def test_mac_overload_ttnn(input_shapes, value1, value2, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.mac(input_tensor1, value1, value2)
@@ -156,8 +150,7 @@ def test_mac_overload_ttnn(input_shapes, value1, value2, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_mac_ttnn(input_shapes, device_module):
-    device = device_module
+def test_mac_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -21,7 +21,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_ternary_addcmul_ttnn(input_shapes, value, device):
+def test_ternary_addcmul_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -80, 80, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -90, 90, device)
@@ -43,7 +44,8 @@ def test_ternary_addcmul_ttnn(input_shapes, value, device):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_ternary_addcdiv_ttnn(input_shapes, value, device):
+def test_ternary_addcdiv_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -65,7 +67,8 @@ def test_ternary_addcdiv_ttnn(input_shapes, value, device):
     ),
 )
 @pytest.mark.parametrize("predicate", [0, 1])
-def test_ternary_where_opt_output(input_shapes, predicate, device):
+def test_ternary_where_opt_output(input_shapes, predicate, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_val(input_shapes, device, val=predicate)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -90, 90, device)
@@ -88,7 +91,8 @@ def test_ternary_where_opt_output(input_shapes, predicate, device):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_lerp_overload_ttnn(input_shapes, value, device):
+def test_lerp_overload_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -108,7 +112,8 @@ def test_lerp_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_lerp_ttnn(input_shapes, device):
+def test_lerp_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -131,7 +136,8 @@ def test_lerp_ttnn(input_shapes, device):
 )
 @pytest.mark.parametrize("value1", [1.0, 5.0, 10.0])
 @pytest.mark.parametrize("value2", [1.0, 5.0, 10.0])
-def test_mac_overload_ttnn(input_shapes, value1, value2, device):
+def test_mac_overload_ttnn(input_shapes, value1, value2, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.mac(input_tensor1, value1, value2)
@@ -150,7 +156,8 @@ def test_mac_overload_ttnn(input_shapes, value1, value2, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_mac_ttnn(input_shapes, device):
+def test_mac_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -1439,7 +1439,8 @@ def test_where_ttt_scalar_bcast_with_block_sharding_uneven(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
+def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -1635,7 +1636,8 @@ def test_where_ttt_identical_mixed_strategy(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
+def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = torch.Size([2, 7, 32 * 2, 4 * 32])  # [2, 7, 64, 128]
     true_shape = torch.Size([1, 7, 1, 4 * 32])  # [1, 7, 1, 128] - height broadcast

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -1439,8 +1439,7 @@ def test_where_ttt_scalar_bcast_with_block_sharding_uneven(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
-    device = device_module
+def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -1636,8 +1635,7 @@ def test_where_ttt_identical_mixed_strategy(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
-    device = device_module
+def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
     torch.manual_seed(0)
     predicate_shape = torch.Size([2, 7, 32 * 2, 4 * 32])  # [2, 7, 64, 128]
     true_shape = torch.Size([1, 7, 1, 4 * 32])  # [1, 7, 1, 128] - height broadcast

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -46,7 +46,7 @@ def torch_equal_nan(a, b):
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_no_bcast_with_sharding(
-    device,
+    device_module,
     shape,
     shard_strategy,
     shard_shape_row_major,
@@ -58,6 +58,7 @@ def test_where_ttt_no_bcast_with_sharding(
     out_sharded,
     shard_orientation,
 ):
+    device = device_module
     torch.manual_seed(0)
     torch_predicate = torch.randint(0, 2, shape, dtype=torch.bfloat16)
     torch_true = torch.rand(shape, dtype=torch.bfloat16)
@@ -117,8 +118,9 @@ def test_where_ttt_no_bcast_with_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_width_bcast_with_height_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (5, 7, 2 * 32, 4 * 32)  # [5, 7, 64, 128]
     true_shape = (5, 7, 2 * 32, 1)  # width broadcast [5, 7, 64, 1]
@@ -192,8 +194,9 @@ def test_where_ttt_width_bcast_with_height_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_width_bcast_with_width_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (1, 2, 2 * 32, 40 * 32)  # [1, 2, 64, 1280]
     true_shape = (1, 1, 2 * 32, 1)  # width broadcast [1, 1, 64, 1]
@@ -267,8 +270,9 @@ def test_where_ttt_width_bcast_with_width_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_height_bcast_with_height_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 4 * 32)  # height broadcast [1, 7, 1, 128]
@@ -342,8 +346,9 @@ def test_where_ttt_height_bcast_with_height_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_height_bcast_with_width_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 1, 2 * 32, 7 * 32)  # [2, 1, 64, 224]
     true_shape = (1, 1, 1, 7 * 32)  # height broadcast [1, 1, 1, 224]
@@ -417,8 +422,9 @@ def test_where_ttt_height_bcast_with_width_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_width_bcast_with_block_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 32 * 2, 1)  # width broadcast [1, 7, 64, 1]
@@ -496,8 +502,9 @@ def test_where_ttt_width_bcast_with_block_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_height_bcast_with_block_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 4 * 32)  # height broadcast [1, 7, 1, 128]
@@ -575,8 +582,9 @@ def test_where_ttt_height_bcast_with_block_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_scalar_bcast_with_height_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 2 * 32, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 1)  # scalar broadcast [1, 7, 1, 1]
@@ -650,8 +658,9 @@ def test_where_ttt_scalar_bcast_with_height_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_scalar_bcast_with_width_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 1, 2 * 32, 7 * 32)  # [2, 1, 64, 224]
     true_shape = (1, 1, 1, 1)  # scalar broadcast [1, 1, 1, 1]
@@ -725,8 +734,9 @@ def test_where_ttt_scalar_bcast_with_width_sharding(
 @pytest.mark.parametrize("out_sharded", [True, False])
 @pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 def test_where_ttt_scalar_bcast_with_block_sharding(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 1)  # scalar broadcast [1, 7, 1, 1]
@@ -803,8 +813,9 @@ def test_where_ttt_scalar_bcast_with_block_sharding(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_width_bcast_with_height_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (5, 7, 2 * 32, 4 * 32)  # [5, 7, 64, 128]
     true_shape = (5, 7, 2 * 32, 1)  # width broadcast [5, 7, 64, 1]
@@ -873,8 +884,9 @@ def test_where_ttt_width_bcast_with_height_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_width_bcast_with_width_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (1, 2, 2 * 32, 40 * 32)  # [1, 2, 64, 1280]
     true_shape = (1, 1, 2 * 32, 1)  # width broadcast [1, 1, 64, 1]
@@ -943,8 +955,9 @@ def test_where_ttt_width_bcast_with_width_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_width_bcast_with_block_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 3 * 32)  # [2, 7, 64, 96]
     true_shape = (1, 7, 32 * 2, 1)  # width broadcast [1, 7, 64, 1]
@@ -1013,8 +1026,9 @@ def test_where_ttt_width_bcast_with_block_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_height_bcast_with_height_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 4 * 32)  # height broadcast [1, 7, 1, 128]
@@ -1083,8 +1097,9 @@ def test_where_ttt_height_bcast_with_height_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_height_bcast_with_width_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     # Height broadcast: true broadcasts along height dimension
     predicate_shape = (2, 1, 64, 7 * 32)  # [2, 1, 64, 224]
@@ -1156,8 +1171,9 @@ def test_where_ttt_height_bcast_with_width_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_height_bcast_with_block_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
 
     predicate_shape = (2, 7, 32 * 2, 5 * 32)  # [2, 7, 64, 160]
@@ -1230,8 +1246,9 @@ def test_where_ttt_height_bcast_with_block_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_scalar_bcast_with_height_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 2 * 32, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (1, 7, 1, 1)  # scalar broadcast [1, 7, 1, 1]
@@ -1300,8 +1317,9 @@ def test_where_ttt_scalar_bcast_with_height_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_scalar_bcast_with_width_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 1, 64, 7 * 32)  # [2, 1, 64, 224]
     true_shape = (1, 1, 1, 1)  # scalar broadcast [1, 1, 1, 1]
@@ -1370,8 +1388,9 @@ def test_where_ttt_scalar_bcast_with_width_sharding_uneven(
 @pytest.mark.parametrize("false_sharded", [True, False])
 @pytest.mark.parametrize("out_sharded", [True, False])
 def test_where_ttt_scalar_bcast_with_block_sharding_uneven(
-    device, predicate_sharded, true_sharded, false_sharded, out_sharded
+    device_module, predicate_sharded, true_sharded, false_sharded, out_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 5 * 32)  # [2, 7, 64, 160]
     true_shape = (1, 7, 1, 1)  # scalar broadcast [1, 7, 1, 1]
@@ -1439,7 +1458,8 @@ def test_where_ttt_scalar_bcast_with_block_sharding_uneven(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device):
+def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, device_module):
+    device = device_module
     torch.manual_seed(0)
     dram_grid_size = device.dram_grid_size()
     input_shape = (1, 1, dram_grid_size.x * dram_grid_size.y * 32, 32)
@@ -1527,8 +1547,9 @@ def test_where_ttt_sharded_shardspec_mixed_buffer_type(dtype_pt, dtype_tt, devic
 @pytest.mark.parametrize("true_sharded", [True, False])
 @pytest.mark.parametrize("false_sharded", [True, False])
 def test_where_ttt_identical_mixed_strategy(
-    device, dtype_pt, dtype_tt, config_permutation, out_strategy, predicate_sharded, true_sharded, false_sharded
+    device_module, dtype_pt, dtype_tt, config_permutation, out_strategy, predicate_sharded, true_sharded, false_sharded
 ):
+    device = device_module
     torch.manual_seed(0)
     predicate_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
     true_shape = (2, 7, 32 * 2, 4 * 32)  # [2, 7, 64, 128]
@@ -1635,7 +1656,10 @@ def test_where_ttt_identical_mixed_strategy(
     "dtype_pt, dtype_tt",
     ([torch.bfloat16, ttnn.bfloat16],),
 )
-def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device, dtype_pt, dtype_tt):
+def test_where_ttt_height_bcast_mixed_strategy_mixed_L1(device_module, dtype_pt, dtype_tt):
+    device = device_module
+    # Clear program cache to ensure correct handling of broadcast shapes
+    device.disable_and_clear_program_cache()
     torch.manual_seed(0)
     predicate_shape = torch.Size([2, 7, 32 * 2, 4 * 32])  # [2, 7, 64, 128]
     true_shape = torch.Size([1, 7, 1, 4 * 32])  # [1, 7, 1, 128] - height broadcast

--- a/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
@@ -8,8 +8,7 @@ import pytest
 
 
 # use case for TG Llama : need to achieve (int32 + int32) addition with (uint16 + int32) inputs
-def test_typecast_uint16(device_module):
-    device = device_module
+def test_typecast_uint16(device):
     torch.manual_seed(0)
 
     in_data1 = torch.tensor([[[[700, 100, 65000, 9500]]]], dtype=torch.int32)
@@ -91,8 +90,7 @@ def test_typecast_uint16(device_module):
         ),
     ],
 )
-def test_typecast_subcore_grid(device_module, shape, sub_core_grid):
-    device = device_module
+def test_typecast_subcore_grid(device, shape, sub_core_grid):
     torch.manual_seed(0)
 
     in_data1 = torch.randint(0, 65500, (shape), dtype=torch.int32)
@@ -139,8 +137,7 @@ def test_typecast_subcore_grid(device_module, shape, sub_core_grid):
 
 
 # for range verification in conversions
-def test_typecast_uint16_subcore_grid(device_module):
-    device = device_module
+def test_typecast_uint16_subcore_grid(device):
     in_data1 = torch.tensor([[[[700, 100, 65000, 9500]]]], dtype=torch.int32)
     in_data2 = torch.tensor([[[[70000, 1000, 65000, 95000]]]], dtype=torch.int32)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
@@ -8,7 +8,8 @@ import pytest
 
 
 # use case for TG Llama : need to achieve (int32 + int32) addition with (uint16 + int32) inputs
-def test_typecast_uint16(device):
+def test_typecast_uint16(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     in_data1 = torch.tensor([[[[700, 100, 65000, 9500]]]], dtype=torch.int32)
@@ -90,7 +91,8 @@ def test_typecast_uint16(device):
         ),
     ],
 )
-def test_typecast_subcore_grid(device, shape, sub_core_grid):
+def test_typecast_subcore_grid(device_module, shape, sub_core_grid):
+    device = device_module
     torch.manual_seed(0)
 
     in_data1 = torch.randint(0, 65500, (shape), dtype=torch.int32)
@@ -137,7 +139,8 @@ def test_typecast_subcore_grid(device, shape, sub_core_grid):
 
 
 # for range verification in conversions
-def test_typecast_uint16_subcore_grid(device):
+def test_typecast_uint16_subcore_grid(device_module):
+    device = device_module
     in_data1 = torch.tensor([[[[700, 100, 65000, 9500]]]], dtype=torch.int32)
     in_data2 = torch.tensor([[[[70000, 1000, 65000, 95000]]]], dtype=torch.int32)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -39,7 +39,8 @@ def create_full_range_tensor(input_shapes, dtype):
     return in_data
 
 
-def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
+def run_unary_test(device_module, h, w, ttnn_function, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -55,7 +56,8 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-def run_unary_with_approx_mode_test(device, h, w, ttnn_function, vector_mode, approx_mode, pcc=0.9999):
+def run_unary_with_approx_mode_test(device_module, h, w, ttnn_function, vector_mode, approx_mode, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -71,7 +73,8 @@ def run_unary_with_approx_mode_test(device, h, w, ttnn_function, vector_mode, ap
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-def run_unary_test_fixed(device, h, w, fill_value, ttnn_function, pcc=0.9999):
+def run_unary_test_fixed(device_module, h, w, fill_value, ttnn_function, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.full((h, w), fill_value, dtype=torch.bfloat16)
@@ -88,7 +91,8 @@ def run_unary_test_fixed(device, h, w, fill_value, ttnn_function, pcc=0.9999):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-def run_identity_test(device, h, w, data_type):
+def run_identity_test(device_module, h, w, data_type):
+    device = device_module
     torch.manual_seed(0)
     ttnn_function = ttnn.identity
     if data_type == ttnn.uint8:
@@ -200,41 +204,43 @@ def run_identity_test(device, h, w, data_type):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
-def test_fp32_uint32(device, h, w, dtype):
-    run_identity_test(device, h, w, dtype)
+def test_fp32_uint32(device_module, h, w, dtype):
+    device = device_module
+    run_identity_test(device_module, h, w, dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp(device, h, w):
-    run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
+def test_exp(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.exp, pcc=0.9998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device, h, w):
-    run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
+def test_gelu(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.gelu, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu(device, h, w):
-    run_unary_test(device, h, w, ttnn.relu)
+def test_relu(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.relu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_silu(device, h, w):
-    run_unary_test(device, h, w, ttnn.silu)
+def test_silu(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.silu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log(device, h, w):
-    run_unary_test(device, h, w, ttnn.log)
+def test_log(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.log)
 
 
-def test_log_edge_cases(device):
+def test_log_edge_cases(device_module):
+    device = device_module
     in_data = torch.tensor(
         [-10.0, 0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch.float32
     )
@@ -277,8 +283,9 @@ def test_log_edge_cases(device):
 )
 # Related to issue 8634 for log based functions with different dtypes
 def test_unary_log_operations_ttnn(
-    input_shapes, log_function, torch_dtype, ttnn_dtype, low_range, high_range, data_seed, device
+    input_shapes, log_function, torch_dtype, ttnn_dtype, low_range, high_range, data_seed, device_module
 ):
+    device = device_module
     """Test logarithm functions (log, log2, log10)"""
     torch.manual_seed(data_seed)
     in_data = torch.Tensor(size=input_shapes).uniform_(low_range, high_range).to(torch_dtype)
@@ -308,57 +315,58 @@ def test_unary_log_operations_ttnn(
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sin(device, h, w):
-    run_unary_test(device, h, w, ttnn.sin)
+def test_sin(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [0])
 @pytest.mark.parametrize("w", [1])
-def test_01_volume_sin(device, h, w):
-    run_unary_test(device, h, w, ttnn.sin)
+def test_01_volume_sin(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin(device, h, w):
-    run_unary_test(device, h, w, ttnn.asin, pcc=0.999)
+def test_asin(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cos(device, h, w):
-    run_unary_test(device, h, w, ttnn.cos, pcc=0.999)
+def test_cos(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.cos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos(device, h, w):
-    run_unary_test(device, h, w, ttnn.acos, pcc=0.999)
+def test_acos(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.acos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tan(device, h, w):
-    run_unary_test(device, h, w, ttnn.tan)
+def test_tan(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.tan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atan(device, h, w):
-    run_unary_test(device, h, w, ttnn.atan)
+def test_atan(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sinh(device, h, w):
-    run_unary_test(device, h, w, ttnn.sinh)
+def test_sinh(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.sinh)
 
 
 @pytest.mark.parametrize("h", [2048 * 128])
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("approx_mode", [True, False])
 @pytest.mark.parametrize("vector_mode", [4])
-def test_sigmoid(device, h, w, vector_mode, approx_mode):
+def test_sigmoid(device_module, h, w, vector_mode, approx_mode):
+    device = device_module
     run_unary_with_approx_mode_test(
         device, h, w, ttnn.sigmoid, vector_mode=vector_mode, approx_mode=approx_mode, pcc=0.999
     )
@@ -366,11 +374,12 @@ def test_sigmoid(device, h, w, vector_mode, approx_mode):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_not(device, h, w):
-    run_unary_test(device, h, w, ttnn.logical_not)
+def test_logical_not(device_module, h, w):
+    run_unary_test(device_module, h, w, ttnn.logical_not)
 
 
-def run_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
+def run_unary_test_range(device_module, h, w, ttnn_function, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
     low = -100
     high = 100
@@ -391,17 +400,18 @@ def run_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_floor(device, h, w):
-    run_unary_test_range(device, h, w, ttnn.floor, pcc=0.99)
+def test_floor(device_module, h, w):
+    run_unary_test_range(device_module, h, w, ttnn.floor, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ceil(device, h, w):
-    run_unary_test_range(device, h, w, ttnn.ceil, pcc=0.99)
+def test_ceil(device_module, h, w):
+    run_unary_test_range(device_module, h, w, ttnn.ceil, pcc=0.99)
 
 
-def run_unary_test_with_float(device, h, w, scalar, ttnn_function, pcc=0.9999):
+def run_unary_test_with_float(device_module, h, w, scalar, ttnn_function, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -417,7 +427,8 @@ def run_unary_test_with_float(device, h, w, scalar, ttnn_function, pcc=0.9999):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc=0.9999):
+def run_unary_test_with_float_remainder(device_module, h, w, scalar, ttnn_function, pcc=0.9999):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
@@ -436,15 +447,16 @@ def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc
 @pytest.mark.parametrize("scalar", [0, 1.0, 2])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_pow(device, h, w, scalar):
-    run_unary_test_with_float(device, h, w, scalar, ttnn.pow, pcc=0.999)
+def test_pow(device_module, h, w, scalar):
+    run_unary_test_with_float(device_module, h, w, scalar, ttnn.pow, pcc=0.999)
 
 
 @pytest.mark.parametrize("lower_limit", [0, 1.0, 2, -5.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_min(device, h, w, lower_limit, dtype):
+def test_relu_min(device_module, h, w, lower_limit, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -469,7 +481,8 @@ def test_relu_min(device, h, w, lower_limit, dtype):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_max(device, h, w, upper_limit, dtype):
+def test_relu_max(device_module, h, w, upper_limit, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -493,30 +506,31 @@ def test_relu_max(device, h, w, upper_limit, dtype):
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_remainder(device, h, w, scalar):
-    run_unary_test_with_float_remainder(device, h, w, scalar, ttnn.remainder)
+def test_remainder(device_module, h, w, scalar):
+    run_unary_test_with_float_remainder(device_module, h, w, scalar, ttnn.remainder)
 
 
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_fmod(device, h, w, scalar):
-    run_unary_test_with_float(device, h, w, scalar, ttnn.fmod)
+def test_fmod(device_module, h, w, scalar):
+    run_unary_test_with_float(device_module, h, w, scalar, ttnn.fmod)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin_fixed(device, h, w):
-    run_unary_test_fixed(device, h, w, 90, ttnn.asin, pcc=0.999)
+def test_asin_fixed(device_module, h, w):
+    run_unary_test_fixed(device_module, h, w, 90, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos_fixed(device, h, w):
-    run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
+def test_acos_fixed(device_module, h, w):
+    run_unary_test_fixed(device_module, h, w, 90, ttnn.acos, pcc=0.999)
 
 
-def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
+def run_unary_test_bitwise_not(device_module, h, w, fill_value, ttnn_function):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.full(size=(h, w), fill_value=fill_value).to(torch.int32)
@@ -535,8 +549,8 @@ def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("fill_value", [-2147483647, 2147483648, 7534, 225, 97, 3])
-def test_bitwise_not(device, h, w, fill_value):
-    run_unary_test_bitwise_not(device, h, w, fill_value, ttnn.bitwise_not)
+def test_bitwise_not(device_module, h, w, fill_value):
+    run_unary_test_bitwise_not(device_module, h, w, fill_value, ttnn.bitwise_not)
 
 
 @pytest.mark.parametrize(
@@ -547,7 +561,8 @@ def test_bitwise_not(device, h, w, fill_value):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_floor(input_shapes, device):
+def test_unary_floor(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.floor(input_tensor1)
@@ -565,7 +580,8 @@ def test_unary_floor(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ceil(input_shapes, device):
+def test_unary_ceil(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.ceil(input_tensor1)
@@ -578,7 +594,8 @@ def test_unary_ceil(input_shapes, device):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_alt_complex_rotate90(device, h: int, w: int, dtype: ttnn.DataType):
+def test_alt_complex_rotate90(device_module, h: int, w: int, dtype: ttnn.DataType):
+    device = device_module
     ttnn_function = ttnn.alt_complex_rotate90
     golden_function = ttnn.get_golden_function(ttnn_function)
 
@@ -616,7 +633,8 @@ def test_alt_complex_rotate90(device, h: int, w: int, dtype: ttnn.DataType):
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
+def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device_module):
+    device = device_module
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -646,7 +664,8 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
         ttnn.nez,
     ],
 )
-def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device):
+def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device_module):
+    device = device_module
     in_data = torch.randint(low, high, input_shapes, dtype=torch_dtype)
     zeroize_prob = 0.50
     if zeroize_prob > 0:
@@ -682,7 +701,8 @@ def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dt
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
+def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device_module):
+    device = device_module
     # Generate a uniform range of values across the valid int32 range
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -724,7 +744,8 @@ def is_int32_overflow(tensor, scalar):
 @pytest.mark.parametrize("ttnn_op", [ttnn.ne, ttnn.eq, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le])
 @pytest.mark.parametrize("use_legacy", [False])
 # TODO: Test use_legacy = True for all cases after #23179 is completed
-def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
+def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device_module):
+    device = device_module
     # Generate a uniform range of values across the valid int32 range
     num_elements = int(torch.prod(torch.tensor(input_shapes)).item())
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -762,7 +783,8 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
         (torch.bfloat16, ttnn.bfloat16, 0.012),
     ],
 )
-def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -791,7 +813,8 @@ def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, devi
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -813,7 +836,8 @@ def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, dev
     "ttnn_function",
     [ttnn.silu, ttnn.asinh, ttnn.tanhshrink, ttnn.rad2deg, ttnn.deg2rad, ttnn.acosh, ttnn.hardsigmoid, ttnn.cbrt],
 )
-def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device):
+def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -833,8 +857,9 @@ def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("ttnn_function", [ttnn.rad2deg, ttnn.deg2rad])
-def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_function):
-    in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
+def test_unary_angle_conversion_ttnn(input_shapes, device_module, ttnn_dtype, ttnn_function):
+    device = device_module
+    in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device_module, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn_function(input_tensor1)
     golden_function = ttnn.get_golden_function(ttnn_function)
@@ -851,7 +876,8 @@ def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_func
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_trunc_ttnn(input_shapes, device):
+def test_unary_trunc_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -868,7 +894,8 @@ def test_unary_trunc_ttnn(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_trunc_ttnn_opt(input_shapes, device):
+def test_unary_trunc_ttnn_opt(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -898,7 +925,8 @@ def test_unary_trunc_ttnn_opt(input_shapes, device):
     ],
 )
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device, atol):
+def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device_module, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -914,7 +942,8 @@ def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_funct
 
 
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_threshold(ttnn_function, device):
+def test_unary_silu_swish_threshold(ttnn_function, device_module):
+    device = device_module
     in_data1 = torch.tensor([[-1.0, 0.0, 0.5, 1.0, 1.5, 3.5, 5.0, 5.2, 5.5]], dtype=torch.bfloat16)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -946,8 +975,9 @@ def test_unary_silu_swish_threshold(ttnn_function, device):
 )
 @pytest.mark.parametrize("ttnn_function", [ttnn.acosh, ttnn.asinh])
 def test_unary_inverse_hyperbolic_edge_case_ttnn(
-    input_shapes, device, torch_dtype, ttnn_dtype, low, high, ttnn_function
+    input_shapes, device_module, torch_dtype, ttnn_dtype, low, high, ttnn_function
 ):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -966,7 +996,8 @@ def test_unary_inverse_hyperbolic_edge_case_ttnn(
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_acosh_ttnn(input_shapes, device):
+def test_unary_acosh_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(1, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -994,7 +1025,8 @@ def test_unary_acosh_ttnn(input_shapes, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1024,7 +1056,8 @@ def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     "low, high",
     [(-0.9, 1), (-100, 100)],
 )
-def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device):
+def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1061,7 +1094,8 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device):
+def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1091,7 +1125,8 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device):
+def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     in_data = ttnn.to_torch(input_tensor, dtype=torch.bfloat16)
@@ -1119,7 +1154,8 @@ def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, de
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device):
+def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1138,7 +1174,8 @@ def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_functio
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_frac_ttnn(input_shapes, device):
+def test_unary_frac_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1155,7 +1192,8 @@ def test_unary_frac_ttnn(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_frac_ttnn_opt(input_shapes, device):
+def test_unary_frac_ttnn_opt(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1184,7 +1222,8 @@ def test_unary_frac_ttnn_opt(input_shapes, device):
         (torch.bfloat16, ttnn.bfloat8_b, 0.004),
     ],
 )
-def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1213,7 +1252,8 @@ def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device
         (torch.bfloat16, ttnn.bfloat8_b, 0.015),
     ],
 )
-def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1242,7 +1282,8 @@ def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, dev
         (torch.bfloat16, ttnn.bfloat16, 0.016),
     ],
 )
-def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1262,7 +1303,8 @@ def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, 
     ),
 )
 @pytest.mark.parametrize("low, high", [(-100, -3), (-2, 2), (3, 100)])
-def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
+def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(low, high)
 
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1299,7 +1341,8 @@ def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
         (-0.5, 21.0),
     ],
 )
-def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device):
+def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1329,7 +1372,8 @@ def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     if torch_dtype == torch.int32:
         in_data = torch.randint(-100, 100, input_shapes, dtype=torch_dtype)
     else:
@@ -1346,7 +1390,8 @@ def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
 
 
-def test_unary_signbit_int32_edge_case_ttnn(device):
+def test_unary_signbit_int32_edge_case_ttnn(device_module):
+    device = device_module
     in_data = torch.tensor([-2147483648, 2147483647, +0, -0, 0], dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1364,7 +1409,8 @@ def test_unary_signbit_int32_edge_case_ttnn(device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
+def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.tensor(
         [-0.0, 0.0, +0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch_dtype
     )
@@ -1386,7 +1432,8 @@ def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
 )
 @pytest.mark.parametrize("threshold", [1.0, 10.0, 100.0, -5, -8.0, -100.0])
 @pytest.mark.parametrize("value", [10.0, 100.0, -7.0, -85.5])
-def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
+def test_unary_threshold_ttnn(input_shapes, threshold, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.threshold(input_tensor1, threshold, value)
     golden_function = ttnn.get_golden_function(ttnn.threshold)
@@ -1422,7 +1469,8 @@ def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device):
+def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     min = min_val
@@ -1452,7 +1500,8 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
         (torch.bfloat16, ttnn.bfloat16, 0.008),
     ],
 )
-def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1481,7 +1530,8 @@ def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1502,7 +1552,8 @@ def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_uint16_ttnn(input_shapes, device):
+def test_unary_square_uint16_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = torch.randint(
         0, 255, input_shapes, dtype=torch.int32
     )  # Beyond 255 leads to overflow of uint16 range, since it a square op.
@@ -1538,7 +1589,8 @@ def test_unary_square_uint16_ttnn(input_shapes, device):
         (0, 1),
     ],
 )
-def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
+def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1569,7 +1621,8 @@ def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1600,7 +1653,8 @@ def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1625,7 +1679,8 @@ def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.5, 8.0, 9.0, 10.0])
-def test_unary_rpow_ttnn(input_shapes, exponent, device):
+def test_unary_rpow_ttnn(input_shapes, exponent, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-30, 30)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.rpow(input_tensor1, exponent)
@@ -1651,7 +1706,8 @@ def test_unary_rpow_ttnn(input_shapes, exponent, device):
         (torch.bfloat16, ttnn.bfloat8_b, 0.05),
     ],
 )
-def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1667,7 +1723,8 @@ def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
         assert_allclose(ttnn.to_torch(output_tensor), golden_tensor, rtol=1e-05, atol=atol)
 
 
-def test_cbrt_arange(device):
+def test_cbrt_arange(device_module):
+    device = device_module
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1703,7 +1760,8 @@ def test_cbrt_arange(device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device):
+def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.tensor(
         [float("-inf"), float("inf"), float("nan"), 5.0, -5.0, 0.0, -0.0, 1e38, 1e-45, 3.4e38, -3.4e38],
         dtype=torch_dtype,
@@ -1733,7 +1791,8 @@ def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device):
     ],
 )
 @pytest.mark.parametrize("negative_slope", [0.01, 0.1, 1.0, 5.75, 10.0])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device):
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1767,7 +1826,8 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_d
         (torch.float32, ttnn.float32),
     ],
 )
-def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = create_full_range_tensor(input_shapes, torch_dtype)
 
     # limit the range to avoid overflow in hardmish
@@ -1784,7 +1844,8 @@ def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
     assert_with_pcc(tt_res, golden_tensor, pcc=0.9999)
 
 
-def test_hardmish_bfloat16_ulp(device):
+def test_hardmish_bfloat16_ulp(device_module):
+    device = device_module
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1815,7 +1876,8 @@ def test_hardmish_bfloat16_ulp(device):
     assert_with_ulp(golden, result, 1, allow_nonfinite=True)
 
 
-def test_hardmish_bfloat16_allclose(device):
+def test_hardmish_bfloat16_allclose(device_module):
+    device = device_module
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1852,7 +1914,8 @@ def test_hardmish_bfloat16_allclose(device):
 )
 @pytest.mark.parametrize("ttnn_op", [ttnn.rsqrt, ttnn.sqrt])
 @pytest.mark.parametrize("fast_approx_mode", [True, False])
-def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device):
+def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device_module):
+    device = device_module
     torch.manual_seed(0)
     if fast_approx_mode:
         in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(1, 100)
@@ -1893,7 +1956,8 @@ def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fas
     {-1.5, 1.7, 0.0},
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_inf_nan_check(param, round_mode, device):
+def test_unary_rdiv_inf_nan_check(param, round_mode, device_module):
+    device = device_module
     dtype = torch.bfloat16
     if dtype == torch.bfloat16 and param == 0.0:
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
@@ -1933,7 +1997,8 @@ def test_unary_rdiv_inf_nan_check(param, round_mode, device):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device):
+def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1975,9 +2040,10 @@ def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mod
     ],
 )
 def test_unary_bitcast_ttnn(
-    input_shapes, input_vals, torch_input_dtype, torch_output_dtype, ttnn_input_dtype, ttnn_output_dtype, device
+    input_shapes, input_vals, torch_input_dtype, torch_output_dtype, ttnn_input_dtype, ttnn_output_dtype, device_module
 ):
     """Test bitcast operation - reinterprets bit pattern without conversion"""
+    device = device_module
     # Create PyTorch reference
     x_torch = torch.tensor(input_vals, dtype=torch_input_dtype)
     y_torch = x_torch.view(torch_output_dtype)
@@ -2051,7 +2117,8 @@ def test_unary_bitcast_ttnn(
     ],
 )
 @pytest.mark.parametrize("scalar", [0.25, 0.38, 0.5, 0.85])
-def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device, atol):
+def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device_module, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(low, high)
     input_tensor_a = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -2073,7 +2140,8 @@ def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, de
     ],
 )
 @pytest.mark.parametrize("eps", [0.0, 1.0, None])
-def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device, eps, atol):
+def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device_module, eps, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(-1, 1.1)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -200,41 +200,48 @@ def run_identity_test(device, h, w, data_type):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
-def test_fp32_uint32(device, h, w, dtype):
+def test_fp32_uint32(device_module, h, w, dtype):
+    device = device_module
     run_identity_test(device, h, w, dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp(device, h, w):
+def test_exp(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device, h, w):
+def test_gelu(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu(device, h, w):
+def test_relu(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.relu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_silu(device, h, w):
+def test_silu(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.silu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log(device, h, w):
+def test_log(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.log)
 
 
-def test_log_edge_cases(device):
+def test_log_edge_cases(device_module):
+    device = device_module
     in_data = torch.tensor(
         [-10.0, 0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch.float32
     )
@@ -308,49 +315,57 @@ def test_unary_log_operations_ttnn(
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sin(device, h, w):
+def test_sin(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [0])
 @pytest.mark.parametrize("w", [1])
-def test_01_volume_sin(device, h, w):
+def test_01_volume_sin(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin(device, h, w):
+def test_asin(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cos(device, h, w):
+def test_cos(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.cos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos(device, h, w):
+def test_acos(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.acos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tan(device, h, w):
+def test_tan(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.tan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atan(device, h, w):
+def test_atan(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sinh(device, h, w):
+def test_sinh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.sinh)
 
 
@@ -358,7 +373,8 @@ def test_sinh(device, h, w):
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("approx_mode", [True, False])
 @pytest.mark.parametrize("vector_mode", [4])
-def test_sigmoid(device, h, w, vector_mode, approx_mode):
+def test_sigmoid(device_module, h, w, vector_mode, approx_mode):
+    device = device_module
     run_unary_with_approx_mode_test(
         device, h, w, ttnn.sigmoid, vector_mode=vector_mode, approx_mode=approx_mode, pcc=0.999
     )
@@ -366,7 +382,8 @@ def test_sigmoid(device, h, w, vector_mode, approx_mode):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_not(device, h, w):
+def test_logical_not(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.logical_not)
 
 
@@ -391,13 +408,15 @@ def run_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_floor(device, h, w):
+def test_floor(device_module, h, w):
+    device = device_module
     run_unary_test_range(device, h, w, ttnn.floor, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ceil(device, h, w):
+def test_ceil(device_module, h, w):
+    device = device_module
     run_unary_test_range(device, h, w, ttnn.ceil, pcc=0.99)
 
 
@@ -436,7 +455,8 @@ def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc
 @pytest.mark.parametrize("scalar", [0, 1.0, 2])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_pow(device, h, w, scalar):
+def test_pow(device_module, h, w, scalar):
+    device = device_module
     run_unary_test_with_float(device, h, w, scalar, ttnn.pow, pcc=0.999)
 
 
@@ -444,7 +464,8 @@ def test_pow(device, h, w, scalar):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_min(device, h, w, lower_limit, dtype):
+def test_relu_min(device_module, h, w, lower_limit, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -469,7 +490,8 @@ def test_relu_min(device, h, w, lower_limit, dtype):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_max(device, h, w, upper_limit, dtype):
+def test_relu_max(device_module, h, w, upper_limit, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -493,26 +515,30 @@ def test_relu_max(device, h, w, upper_limit, dtype):
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_remainder(device, h, w, scalar):
+def test_remainder(device_module, h, w, scalar):
+    device = device_module
     run_unary_test_with_float_remainder(device, h, w, scalar, ttnn.remainder)
 
 
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_fmod(device, h, w, scalar):
+def test_fmod(device_module, h, w, scalar):
+    device = device_module
     run_unary_test_with_float(device, h, w, scalar, ttnn.fmod)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin_fixed(device, h, w):
+def test_asin_fixed(device_module, h, w):
+    device = device_module
     run_unary_test_fixed(device, h, w, 90, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos_fixed(device, h, w):
+def test_acos_fixed(device_module, h, w):
+    device = device_module
     run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
 
 
@@ -535,7 +561,8 @@ def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("fill_value", [-2147483647, 2147483648, 7534, 225, 97, 3])
-def test_bitwise_not(device, h, w, fill_value):
+def test_bitwise_not(device_module, h, w, fill_value):
+    device = device_module
     run_unary_test_bitwise_not(device, h, w, fill_value, ttnn.bitwise_not)
 
 
@@ -547,7 +574,8 @@ def test_bitwise_not(device, h, w, fill_value):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_floor(input_shapes, device):
+def test_unary_floor(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.floor(input_tensor1)
@@ -565,7 +593,8 @@ def test_unary_floor(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ceil(input_shapes, device):
+def test_unary_ceil(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.ceil(input_tensor1)
@@ -578,7 +607,8 @@ def test_unary_ceil(input_shapes, device):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_alt_complex_rotate90(device, h: int, w: int, dtype: ttnn.DataType):
+def test_alt_complex_rotate90(device_module, h: int, w: int, dtype: ttnn.DataType):
+    device = device_module
     ttnn_function = ttnn.alt_complex_rotate90
     golden_function = ttnn.get_golden_function(ttnn_function)
 
@@ -616,7 +646,8 @@ def test_alt_complex_rotate90(device, h: int, w: int, dtype: ttnn.DataType):
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
+def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device_module):
+    device = device_module
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -646,7 +677,8 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
         ttnn.nez,
     ],
 )
-def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device):
+def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device_module):
+    device = device_module
     in_data = torch.randint(low, high, input_shapes, dtype=torch_dtype)
     zeroize_prob = 0.50
     if zeroize_prob > 0:
@@ -682,7 +714,8 @@ def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dt
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
+def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device_module):
+    device = device_module
     # Generate a uniform range of values across the valid int32 range
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -724,7 +757,8 @@ def is_int32_overflow(tensor, scalar):
 @pytest.mark.parametrize("ttnn_op", [ttnn.ne, ttnn.eq, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le])
 @pytest.mark.parametrize("use_legacy", [False])
 # TODO: Test use_legacy = True for all cases after #23179 is completed
-def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
+def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device_module):
+    device = device_module
     # Generate a uniform range of values across the valid int32 range
     num_elements = int(torch.prod(torch.tensor(input_shapes)).item())
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -762,7 +796,8 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
         (torch.bfloat16, ttnn.bfloat16, 0.012),
     ],
 )
-def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -791,7 +826,8 @@ def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, devi
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -813,7 +849,8 @@ def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, dev
     "ttnn_function",
     [ttnn.silu, ttnn.asinh, ttnn.tanhshrink, ttnn.rad2deg, ttnn.deg2rad, ttnn.acosh, ttnn.hardsigmoid, ttnn.cbrt],
 )
-def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device):
+def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -833,7 +870,8 @@ def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("ttnn_function", [ttnn.rad2deg, ttnn.deg2rad])
-def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_function):
+def test_unary_angle_conversion_ttnn(input_shapes, device_module, ttnn_dtype, ttnn_function):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn_function(input_tensor1)
@@ -851,7 +889,8 @@ def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_func
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_trunc_ttnn(input_shapes, device):
+def test_unary_trunc_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -868,7 +907,8 @@ def test_unary_trunc_ttnn(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_trunc_ttnn_opt(input_shapes, device):
+def test_unary_trunc_ttnn_opt(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -898,7 +938,8 @@ def test_unary_trunc_ttnn_opt(input_shapes, device):
     ],
 )
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device, atol):
+def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device_module, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -914,7 +955,8 @@ def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_funct
 
 
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_threshold(ttnn_function, device):
+def test_unary_silu_swish_threshold(ttnn_function, device_module):
+    device = device_module
     in_data1 = torch.tensor([[-1.0, 0.0, 0.5, 1.0, 1.5, 3.5, 5.0, 5.2, 5.5]], dtype=torch.bfloat16)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -966,7 +1008,8 @@ def test_unary_inverse_hyperbolic_edge_case_ttnn(
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_acosh_ttnn(input_shapes, device):
+def test_unary_acosh_ttnn(input_shapes, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(1, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -994,7 +1037,8 @@ def test_unary_acosh_ttnn(input_shapes, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1024,7 +1068,8 @@ def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     "low, high",
     [(-0.9, 1), (-100, 100)],
 )
-def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device):
+def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1061,7 +1106,8 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device):
+def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1091,7 +1137,8 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device):
+def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     in_data = ttnn.to_torch(input_tensor, dtype=torch.bfloat16)
@@ -1119,7 +1166,8 @@ def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, de
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device):
+def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1138,7 +1186,8 @@ def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_functio
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_frac_ttnn(input_shapes, device):
+def test_unary_frac_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1155,7 +1204,8 @@ def test_unary_frac_ttnn(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_frac_ttnn_opt(input_shapes, device):
+def test_unary_frac_ttnn_opt(input_shapes, device_module):
+    device = device_module
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1184,7 +1234,8 @@ def test_unary_frac_ttnn_opt(input_shapes, device):
         (torch.bfloat16, ttnn.bfloat8_b, 0.004),
     ],
 )
-def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1213,7 +1264,8 @@ def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device
         (torch.bfloat16, ttnn.bfloat8_b, 0.015),
     ],
 )
-def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1242,7 +1294,8 @@ def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, dev
         (torch.bfloat16, ttnn.bfloat16, 0.016),
     ],
 )
-def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1262,7 +1315,8 @@ def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, 
     ),
 )
 @pytest.mark.parametrize("low, high", [(-100, -3), (-2, 2), (3, 100)])
-def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
+def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(low, high)
 
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1299,7 +1353,8 @@ def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
         (-0.5, 21.0),
     ],
 )
-def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device):
+def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1329,7 +1384,8 @@ def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     if torch_dtype == torch.int32:
         in_data = torch.randint(-100, 100, input_shapes, dtype=torch_dtype)
     else:
@@ -1346,7 +1402,8 @@ def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
 
 
-def test_unary_signbit_int32_edge_case_ttnn(device):
+def test_unary_signbit_int32_edge_case_ttnn(device_module):
+    device = device_module
     in_data = torch.tensor([-2147483648, 2147483647, +0, -0, 0], dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1364,7 +1421,8 @@ def test_unary_signbit_int32_edge_case_ttnn(device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
+def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.tensor(
         [-0.0, 0.0, +0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch_dtype
     )
@@ -1386,7 +1444,8 @@ def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
 )
 @pytest.mark.parametrize("threshold", [1.0, 10.0, 100.0, -5, -8.0, -100.0])
 @pytest.mark.parametrize("value", [10.0, 100.0, -7.0, -85.5])
-def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
+def test_unary_threshold_ttnn(input_shapes, threshold, value, device_module):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.threshold(input_tensor1, threshold, value)
     golden_function = ttnn.get_golden_function(ttnn.threshold)
@@ -1422,7 +1481,8 @@ def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device):
+def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     min = min_val
@@ -1452,7 +1512,8 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
         (torch.bfloat16, ttnn.bfloat16, 0.008),
     ],
 )
-def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1481,7 +1542,8 @@ def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1502,7 +1564,8 @@ def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_uint16_ttnn(input_shapes, device):
+def test_unary_square_uint16_ttnn(input_shapes, device_module):
+    device = device_module
     in_data = torch.randint(
         0, 255, input_shapes, dtype=torch.int32
     )  # Beyond 255 leads to overflow of uint16 range, since it a square op.
@@ -1538,7 +1601,8 @@ def test_unary_square_uint16_ttnn(input_shapes, device):
         (0, 1),
     ],
 )
-def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
+def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1569,7 +1633,8 @@ def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1600,7 +1665,8 @@ def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1625,7 +1691,8 @@ def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.5, 8.0, 9.0, 10.0])
-def test_unary_rpow_ttnn(input_shapes, exponent, device):
+def test_unary_rpow_ttnn(input_shapes, exponent, device_module):
+    device = device_module
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-30, 30)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.rpow(input_tensor1, exponent)
@@ -1651,7 +1718,8 @@ def test_unary_rpow_ttnn(input_shapes, exponent, device):
         (torch.bfloat16, ttnn.bfloat8_b, 0.05),
     ],
 )
-def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
+def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1667,7 +1735,8 @@ def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
         assert_allclose(ttnn.to_torch(output_tensor), golden_tensor, rtol=1e-05, atol=atol)
 
 
-def test_cbrt_arange(device):
+def test_cbrt_arange(device_module):
+    device = device_module
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1703,7 +1772,8 @@ def test_cbrt_arange(device):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device):
+def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.tensor(
         [float("-inf"), float("inf"), float("nan"), 5.0, -5.0, 0.0, -0.0, 1e38, 1e-45, 3.4e38, -3.4e38],
         dtype=torch_dtype,
@@ -1733,7 +1803,8 @@ def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device):
     ],
 )
 @pytest.mark.parametrize("negative_slope", [0.01, 0.1, 1.0, 5.75, 10.0])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device):
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1767,7 +1838,8 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_d
         (torch.float32, ttnn.float32),
     ],
 )
-def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     in_data1 = create_full_range_tensor(input_shapes, torch_dtype)
 
     # limit the range to avoid overflow in hardmish
@@ -1784,7 +1856,8 @@ def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
     assert_with_pcc(tt_res, golden_tensor, pcc=0.9999)
 
 
-def test_hardmish_bfloat16_ulp(device):
+def test_hardmish_bfloat16_ulp(device_module):
+    device = device_module
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1815,7 +1888,8 @@ def test_hardmish_bfloat16_ulp(device):
     assert_with_ulp(golden, result, 1, allow_nonfinite=True)
 
 
-def test_hardmish_bfloat16_allclose(device):
+def test_hardmish_bfloat16_allclose(device_module):
+    device = device_module
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1852,7 +1926,8 @@ def test_hardmish_bfloat16_allclose(device):
 )
 @pytest.mark.parametrize("ttnn_op", [ttnn.rsqrt, ttnn.sqrt])
 @pytest.mark.parametrize("fast_approx_mode", [True, False])
-def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device):
+def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device_module):
+    device = device_module
     torch.manual_seed(0)
     if fast_approx_mode:
         in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(1, 100)
@@ -1893,7 +1968,8 @@ def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fas
     {-1.5, 1.7, 0.0},
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_inf_nan_check(param, round_mode, device):
+def test_unary_rdiv_inf_nan_check(param, round_mode, device_module):
+    device = device_module
     dtype = torch.bfloat16
     if dtype == torch.bfloat16 and param == 0.0:
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
@@ -1933,7 +2009,8 @@ def test_unary_rdiv_inf_nan_check(param, round_mode, device):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device):
+def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -2051,7 +2128,8 @@ def test_unary_bitcast_ttnn(
     ],
 )
 @pytest.mark.parametrize("scalar", [0.25, 0.38, 0.5, 0.85])
-def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device, atol):
+def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device_module, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(low, high)
     input_tensor_a = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -2073,7 +2151,8 @@ def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, de
     ],
 )
 @pytest.mark.parametrize("eps", [0.0, 1.0, None])
-def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device, eps, atol):
+def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device_module, eps, atol):
+    device = device_module
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(-1, 1.1)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -200,48 +200,41 @@ def run_identity_test(device, h, w, data_type):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
-def test_fp32_uint32(device_module, h, w, dtype):
-    device = device_module
+def test_fp32_uint32(device, h, w, dtype):
     run_identity_test(device, h, w, dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp(device_module, h, w):
-    device = device_module
+def test_exp(device, h, w):
     run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device_module, h, w):
-    device = device_module
+def test_gelu(device, h, w):
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_relu(device_module, h, w):
-    device = device_module
+def test_relu(device, h, w):
     run_unary_test(device, h, w, ttnn.relu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_silu(device_module, h, w):
-    device = device_module
+def test_silu(device, h, w):
     run_unary_test(device, h, w, ttnn.silu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log(device_module, h, w):
-    device = device_module
+def test_log(device, h, w):
     run_unary_test(device, h, w, ttnn.log)
 
 
-def test_log_edge_cases(device_module):
-    device = device_module
+def test_log_edge_cases(device):
     in_data = torch.tensor(
         [-10.0, 0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch.float32
     )
@@ -315,57 +308,49 @@ def test_unary_log_operations_ttnn(
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sin(device_module, h, w):
-    device = device_module
+def test_sin(device, h, w):
     run_unary_test(device, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [0])
 @pytest.mark.parametrize("w", [1])
-def test_01_volume_sin(device_module, h, w):
-    device = device_module
+def test_01_volume_sin(device, h, w):
     run_unary_test(device, h, w, ttnn.sin)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin(device_module, h, w):
-    device = device_module
+def test_asin(device, h, w):
     run_unary_test(device, h, w, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cos(device_module, h, w):
-    device = device_module
+def test_cos(device, h, w):
     run_unary_test(device, h, w, ttnn.cos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos(device_module, h, w):
-    device = device_module
+def test_acos(device, h, w):
     run_unary_test(device, h, w, ttnn.acos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tan(device_module, h, w):
-    device = device_module
+def test_tan(device, h, w):
     run_unary_test(device, h, w, ttnn.tan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atan(device_module, h, w):
-    device = device_module
+def test_atan(device, h, w):
     run_unary_test(device, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sinh(device_module, h, w):
-    device = device_module
+def test_sinh(device, h, w):
     run_unary_test(device, h, w, ttnn.sinh)
 
 
@@ -373,8 +358,7 @@ def test_sinh(device_module, h, w):
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("approx_mode", [True, False])
 @pytest.mark.parametrize("vector_mode", [4])
-def test_sigmoid(device_module, h, w, vector_mode, approx_mode):
-    device = device_module
+def test_sigmoid(device, h, w, vector_mode, approx_mode):
     run_unary_with_approx_mode_test(
         device, h, w, ttnn.sigmoid, vector_mode=vector_mode, approx_mode=approx_mode, pcc=0.999
     )
@@ -382,8 +366,7 @@ def test_sigmoid(device_module, h, w, vector_mode, approx_mode):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_logical_not(device_module, h, w):
-    device = device_module
+def test_logical_not(device, h, w):
     run_unary_test(device, h, w, ttnn.logical_not)
 
 
@@ -408,15 +391,13 @@ def run_unary_test_range(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_floor(device_module, h, w):
-    device = device_module
+def test_floor(device, h, w):
     run_unary_test_range(device, h, w, ttnn.floor, pcc=0.99)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_ceil(device_module, h, w):
-    device = device_module
+def test_ceil(device, h, w):
     run_unary_test_range(device, h, w, ttnn.ceil, pcc=0.99)
 
 
@@ -455,8 +436,7 @@ def run_unary_test_with_float_remainder(device, h, w, scalar, ttnn_function, pcc
 @pytest.mark.parametrize("scalar", [0, 1.0, 2])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_pow(device_module, h, w, scalar):
-    device = device_module
+def test_pow(device, h, w, scalar):
     run_unary_test_with_float(device, h, w, scalar, ttnn.pow, pcc=0.999)
 
 
@@ -464,8 +444,7 @@ def test_pow(device_module, h, w, scalar):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_min(device_module, h, w, lower_limit, dtype):
-    device = device_module
+def test_relu_min(device, h, w, lower_limit, dtype):
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -490,8 +469,7 @@ def test_relu_min(device_module, h, w, lower_limit, dtype):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu_max(device_module, h, w, upper_limit, dtype):
-    device = device_module
+def test_relu_max(device, h, w, upper_limit, dtype):
     torch.manual_seed(0)
 
     if dtype == ttnn.bfloat16:
@@ -515,30 +493,26 @@ def test_relu_max(device_module, h, w, upper_limit, dtype):
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_remainder(device_module, h, w, scalar):
-    device = device_module
+def test_remainder(device, h, w, scalar):
     run_unary_test_with_float_remainder(device, h, w, scalar, ttnn.remainder)
 
 
 @pytest.mark.parametrize("scalar", [1.5, 2.0])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_fmod(device_module, h, w, scalar):
-    device = device_module
+def test_fmod(device, h, w, scalar):
     run_unary_test_with_float(device, h, w, scalar, ttnn.fmod)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin_fixed(device_module, h, w):
-    device = device_module
+def test_asin_fixed(device, h, w):
     run_unary_test_fixed(device, h, w, 90, ttnn.asin, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos_fixed(device_module, h, w):
-    device = device_module
+def test_acos_fixed(device, h, w):
     run_unary_test_fixed(device, h, w, 90, ttnn.acos, pcc=0.999)
 
 
@@ -561,8 +535,7 @@ def run_unary_test_bitwise_not(device, h, w, fill_value, ttnn_function):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("fill_value", [-2147483647, 2147483648, 7534, 225, 97, 3])
-def test_bitwise_not(device_module, h, w, fill_value):
-    device = device_module
+def test_bitwise_not(device, h, w, fill_value):
     run_unary_test_bitwise_not(device, h, w, fill_value, ttnn.bitwise_not)
 
 
@@ -574,8 +547,7 @@ def test_bitwise_not(device_module, h, w, fill_value):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_floor(input_shapes, device_module):
-    device = device_module
+def test_unary_floor(input_shapes, device):
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.floor(input_tensor1)
@@ -593,8 +565,7 @@ def test_unary_floor(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ceil(input_shapes, device_module):
-    device = device_module
+def test_unary_ceil(input_shapes, device):
     in_data1 = torch.empty(input_shapes, dtype=torch.float32).uniform_(-43566, 43565)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.ceil(input_tensor1)
@@ -607,8 +578,7 @@ def test_unary_ceil(input_shapes, device_module):
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_alt_complex_rotate90(device_module, h: int, w: int, dtype: ttnn.DataType):
-    device = device_module
+def test_alt_complex_rotate90(device, h: int, w: int, dtype: ttnn.DataType):
     ttnn_function = ttnn.alt_complex_rotate90
     golden_function = ttnn.get_golden_function(ttnn_function)
 
@@ -646,8 +616,7 @@ def test_alt_complex_rotate90(device_module, h: int, w: int, dtype: ttnn.DataTyp
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device_module):
-    device = device_module
+def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device):
     in_data = torch.randint(low, high, input_shapes, dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -677,8 +646,7 @@ def test_unary_zero_comp_ttnn(input_shapes, low, high, ttnn_function, device_mod
         ttnn.nez,
     ],
 )
-def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device_module):
-    device = device_module
+def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, ttnn_function, device):
     in_data = torch.randint(low, high, input_shapes, dtype=torch_dtype)
     zeroize_prob = 0.50
     if zeroize_prob > 0:
@@ -714,8 +682,7 @@ def test_unary_zero_comp_uint_ttnn(input_shapes, low, high, torch_dtype, ttnn_dt
         ttnn.gez,
     ],
 )
-def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device_module):
-    device = device_module
+def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
     # Generate a uniform range of values across the valid int32 range
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -757,8 +724,7 @@ def is_int32_overflow(tensor, scalar):
 @pytest.mark.parametrize("ttnn_op", [ttnn.ne, ttnn.eq, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le])
 @pytest.mark.parametrize("use_legacy", [False])
 # TODO: Test use_legacy = True for all cases after #23179 is completed
-def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device_module):
-    device = device_module
+def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
     # Generate a uniform range of values across the valid int32 range
     num_elements = int(torch.prod(torch.tensor(input_shapes)).item())
     uniform_values = torch.linspace(-2147483647, 2147483647, num_elements, dtype=torch.int32)
@@ -796,8 +762,7 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device_module
         (torch.bfloat16, ttnn.bfloat16, 0.012),
     ],
 )
-def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -826,8 +791,7 @@ def test_unary_tanhshrink_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, devi
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -849,8 +813,7 @@ def test_unary_tanhshrink_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, dev
     "ttnn_function",
     [ttnn.silu, ttnn.asinh, ttnn.tanhshrink, ttnn.rad2deg, ttnn.deg2rad, ttnn.acosh, ttnn.hardsigmoid, ttnn.cbrt],
 )
-def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device_module):
-    device = device_module
+def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -870,8 +833,7 @@ def test_unary_edge_case_ttnn(input_shapes, ttnn_function, device_module):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("ttnn_function", [ttnn.rad2deg, ttnn.deg2rad])
-def test_unary_angle_conversion_ttnn(input_shapes, device_module, ttnn_dtype, ttnn_function):
-    device = device_module
+def test_unary_angle_conversion_ttnn(input_shapes, device, ttnn_dtype, ttnn_function):
     in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn_function(input_tensor1)
@@ -889,8 +851,7 @@ def test_unary_angle_conversion_ttnn(input_shapes, device_module, ttnn_dtype, tt
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_trunc_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_trunc_ttnn(input_shapes, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -907,8 +868,7 @@ def test_unary_trunc_ttnn(input_shapes, device_module):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_trunc_ttnn_opt(input_shapes, device_module):
-    device = device_module
+def test_unary_trunc_ttnn_opt(input_shapes, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -938,8 +898,7 @@ def test_unary_trunc_ttnn_opt(input_shapes, device_module):
     ],
 )
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device_module, atol):
-    device = device_module
+def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_function, device, atol):
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -955,8 +914,7 @@ def test_unary_silu_swish_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_funct
 
 
 @pytest.mark.parametrize("ttnn_function", [ttnn.silu, ttnn.swish])
-def test_unary_silu_swish_threshold(ttnn_function, device_module):
-    device = device_module
+def test_unary_silu_swish_threshold(ttnn_function, device):
     in_data1 = torch.tensor([[-1.0, 0.0, 0.5, 1.0, 1.5, 3.5, 5.0, 5.2, 5.5]], dtype=torch.bfloat16)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1008,8 +966,7 @@ def test_unary_inverse_hyperbolic_edge_case_ttnn(
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_acosh_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_acosh_ttnn(input_shapes, device):
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(1, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1037,8 +994,7 @@ def test_unary_acosh_ttnn(input_shapes, device_module):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1068,8 +1024,7 @@ def test_unary_asinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
     "low, high",
     [(-0.9, 1), (-100, 100)],
 )
-def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device_module):
-    device = device_module
+def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1106,8 +1061,7 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device_module):
-    device = device_module
+def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtype, ttnn_function, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1137,8 +1091,7 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device_module):
-    device = device_module
+def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, device):
     in_data = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     in_data = ttnn.to_torch(input_tensor, dtype=torch.bfloat16)
@@ -1166,8 +1119,7 @@ def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, de
         ttnn.softshrink,
     ],
 )
-def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device_module):
-    device = device_module
+def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_function, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1186,8 +1138,7 @@ def test_unary_shrink_functions_edge_case_ttnn(input_shapes, param, ttnn_functio
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_frac_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_frac_ttnn(input_shapes, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1204,8 +1155,7 @@ def test_unary_frac_ttnn(input_shapes, device_module):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_unary_frac_ttnn_opt(input_shapes, device_module):
-    device = device_module
+def test_unary_frac_ttnn_opt(input_shapes, device):
     in_data = create_full_range_tensor(input_shapes, torch.bfloat16)
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1234,8 +1184,7 @@ def test_unary_frac_ttnn_opt(input_shapes, device_module):
         (torch.bfloat16, ttnn.bfloat8_b, 0.004),
     ],
 )
-def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1264,8 +1213,7 @@ def test_unary_softsign_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device
         (torch.bfloat16, ttnn.bfloat8_b, 0.015),
     ],
 )
-def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1294,8 +1242,7 @@ def test_unary_hardsigmoid_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, dev
         (torch.bfloat16, ttnn.bfloat16, 0.016),
     ],
 )
-def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, atol, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1315,8 +1262,7 @@ def test_unary_hardswish_ttnn(input_shapes, low, high, torch_dtype, ttnn_dtype, 
     ),
 )
 @pytest.mark.parametrize("low, high", [(-100, -3), (-2, 2), (3, 100)])
-def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device_module):
-    device = device_module
+def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device):
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(low, high)
 
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1353,8 +1299,7 @@ def test_unary_hardswish_bf8b_ttnn(input_shapes, low, high, device_module):
         (-0.5, 21.0),
     ],
 )
-def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device_module):
-    device = device_module
+def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max_val, device):
     torch.manual_seed(0)
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1384,8 +1329,7 @@ def test_unary_hardtanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, min_val, max
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     if torch_dtype == torch.int32:
         in_data = torch.randint(-100, 100, input_shapes, dtype=torch_dtype)
     else:
@@ -1402,8 +1346,7 @@ def test_unary_signbit_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module
     assert torch.equal(golden_tensor, ttnn.to_torch(output_tensor))
 
 
-def test_unary_signbit_int32_edge_case_ttnn(device_module):
-    device = device_module
+def test_unary_signbit_int32_edge_case_ttnn(device):
     in_data = torch.tensor([-2147483648, 2147483647, +0, -0, 0], dtype=torch.int32)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -1421,8 +1364,7 @@ def test_unary_signbit_int32_edge_case_ttnn(device_module):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device):
     in_data = torch.tensor(
         [-0.0, 0.0, +0.0, -float("inf"), +float("inf"), +float("nan"), -float("nan")], dtype=torch_dtype
     )
@@ -1444,8 +1386,7 @@ def test_unary_signbit_float_edge_case_ttnn(torch_dtype, ttnn_dtype, device_modu
 )
 @pytest.mark.parametrize("threshold", [1.0, 10.0, 100.0, -5, -8.0, -100.0])
 @pytest.mark.parametrize("value", [10.0, 100.0, -7.0, -85.5])
-def test_unary_threshold_ttnn(input_shapes, threshold, value, device_module):
-    device = device_module
+def test_unary_threshold_ttnn(input_shapes, threshold, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.threshold(input_tensor1, threshold, value)
     golden_function = ttnn.get_golden_function(ttnn.threshold)
@@ -1481,8 +1422,7 @@ def test_unary_threshold_ttnn(input_shapes, threshold, value, device_module):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype, ttnn_dtype, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     min = min_val
@@ -1512,8 +1452,7 @@ def test_unary_clamp_tss_float_ttnn(input_shapes, min_val, max_val, torch_dtype,
         (torch.bfloat16, ttnn.bfloat16, 0.008),
     ],
 )
-def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1542,8 +1481,7 @@ def test_unary_tanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_mod
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data1 = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-10, 10)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1564,8 +1502,7 @@ def test_unary_tanh_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_mo
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_uint16_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_square_uint16_ttnn(input_shapes, device):
     in_data = torch.randint(
         0, 255, input_shapes, dtype=torch.int32
     )  # Beyond 255 leads to overflow of uint16 range, since it a square op.
@@ -1601,8 +1538,7 @@ def test_unary_square_uint16_ttnn(input_shapes, device_module):
         (0, 1),
     ],
 )
-def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device_module):
-    device = device_module
+def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device):
     torch.manual_seed(0)
     in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1633,8 +1569,7 @@ def test_unary_clamp_tss_int32_ttnn(input_shapes, min_val, max_val, device_modul
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1665,8 +1600,7 @@ def test_unary_cosh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-9, 9)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1691,8 +1625,7 @@ def test_unary_sinh_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.5, 8.0, 9.0, 10.0])
-def test_unary_rpow_ttnn(input_shapes, exponent, device_module):
-    device = device_module
+def test_unary_rpow_ttnn(input_shapes, exponent, device):
     in_data1 = torch.empty(input_shapes, dtype=torch.bfloat16).uniform_(-30, 30)
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.rpow(input_tensor1, exponent)
@@ -1718,8 +1651,7 @@ def test_unary_rpow_ttnn(input_shapes, exponent, device_module):
         (torch.bfloat16, ttnn.bfloat8_b, 0.05),
     ],
 )
-def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_module):
-    device = device_module
+def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1735,8 +1667,7 @@ def test_unary_cbrt_ttnn(input_shapes, torch_dtype, ttnn_dtype, atol, device_mod
         assert_allclose(ttnn.to_torch(output_tensor), golden_tensor, rtol=1e-05, atol=atol)
 
 
-def test_cbrt_arange(device_module):
-    device = device_module
+def test_cbrt_arange(device):
     # Generate all possible bit patterns for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1772,8 +1703,7 @@ def test_cbrt_arange(device_module):
         (torch.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device):
     in_data = torch.tensor(
         [float("-inf"), float("inf"), float("nan"), 5.0, -5.0, 0.0, -0.0, 1e38, 1e-45, 3.4e38, -3.4e38],
         dtype=torch_dtype,
@@ -1803,8 +1733,7 @@ def test_inf_nan_check(ttnn_op, torch_dtype, ttnn_dtype, device_module):
     ],
 )
 @pytest.mark.parametrize("negative_slope", [0.01, 0.1, 1.0, 5.75, 10.0])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_dtype, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     if ttnn_dtype == ttnn.bfloat8_b:
@@ -1838,8 +1767,7 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, torch_dtype, ttnn_d
         (torch.float32, ttnn.float32),
     ],
 )
-def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device):
     in_data1 = create_full_range_tensor(input_shapes, torch_dtype)
 
     # limit the range to avoid overflow in hardmish
@@ -1856,8 +1784,7 @@ def test_unary_hardmish(input_shapes, torch_dtype, ttnn_dtype, device_module):
     assert_with_pcc(tt_res, golden_tensor, pcc=0.9999)
 
 
-def test_hardmish_bfloat16_ulp(device_module):
-    device = device_module
+def test_hardmish_bfloat16_ulp(device):
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1888,8 +1815,7 @@ def test_hardmish_bfloat16_ulp(device_module):
     assert_with_ulp(golden, result, 1, allow_nonfinite=True)
 
 
-def test_hardmish_bfloat16_allclose(device_module):
-    device = device_module
+def test_hardmish_bfloat16_allclose(device):
     # Generate all possible bit pattersn for bf16
     all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
     input_tensor = all_bitpatterns.view(torch.bfloat16)
@@ -1926,8 +1852,7 @@ def test_hardmish_bfloat16_allclose(device_module):
 )
 @pytest.mark.parametrize("ttnn_op", [ttnn.rsqrt, ttnn.sqrt])
 @pytest.mark.parametrize("fast_approx_mode", [True, False])
-def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device_module):
-    device = device_module
+def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_approx_mode, device):
     torch.manual_seed(0)
     if fast_approx_mode:
         in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(1, 100)
@@ -1968,8 +1893,7 @@ def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fas
     {-1.5, 1.7, 0.0},
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_inf_nan_check(param, round_mode, device_module):
-    device = device_module
+def test_unary_rdiv_inf_nan_check(param, round_mode, device):
     dtype = torch.bfloat16
     if dtype == torch.bfloat16 and param == 0.0:
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
@@ -2009,8 +1933,7 @@ def test_unary_rdiv_inf_nan_check(param, round_mode, device_module):
     ],
 )
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
-def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device_module):
-    device = device_module
+def test_unary_rdiv_ttnn(input_shapes, torch_dtype, ttnn_dtype, param, round_mode, device):
     torch.manual_seed(0)
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(-100, 100)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -2128,8 +2051,7 @@ def test_unary_bitcast_ttnn(
     ],
 )
 @pytest.mark.parametrize("scalar", [0.25, 0.38, 0.5, 0.85])
-def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device_module, atol):
-    device = device_module
+def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, device, atol):
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(low, high)
     input_tensor_a = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
@@ -2151,8 +2073,7 @@ def test_unary_logit(input_shape, scalar, torch_dtype, ttnn_dtype, high, low, de
     ],
 )
 @pytest.mark.parametrize("eps", [0.0, 1.0, None])
-def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device_module, eps, atol):
-    device = device_module
+def test_unary_logit_edge_cases(input_shape, torch_dtype, ttnn_dtype, device, eps, atol):
     torch.manual_seed(0)
     in_data = torch.empty(input_shape, dtype=torch_dtype).uniform_(-1, 1.1)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -28,8 +28,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (torch.bfloat16),
     ],
 )
-def test_add_and_apply_activations(device_module, shape, activations, torch_dtype):
-    device = device_module
+def test_add_and_apply_activations(device, shape, activations, torch_dtype):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.Tensor(size=shape).uniform_(-100, 100).to(torch_dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -28,7 +28,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (torch.bfloat16),
     ],
 )
-def test_add_and_apply_activations(device, shape, activations, torch_dtype):
+def test_add_and_apply_activations(device_module, shape, activations, torch_dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.Tensor(size=shape).uniform_(-100, 100).to(torch_dtype)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -15,8 +15,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ttnn.neg,
     ],
 )
-def test_neg_fp32(device_module, ttnn_function):
-    device = device_module
+def test_neg_fp32(device, ttnn_function):
     x_torch = torch.tensor([[0.00001]], dtype=torch.float32)
     y_torch = -x_torch
 
@@ -35,8 +34,7 @@ def test_neg_fp32(device_module, ttnn_function):
         ttnn.sin,
     ],
 )
-def test_sin_fp32(device_module, ttnn_function):
-    device = device_module
+def test_sin_fp32(device, ttnn_function):
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.sin(x_torch)
 
@@ -55,8 +53,7 @@ def test_sin_fp32(device_module, ttnn_function):
         ttnn.cos,
     ],
 )
-def test_cos_fp32(device_module, ttnn_function):
-    device = device_module
+def test_cos_fp32(device, ttnn_function):
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.cos(x_torch)
 
@@ -75,8 +72,7 @@ def test_cos_fp32(device_module, ttnn_function):
         ttnn.tan,
     ],
 )
-def test_tan_fp32(device_module, ttnn_function):
-    device = device_module
+def test_tan_fp32(device, ttnn_function):
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.tan(x_torch)
 
@@ -95,8 +91,7 @@ def test_tan_fp32(device_module, ttnn_function):
         ttnn.relu,
     ],
 )
-def test_relu_fp32(device_module, ttnn_function):
-    device = device_module
+def test_relu_fp32(device, ttnn_function):
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.relu(x_torch)
 
@@ -126,91 +121,78 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp(device_module, h, w):
-    device = device_module
+def test_exp(device, h, w):
     run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanh(device_module, h, w):
-    device = device_module
+def test_tanh(device, h, w):
     run_unary_test(device, h, w, ttnn.tanh, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device_module, h, w):
-    device = device_module
+def test_gelu(device, h, w):
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rsqrt(device_module, h, w):
-    device = device_module
+def test_rsqrt(device, h, w):
     run_unary_test(device, h, w, ttnn.rsqrt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_silu(device_module, h, w):
-    device = device_module
+def test_silu(device, h, w):
     run_unary_test(device, h, w, ttnn.silu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log(device_module, h, w):
-    device = device_module
+def test_log(device, h, w):
     run_unary_test(device, h, w, ttnn.log)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin(device_module, h, w):
-    device = device_module
+def test_asin(device, h, w):
     run_unary_test(device, h, w, ttnn.asin, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos(device_module, h, w):
-    device = device_module
+def test_acos(device, h, w):
     run_unary_test(device, h, w, ttnn.acos, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atan(device_module, h, w):
-    device = device_module
+def test_atan(device, h, w):
     run_unary_test(device, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sinh(device_module, h, w):
-    device = device_module
+def test_sinh(device, h, w):
     run_unary_test(device, h, w, ttnn.sinh)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cosh(device_module, h, w):
-    device = device_module
+def test_cosh(device, h, w):
     run_unary_test(device, h, w, ttnn.cosh, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acosh(device_module, h, w):
-    device = device_module
+def test_acosh(device, h, w):
     run_unary_test(device, h, w, ttnn.acosh)
 
 
 @pytest.mark.skip("The current version doesn’t work with float32, but this will be fixed in issue #231689.")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atanh(device_module, h, w):
-    device = device_module
+def test_atanh(device, h, w):
     run_unary_test(device, h, w, ttnn.atanh, pcc=0.997)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -15,7 +15,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ttnn.neg,
     ],
 )
-def test_neg_fp32(device, ttnn_function):
+def test_neg_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.tensor([[0.00001]], dtype=torch.float32)
     y_torch = -x_torch
 
@@ -34,7 +35,8 @@ def test_neg_fp32(device, ttnn_function):
         ttnn.sin,
     ],
 )
-def test_sin_fp32(device, ttnn_function):
+def test_sin_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.sin(x_torch)
 
@@ -53,7 +55,8 @@ def test_sin_fp32(device, ttnn_function):
         ttnn.cos,
     ],
 )
-def test_cos_fp32(device, ttnn_function):
+def test_cos_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.cos(x_torch)
 
@@ -72,7 +75,8 @@ def test_cos_fp32(device, ttnn_function):
         ttnn.tan,
     ],
 )
-def test_tan_fp32(device, ttnn_function):
+def test_tan_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.tan(x_torch)
 
@@ -91,7 +95,8 @@ def test_tan_fp32(device, ttnn_function):
         ttnn.relu,
     ],
 )
-def test_relu_fp32(device, ttnn_function):
+def test_relu_fp32(device_module, ttnn_function):
+    device = device_module
     x_torch = torch.rand((64, 128), dtype=torch.float32)
     y_torch = torch.relu(x_torch)
 
@@ -121,78 +126,91 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_exp(device, h, w):
+def test_exp(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_tanh(device, h, w):
+def test_tanh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.tanh, pcc=0.993)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_gelu(device, h, w):
+def test_gelu(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_rsqrt(device, h, w):
+def test_rsqrt(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.rsqrt)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_silu(device, h, w):
+def test_silu(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.silu)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_log(device, h, w):
+def test_log(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.log)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_asin(device, h, w):
+def test_asin(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.asin, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acos(device, h, w):
+def test_acos(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.acos, pcc=0.998)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atan(device, h, w):
+def test_atan(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_sinh(device, h, w):
+def test_sinh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.sinh)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_cosh(device, h, w):
+def test_cosh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.cosh, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_acosh(device, h, w):
+def test_acosh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.acosh)
 
 
 @pytest.mark.skip("The current version doesn’t work with float32, but this will be fixed in issue #231689.")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-def test_atanh(device, h, w):
+def test_atanh(device_module, h, w):
+    device = device_module
     run_unary_test(device, h, w, ttnn.atanh, pcc=0.997)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
@@ -20,8 +20,7 @@ import ttnn
         [3, 128, 512],
     ],
 )
-def test_i1_range(device_module, shapes):
-    device = device_module
+def test_i1_range(device, shapes):
     torch.manual_seed(0)
 
     high = 10
@@ -50,8 +49,7 @@ def test_i1_range(device_module, shapes):
         [1, 1, 64, 64],
     ],
 )
-def test_i1_zero(device_module, shapes):
-    device = device_module
+def test_i1_zero(device, shapes):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.zeros(shapes, dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
@@ -20,7 +20,8 @@ import ttnn
         [3, 128, 512],
     ],
 )
-def test_i1_range(device, shapes):
+def test_i1_range(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     high = 10
@@ -49,7 +50,8 @@ def test_i1_range(device, shapes):
         [1, 1, 64, 64],
     ],
 )
-def test_i1_zero(device, shapes):
+def test_i1_zero(device_module, shapes):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.zeros(shapes, dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -30,8 +30,7 @@ import ttnn
         ttnn.logical_not,
     ],
 )
-def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device_module):
-    device = device_module
+def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a[::5] = 0  # every 5th element is zero
@@ -60,8 +59,7 @@ def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device_mod
         ttnn.logical_not,
     ],
 )
-def test_unary_logical_int32_edge_cases(logical_op, device_module):
-    device = device_module
+def test_unary_logical_int32_edge_cases(logical_op, device):
     # Note: torch.logical_not(-2147483648) returns False, whereas ttnn.logical_not(-2147483648) returns True.
     # This discrepancy occurs because, in Wormhole, the value -2147483648 wraps around to 0 due to integer overflow.
     torch_input_tensor_a = torch.tensor([0, 1, -1, 2147483647, -2147483647])
@@ -126,8 +124,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         "square",
     ],
 )
-def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device_module):
-    device = device_module
+def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device):
     ttnn_op = getattr(ttnn, ttnn_op)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
@@ -168,8 +165,7 @@ def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device_mo
         (-46340, 46340),  # output overflows beyond this range
     ],
 )
-def test_unary_square_int32(input_shapes, low_a, high_a, device_module):
-    device = device_module
+def test_unary_square_int32(input_shapes, low_a, high_a, device):
     if len(input_shapes) == 0:
         torch_input_tensor = torch.randint(low=-(2**15), high=2**15, size=(), dtype=torch.int32)
     else:
@@ -194,8 +190,7 @@ def test_unary_square_int32(input_shapes, low_a, high_a, device_module):
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_abs_int32(device_module):
-    device = device_module
+def test_abs_int32(device):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randint(low=-1000, high=100, size=(1, 1, 320, 384), dtype=torch.int32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -30,7 +30,8 @@ import ttnn
         ttnn.logical_not,
     ],
 )
-def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device):
+def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     torch_input_tensor_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
     torch_input_tensor_a[::5] = 0  # every 5th element is zero
@@ -59,7 +60,8 @@ def test_unary_logical_int32(input_shapes, low_a, high_a, logical_op, device):
         ttnn.logical_not,
     ],
 )
-def test_unary_logical_int32_edge_cases(logical_op, device):
+def test_unary_logical_int32_edge_cases(logical_op, device_module):
+    device = device_module
     # Note: torch.logical_not(-2147483648) returns False, whereas ttnn.logical_not(-2147483648) returns True.
     # This discrepancy occurs because, in Wormhole, the value -2147483648 wraps around to 0 due to integer overflow.
     torch_input_tensor_a = torch.tensor([0, 1, -1, 2147483647, -2147483647])
@@ -124,7 +126,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         "square",
     ],
 )
-def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device):
+def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device_module):
+    device = device_module
     ttnn_op = getattr(ttnn, ttnn_op)
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(-100, 100, num_elements, dtype=torch.int32)
@@ -165,7 +168,8 @@ def test_unary_logical_int32_sharded(a_shape, sharded_config, ttnn_op, device):
         (-46340, 46340),  # output overflows beyond this range
     ],
 )
-def test_unary_square_int32(input_shapes, low_a, high_a, device):
+def test_unary_square_int32(input_shapes, low_a, high_a, device_module):
+    device = device_module
     if len(input_shapes) == 0:
         torch_input_tensor = torch.randint(low=-(2**15), high=2**15, size=(), dtype=torch.int32)
     else:
@@ -190,7 +194,8 @@ def test_unary_square_int32(input_shapes, low_a, high_a, device):
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
-def test_abs_int32(device):
+def test_abs_int32(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randint(low=-1000, high=100, size=(1, 1, 320, 384), dtype=torch.int32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -24,8 +24,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize("scalar", [-2, 0, 10, -16777216, 16777216, 2147483647, -2147483647])
-def test_unary_max_int32(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_max_int32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -65,8 +64,7 @@ def test_unary_max_int32(input_shapes, low, high, scalar, device_module):
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device_module):
-    device = device_module
+def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
@@ -107,8 +105,7 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device_module)
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device_module):
-    device = device_module
+def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
@@ -139,8 +136,7 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device_module)
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
-def test_unary_max_bf16(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_max_bf16(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -175,8 +171,7 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device_module):
 @pytest.mark.parametrize(
     "scalar", [0.5, 0.1, 0.0, 1.0, 10.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")]
 )
-def test_unary_max_fp32(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_max_fp32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -201,8 +196,7 @@ def test_unary_max_fp32(input_shapes, low, high, scalar, device_module):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_unary_max_fp32_opt(input_shapes, device_module):
-    device = device_module
+def test_unary_max_fp32_opt(input_shapes, device):
     scalar = 11.3
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(100, -100, num_elements, dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -24,7 +24,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize("scalar", [-2, 0, 10, -16777216, 16777216, 2147483647, -2147483647])
-def test_unary_max_int32(input_shapes, low, high, scalar, device):
+def test_unary_max_int32(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -64,7 +65,8 @@ def test_unary_max_int32(input_shapes, low, high, scalar, device):
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
+def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device_module):
+    device = device_module
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
@@ -105,7 +107,8 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
+def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device_module):
+    device = device_module
     torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
@@ -136,7 +139,8 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
-def test_unary_max_bf16(input_shapes, low, high, scalar, device):
+def test_unary_max_bf16(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -171,7 +175,8 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device):
 @pytest.mark.parametrize(
     "scalar", [0.5, 0.1, 0.0, 1.0, 10.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")]
 )
-def test_unary_max_fp32(input_shapes, low, high, scalar, device):
+def test_unary_max_fp32(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -196,7 +201,8 @@ def test_unary_max_fp32(input_shapes, low, high, scalar, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-def test_unary_max_fp32_opt(input_shapes, device):
+def test_unary_max_fp32_opt(input_shapes, device_module):
+    device = device_module
     scalar = 11.3
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(100, -100, num_elements, dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -28,7 +28,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
+def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device_module):
+    device = device_module
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
@@ -62,7 +63,8 @@ def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38])
-def test_unary_min_bf16(input_shapes, low, high, scalar, device):
+def test_unary_min_bf16(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes).nan_to_num(0.0)
@@ -95,7 +97,8 @@ def test_unary_min_bf16(input_shapes, low, high, scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.1, 0.0, 1.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
-def test_unary_min_fp32(input_shapes, low, high, scalar, device):
+def test_unary_min_fp32(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -117,7 +120,8 @@ def test_unary_min_fp32(input_shapes, low, high, scalar, device):
 
 
 @pytest.mark.parametrize("scalar", [-2, 0, 10, 2147483647, -2147483647])
-def test_unary_min_int32_test(scalar, device):
+def test_unary_min_int32_test(scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(torch.Size([1, 1, 32, 32]))).item()
     torch_input = torch.linspace(-10, 10, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 1, 32, 32]))
@@ -152,7 +156,8 @@ def test_unary_min_int32_test(scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [-5, 3, 0, -2147483647, 2147483647])
-def test_unary_min_int32(input_shapes, low, high, scalar, device):
+def test_unary_min_int32(input_shapes, low, high, scalar, device_module):
+    device = device_module
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -187,7 +192,8 @@ def test_unary_min_int32(input_shapes, low, high, scalar, device):
         (11, 53),
     ],
 )
-def test_unary_min_fill_val_int32(input_shapes, input_val, scalar, device):
+def test_unary_min_fill_val_int32(input_shapes, input_val, scalar, device_module):
+    device = device_module
     torch_input = torch.ones(input_shapes, dtype=torch.int32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -28,8 +28,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (-3.4 * 10**38, -float("inf")),
     ],
 )
-def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device_module):
-    device = device_module
+def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
@@ -63,8 +62,7 @@ def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device_module)
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.0, 20.0, 3.4 * 10**38, -3.4 * 10**38])
-def test_unary_min_bf16(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_min_bf16(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes).nan_to_num(0.0)
@@ -97,8 +95,7 @@ def test_unary_min_bf16(input_shapes, low, high, scalar, device_module):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.1, 0.0, 1.0, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
-def test_unary_min_fp32(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_min_fp32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -120,8 +117,7 @@ def test_unary_min_fp32(input_shapes, low, high, scalar, device_module):
 
 
 @pytest.mark.parametrize("scalar", [-2, 0, 10, 2147483647, -2147483647])
-def test_unary_min_int32_test(scalar, device_module):
-    device = device_module
+def test_unary_min_int32_test(scalar, device):
     num_elements = torch.prod(torch.tensor(torch.Size([1, 1, 32, 32]))).item()
     torch_input = torch.linspace(-10, 10, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(torch.Size([1, 1, 32, 32]))
@@ -156,8 +152,7 @@ def test_unary_min_int32_test(scalar, device_module):
     ],
 )
 @pytest.mark.parametrize("scalar", [-5, 3, 0, -2147483647, 2147483647])
-def test_unary_min_int32(input_shapes, low, high, scalar, device_module):
-    device = device_module
+def test_unary_min_int32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.int32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)
@@ -192,8 +187,7 @@ def test_unary_min_int32(input_shapes, low, high, scalar, device_module):
         (11, 53),
     ],
 )
-def test_unary_min_fill_val_int32(input_shapes, input_val, scalar, device_module):
-    device = device_module
+def test_unary_min_fill_val_int32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.int32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -22,7 +22,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_w
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_ttnn(input_shapes, device):
+def test_unary_square_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -43,7 +44,8 @@ def test_unary_square_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 2.0])
-def test_unary_pow_ttnn(input_shapes, exponent, device):
+def test_unary_pow_ttnn(input_shapes, exponent, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -63,7 +65,8 @@ def test_unary_pow_ttnn(input_shapes, exponent, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_abs_ttnn(input_shapes, device):
+def test_unary_abs_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -101,7 +104,10 @@ def test_unary_abs_ttnn(input_shapes, device):
     "ttnn_op",
     [ttnn.asin, ttnn.acos],
 )
-def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device):
+def test_unary_inverse_trig_functions_ttnn(
+    input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device_module
+):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -125,7 +131,8 @@ def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_atan_ttnn(input_shapes, device):
+def test_unary_atan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -145,7 +152,8 @@ def test_unary_atan_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_cos_ttnn(input_shapes, device):
+def test_unary_cos_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -165,7 +173,8 @@ def test_unary_cos_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device):
+def test_unary_eqz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -185,7 +194,8 @@ def test_unary_eqz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device):
+def test_unary_eqz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -205,7 +215,8 @@ def test_unary_eqz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_nez_ttnn(input_shapes, device):
+def test_unary_nez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -225,7 +236,8 @@ def test_unary_nez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gez_ttnn(input_shapes, device):
+def test_unary_gez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -245,7 +257,8 @@ def test_unary_gez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_lez_ttnn(input_shapes, device):
+def test_unary_lez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -265,7 +278,8 @@ def test_unary_lez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ltz_ttnn(input_shapes, device):
+def test_unary_ltz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -285,7 +299,8 @@ def test_unary_ltz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gtz_ttnn(input_shapes, device):
+def test_unary_gtz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -306,7 +321,8 @@ def test_unary_gtz_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_erf_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -327,7 +343,8 @@ def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -347,7 +364,8 @@ def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_erfinv_ttnn(input_shapes, device):
+def test_unary_erfinv_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -367,7 +385,8 @@ def test_unary_erfinv_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_expm1_ttnn(input_shapes, device):
+def test_unary_expm1_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -388,7 +407,8 @@ def test_unary_expm1_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -409,7 +429,8 @@ def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device):
     ),
 )
 @pytest.mark.parametrize("negative_slope", [1.0, 5.0, 10.0, 0.1])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -436,7 +457,8 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data = torch.linspace(-100, 100, num_elements, dtype=torch_dtype)
     in_data[::5] = 0  # every 5th element is zero
@@ -470,7 +492,8 @@ def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_i0_ttnn(input_shapes, device):
+def test_unary_i0_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -491,7 +514,8 @@ def test_unary_i0_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
-def test_unary_neg_ttnn(input_shapes, device, ttnn_dtype):
+def test_unary_neg_ttnn(input_shapes, device_module, ttnn_dtype):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn.neg(input_tensor1)
@@ -512,7 +536,8 @@ def test_unary_neg_ttnn(input_shapes, device, ttnn_dtype):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu_ttnn(input_shapes, device):
+def test_unary_relu_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -532,7 +557,8 @@ def test_unary_relu_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu6_ttnn(input_shapes, device):
+def test_unary_relu6_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -552,7 +578,8 @@ def test_unary_relu6_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tan_ttnn(input_shapes, device):
+def test_unary_tan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -572,7 +599,8 @@ def test_unary_tan_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tanh_ttnn(input_shapes, device):
+def test_unary_tanh_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -592,7 +620,8 @@ def test_unary_tanh_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_sign_ttnn(input_shapes, device):
+def test_unary_sign_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -612,7 +641,8 @@ def test_unary_sign_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_signbit_ttnn(input_shapes, device):
+def test_unary_signbit_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -632,7 +662,8 @@ def test_unary_signbit_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn(input_shapes, device):
+def test_unary_silu_ttnn(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(0)
     max_atol = 0.03125
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
@@ -657,7 +688,8 @@ def test_unary_silu_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
+def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
 
@@ -679,7 +711,8 @@ def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log_sigmoid_ttnn(input_shapes, device):
+def test_unary_log_sigmoid_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -703,7 +736,9 @@ def test_unary_log_sigmoid_ttnn(input_shapes, device):
     "approx_mode",
     (False, True),
 )
-def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
+def test_unary_sigmoid_ttnn(input_shapes, device_module, approx_mode):
+    device = device_module
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -725,7 +760,8 @@ def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_recip_ttnn(input_shapes, device):
+def test_unary_recip_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -746,7 +782,8 @@ def test_unary_recip_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_unary_heaviside_ttnn(input_shapes, value, device):
+def test_unary_heaviside_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -766,7 +803,8 @@ def test_unary_heaviside_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log2_ttnn(input_shapes, device):
+def test_unary_log2_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -786,7 +824,8 @@ def test_unary_log2_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log10_ttnn(input_shapes, device):
+def test_unary_log10_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -807,7 +846,8 @@ def test_unary_log10_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_bitwise_not(input_shapes, device):
+def test_unary_bitwise_not(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -842,7 +882,8 @@ def test_unary_bitwise_not(input_shapes, device):
         (torch.Size([])),
     ),
 )
-def test_unary_log1p_ttnn(input_shapes, device):
+def test_unary_log1p_ttnn(input_shapes, device_module):
+    device = device_module
     if len(input_shapes) == 0:
         torch_input_tensor = torch.rand((), dtype=torch.bfloat16)
     else:
@@ -895,7 +936,10 @@ def test_unary_log1p_ttnn(input_shapes, device):
     ],
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_log_like_fast_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device):
+def test_unary_log_like_fast_approx_ttnn(
+    input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device_module
+):
+    device = device_module
     torch.manual_seed(0)
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     if fast_and_approx:
@@ -937,7 +981,8 @@ def test_unary_log_like_fast_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, 
         (torch.uint32, ttnn.uint32),
     ],
 )
-def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
+def test_fill(device_module, h, w, scalar, torch_dtype, ttnn_dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if torch_dtype.is_floating_point:
@@ -972,7 +1017,8 @@ def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
     "param",
     {-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9, float("inf"), float("-inf"), float("nan")},
 )
-def test_unary_celu(input_shapes, param, device):
+def test_unary_celu(input_shapes, param, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.celu(input_tensor, alpha=param)
     golden_function = ttnn.get_golden_function(ttnn.celu)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -22,7 +22,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_w
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_ttnn(input_shapes, device):
+def test_unary_square_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -43,7 +44,8 @@ def test_unary_square_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 2.0])
-def test_unary_pow_ttnn(input_shapes, exponent, device):
+def test_unary_pow_ttnn(input_shapes, exponent, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -63,7 +65,8 @@ def test_unary_pow_ttnn(input_shapes, exponent, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_abs_ttnn(input_shapes, device):
+def test_unary_abs_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -101,7 +104,10 @@ def test_unary_abs_ttnn(input_shapes, device):
     "ttnn_op",
     [ttnn.asin, ttnn.acos],
 )
-def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device):
+def test_unary_inverse_trig_functions_ttnn(
+    input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device_module
+):
+    device = device_module
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -125,7 +131,8 @@ def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_atan_ttnn(input_shapes, device):
+def test_unary_atan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -145,7 +152,8 @@ def test_unary_atan_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_cos_ttnn(input_shapes, device):
+def test_unary_cos_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -165,7 +173,8 @@ def test_unary_cos_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device):
+def test_unary_eqz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -185,7 +194,8 @@ def test_unary_eqz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device):
+def test_unary_eqz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -205,7 +215,8 @@ def test_unary_eqz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_nez_ttnn(input_shapes, device):
+def test_unary_nez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -225,7 +236,8 @@ def test_unary_nez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gez_ttnn(input_shapes, device):
+def test_unary_gez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -245,7 +257,8 @@ def test_unary_gez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_lez_ttnn(input_shapes, device):
+def test_unary_lez_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -265,7 +278,8 @@ def test_unary_lez_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ltz_ttnn(input_shapes, device):
+def test_unary_ltz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -285,7 +299,8 @@ def test_unary_ltz_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gtz_ttnn(input_shapes, device):
+def test_unary_gtz_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -306,7 +321,8 @@ def test_unary_gtz_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_erf_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -327,7 +343,8 @@ def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -347,7 +364,8 @@ def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_erfinv_ttnn(input_shapes, device):
+def test_unary_erfinv_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -367,7 +385,8 @@ def test_unary_erfinv_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_expm1_ttnn(input_shapes, device):
+def test_unary_expm1_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -388,7 +407,8 @@ def test_unary_expm1_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device):
+def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -409,7 +429,8 @@ def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device):
     ),
 )
 @pytest.mark.parametrize("negative_slope", [1.0, 5.0, 10.0, 0.1])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -436,7 +457,8 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
+def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data = torch.linspace(-100, 100, num_elements, dtype=torch_dtype)
     in_data[::5] = 0  # every 5th element is zero
@@ -470,7 +492,8 @@ def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_i0_ttnn(input_shapes, device):
+def test_unary_i0_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -491,7 +514,8 @@ def test_unary_i0_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
-def test_unary_neg_ttnn(input_shapes, device, ttnn_dtype):
+def test_unary_neg_ttnn(input_shapes, device_module, ttnn_dtype):
+    device = device_module
     in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn.neg(input_tensor1)
@@ -512,7 +536,8 @@ def test_unary_neg_ttnn(input_shapes, device, ttnn_dtype):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu_ttnn(input_shapes, device):
+def test_unary_relu_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -532,7 +557,8 @@ def test_unary_relu_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu6_ttnn(input_shapes, device):
+def test_unary_relu6_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -552,7 +578,8 @@ def test_unary_relu6_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tan_ttnn(input_shapes, device):
+def test_unary_tan_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -572,7 +599,8 @@ def test_unary_tan_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tanh_ttnn(input_shapes, device):
+def test_unary_tanh_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -592,7 +620,8 @@ def test_unary_tanh_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_sign_ttnn(input_shapes, device):
+def test_unary_sign_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -612,7 +641,8 @@ def test_unary_sign_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_signbit_ttnn(input_shapes, device):
+def test_unary_signbit_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -632,7 +662,8 @@ def test_unary_signbit_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn(input_shapes, device):
+def test_unary_silu_ttnn(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(0)
     max_atol = 0.03125
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
@@ -657,7 +688,8 @@ def test_unary_silu_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
+def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(0)
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
 
@@ -679,7 +711,8 @@ def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log_sigmoid_ttnn(input_shapes, device):
+def test_unary_log_sigmoid_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -703,7 +736,8 @@ def test_unary_log_sigmoid_ttnn(input_shapes, device):
     "approx_mode",
     (False, True),
 )
-def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
+def test_unary_sigmoid_ttnn(input_shapes, device_module, approx_mode):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -725,7 +759,8 @@ def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_recip_ttnn(input_shapes, device):
+def test_unary_recip_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -746,7 +781,8 @@ def test_unary_recip_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_unary_heaviside_ttnn(input_shapes, value, device):
+def test_unary_heaviside_ttnn(input_shapes, value, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -766,7 +802,8 @@ def test_unary_heaviside_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log2_ttnn(input_shapes, device):
+def test_unary_log2_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -786,7 +823,8 @@ def test_unary_log2_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log10_ttnn(input_shapes, device):
+def test_unary_log10_ttnn(input_shapes, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -807,7 +845,8 @@ def test_unary_log10_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_bitwise_not(input_shapes, device):
+def test_unary_bitwise_not(input_shapes, device_module):
+    device = device_module
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -842,7 +881,8 @@ def test_unary_bitwise_not(input_shapes, device):
         (torch.Size([])),
     ),
 )
-def test_unary_log1p_ttnn(input_shapes, device):
+def test_unary_log1p_ttnn(input_shapes, device_module):
+    device = device_module
     if len(input_shapes) == 0:
         torch_input_tensor = torch.rand((), dtype=torch.bfloat16)
     else:
@@ -895,7 +935,10 @@ def test_unary_log1p_ttnn(input_shapes, device):
     ],
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_log_like_fast_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device):
+def test_unary_log_like_fast_approx_ttnn(
+    input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device_module
+):
+    device = device_module
     torch.manual_seed(0)
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     if fast_and_approx:
@@ -937,7 +980,8 @@ def test_unary_log_like_fast_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, 
         (torch.uint32, ttnn.uint32),
     ],
 )
-def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
+def test_fill(device_module, h, w, scalar, torch_dtype, ttnn_dtype):
+    device = device_module
     torch.manual_seed(0)
 
     if torch_dtype.is_floating_point:
@@ -972,7 +1016,8 @@ def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
     "param",
     {-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9, float("inf"), float("-inf"), float("nan")},
 )
-def test_unary_celu(input_shapes, param, device):
+def test_unary_celu(input_shapes, param, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.celu(input_tensor, alpha=param)
     golden_function = ttnn.get_golden_function(ttnn.celu)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -22,8 +22,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_w
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_square_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_square_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -44,8 +43,7 @@ def test_unary_square_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("exponent", [0.5, 2.0])
-def test_unary_pow_ttnn(input_shapes, exponent, device_module):
-    device = device_module
+def test_unary_pow_ttnn(input_shapes, exponent, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -65,8 +63,7 @@ def test_unary_pow_ttnn(input_shapes, exponent, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_abs_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_abs_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -104,10 +101,7 @@ def test_unary_abs_ttnn(input_shapes, device_module):
     "ttnn_op",
     [ttnn.asin, ttnn.acos],
 )
-def test_unary_inverse_trig_functions_ttnn(
-    input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device_module
-):
-    device = device_module
+def test_unary_inverse_trig_functions_ttnn(input_shapes, torch_dtype, ttnn_dtype, pcc, low, high, ttnn_op, device):
     in_data = torch.empty(input_shapes, dtype=torch_dtype).uniform_(low, high)
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -131,8 +125,7 @@ def test_unary_inverse_trig_functions_ttnn(
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_atan_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_atan_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -152,8 +145,7 @@ def test_unary_atan_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_cos_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_cos_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -173,8 +165,7 @@ def test_unary_cos_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_eqz_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -194,8 +185,7 @@ def test_unary_eqz_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_eqz_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_eqz_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -215,8 +205,7 @@ def test_unary_eqz_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_nez_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_nez_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -236,8 +225,7 @@ def test_unary_nez_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gez_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_gez_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -257,8 +245,7 @@ def test_unary_gez_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_lez_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_lez_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -278,8 +265,7 @@ def test_unary_lez_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_ltz_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_ltz_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -299,8 +285,7 @@ def test_unary_ltz_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_gtz_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_gtz_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -321,8 +306,7 @@ def test_unary_gtz_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erf_ttnn(input_shapes, fast_and_approx, device_module):
-    device = device_module
+def test_unary_erf_ttnn(input_shapes, fast_and_approx, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -343,8 +327,7 @@ def test_unary_erf_ttnn(input_shapes, fast_and_approx, device_module):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device_module):
-    device = device_module
+def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -364,8 +347,7 @@ def test_unary_erfc_ttnn(input_shapes, fast_and_approx, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_erfinv_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_erfinv_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -385,8 +367,7 @@ def test_unary_erfinv_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_expm1_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_expm1_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -407,8 +388,7 @@ def test_unary_expm1_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device_module):
-    device = device_module
+def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -429,8 +409,7 @@ def test_unary_gelu_ttnn(input_shapes, fast_and_approx, device_module):
     ),
 )
 @pytest.mark.parametrize("negative_slope", [1.0, 5.0, 10.0, 0.1])
-def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device_module):
-    device = device_module
+def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -457,8 +436,7 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device_module):
         (torch.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
     num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
     in_data = torch.linspace(-100, 100, num_elements, dtype=torch_dtype)
     in_data[::5] = 0  # every 5th element is zero
@@ -492,8 +470,7 @@ def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device_mo
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_i0_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_i0_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -514,8 +491,7 @@ def test_unary_i0_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32])
-def test_unary_neg_ttnn(input_shapes, device_module, ttnn_dtype):
-    device = device_module
+def test_unary_neg_ttnn(input_shapes, device, ttnn_dtype):
     in_data1, input_tensor1 = data_gen_with_range_dtype(input_shapes, -100, 100, device, ttnn_dtype=ttnn_dtype)
 
     output_tensor = ttnn.neg(input_tensor1)
@@ -536,8 +512,7 @@ def test_unary_neg_ttnn(input_shapes, device_module, ttnn_dtype):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_relu_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -557,8 +532,7 @@ def test_unary_relu_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_relu6_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_relu6_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -578,8 +552,7 @@ def test_unary_relu6_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tan_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_tan_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -599,8 +572,7 @@ def test_unary_tan_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_tanh_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_tanh_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -620,8 +592,7 @@ def test_unary_tanh_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_sign_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_sign_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -641,8 +612,7 @@ def test_unary_sign_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_signbit_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_signbit_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -662,8 +632,7 @@ def test_unary_signbit_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_silu_ttnn(input_shapes, device):
     torch.manual_seed(0)
     max_atol = 0.03125
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
@@ -688,8 +657,7 @@ def test_unary_silu_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device_module):
-    device = device_module
+def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device):
     torch.manual_seed(0)
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
 
@@ -711,8 +679,7 @@ def test_unary_silu_ttnn_pos_ulp_check(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log_sigmoid_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_log_sigmoid_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -736,8 +703,7 @@ def test_unary_log_sigmoid_ttnn(input_shapes, device_module):
     "approx_mode",
     (False, True),
 )
-def test_unary_sigmoid_ttnn(input_shapes, device_module, approx_mode):
-    device = device_module
+def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -759,8 +725,7 @@ def test_unary_sigmoid_ttnn(input_shapes, device_module, approx_mode):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_recip_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_recip_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -781,8 +746,7 @@ def test_unary_recip_ttnn(input_shapes, device_module):
     ),
 )
 @pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
-def test_unary_heaviside_ttnn(input_shapes, value, device_module):
-    device = device_module
+def test_unary_heaviside_ttnn(input_shapes, value, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -802,8 +766,7 @@ def test_unary_heaviside_ttnn(input_shapes, value, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log2_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_log2_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -823,8 +786,7 @@ def test_unary_log2_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_log10_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_log10_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -845,8 +807,7 @@ def test_unary_log10_ttnn(input_shapes, device_module):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_bitwise_not(input_shapes, device_module):
-    device = device_module
+def test_unary_bitwise_not(input_shapes, device):
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -881,8 +842,7 @@ def test_unary_bitwise_not(input_shapes, device_module):
         (torch.Size([])),
     ),
 )
-def test_unary_log1p_ttnn(input_shapes, device_module):
-    device = device_module
+def test_unary_log1p_ttnn(input_shapes, device):
     if len(input_shapes) == 0:
         torch_input_tensor = torch.rand((), dtype=torch.bfloat16)
     else:
@@ -935,10 +895,7 @@ def test_unary_log1p_ttnn(input_shapes, device_module):
     ],
 )
 @pytest.mark.parametrize("fast_and_approx", [False, True])
-def test_unary_log_like_fast_approx_ttnn(
-    input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device_module
-):
-    device = device_module
+def test_unary_log_like_fast_approx_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fast_and_approx, device):
     torch.manual_seed(0)
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     if fast_and_approx:
@@ -980,8 +937,7 @@ def test_unary_log_like_fast_approx_ttnn(
         (torch.uint32, ttnn.uint32),
     ],
 )
-def test_fill(device_module, h, w, scalar, torch_dtype, ttnn_dtype):
-    device = device_module
+def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
     torch.manual_seed(0)
 
     if torch_dtype.is_floating_point:
@@ -1016,8 +972,7 @@ def test_fill(device_module, h, w, scalar, torch_dtype, ttnn_dtype):
     "param",
     {-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9, float("inf"), float("-inf"), float("nan")},
 )
-def test_unary_celu(input_shapes, param, device_module):
-    device = device_module
+def test_unary_celu(input_shapes, param, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     output_tensor = ttnn.celu(input_tensor, alpha=param)
     golden_function = ttnn.get_golden_function(ttnn.celu)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
@@ -49,7 +49,8 @@ def _run_unary_uint16_test(torch_input_tensor, ttnn_fn, device, memory_config=No
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", [ttnn.logical_not])
-def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device):
+def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device_module):
+    device = device_module
     """Test uint16 unary operations with various shapes and value ranges"""
     if len(input_shapes) == 0:
         torch_input_tensor = torch.randint(low=0, high=2**16, size=(), dtype=torch.int32)
@@ -78,7 +79,8 @@ def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device):
         "sequential_pattern",
     ],
 )
-def test_unary_uint16_edge_cases(ttnn_fn, edge_pattern, device):
+def test_unary_uint16_edge_cases(ttnn_fn, edge_pattern, device_module):
+    device = device_module
     """Test uint16 unary operations with specific edge case patterns"""
 
     if edge_pattern == "critical_values":
@@ -147,7 +149,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", [ttnn.logical_not])
-def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device):
+def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device_module):
+    device = device_module
     """Test uint16 unary operations with sharded memory configurations"""
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor = torch.linspace(0, 65535, num_elements, dtype=torch.int32)
@@ -173,7 +176,8 @@ def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device):
         "random_sparse",
     ],
 )
-def test_unary_uint16_stress_patterns(ttnn_fn, test_pattern, device):
+def test_unary_uint16_stress_patterns(ttnn_fn, test_pattern, device_module):
+    device = device_module
     """Test uint16 unary operations with stress/edge patterns"""
     shape = torch.Size([1, 1, 64, 64])
     num_elements = int(torch.prod(torch.tensor(shape)).item())

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
@@ -49,8 +49,7 @@ def _run_unary_uint16_test(torch_input_tensor, ttnn_fn, device, memory_config=No
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", [ttnn.logical_not])
-def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device_module):
-    device = device_module
+def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device):
     """Test uint16 unary operations with various shapes and value ranges"""
     if len(input_shapes) == 0:
         torch_input_tensor = torch.randint(low=0, high=2**16, size=(), dtype=torch.int32)
@@ -79,8 +78,7 @@ def test_unary_uint16_operations(input_shapes, low_a, high_a, ttnn_fn, device_mo
         "sequential_pattern",
     ],
 )
-def test_unary_uint16_edge_cases(ttnn_fn, edge_pattern, device_module):
-    device = device_module
+def test_unary_uint16_edge_cases(ttnn_fn, edge_pattern, device):
     """Test uint16 unary operations with specific edge case patterns"""
 
     if edge_pattern == "critical_values":
@@ -149,8 +147,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
     ],
 )
 @pytest.mark.parametrize("ttnn_fn", [ttnn.logical_not])
-def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device_module):
-    device = device_module
+def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device):
     """Test uint16 unary operations with sharded memory configurations"""
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor = torch.linspace(0, 65535, num_elements, dtype=torch.int32)
@@ -176,8 +173,7 @@ def test_unary_uint16_sharded(a_shape, sharded_config, ttnn_fn, device_module):
         "random_sparse",
     ],
 )
-def test_unary_uint16_stress_patterns(ttnn_fn, test_pattern, device_module):
-    device = device_module
+def test_unary_uint16_stress_patterns(ttnn_fn, test_pattern, device):
     """Test uint16 unary operations with stress/edge patterns"""
     shape = torch.Size([1, 1, 64, 64])
     num_elements = int(torch.prod(torch.tensor(shape)).item())

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
@@ -52,8 +52,7 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
         torch.Size([1, 2, 32, 128]),
     ],
 )
-def test_unary_uint32(ttnn_op, value_ranges, input_shape, device_module):
-    device = device_module
+def test_unary_uint32(ttnn_op, value_ranges, input_shape, device):
     torch_input_tensor = create_full_range_tensor(input_shape=input_shape, dtype=torch.int64, value_ranges=value_ranges)
     if ttnn_op == ttnn.logical_not:
         torch_input_tensor[..., ::5] = 0  # every 5th element is zero
@@ -123,8 +122,7 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         ttnn.logical_not,
     ],
 )
-def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device_module):
-    device = device_module
+def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device):
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor = torch.linspace(0, 4000, num_elements, dtype=torch.int32)
     if ttnn_op == ttnn.logical_not:
@@ -150,8 +148,7 @@ def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device_module):
 
 # Inputs beyond 65535 will give an output > 2^32-1 when squared, causing overflow.
 # This test checks that overflow is handled correctly.
-def test_unary_square_uint32_overflow(device_module):
-    device = device_module
+def test_unary_square_uint32_overflow(device):
     torch_input_tensor = torch.tensor([0, 1, 46340, 65535, 65536, 70000])
     input_tensor = ttnn.from_torch(
         torch_input_tensor,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint32.py
@@ -52,7 +52,8 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
         torch.Size([1, 2, 32, 128]),
     ],
 )
-def test_unary_uint32(ttnn_op, value_ranges, input_shape, device):
+def test_unary_uint32(ttnn_op, value_ranges, input_shape, device_module):
+    device = device_module
     torch_input_tensor = create_full_range_tensor(input_shape=input_shape, dtype=torch.int64, value_ranges=value_ranges)
     if ttnn_op == ttnn.logical_not:
         torch_input_tensor[..., ::5] = 0  # every 5th element is zero
@@ -122,7 +123,8 @@ block_sharded_memory_config = ttnn.create_sharded_memory_config(
         ttnn.logical_not,
     ],
 )
-def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device):
+def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device_module):
+    device = device_module
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor = torch.linspace(0, 4000, num_elements, dtype=torch.int32)
     if ttnn_op == ttnn.logical_not:
@@ -148,7 +150,8 @@ def test_unary_uint32_sharded(a_shape, sharded_config, ttnn_op, device):
 
 # Inputs beyond 65535 will give an output > 2^32-1 when squared, causing overflow.
 # This test checks that overflow is handled correctly.
-def test_unary_square_uint32_overflow(device):
+def test_unary_square_uint32_overflow(device_module):
+    device = device_module
     torch_input_tensor = torch.tensor([0, 1, 46340, 65535, 65536, 70000])
     input_tensor = ttnn.from_torch(
         torch_input_tensor,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -55,8 +55,7 @@ def make_condition_tensor(shape, dtype, condition, stride=8):
 @pytest.mark.parametrize("scalar", [15.5, 5.0, -11.33])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, device_module):
-    device = device_module
+def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, device):
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=torch.float32) * condition
     if variant == "TTS":
@@ -97,8 +96,7 @@ def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, devic
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
 @pytest.mark.parametrize("scalar", [-9, 10, 7])
-def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar, device_module):
-    device = device_module
+def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar, device):
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=torch.int32) * condition
     if variant == "TTS":
@@ -145,10 +143,7 @@ def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar,
 @pytest.mark.parametrize("scalar", [15.5, -11.5, 0, 55.5])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where_bfloat8b(
-    tor_dtype, ttnn_dtype, c_shape, t_shape, f_shape, scalar, variant, condition, device_module
-):
-    device = device_module
+def test_ttnn_where_bfloat8b(tor_dtype, ttnn_dtype, c_shape, t_shape, f_shape, scalar, variant, condition, device):
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=tor_dtype) * condition
     if variant == "TTS":
@@ -202,8 +197,7 @@ def test_ttnn_where_forge():
     assert torch.equal(result, expected), f"Expected {expected}, got {result}"
 
 
-def test_ttnn_where_nan(device_module):
-    device = device_module
+def test_ttnn_where_nan(device):
     tor_dtype = torch.float32
 
     condition = torch.tensor([1, 0, -2, 0, 5, 0, 0, 8, 0, -1, float("inf"), float("nan")], dtype=tor_dtype)
@@ -254,8 +248,7 @@ def test_ttnn_where_nan(device_module):
 @pytest.mark.parametrize(
     "tor_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32), (torch.int32, ttnn.int32)]
 )
-def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device_module):
-    device = device_module
+def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device):
     C = torch.arange(h * w, dtype=tor_dtype)
     C = (C % 2).float()  # Alternates 0, 1, 0, 1, ...
     C = C.reshape(1, 1, h, w)
@@ -273,8 +266,7 @@ def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device_module):
     assert torch.equal(result, golden)
 
 
-def test_ttnn_where_edge_cases_bf16(device_module):
-    device = device_module
+def test_ttnn_where_edge_cases_bf16(device):
     tor_dtype = torch.bfloat16
     ttnn_dtype = ttnn.bfloat16
 
@@ -321,8 +313,7 @@ def test_ttnn_where_edge_cases_bf16(device_module):
     assert torch_equal_nan(tt_result3, result3)
 
 
-def test_bf8b_exponent_behaviour(device_module):
-    device = device_module
+def test_bf8b_exponent_behaviour(device):
     tor_dtype = torch.float32
     ttnn_dtype = ttnn.bfloat8_b
 
@@ -374,8 +365,7 @@ def test_bf8b_exponent_behaviour(device_module):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("h, w", [[64, 128]])
 @pytest.mark.parametrize("scalar", [15.5, float("nan"), float("inf"), -float("inf")])
-def test_where_tts(device_module, dtype, h, w, scalar):
-    device = device_module
+def test_where_tts(device, dtype, h, w, scalar):
     if dtype == torch.bfloat16 and isnan(scalar):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -403,8 +393,7 @@ def test_where_tts(device_module, dtype, h, w, scalar):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("h, w", [[64, 128]])
 @pytest.mark.parametrize("scalar", [15.5, float("nan"), float("inf"), -float("inf")])
-def test_where_tst(device_module, dtype, h, w, scalar):
-    device = device_module
+def test_where_tst(device, dtype, h, w, scalar):
     if dtype == torch.bfloat16 and isnan(scalar):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -441,8 +430,7 @@ def test_where_tst(device_module, dtype, h, w, scalar):
         [-float("inf"), float("nan")],
     ],
 )
-def test_where_tss(device_module, dtype, h, w, scalar1, scalar2):
-    device = device_module
+def test_where_tss(device, dtype, h, w, scalar1, scalar2):
     if dtype == torch.bfloat16 and (isnan(scalar1) or isnan(scalar2)):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -494,8 +482,7 @@ def test_where_tss(device_module, dtype, h, w, scalar1, scalar2):
         torch.Size([3, 128, 32]),
     ],
 )
-def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, device_module):
-    device = device_module
+def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, device):
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch_dtype)
     scalar_true, scalar_false = scalars
 
@@ -531,8 +518,7 @@ def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, d
         torch.Size([1, 3, 320, 384]),
     ],
 )
-def test_where_TSS_int_types(scalars, input_shapes, device_module):
-    device = device_module
+def test_where_TSS_int_types(scalars, input_shapes, device):
     scalar_true, scalar_false = scalars
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch.int32)
 
@@ -565,8 +551,7 @@ def test_where_TSS_int_types(scalars, input_shapes, device_module):
         torch.Size([64, 128]),
     ],
 )
-def test_where_TSS_uint32_types(scalars, input_shapes, device_module):
-    device = device_module
+def test_where_TSS_uint32_types(scalars, input_shapes, device):
     scalar_true, scalar_false = scalars
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch.uint32)
 
@@ -580,8 +565,7 @@ def test_where_TSS_uint32_types(scalars, input_shapes, device_module):
     assert torch.equal(tt_result, torch_result)
 
 
-def test_div_edgcase(device_module):
-    device = device_module
+def test_div_edgcase(device):
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.bfloat16)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.bfloat16)
 
@@ -604,8 +588,7 @@ def test_div_edgcase(device_module):
     assert torch.allclose(output_tensor, golden_tensor, equal_nan=False)
 
 
-def test_addcdiv_edgcase(device_module):
-    device = device_module
+def test_addcdiv_edgcase(device):
     # Hardcoded input tensors
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.bfloat16)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.bfloat16)
@@ -631,8 +614,7 @@ def test_addcdiv_edgcase(device_module):
     assert torch.allclose(output_tensor, golden_tensor, equal_nan=False)
 
 
-def test_addcdiv_edgcase_fp32(device_module):
-    device = device_module
+def test_addcdiv_edgcase_fp32(device):
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.float32)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.float32)
     c = torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.float32)
@@ -652,8 +634,7 @@ def test_addcdiv_edgcase_fp32(device_module):
     assert torch_equal_nan(output_tensor1, golden_tensor)
 
 
-def test_ttnn_where_forge_nan(device_module):
-    device = device_module
+def test_ttnn_where_forge_nan(device):
     C = torch.ones(1, 4, 1, dtype=torch.float32)
     T = torch.randn(1, 4, 768, dtype=torch.float32)
     F = torch.ones(1, 4, 768, dtype=torch.float32) * float("nan")
@@ -678,8 +659,7 @@ def test_ttnn_where_forge_nan(device_module):
         [(1, 512, 14, 14), (1, 512, 14, 14), (1,)],
     ],
 )
-def test_where_int_golden_verification(c_shape, t_shape, f_shape, device_module):
-    device = device_module
+def test_where_int_golden_verification(c_shape, t_shape, f_shape, device):
     torch.manual_seed(42)
 
     # Generate random input tensors
@@ -723,8 +703,7 @@ def test_where_int_golden_verification(c_shape, t_shape, f_shape, device_module)
 @pytest.mark.parametrize("scalar", [15.5])
 @pytest.mark.parametrize("variant", ["TTT", "TST", "TTS"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, condition, device_module):
-    device = device_module
+def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, condition, device):
     torch.manual_seed(0)
 
     C = torch.ones(a_shape, dtype=torch.float32) * condition
@@ -823,8 +802,7 @@ def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, con
 @pytest.mark.parametrize("scalar", [15.5, 5.0, -11.33])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_where_subcore_grid(device_module, shape, sub_core_grid, dtype, scalar, variant, condition):
-    device = device_module
+def test_where_subcore_grid(device, shape, sub_core_grid, dtype, scalar, variant, condition):
     torch.manual_seed(0)
     tor_dtype = dtype
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where.py
@@ -55,7 +55,8 @@ def make_condition_tensor(shape, dtype, condition, stride=8):
 @pytest.mark.parametrize("scalar", [15.5, 5.0, -11.33])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, device):
+def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, device_module):
+    device = device_module
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=torch.float32) * condition
     if variant == "TTS":
@@ -96,7 +97,8 @@ def test_ttnn_where(c_shape, t_shape, f_shape, scalar, variant, condition, devic
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
 @pytest.mark.parametrize("scalar", [-9, 10, 7])
-def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar, device):
+def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar, device_module):
+    device = device_module
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=torch.int32) * condition
     if variant == "TTS":
@@ -143,7 +145,10 @@ def test_ttnn_where_int32(c_shape, t_shape, f_shape, variant, condition, scalar,
 @pytest.mark.parametrize("scalar", [15.5, -11.5, 0, 55.5])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where_bfloat8b(tor_dtype, ttnn_dtype, c_shape, t_shape, f_shape, scalar, variant, condition, device):
+def test_ttnn_where_bfloat8b(
+    tor_dtype, ttnn_dtype, c_shape, t_shape, f_shape, scalar, variant, condition, device_module
+):
+    device = device_module
     torch.manual_seed(0)
     C = torch.ones(c_shape, dtype=tor_dtype) * condition
     if variant == "TTS":
@@ -197,7 +202,8 @@ def test_ttnn_where_forge():
     assert torch.equal(result, expected), f"Expected {expected}, got {result}"
 
 
-def test_ttnn_where_nan(device):
+def test_ttnn_where_nan(device_module):
+    device = device_module
     tor_dtype = torch.float32
 
     condition = torch.tensor([1, 0, -2, 0, 5, 0, 0, 8, 0, -1, float("inf"), float("nan")], dtype=tor_dtype)
@@ -248,7 +254,8 @@ def test_ttnn_where_nan(device):
 @pytest.mark.parametrize(
     "tor_dtype, ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32), (torch.int32, ttnn.int32)]
 )
-def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device):
+def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device_module):
+    device = device_module
     C = torch.arange(h * w, dtype=tor_dtype)
     C = (C % 2).float()  # Alternates 0, 1, 0, 1, ...
     C = C.reshape(1, 1, h, w)
@@ -266,7 +273,8 @@ def test_ttnn_where_mcw(h, w, tor_dtype, ttnn_dtype, device):
     assert torch.equal(result, golden)
 
 
-def test_ttnn_where_edge_cases_bf16(device):
+def test_ttnn_where_edge_cases_bf16(device_module):
+    device = device_module
     tor_dtype = torch.bfloat16
     ttnn_dtype = ttnn.bfloat16
 
@@ -313,7 +321,8 @@ def test_ttnn_where_edge_cases_bf16(device):
     assert torch_equal_nan(tt_result3, result3)
 
 
-def test_bf8b_exponent_behaviour(device):
+def test_bf8b_exponent_behaviour(device_module):
+    device = device_module
     tor_dtype = torch.float32
     ttnn_dtype = ttnn.bfloat8_b
 
@@ -365,7 +374,8 @@ def test_bf8b_exponent_behaviour(device):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("h, w", [[64, 128]])
 @pytest.mark.parametrize("scalar", [15.5, float("nan"), float("inf"), -float("inf")])
-def test_where_tts(device, dtype, h, w, scalar):
+def test_where_tts(device_module, dtype, h, w, scalar):
+    device = device_module
     if dtype == torch.bfloat16 and isnan(scalar):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -393,7 +403,8 @@ def test_where_tts(device, dtype, h, w, scalar):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("h, w", [[64, 128]])
 @pytest.mark.parametrize("scalar", [15.5, float("nan"), float("inf"), -float("inf")])
-def test_where_tst(device, dtype, h, w, scalar):
+def test_where_tst(device_module, dtype, h, w, scalar):
+    device = device_module
     if dtype == torch.bfloat16 and isnan(scalar):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -430,7 +441,8 @@ def test_where_tst(device, dtype, h, w, scalar):
         [-float("inf"), float("nan")],
     ],
 )
-def test_where_tss(device, dtype, h, w, scalar1, scalar2):
+def test_where_tss(device_module, dtype, h, w, scalar1, scalar2):
+    device = device_module
     if dtype == torch.bfloat16 and (isnan(scalar1) or isnan(scalar2)):
         pytest.xfail("NaN is packed as inf for ttnn.bfloat16")
 
@@ -482,7 +494,8 @@ def test_where_tss(device, dtype, h, w, scalar1, scalar2):
         torch.Size([3, 128, 32]),
     ],
 )
-def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, device):
+def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, device_module):
+    device = device_module
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch_dtype)
     scalar_true, scalar_false = scalars
 
@@ -518,7 +531,8 @@ def test_where_TSS_float_types(torch_dtype, ttnn_dtype, scalars, input_shapes, d
         torch.Size([1, 3, 320, 384]),
     ],
 )
-def test_where_TSS_int_types(scalars, input_shapes, device):
+def test_where_TSS_int_types(scalars, input_shapes, device_module):
+    device = device_module
     scalar_true, scalar_false = scalars
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch.int32)
 
@@ -551,7 +565,8 @@ def test_where_TSS_int_types(scalars, input_shapes, device):
         torch.Size([64, 128]),
     ],
 )
-def test_where_TSS_uint32_types(scalars, input_shapes, device):
+def test_where_TSS_uint32_types(scalars, input_shapes, device_module):
+    device = device_module
     scalar_true, scalar_false = scalars
     condition = torch.tensor([[0, 1] * (input_shapes[-1] // 2)] * input_shapes[0], dtype=torch.uint32)
 
@@ -565,7 +580,8 @@ def test_where_TSS_uint32_types(scalars, input_shapes, device):
     assert torch.equal(tt_result, torch_result)
 
 
-def test_div_edgcase(device):
+def test_div_edgcase(device_module):
+    device = device_module
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.bfloat16)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.bfloat16)
 
@@ -588,7 +604,8 @@ def test_div_edgcase(device):
     assert torch.allclose(output_tensor, golden_tensor, equal_nan=False)
 
 
-def test_addcdiv_edgcase(device):
+def test_addcdiv_edgcase(device_module):
+    device = device_module
     # Hardcoded input tensors
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.bfloat16)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.bfloat16)
@@ -614,7 +631,8 @@ def test_addcdiv_edgcase(device):
     assert torch.allclose(output_tensor, golden_tensor, equal_nan=False)
 
 
-def test_addcdiv_edgcase_fp32(device):
+def test_addcdiv_edgcase_fp32(device_module):
+    device = device_module
     a = torch.tensor([1, 2, -4, 0, -6, 0], dtype=torch.float32)
     b = torch.tensor([-1, 0, 0, 0, -2, 7], dtype=torch.float32)
     c = torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.float32)
@@ -634,7 +652,8 @@ def test_addcdiv_edgcase_fp32(device):
     assert torch_equal_nan(output_tensor1, golden_tensor)
 
 
-def test_ttnn_where_forge_nan(device):
+def test_ttnn_where_forge_nan(device_module):
+    device = device_module
     C = torch.ones(1, 4, 1, dtype=torch.float32)
     T = torch.randn(1, 4, 768, dtype=torch.float32)
     F = torch.ones(1, 4, 768, dtype=torch.float32) * float("nan")
@@ -659,7 +678,8 @@ def test_ttnn_where_forge_nan(device):
         [(1, 512, 14, 14), (1, 512, 14, 14), (1,)],
     ],
 )
-def test_where_int_golden_verification(c_shape, t_shape, f_shape, device):
+def test_where_int_golden_verification(c_shape, t_shape, f_shape, device_module):
+    device = device_module
     torch.manual_seed(42)
 
     # Generate random input tensors
@@ -703,7 +723,8 @@ def test_where_int_golden_verification(c_shape, t_shape, f_shape, device):
 @pytest.mark.parametrize("scalar", [15.5])
 @pytest.mark.parametrize("variant", ["TTT", "TST", "TTS"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, condition, device):
+def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, condition, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     C = torch.ones(a_shape, dtype=torch.float32) * condition
@@ -802,7 +823,8 @@ def test_ttnn_where_preallocated(a_shape, b_shape, c_shape, scalar, variant, con
 @pytest.mark.parametrize("scalar", [15.5, 5.0, -11.33])
 @pytest.mark.parametrize("variant", ["TTS", "TST", "TTT"])
 @pytest.mark.parametrize("condition", [1, 0])
-def test_where_subcore_grid(device, shape, sub_core_grid, dtype, scalar, variant, condition):
+def test_where_subcore_grid(device_module, shape, sub_core_grid, dtype, scalar, variant, condition):
+    device = device_module
     torch.manual_seed(0)
     tor_dtype = dtype
 

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -38,8 +38,9 @@ from models.common.utility_functions import comp_pcc
 @pytest.mark.parametrize("momentum", [0.0, 0.1])
 @pytest.mark.parametrize("testing_dtype", ["float32", "bfloat16"])
 def test_batch_norm_tests(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, momentum, training, testing_dtype
+    input_shapes, check_mean, check_var, weight, bias, eps, device_module, momentum, training, testing_dtype
 ):
+    device = device_module
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
     )
@@ -125,7 +126,8 @@ def test_batch_norm_tests(
 @pytest.mark.parametrize("channel_size", [1, 4])
 @pytest.mark.parametrize("weight", [True, False])
 @pytest.mark.parametrize("bias", [True, False])
-def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
+def test_BN_fp32_full_value(device_module, channel_size, eps, weight, bias):
+    device = device_module
     input_tensor_torch = torch.full(torch.Size([3, channel_size, 64, 120]), 1, dtype=torch.float32)
     batch_mean_torch = torch.full(torch.Size([channel_size]), 0.00030171126, dtype=torch.float32)
     batch_var_torch = torch.full(torch.Size([channel_size]), 0.1262342343, dtype=torch.float32)
@@ -185,8 +187,9 @@ def test_BN_fp32_full_value(device, channel_size, eps, weight, bias):
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [0.0, 1e-05])
 def test_batch_norm_fp32(
-    input_shapes, check_mean, check_var, weight, bias, eps, device, training=False, testing_dtype="float32"
+    input_shapes, check_mean, check_var, weight, bias, eps, device_module, training=False, testing_dtype="float32"
 ):
+    device = device_module
     in_data, input_tensor = data_gen_with_range_batch_norm(
         input_shapes, 5, 10, device, is_input=True, testing_dtype=testing_dtype
     )
@@ -264,7 +267,8 @@ def test_batch_norm_fp32(
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("eps", [1.0, 2.34])
 @pytest.mark.parametrize("momentum", [0.0, 0.5])
-def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device):
+def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias, eps, momentum, device_module):
+    device = device_module
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = (
         data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if (check_mean) else (None, None)
@@ -338,7 +342,8 @@ def test_batch_norm(input_shapes, training, check_mean, check_var, weight, bias,
     ],
 )
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.TensorMemoryLayout.HEIGHT_SHARDED])
-def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device):
+def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device_module):
+    device = device_module
     N, H, W, C = input_shapes
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
@@ -369,7 +374,8 @@ def test_batch_norm_program_cache_and_default(input_shapes, mem_layout, device):
         torch.Size([3, 2, 32, 32]),
     ],
 )
-def test_batch_norm_qid_Default(input_shapes, device):
+def test_batch_norm_qid_Default(input_shapes, device_module):
+    device = device_module
     N, H, W, C = input_shapes
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
@@ -390,7 +396,8 @@ def test_batch_norm_qid_Default(input_shapes, device):
         torch.Size([3, 2, 32, 32]),
     ],
 )
-def test_batch_norm_qid(input_shapes, device):
+def test_batch_norm_qid(input_shapes, device_module):
+    device = device_module
     N, H, W, C = input_shapes
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 2, 10, device, is_input=True)
     mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 2, 10, device)
@@ -409,7 +416,8 @@ def test_batch_norm_qid(input_shapes, device):
         torch.Size([2, 3, 120, 120]),
     ],
 )
-def test_batch_norm_output_Default(input_shapes, device):
+def test_batch_norm_output_Default(input_shapes, device_module):
+    device = device_module
     N, H, W, C = input_shapes
     _, tt_output_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
@@ -438,7 +446,8 @@ def test_batch_norm_output_Default(input_shapes, device):
         (False, False, False),
     ],
 )
-def test_batch_norm_compute_config(input_shapes, training, weight, bias, device):
+def test_batch_norm_compute_config(input_shapes, training, weight, bias, device_module):
+    device = device_module
     N, H, W, C = input_shapes
     d_type = "float32"
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_eltwise_softmax_in_place.py
@@ -69,5 +69,6 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_eltwise_softmax_in_place_test(input_shape, dtype, dlayout, in_mem_config, data_seed, device):
+def test_eltwise_softmax_in_place_test(input_shape, dtype, dlayout, in_mem_config, data_seed, device_module):
+    device = device_module
     run_eltwise_softmax_in_place_tests(input_shape, dtype, dlayout, in_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -49,7 +49,8 @@ def assert_output_accuracy(torch_output, ttnn_output):
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm(device, h, w, use_welford, dtype):
+def test_layer_norm(device_module, h, w, use_welford, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -66,7 +67,8 @@ def test_layer_norm(device, h, w, use_welford, dtype):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("use_welford", [True, False])
-def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
+def test_layer_norm_with_weight_and_bias(device_module, h, w, use_welford):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -92,7 +94,8 @@ def test_layer_norm_with_weight_and_bias(device, h, w, use_welford):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("use_welford", [True, False])
-def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
+def test_layer_norm_with_weight_and_bias_row_major(device_module, h, w, use_welford):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -120,7 +123,8 @@ def test_layer_norm_with_weight_and_bias_row_major(device, h, w, use_welford):
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
+def test_layer_norm_with_weight_bias_and_residual_input(device_module, h, w, use_welford, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -152,7 +156,8 @@ def test_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welfor
 
 @pytest.mark.parametrize("h", [2])
 @pytest.mark.parametrize("w", [512])
-def test_layer_norm_with_tile_layout(device, h, w):
+def test_layer_norm_with_tile_layout(device_module, h, w):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -194,7 +199,8 @@ def test_layer_norm_with_tile_layout(device, h, w):
 @pytest.mark.parametrize("w", [3200, 4128])
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_large_layer_norm(device, h, w, use_welford, dtype):
+def test_large_layer_norm(device_module, h, w, use_welford, dtype):
+    device = device_module
     torch.manual_seed(15)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -212,7 +218,8 @@ def test_large_layer_norm(device, h, w, use_welford, dtype):
 @pytest.mark.parametrize("h", [2048])
 @pytest.mark.parametrize("w", [4096])
 @pytest.mark.parametrize("use_welford", [True, False])
-def test_large_layer_norm_with_weight_and_bias(device, h, w, use_welford):
+def test_large_layer_norm_with_weight_and_bias(device_module, h, w, use_welford):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -239,7 +246,8 @@ def test_large_layer_norm_with_weight_and_bias(device, h, w, use_welford):
 @pytest.mark.parametrize("h", [2048])
 @pytest.mark.parametrize("w", [4096])
 @pytest.mark.parametrize("use_welford", [True, False])
-def test_large_layer_norm_with_weight(device, h, w, use_welford):
+def test_large_layer_norm_with_weight(device_module, h, w, use_welford):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -262,7 +270,8 @@ def test_large_layer_norm_with_weight(device, h, w, use_welford):
 @pytest.mark.parametrize("h", [2048])
 @pytest.mark.parametrize("w", [4096])
 @pytest.mark.parametrize("use_welford", [True, False])
-def test_large_layer_norm_with_bias(device, h, w, use_welford):
+def test_large_layer_norm_with_bias(device_module, h, w, use_welford):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -285,7 +294,8 @@ def test_large_layer_norm_with_bias(device, h, w, use_welford):
 @pytest.mark.parametrize("h, w", [(2048, 2048)])
 @pytest.mark.parametrize("legacy_reduction", [True, False])
 @pytest.mark.parametrize("legacy_rsqrt", [True, False])
-def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_reduction, legacy_rsqrt):
+def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device_module, h, w, legacy_reduction, legacy_rsqrt):
+    device = device_module
     torch.manual_seed(0)
     dtype = torch.bfloat16
 
@@ -321,7 +331,8 @@ def test_large_layer_norm_with_legacy_reduction_and_rsqrt(device, h, w, legacy_r
 @pytest.mark.parametrize("h, w", [(32, 2592), (32, 3232), (1024, 2880)])
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_welford, dtype):
+def test_large_layer_norm_with_weight_bias_and_residual_input(device_module, h, w, use_welford, dtype):
+    device = device_module
     torch.manual_seed(3333)
 
     torch_input_tensor = torch.rand((h, w), dtype=dtype)
@@ -357,7 +368,8 @@ def test_large_layer_norm_with_weight_bias_and_residual_input(device, h, w, use_
 
 @pytest.mark.parametrize("use_welford", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_l1_interleaved(device, use_welford, dtype):
+def test_l1_interleaved(device_module, use_welford, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     h, w = 32, 64
@@ -384,7 +396,8 @@ def test_l1_interleaved(device, use_welford, dtype):
 @pytest.mark.parametrize("dim_a", [2048, 3072, 4096])
 @pytest.mark.parametrize("dim_b", [2048, 3072, 4096])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
-def test_layer_norm_across_dtypes(*, device: ttnn.Device, dim_a: int, dim_b: int, dtype: ttnn.DataType) -> None:
+def test_layer_norm_across_dtypes(device_module, *, dim_a: int, dim_b: int, dtype: ttnn.DataType) -> None:
+    device = device_module
     torch.manual_seed(0)
 
     epsilon = 1e-5

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -22,8 +22,20 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_single_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, use_welford, two_stage, tensor_type, dtype
+    device_module,
+    h,
+    w,
+    num_cores_h,
+    num_cores_w,
+    block_ht,
+    block_wt,
+    subblock_wt,
+    use_welford,
+    two_stage,
+    tensor_type,
+    dtype,
 ):
+    device = device_module
     layernorm_test_main(
         device,
         h,
@@ -49,8 +61,20 @@ def test_layer_norm_sharded_single_stage(
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_layer_norm_sharded_two_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, use_welford, two_stage, tensor_type, dtype
+    device_module,
+    h,
+    w,
+    num_cores_h,
+    num_cores_w,
+    block_ht,
+    block_wt,
+    subblock_wt,
+    use_welford,
+    two_stage,
+    tensor_type,
+    dtype,
 ):
+    device = device_module
     layernorm_test_main(
         device,
         h,
@@ -71,7 +95,8 @@ def test_layer_norm_sharded_two_stage(
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor_type, dtype):
+def test_layer_norm_sharded_with_residual(device_module, use_welford, two_stage, tensor_type, dtype):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -98,7 +123,8 @@ def test_layer_norm_sharded_with_residual(device, use_welford, two_stage, tensor
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage, tensor_type, dtype):
+def test_layer_norm_sharded_with_weight_and_bias(device_module, use_welford, two_stage, tensor_type, dtype):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -126,7 +152,8 @@ def test_layer_norm_sharded_with_weight_and_bias(device, use_welford, two_stage,
 @pytest.mark.parametrize("two_stage", [False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, two_stage, tensor_type, dtype):
+def test_layer_norm_sharded_with_weight_and_bias_row_major(device_module, use_welford, two_stage, tensor_type, dtype):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = 64, 32, 2, 1, 1, 1, 1
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -155,7 +182,10 @@ def test_layer_norm_sharded_with_weight_and_bias_row_major(device, use_welford, 
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welford, two_stage, tensor_type, dtype):
+def test_layer_norm_sharded_with_weight_and_bias_and_residual(
+    device_module, use_welford, two_stage, tensor_type, dtype
+):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     residual = generate_input_tensor(h, w, "random_normal", dtype)
@@ -181,7 +211,8 @@ def test_layer_norm_sharded_with_weight_and_bias_and_residual(device, use_welfor
 
 
 @pytest.mark.parametrize("use_welford", [True])
-def test_layer_norm_sharded_padded(device, use_welford):
+def test_layer_norm_sharded_padded(device_module, use_welford):
+    device = device_module
     """
     Test layer norm on a sharded tensor that is padded with zeros
     in the width dimension.
@@ -250,7 +281,8 @@ def test_layer_norm_sharded_padded(device, use_welford):
 
 @pytest.mark.parametrize("h,w", [(32, 2048)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_layer_norm_sharded_width_default_config(device, h, w, dtype):
+def test_layer_norm_sharded_width_default_config(device_module, h, w, dtype):
+    device = device_module
     """
     Test layer norm with width-sharded input on L1 and interleaved weight/bias on DRAM.
     Uses default config (no explicit program_config).

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -14,7 +14,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("h", [32, 384])
 @pytest.mark.parametrize("w", [64, 1024])
-def test_rms_norm(device, batch_size, h, w):
+def test_rms_norm(device_module, batch_size, h, w):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((batch_size, h, w), dtype=torch.bfloat16)
@@ -34,7 +35,8 @@ def test_rms_norm(device, batch_size, h, w):
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [32])
-def test_rms_norm_row_major(device, batch_size, h, w):
+def test_rms_norm_row_major(device_module, batch_size, h, w):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((batch_size, h, w), dtype=torch.bfloat16)
@@ -55,7 +57,8 @@ def test_rms_norm_row_major(device, batch_size, h, w):
 @pytest.mark.parametrize("h", [2048])
 @pytest.mark.parametrize("w", [4096])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_large_rms_norm(device, batch_size, h, w, dtype):
+def test_large_rms_norm(device_module, batch_size, h, w, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((batch_size, h, w), dtype=dtype)

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
@@ -22,8 +22,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_single_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
+    device_module, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
 ):
+    device = device_module
     rms_norm_test_main(
         device,
         h,
@@ -47,8 +48,9 @@ def test_rms_norm_sharded_single_stage(
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_sharded_two_stage(
-    device, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
+    device_module, h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt, two_stage, tensor_type, dtype
 ):
+    device = device_module
     rms_norm_test_main(
         device,
         h,
@@ -67,7 +69,8 @@ def test_rms_norm_sharded_two_stage(
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_rms_norm_sharded_with_residual(device, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_residual(device_module, two_stage, tensor_type, dtype):
+    device = device_module
     if tensor_type == "random" or tensor_type == "random_normal":
         pytest.skip("Low PCC, see #30455")
 
@@ -94,7 +97,8 @@ def test_rms_norm_sharded_with_residual(device, two_stage, tensor_type, dtype):
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_rms_norm_sharded_with_weight_and_bias(device, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias(device_module, two_stage, tensor_type, dtype):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = simple_size_params(two_stage)
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -118,7 +122,8 @@ def test_rms_norm_sharded_with_weight_and_bias(device, two_stage, tensor_type, d
 @pytest.mark.parametrize("two_stage", [False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random_normal"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_rms_norm_sharded_with_weight_and_bias_row_major(device, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias_row_major(device_module, two_stage, tensor_type, dtype):
+    device = device_module
     h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt = 64, 32, 2, 1, 1, 1, 1
 
     weight = generate_input_tensor(1, w, "random", dtype)
@@ -143,7 +148,8 @@ def test_rms_norm_sharded_with_weight_and_bias_row_major(device, two_stage, tens
 @pytest.mark.parametrize("two_stage", [True, False])
 @pytest.mark.parametrize("tensor_type", ["ascending_values_repeated_rows", "random"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_rms_norm_sharded_with_weight_and_bias_and_residual(device, two_stage, tensor_type, dtype):
+def test_rms_norm_sharded_with_weight_and_bias_and_residual(device_module, two_stage, tensor_type, dtype):
+    device = device_module
     if tensor_type == "random" or tensor_type == "random_normal":
         pytest.skip("Low PCC, see #30455")
 
@@ -169,7 +175,8 @@ def test_rms_norm_sharded_with_weight_and_bias_and_residual(device, two_stage, t
 
 
 @pytest.mark.parametrize("h,w", [(32, 256)])
-def test_rms_norm_sharded_padded(device, h, w):
+def test_rms_norm_sharded_padded(device_module, h, w):
+    device = device_module
     """
     Test layer norm on a sharded tensor that is padded with zeros
     in the width dimension.
@@ -237,7 +244,8 @@ def test_rms_norm_sharded_padded(device, h, w):
 
 @pytest.mark.parametrize("h,w", [(32, 2048)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_rms_norm_sharded_width_default_config(device, h, w, dtype):
+def test_rms_norm_sharded_width_default_config(device_module, h, w, dtype):
+    device = device_module
     """
     Test RMS norm with width-sharded input on L1 and interleaved weight on DRAM.
     Uses default config (no explicit program_config).

--- a/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
@@ -11,7 +11,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
 @pytest.mark.parametrize("matrix_size", [4, 8, 16, 32, 64, 128, 256, 512, 1024])
-def test_addmm_square_matrices(device, dtype, matrix_size):
+def test_addmm_square_matrices(device_module, dtype, matrix_size):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((matrix_size, matrix_size), dtype=torch.bfloat16)
@@ -54,7 +55,8 @@ def test_addmm_square_matrices(device, dtype, matrix_size):
 @pytest.mark.parametrize("matrix_size", [4, 8, 16, 32])
 @pytest.mark.parametrize("alpha", [-0.5, 0.5, 1.0, 1.5])
 @pytest.mark.parametrize("beta", [-0.5, 0.0, 0.5, 1.0, 1.5])
-def test_addmm_with_alpha_beta(device, dtype, matrix_size, alpha, beta):
+def test_addmm_with_alpha_beta(device_module, dtype, matrix_size, alpha, beta):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(matrix_size, matrix_size, dtype=torch.bfloat16)
@@ -107,7 +109,8 @@ def test_addmm_with_alpha_beta(device, dtype, matrix_size, alpha, beta):
         (32, 128, 64),
     ],
 )
-def test_addmm_rectangular_matrices(device, dtype, matrix_dims):
+def test_addmm_rectangular_matrices(device_module, dtype, matrix_dims):
+    device = device_module
     torch.manual_seed(0)
 
     n, m, p = matrix_dims
@@ -152,7 +155,8 @@ def test_addmm_rectangular_matrices(device, dtype, matrix_dims):
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
 @pytest.mark.parametrize("size", [4, 8, 16, 32, 64])
 @pytest.mark.parametrize("case_type", ["matrix_vector"])  # TODO "vector_matrix" not working
-def test_vector_matrix_multiplication(device, dtype, size, case_type):
+def test_vector_matrix_multiplication(device_module, dtype, size, case_type):
+    device = device_module
     """
     Test vector-matrix and matrix-vector multiplication cases:
     - vector_matrix: n=1, testing (1, m) @ (m, p) + (1, p)
@@ -224,7 +228,8 @@ def test_vector_matrix_multiplication(device, dtype, size, case_type):
         (95, 127, 63),  # Larger dimensions not multiple of 32
     ],
 )
-def test_addmm_non_tile_multiple_dimensions(device, dtype, shape):
+def test_addmm_non_tile_multiple_dimensions(device_module, dtype, shape):
+    device = device_module
     torch.manual_seed(0)
 
     n, m, p = shape
@@ -265,7 +270,8 @@ def test_addmm_non_tile_multiple_dimensions(device, dtype, shape):
     assert_with_pcc(torch_output_tensor, output_tensor_torch, pcc=target_pcc)
 
 
-def test_alpha_zero_should_throw_error(device):
+def test_alpha_zero_should_throw_error(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(4, 4, dtype=torch.bfloat16)
@@ -300,7 +306,8 @@ def test_alpha_zero_should_throw_error(device):
         pytest.fail("Calling ttnn.addmm with alpha=0 should throw an error.")
 
 
-def test_input_tensor_with_invalid_shape_should_throw_error(device):
+def test_input_tensor_with_invalid_shape_should_throw_error(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(8, 8, dtype=torch.bfloat16)
@@ -335,7 +342,8 @@ def test_input_tensor_with_invalid_shape_should_throw_error(device):
         pytest.fail("Calling ttnn.addmm with incompatible shapes should throw an error.")
 
 
-def test_input_tensor_with_invalid_shape_should_be_ignored_if_beta_is_0(device):
+def test_input_tensor_with_invalid_shape_should_be_ignored_if_beta_is_0(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(8, 8, dtype=torch.bfloat16)
@@ -364,7 +372,8 @@ def test_input_tensor_with_invalid_shape_should_be_ignored_if_beta_is_0(device):
     ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor, beta=0.0)
 
 
-def test_cast_to_another_dtype(device):
+def test_cast_to_another_dtype(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(4, 4, dtype=torch.bfloat16)
@@ -394,7 +403,8 @@ def test_cast_to_another_dtype(device):
     assert output_tensor.dtype == ttnn.float32, "Output tensor must be float32"
 
 
-def test_unsupported_dtype_should_throw_error(device):
+def test_unsupported_dtype_should_throw_error(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(4, 4, dtype=torch.bfloat16)
@@ -430,7 +440,8 @@ def test_unsupported_dtype_should_throw_error(device):
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
-def test_addmm_with_output_tensor_inplace_op(device, dtype):
+def test_addmm_with_output_tensor_inplace_op(device_module, dtype):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((32, 32), dtype=torch.bfloat16)
@@ -479,7 +490,8 @@ def test_addmm_with_output_tensor_inplace_op(device, dtype):
     assert_with_pcc(torch_output_tensor, out_tensor, pcc=target_pcc)
 
 
-def test_addmm_with_output_tensor_inplace_op_with_different_dtype(device):
+def test_addmm_with_output_tensor_inplace_op_with_different_dtype(device_module):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((32, 32), dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -20,7 +20,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [32])
 @pytest.mark.parametrize("width", [32])
-def test_ttnn_experimental_tensor_exp(device, height, width):
+def test_ttnn_experimental_tensor_exp(device_module, height, width):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((1, 1, height, width), -1, 1, dtype=torch.bfloat16)
@@ -39,7 +40,8 @@ def test_ttnn_experimental_tensor_exp(device, height, width):
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [32])
 @pytest.mark.parametrize("n_size", [32])
-def test_ttnn_matmul(device, m_size, k_size, n_size):
+def test_ttnn_matmul(device_module, m_size, k_size, n_size):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch_random((1, 1, m_size, k_size), -1, 1, dtype=torch.bfloat16)
@@ -63,7 +65,15 @@ def test_ttnn_matmul(device, m_size, k_size, n_size):
 @pytest.mark.parametrize("input_a_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("input_b_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_ttnn_linear(
-    device, input_a_is_sharded, output_is_sharded, m_size, k_size, n_size, num_cores, input_a_dtype, input_b_dtype
+    device_module,
+    input_a_is_sharded,
+    output_is_sharded,
+    m_size,
+    k_size,
+    n_size,
+    num_cores,
+    input_a_dtype,
+    input_b_dtype,
 ):
     grid_size = (6, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -149,7 +159,8 @@ def test_ttnn_linear(
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [8192])
 @pytest.mark.parametrize("n_size", [1024])
-def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
+def test_ttnn_matmul_dram_sharded(device_module, m_size, k_size, n_size):
+    device = device_module
     torch.manual_seed(0)
 
     dram_grid_size = device.dram_grid_size().x
@@ -226,7 +237,8 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
 
 @pytest.mark.parametrize("H, num_cores", [[64, 64]])
 @pytest.mark.parametrize("num_slices", [2])
-def test_sharded_partial_op(device, H, num_cores, num_slices):
+def test_sharded_partial_op(device_module, H, num_cores, num_slices):
+    device = device_module
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -24,8 +24,9 @@ def test_linear(
     n_size,
     use_bias,
     *,
-    device,
+    device_module,
 ):
+    device = device_module
     input_shape_a = (*batch_sizes, m_size, k_size)
     input_shape_b = (k_size, n_size)
 
@@ -85,8 +86,9 @@ def test_linear_with_core_grid(
     use_bias,
     core_grid,
     *,
-    device,
+    device_module,
 ):
+    device = device_module
     if device.core_grid.y == 7:
         pytest.skip("Issue #6984: Compute Grid size too small")
     input_shape_a = (batch_size, 1, m_size, k_size)
@@ -142,8 +144,9 @@ def test_linear_with_core_grid(
 @pytest.mark.parametrize("n_size", [1024])
 @pytest.mark.parametrize("activation", [None, "relu", "silu", "gelu", "gelu_approx", "relu6"])
 def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
-    device, batch_size, m_size, k_size, n_size, activation
+    device_module, batch_size, m_size, k_size, n_size, activation
 ):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -180,7 +183,8 @@ def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
         ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
     ],
 )
-def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_size, activation):
+def test_linear_with_compound_activation(device_module, batch_size, m_size, k_size, n_size, activation):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -206,7 +210,10 @@ def test_linear_with_compound_activation(device, batch_size, m_size, k_size, n_s
 @pytest.mark.parametrize("k_size", [1024])
 @pytest.mark.parametrize("n_size", [1024])
 @pytest.mark.parametrize("activation", [None, "relu"])
-def test_linear_by_passing_in_1D_systolic_array_program_config(device, batch_size, m_size, k_size, n_size, activation):
+def test_linear_by_passing_in_1D_systolic_array_program_config(
+    device_module, batch_size, m_size, k_size, n_size, activation
+):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -232,7 +239,8 @@ def test_linear_by_passing_in_1D_systolic_array_program_config(device, batch_siz
 @pytest.mark.parametrize("m_size", [32, 512])
 @pytest.mark.parametrize("k_size", [1024, 2048])
 @pytest.mark.parametrize("n_size", [1024, 2048])
-def test_linear_fp32_acc(device, m_size, k_size, n_size):
+def test_linear_fp32_acc(device_module, m_size, k_size, n_size):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((1, m_size, k_size), dtype=torch.bfloat16)
@@ -268,7 +276,8 @@ def test_linear_fp32_acc(device, m_size, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
 
 
-def test_bloom_ff2_linear(device):
+def test_bloom_ff2_linear(device_module):
+    device = device_module
     torch_input_tensor = torch_random((8, 384, 4096), -0.1, 0.1, dtype=torch.float32)
     torch_weight = torch_random((4096, 1024), -0.1, 0.1, dtype=torch.float32)
     torch_bias = torch_random((1024,), -0.01, 0.01, dtype=torch.float32)
@@ -311,8 +320,9 @@ def test_bloom_ff2_linear(device):
 @pytest.mark.parametrize("n_size", [1024, 2048])
 @pytest.mark.parametrize("activation", [None, "relu"])
 def test_linear_by_passing_in_1D_systolic_array_program_config_and_optional_outout_tensor(
-    device, batch_size, m_size, k_size, n_size, activation
+    device_module, batch_size, m_size, k_size, n_size, activation
 ):
+    device = device_module
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -353,7 +363,8 @@ def test_linear_by_passing_in_1D_systolic_array_program_config_and_optional_outo
     assert_with_pcc(optional_output_tensor, output_tensor, 0.997)
 
 
-def test_linear_with_fp32_dest_acc_and_bias(device):
+def test_linear_with_fp32_dest_acc_and_bias(device_module):
+    device = device_module
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand([64, 1, 256, 384])
     torch_input_tensor_b = torch.rand([1, 1, 1152, 384])
@@ -384,7 +395,8 @@ def test_linear_with_fp32_dest_acc_and_bias(device):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
 
 
-def test_resnet50_linear(device):
+def test_resnet50_linear(device_module):
+    device = device_module
     torch.manual_seed(0)
     batch_size = 16
     input_channels = 2048
@@ -473,7 +485,8 @@ def test_resnet50_linear(device):
         ((32, 2, 32), (32, 32), (1, 32)),  # 4D tensors with no bias
     ],
 )
-def test_vector_linear(device, shape_a, shape_b, shape_bias) -> tuple:
+def test_vector_linear(device_module, shape_a, shape_b, shape_bias) -> tuple:
+    device = device_module
     """
     Test the compatibility of the torch and ttnn linear for the given operation and different
     tensor shapes.
@@ -557,7 +570,7 @@ def test_vector_linear(device, shape_a, shape_b, shape_bias) -> tuple:
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("compute_config_params", [[ttnn.MathFidelity.LoFi, True, False, False, False]])
 def test_linear_yolov7(
-    device,
+    device_module,
     in0_block_w,
     out_subblock,
     out_block,
@@ -567,6 +580,7 @@ def test_linear_yolov7(
     output_dtype,
     compute_config_params,
 ):
+    device = device_module
     torch.manual_seed(0)
     nhw = 6400
     input_channels = 512

--- a/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_accessor_args.py
@@ -8,7 +8,8 @@ import torch
 import ttnn
 
 
-def test_tensor_accessor_args(device):
+def test_tensor_accessor_args(device_module):
+    device = device_module
     shape = [3, 128, 160]
     shard_shape = [3, 128, 32]
     py_tensor = torch.rand(shape).to(torch.bfloat16)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_alignment.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_alignment.py
@@ -6,7 +6,8 @@ import ttnn
 import torch
 
 
-def test_tensor_alignment(device):
+def test_tensor_alignment(device_module):
+    device = device_module
     a = torch.arange(1022).to(torch.bfloat16).reshape(1, 1, 1, 1022)
     b = torch.arange(1024).to(torch.bfloat16).reshape(1, 1, 32, 32)
 

--- a/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
@@ -30,7 +30,8 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype, tt_dtype_to_np
 )
 @pytest.mark.parametrize("shape", [(2, 3, 64, 96)])
 @pytest.mark.parametrize("python_lib", [torch, np])
-def test_tensor_conversion_with_tt_dtype(python_lib, shape, tt_dtype, convert_to_device, device):
+def test_tensor_conversion_with_tt_dtype(python_lib, shape, tt_dtype, convert_to_device, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if python_lib == torch:
@@ -118,7 +119,8 @@ string_to_np_dtype = {
 )
 @pytest.mark.parametrize("shape", [(2, 3, 64, 96)])
 @pytest.mark.parametrize("python_lib", [torch, np])
-def test_tensor_conversion_with_python_dtype(python_lib, shape, python_dtype_str, convert_to_device, device):
+def test_tensor_conversion_with_python_dtype(python_lib, shape, python_dtype_str, convert_to_device, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if python_lib == torch:

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -35,7 +35,8 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
     ],
 )
 @pytest.mark.parametrize("shape", [(2, 3, 64, 96)])
-def test_tensor_creation(shape, tt_dtype, layout, device):
+def test_tensor_creation(shape, tt_dtype, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
@@ -88,7 +89,8 @@ def test_tensor_creation(shape, tt_dtype, layout, device):
     ],
 )
 @pytest.mark.parametrize("shape", [(2, 3, 64, 96)])
-def test_tensor_creation_api_parity(shape, tt_dtype, layout, device):
+def test_tensor_creation_api_parity(shape, tt_dtype, layout, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
@@ -180,7 +182,8 @@ core_ranges = ttnn.num_cores_to_corerangeset(56, grid_size, True)
         "width_sharded",
     ],
 )
-def test_tensor_creation_with_memory_config(shape, memory_config, tt_dtype, layout, tile, device):
+def test_tensor_creation_with_memory_config(shape, memory_config, tt_dtype, layout, tile, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
@@ -288,7 +291,8 @@ def test_tensor_creation_with_memory_config(shape, memory_config, tt_dtype, layo
         ),
     ],
 )
-def test_tensor_creation_with_tensor_spec(tensor_spec, device):
+def test_tensor_creation_with_tensor_spec(tensor_spec, device_module):
+    device = device_module
     torch.manual_seed(0)
     dtype = tt_dtype_to_torch_dtype[tensor_spec.dtype]
     py_tensor = torch.rand(list(tensor_spec.shape), dtype=dtype)
@@ -385,7 +389,8 @@ def test_tensor_creation_with_tensor_spec(tensor_spec, device):
         ),
     ],
 )
-def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
+def test_tensor_creation_from_buffer(dtype, shape, buffer, device_module):
+    device = device_module
     tt_tensor = ttnn.from_buffer(buffer, shape, dtype=dtype, device=device)
     assert tt_tensor.shape == shape
     assert tt_tensor.dtype == dtype
@@ -416,7 +421,8 @@ def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
         (ttnn.DataType.INVALID, [[1, 2, 3], [4, 5, 6]]),
     ],
 )
-def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device):
+def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device_module):
+    device = device_module
     try:
         tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
     except Exception as e:
@@ -439,7 +445,8 @@ def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, devic
         (ttnn.float32, [1, 2, 3, 4, 5, 6, 7, 8], [2, 1, 1, 1, 1, 4]),  # 2 x 1 x 1 x 1 x 4 # 6d!
     ],
 )
-def test_tensor_creation_with_multiple_buffer_sizes(dtype, buffer, device, shape):
+def test_tensor_creation_with_multiple_buffer_sizes(dtype, buffer, device_module, shape):
+    device = device_module
     tt_tensor = ttnn.Tensor(
         buffer,
         shape,
@@ -616,7 +623,8 @@ def flatten_list(nested_list):
     ],
 )
 @pytest.mark.parametrize("shape", [(2, 8), (2, 2, 2, 2)])
-def test_tensor_creation_from_list(shape, tt_dtype, data, layout, atol, device):
+def test_tensor_creation_from_list(shape, tt_dtype, data, layout, atol, device_module):
+    device = device_module
     if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("{} is only valid for ttnn.TILE_LAYOUT!".format(tt_dtype))
 
@@ -701,7 +709,8 @@ def test_tensor_creation_from_list(shape, tt_dtype, data, layout, atol, device):
     ],
     ids=["bfloat8_b", "bfloat4_b"],
 )
-def test_tensor_creation_from_list_block_float(tt_dtype, data, tol, device):
+def test_tensor_creation_from_list_block_float(tt_dtype, data, tol, device_module):
+    device = device_module
     """Test creating block float tensors (bfloat8_b, bfloat4_b) from Python lists"""
 
     # Block float types require TILE_LAYOUT and tile-aligned shapes
@@ -805,7 +814,8 @@ def test_tensor_creation_from_list_block_float(tt_dtype, data, tol, device):
         (ttnn.int32, int),
     ],
 )
-def test_tensor_creation_from_list_with_mem_config(shape, tt_dtype, data_type, memory_config, device):
+def test_tensor_creation_from_list_with_mem_config(shape, tt_dtype, data_type, memory_config, device_module):
+    device = device_module
     """Test creating tensors from Python lists with different memory configs"""
 
     total_elements = int(np.prod(shape))

--- a/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
@@ -60,7 +60,8 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype, assert_with_pc
         ttnn.bfloat4_b,
     ],
 )
-def test_tensor_nd_sharding_loopback(tensor_shape, shard_shape, layout, buffer_type, tt_dtype, device):
+def test_tensor_nd_sharding_loopback(tensor_shape, shard_shape, layout, buffer_type, tt_dtype, device_module):
+    device = device_module
     torch.manual_seed(0)
 
     if tt_dtype in (ttnn.bfloat8_b, ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:

--- a/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
@@ -16,7 +16,10 @@ from models.common.utility_functions import is_grayskull
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED])
 @pytest.mark.parametrize("memory_location", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_tensor_preallocation_and_write_apis(shape, in_dtype, mem_layout, memory_location, tensor_layout, device):
+def test_tensor_preallocation_and_write_apis(
+    shape, in_dtype, mem_layout, memory_location, tensor_layout, device_module
+):
+    device = device_module
     if in_dtype == ttnn.bfloat8_b and tensor_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Row Major Layout not supported for Bfp8")
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_ranks.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_ranks.py
@@ -19,7 +19,8 @@ import torch
         (2, 2, 2, 2, 2, 3, 30, 30),
     ],
 )
-def test_tensor_ranks(shape, device):
+def test_tensor_ranks(shape, device_module):
+    device = device_module
     torch_input_tensor = torch.randint(low=0, high=100, size=shape).to(torch.bfloat16)
 
     tt_tensor = ttnn.Tensor(torch_input_tensor, ttnn.bfloat16)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_serialization.py
@@ -82,7 +82,8 @@ core_ranges = ttnn.num_cores_to_corerangeset(56, [8, 7], True)
         ),
     ],
 )
-def test_sharded_tensor_serialization(tmp_path, device, tensor_spec):
+def test_sharded_tensor_serialization(tmp_path, device_module, tensor_spec):
+    device = device_module
     torch.manual_seed(0)
     dtype = tt_dtype_to_torch_dtype[tensor_spec.dtype]
     py_tensor = torch.rand(list(tensor_spec.shape), dtype=dtype)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
@@ -33,7 +33,8 @@ TEST_SHAPES = [(5, 5), (32, 32), (50, 50), (16, 16, 16), (16, 16, 16, 16), (16, 
 @pytest.mark.parametrize("dtype", ALL_TYPES)
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("is_device", [False, True])
-def test_to_list_all_types(device, is_device, shape, dtype, layout):
+def test_to_list_all_types(device_module, is_device, shape, dtype, layout):
+    device = device_module
     if dtype == ttnn.bfloat4_b or dtype == ttnn.bfloat8_b and layout != ttnn.TILE_LAYOUT:
         pytest.skip("types `bfloat4_b` and `bfloat8_b` can only be used with tile layout")
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
- ttnn pytests are many, and slow for unit tests
- They are EVEN slower (1.5x) when utilizing an ASan build

### What's changed
- change from function scoped device fixture to module scoped device fixture for some tests, so that the device is shared across parameter sets, avoiding costly device setup and tear down per test.

### Checklist
- [x] [All post commit - base_functionality enhanced](https://github.com/tenstorrent/tt-metal/actions/runs/20380024395) CI passes
- [x] [All post commit - tensor enhanced](https://github.com/tenstorrent/tt-metal/actions/runs/20383920680/job/58581149391)
- [x] [All post commit - some eltwise ops enhanced](https://github.com/tenstorrent/tt-metal/actions/runs/20386174926)
- [x] [All post commit - binary_bcast completed](https://github.com/tenstorrent/tt-metal/actions/runs/20396965473)
- [x] [All post commit - test_binary* done](https://github.com/tenstorrent/tt-metal/actions/runs/20397732338)
- [x] [All post commit - bunch more fixed](https://github.com/tenstorrent/tt-metal/actions/runs/20402264349)
- [ ] [All post commit - fused + matmul](https://github.com/tenstorrent/tt-metal/actions/runs/20414147544)
- [x] New/Existing tests provide coverage for changes