### PR TITLE
[skip ci] Fix BH Galaxy in Galaxy Nightly pipelines to be enabled with scheduled cron

### DIFF
--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy WH CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
+          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           # {

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
+          { name: "Galaxy WH CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           # {
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy CCL tests", arch: blackhole, cmd: "pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly", timeout: 40, owner_id: U05ACKAJTHS} # Naif Tarafdar, Camilo Vega
+          { name: "BH Galaxy CCL tests", arch: blackhole, cmd: "pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly", timeout: 40, owner_id: U05ACKAJTHS} # Naif Tarafdar, Camilo Vega
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -94,7 +94,6 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
-
   galaxy-bh-nightly-tests:
     if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
     strategy:

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "in-service"
+      wormhole:
+        required: false
+        type: boolean
+        default: true
       blackhole:
         required: false
         type: boolean
@@ -26,7 +30,7 @@ on:
         default: false
 jobs:
   galaxy-nightly-tests:
-    if: ${{ inputs.blackhole == false || inputs.scheduled == true }}
+    if: ${{ inputs.wormhole == true || inputs.scheduled == true }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -33,3 +33,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       blackhole: ${{ github.event.inputs.blackhole == 'true' || github.event_name == 'schedule' }}
       wormhole: ${{ github.event.inputs.wormhole == 'true' || github.event_name == 'schedule' }}
+

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -31,5 +31,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      blackhole: ${{ github.event.inputs.blackhole || github.event_name == 'schedule' }}
-      wormhole: ${{ github.event.inputs.wormhole || github.event_name == 'schedule' }}
+      blackhole: ${{ github.event.inputs.blackhole == 'true' || github.event_name == 'schedule' }}
+      wormhole: ${{ github.event.inputs.wormhole == 'true' || github.event_name == 'schedule' }}

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -33,4 +33,3 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       blackhole: ${{ github.event.inputs.blackhole == 'true' || github.event_name == 'schedule' }}
       wormhole: ${{ github.event.inputs.wormhole == 'true' || github.event_name == 'schedule' }}
-

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -3,13 +3,14 @@ name: "(Galaxy) nightly tests"
 on:
   workflow_dispatch:
     inputs:
-      arch:
-        required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-        default: wormhole_b0
+      wormhole:
+        required: false
+        type: boolean
+        default: true
+      blackhole:
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: "0 0 * * *" # Runs every day at 12am UTC
 
@@ -30,6 +31,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      blackhole: ${{ github.event.inputs.arch == 'blackhole' }}
-      scheduled: ${{ github.event_name == 'schedule' }}
-
+      blackhole: ${{ github.event.inputs.blackhole || github.event_name == 'schedule' }}
+      wormhole: ${{ github.event.inputs.wormhole || github.event_name == 'schedule' }}

--- a/.github/workflows/galaxy-nightly-tests.yaml
+++ b/.github/workflows/galaxy-nightly-tests.yaml
@@ -32,4 +32,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       blackhole: ${{ github.event.inputs.arch == 'blackhole' }}
       scheduled: ${{ github.event_name == 'schedule' }}
-      schedule:  ${{ github.event_name == 'schedule' }}
+


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Added few syntax corrects to the test.

### Checklist
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/20381778649