### PR TITLE
[skip ci] Remove light_metal from core ttnn unit test group

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -89,7 +89,7 @@ jobs:
             { name: "ttnn fused group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn transformers group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             { name: "ttnn reduce and misc ops group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "core ttnn unit test group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/light_metal tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
+            { name: "core ttnn unit test group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
             # { name: "ttnn fast runtime off", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off', merge_gate: false, fast_runtime_mode_off: true },
           ]]
     steps:


### PR DESCRIPTION
light_metal was deprioritized a long time ago.
Disable tests to save CI time.