### PR TITLE
Fix concurrent access to WatcherSettings in RunTimeOptions

### DIFF
--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -73,16 +73,16 @@ struct TargetSelection {
 };
 
 struct WatcherSettings {
-    bool enabled = false;
-    bool dump_all = false;
-    bool append = false;
-    bool auto_unpause = false;
-    bool noinline = false;
+    std::atomic<bool> enabled = false;
+    std::atomic<bool> dump_all = false;
+    std::atomic<bool> append = false;
+    std::atomic<bool> auto_unpause = false;
+    std::atomic<bool> noinline = false;
     bool phys_coords = false;
     bool text_start = false;
     bool skip_logging = false;
     bool noc_sanitize_linked_transaction = false;
-    int interval_ms = 0;
+    std::atomic<int> interval_ms = 0;
 };
 
 struct InspectorSettings {
@@ -161,7 +161,7 @@ class RunTimeOptions {
 
     TargetSelection feature_targets[RunTimeDebugFeatureCount];
 
-    bool test_mode_enabled = false;
+    std::atomic<bool> test_mode_enabled = false;
 
     bool profiler_enabled = false;
     bool profile_dispatch_cores = false;
@@ -313,20 +313,24 @@ public:
 
     // Info from watcher environment variables, setters included so that user
     // can override with a SW call.
-    bool get_watcher_enabled() const { return watcher_settings.enabled; }
-    void set_watcher_enabled(bool enabled) { watcher_settings.enabled = enabled; }
+    bool get_watcher_enabled() const { return watcher_settings.enabled.load(std::memory_order_relaxed); }
+    void set_watcher_enabled(bool enabled) { watcher_settings.enabled.store(enabled, std::memory_order_relaxed); }
     // Return a hash of which watcher features are enabled
     uint32_t get_watcher_hash() const;
-    int get_watcher_interval() const { return watcher_settings.interval_ms; }
-    void set_watcher_interval(int interval_ms) { watcher_settings.interval_ms = interval_ms; }
-    int get_watcher_dump_all() const { return watcher_settings.dump_all; }
-    void set_watcher_dump_all(bool dump_all) { watcher_settings.dump_all = dump_all; }
-    int get_watcher_append() const { return watcher_settings.append; }
-    void set_watcher_append(bool append) { watcher_settings.append = append; }
-    int get_watcher_auto_unpause() const { return watcher_settings.auto_unpause; }
-    void set_watcher_auto_unpause(bool auto_unpause) { watcher_settings.auto_unpause = auto_unpause; }
-    int get_watcher_noinline() const { return watcher_settings.noinline; }
-    void set_watcher_noinline(bool noinline) { watcher_settings.noinline = noinline; }
+    int get_watcher_interval() const { return watcher_settings.interval_ms.load(std::memory_order_relaxed); }
+    void set_watcher_interval(int interval_ms) {
+        watcher_settings.interval_ms.store(interval_ms, std::memory_order_relaxed);
+    }
+    int get_watcher_dump_all() const { return watcher_settings.dump_all.load(std::memory_order_relaxed); }
+    void set_watcher_dump_all(bool dump_all) { watcher_settings.dump_all.store(dump_all, std::memory_order_relaxed); }
+    int get_watcher_append() const { return watcher_settings.append.load(std::memory_order_relaxed); }
+    void set_watcher_append(bool append) { watcher_settings.append.store(append, std::memory_order_relaxed); }
+    int get_watcher_auto_unpause() const { return watcher_settings.auto_unpause.load(std::memory_order_relaxed); }
+    void set_watcher_auto_unpause(bool auto_unpause) {
+        watcher_settings.auto_unpause.store(auto_unpause, std::memory_order_relaxed);
+    }
+    int get_watcher_noinline() const { return watcher_settings.noinline.load(std::memory_order_relaxed); }
+    void set_watcher_noinline(bool noinline) { watcher_settings.noinline.store(noinline, std::memory_order_relaxed); }
     int get_watcher_phys_coords() const { return watcher_settings.phys_coords; }
     void set_watcher_phys_coords(bool phys_coords) { watcher_settings.phys_coords = phys_coords; }
     bool get_watcher_text_start() const { return watcher_settings.text_start; }
@@ -487,8 +491,8 @@ public:
     // (test mode = false). We need to catch for gtesting, since an unhandled exception will kill
     // the gtest (and can't catch an exception from the server thread in main thread), but by
     // default we should throw so that the user can see the exception as soon as it happens.
-    bool get_test_mode_enabled() const { return test_mode_enabled; }
-    void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
+    bool get_test_mode_enabled() const { return test_mode_enabled.load(std::memory_order_relaxed); }
+    void set_test_mode_enabled(bool enable) { test_mode_enabled.store(enable, std::memory_order_relaxed); }
 
     bool get_profiler_enabled() const { return profiler_enabled; }
     bool get_profiler_do_dispatch_cores() const { return profile_dispatch_cores; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -321,17 +321,17 @@ public:
     void set_watcher_interval(int interval_ms) {
         watcher_settings.interval_ms.store(interval_ms, std::memory_order_relaxed);
     }
-    int get_watcher_dump_all() const { return watcher_settings.dump_all.load(std::memory_order_relaxed); }
+    bool get_watcher_dump_all() const { return watcher_settings.dump_all.load(std::memory_order_relaxed); }
     void set_watcher_dump_all(bool dump_all) { watcher_settings.dump_all.store(dump_all, std::memory_order_relaxed); }
-    int get_watcher_append() const { return watcher_settings.append.load(std::memory_order_relaxed); }
+    bool get_watcher_append() const { return watcher_settings.append.load(std::memory_order_relaxed); }
     void set_watcher_append(bool append) { watcher_settings.append.store(append, std::memory_order_relaxed); }
-    int get_watcher_auto_unpause() const { return watcher_settings.auto_unpause.load(std::memory_order_relaxed); }
+    bool get_watcher_auto_unpause() const { return watcher_settings.auto_unpause.load(std::memory_order_relaxed); }
     void set_watcher_auto_unpause(bool auto_unpause) {
         watcher_settings.auto_unpause.store(auto_unpause, std::memory_order_relaxed);
     }
-    int get_watcher_noinline() const { return watcher_settings.noinline.load(std::memory_order_relaxed); }
+    bool get_watcher_noinline() const { return watcher_settings.noinline.load(std::memory_order_relaxed); }
     void set_watcher_noinline(bool noinline) { watcher_settings.noinline.store(noinline, std::memory_order_relaxed); }
-    int get_watcher_phys_coords() const { return watcher_settings.phys_coords; }
+    bool get_watcher_phys_coords() const { return watcher_settings.phys_coords; }
     void set_watcher_phys_coords(bool phys_coords) { watcher_settings.phys_coords = phys_coords; }
     bool get_watcher_text_start() const { return watcher_settings.text_start; }
     void set_watcher_text_start(bool text_start) { watcher_settings.text_start = text_start; }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34831

### Problem description
TSan reported multiple data races when Watcher test fixture `MeshWatcherFixture` ran. The race occurs when the main thread executes `TearDown()` in `MeshWatcherFixture` to restore `RunTimeOptions::WatcherSettings` flags to default while Watcher background thread is actively polling the same flags in `WatcherServer::Impl::poll_watcher_data()`.

### What's changed

- Changed the flags in `RunTimeOptions::WatcherSettings` to be std::atomic
- Setters/Getters of these flags use `std::memory_order_relaxed` store/load for minimal overhead

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes