### PR TITLE
[skip ci] #0: remove debug code from bmm reader

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -518,7 +518,6 @@ void kernel_main() {
                                 uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                                 for (uint32_t w = 0; w < out_subblock_w_; ++w) {
                                     if (bw < num_blocks_w_dim_) {
-                                        WATCHER_RING_BUFFER_PUSH(s.get_noc_addr(id, /*offset=*/0));
                                         noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
                                     }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
Running matmul with watcher on resulted in an error:
```
/localdev/bbradel/tt-metal/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp:521:81: error: 'id' was not declared in this scope
  521 |                                         WATCHER_RING_BUFFER_PUSH(s.get_noc_addr(id, /*offset=*/0));
      |                                                                                 ^~
```

### What's changed
`id` should probably be `out_tensor_tile_id`. However, since this code is no longer being debugged, this line is unnecessary and it's better to remove this line.