### PR TITLE
Fix silu accuracy

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -33,7 +33,6 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;
@@ -63,6 +62,10 @@ inline void calculate_sigmoid() {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -15,7 +15,7 @@ inline void calculate_silu() {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<true>(x);
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,7 +8,7 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,7 +8,7 @@
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -27,7 +27,6 @@ inline void calculate_silu() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     _init_reciprocal_<false, false>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -15,7 +15,7 @@ inline void calculate_silu() {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        sfpi::vFloat result = x * _sfpu_sigmoid_<true>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -34,7 +34,6 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;
@@ -65,6 +64,10 @@ inline void calculate_sigmoid() {
             sfpi::vFloat val = sfpi::dst_reg[0];
 
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -15,7 +15,7 @@ inline void calculate_silu() {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<true>(x);
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,7 +8,7 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -4,36 +4,32 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_polyval.h"
-#include "sfpi.h"
+#include "ckernel_sfpu_sigmoid.h"
 
 namespace ckernel::sfpu {
 
-inline sfpi::vFloat silu_sigmoid_piecewise_linear_positive(sfpi::vFloat val) {
-    sfpi::vFloat result = 1.0f;
-    v_if(val <= 1.0f) {
-        result = 0.2415f * val + 0.5f;  // linear appx as y = 0.2415f + 0.5
-    }
-    v_elseif(val < 7.7f) {
-        result = POLYVAL5<sfpi::vFloat>(
-            -3.82558889e-04f, 9.22008486e-03f, -8.34694910e-02f, 3.39967832e-01f, 4.66254244e-01f, val);
-    }
-    v_endif;
-    return result;
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_silu() {
-    // SFPU microcode
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = sfpi::abs(val);
-        result = silu_sigmoid_piecewise_linear_positive(result);
-        v_if(val < 0.0f) { result = 1.0f - result; }
-        v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+
+        // silu(x) = x * sigmoid(x)
+        sfpi::vFloat result = x * _sfpu_sigmoid_<true>(x);
+
+        // Round to bfloat16 if not in fp32 accumulation mode
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void silu_init() {
+    _init_reciprocal_<false, false>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,7 +8,7 @@
 
 namespace ckernel::sfpu {
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+template <bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -27,7 +27,6 @@ inline void calculate_silu() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
 inline void silu_init() {
     _init_reciprocal_<false, false>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -443,7 +443,7 @@ ALWI void expm1_tile_init() { MATH((llk_math_eltwise_unary_sfpu_expm1_init<true>
 // Function SILU (same as Swish)
 // use activation Silu[x] = x*Sigmoid[x]
 // Ref: https://pytorch.org/docs/stable/generated/torch.nn.SiLU.html?highlight=silu#torch.nn.SiLU
-ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX>(idst))); }
+ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst))); }
 
 ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>())); }
 

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -439,10 +439,21 @@ ALWI void expm1_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_expm1<tr
  */
 ALWI void expm1_tile_init() { MATH((llk_math_eltwise_unary_sfpu_expm1_init<true>())); }
 
-// silu
-// Function SILU (same as Swish)
-// use activation Silu[x] = x*Sigmoid[x]
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.SiLU.html?highlight=silu#torch.nn.SiLU
+// clang-format off
+/**
+ * Performs SILU (same as Swish) operation on each element of a tile
+ * in DST register at index tile_index. Uses the following implementation:
+ * Silu[x] = x*Sigmoid[x]
+ *
+ * Ref: https://pytorch.org/docs/stable/generated/torch.nn.SiLU.html?highlight=silu#torch.nn.SiLU
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
 ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst))); }
 
 ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>())); }


### PR DESCRIPTION
### Ticket
#34861

### Problem description
Accuracy of silu is causing issue with Qwen3 32B accuracy.


### What's changed

This PR fixes silu, which becomes accurate within 1 ULP of bfloat16 and within 5 ULP on float32.

Define silu(x) as `x * sigmoid(x)`. sigmoid(x) is accurate within 1 ULP for bfloat16 and 4 for float32 -> this makes silo(x) accurate as well.

#### Accuracy

<img width="707" height="378" alt="silu-bfloat16" src="https://github.com/user-attachments/assets/98ff727e-c4ec-456b-b611-8a3f88868b3a" />

<img width="597" height="378" alt="silu-float32" src="https://github.com/user-attachments/assets/2864be56-6872-4846-8060-0a58fa604406" />

Note: There's an outlier with a high ULP error near -87. This is probably a problem with subnormals (to check and possibly fix). Either way, new implementation is more accurate in every way than current one. 

#### Performance

Wormhole_b0:

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
bfloat16 | main | 1.533844 | 1571
bfloat16 | new | 1.92 | 1971
float32 | main | 1.65 | 1689
float32 | new | 3.38 | 3462


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20402083103)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20402081125)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20402077511)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK, failures in main](https://github.com/tenstorrent/tt-metal/actions/runs/20402088516)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) [OK, failures in main](https://github.com/tenstorrent/tt-metal/actions/runs/20402079924)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
- [x] (Single card) Frequent ttnn model tests : [OK, failures in main/unrelated](https://github.com/tenstorrent/tt-metal/actions/runs/20402407001)