### PR TITLE
Restore device perf to green state

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,8 +13,8 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10610.0],
-        [32, "True-act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 14815.0],
+        [16, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-16-device_params0", 10610.0],
+        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 14815.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py
@@ -13,7 +13,7 @@ from models.demos.ttnn_resnet.tests.common.perf_device_resnet50 import run_perf_
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 6140.0],
+        [16, "True-16-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-device_params0", 6140.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -47,6 +47,9 @@ def run_unet_model(batch, groups, device, iterations=1):
         UNET_FULL_MODEL_PCC if is_wormhole_b0(device) else UNET_FULL_MODEL_PCC_BH,
     )
 
+    del output_tensor
+    del ttnn_output_tensor
+
     for _ in range(iterations - 1):
         _, ttnn_input = create_unet_input_tensors(
             batch,

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -193,16 +193,9 @@ struct launch_msg_t {  // must be cacheline aligned
 } __attribute__((packed));
 
 struct subordinate_sync_msg_t {
+#if defined(ARCH_QUASAR)
+    // Quasar: expanded structure for multiple DM cores
     union {
-        // this is for WH/BH
-        volatile uint32_t all;
-        struct {
-            volatile uint8_t dm1;  // ncrisc must come first, see ncrisc-halt.S
-            volatile uint8_t trisc0;
-            volatile uint8_t trisc1;
-            volatile uint8_t trisc2;
-        };
-        // QSR starts here
         struct {
             volatile uint64_t allDMs;
             volatile uint32_t allNeo0;
@@ -211,7 +204,7 @@ struct subordinate_sync_msg_t {
             volatile uint32_t allNeo3;
         };
         struct {
-            volatile uint8_t dm1Q;
+            volatile uint8_t dm1;  // Keep dm1 name for compatibility
             volatile uint8_t dm2;
             volatile uint8_t dm3;
             volatile uint8_t dm4;
@@ -238,7 +231,19 @@ struct subordinate_sync_msg_t {
             uint8_t pad[12];
         };
     } __attribute__((packed));
-} __attribute__((packed));
+#else
+    // WH/BH: original compact structure for single DM core + triscs
+    union {
+        volatile uint32_t all;
+        struct {
+            volatile uint8_t dm1;  // ncrisc must come first, see ncrisc-halt.S
+            volatile uint8_t trisc0;
+            volatile uint8_t trisc1;
+            volatile uint8_t trisc2;
+        };
+    };
+#endif
+};
 
 constexpr int num_waypoint_bytes_per_riscv = 4;
 struct debug_waypoint_msg_t {

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12800
+#define MEM_MAILBOX_SIZE 12768
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -86,7 +86,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12800
+#define MEM_MAILBOX_SIZE 12768
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 8)


### PR DESCRIPTION
Multiple regressions over past week piled up.

1. TTNN Nanobind support (https://github.com/tenstorrent/tt-metal/pull/34447) #4d0c198
Test invocation got messed up in some cases, leading tests to fail
2. Enabling all DM cores through subordinate_sync message (https://github.com/tenstorrent/tt-metal/pull/34336) #e863609
Firmware changes that were design to enable use-cases on Quasar regressed WH and BH
3. chore: update LLK submodule to 276a811 (https://github.com/tenstorrent/tt-metal/pull/34812) e863609
LLK uplift caused regression on multiple models

To address these issues
1. Tests where tweaked to work with nano-bind
2. Restored original layout of subordinate_sync_msg_t on WH/BH kept new one on Quasar
3. Revert the LLK change 

After this device perf is green with exception of SDXL which is failing on WH with PCC errors.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20411490205)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20412510630)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20411487702)