### PR TITLE
Python Multi-Mesh APIs and Programming Example

### DIFF
--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -195,6 +195,7 @@ jobs:
         run: |
           python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
           tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_dual_big_mesh_fabric_2d_sanity.yaml
+          tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--tag-output --allow-run-as-root"  python3 tests/ttnn/distributed/test_multi_mesh.py
       - name: Run Llama3-70b unit tests
         if: ${{ matrix.test-group.model == 'llama3-70b' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
@@ -4,7 +4,7 @@ mesh_descriptors {
   name: "M0"
   arch: WORMHOLE_B0
   device_topology { dims: [ 4, 4 ] }
-  host_topology   { dims: [ 1, 2 ] }
+  host_topology   { dims: [ 1, 1 ] }
   channels {
     count: 4
     policy: RELAXED

--- a/tests/ttnn/distributed/test_multi_mesh.py
+++ b/tests/ttnn/distributed/test_multi_mesh.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Simple TTNN example demonstrating the ability to interface with multiple MeshDevices across multiple processes.
+# We also demonstrate how a user can setup a pipeline across MeshDevices using sockets.
+# Run this on a Tenstorrent Galaxy system as follows:
+# python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py (this generates the rank binding file)
+# tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--tag-output"  python3 tests/ttnn/distributed/test_multi_mesh.py
+
+# The rank binding file initializes a single physical 4x4 mesh per process.
+# The mesh graph descriptor used for this workload is: tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
+
+import torch
+import ttnn
+
+
+def run_multiprocess_workload():
+    torch.manual_seed(0)
+    # Initialize TT-Fabric to route data over Ethernet
+    # Use Fabric 2D mode in this case, to route date between meshes
+    ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_2D)
+    # Each process interfaces with a single 4x4 MeshDevice
+    # Sockets are used to route data between meshes
+    mesh_shape = ttnn.MeshShape(4, 4)
+    device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    # The distributed context gets initialized once a device is opened.
+    # This allows the user to use Multi-Host APIs without having to explicitly initialize the distributed context.
+    if not ttnn.distributed_context_is_initialized():
+        raise ValueError("Distributed context not initialized")
+    if int(ttnn.distributed_context_get_size()) != 2:
+        raise ValueError("This test requires 2 processes to run")
+
+    # Setup the sender and receiver sockets
+    # Each socket endpoint is bound to a single core (0, 0)
+    # The socket connects each physical device in the sender mesh
+    # to a corresponding physical device in the receiver mesh (as specified by the socket connections)
+    sender_logical_coord = ttnn.CoreCoord(0, 0)
+    recv_logical_coord = ttnn.CoreCoord(0, 0)
+    socket_connections = []
+    for coord in ttnn.MeshCoordinateRange(mesh_shape):
+        socket_connections.append(
+            ttnn.SocketConnection(
+                ttnn.MeshCoreCoord(coord, sender_logical_coord), ttnn.MeshCoreCoord(coord, recv_logical_coord)
+            )
+        )
+    # Setup the socket intermediate buffer in L1 and initialize its size to 4KB
+    socket_mem_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, 4096)
+    # Process 0 is the sender and process 1 is the receiver. Reflect this in the socket config
+    sender_rank = 0
+    receiver_rank = 1
+    socket_config = ttnn.SocketConfig(socket_connections, socket_mem_config, sender_rank, receiver_rank)
+
+    # Initialize random input tensor and move it to the device
+    torch_input = torch.randn(1, 1, 1024, 1024, dtype=torch.float32)
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=(2, 3), mesh_shape=mesh_shape),
+    )
+
+    def torch_op_chain(tensor):
+        return torch.exp(torch.nn.functional.relu(tensor))
+
+    if int(ttnn.distributed_context_get_rank()) == 0:
+        # Create send socket, run the first op on the input tensor and forward the result to the receiver
+        send_socket = ttnn.MeshSocket(device, socket_config)
+        ttnn.experimental.send_async(ttnn.relu(ttnn_input), send_socket)
+    else:
+        # Create the recv socket and allocate a tensor on the device to receive the result from the sender
+        recv_socket = ttnn.MeshSocket(device, socket_config)
+        upstream_input = ttnn.allocate_tensor_on_device(ttnn_input.spec, device)
+        ttnn.experimental.recv_async(upstream_input, recv_socket)
+        # Run the second op on the received tensor and convert it to a torch tensor
+        torch_tensor = ttnn.to_torch(
+            ttnn.from_device(ttnn.exp(upstream_input)),
+            mesh_composer=ttnn.ConcatMesh2dToTensor(device, mesh_shape=mesh_shape, dims=(2, 3)),
+        )
+        # Compare the result with the expected result
+        if torch.allclose(torch_tensor, torch_op_chain(torch_input)):
+            print("Test passed: Output tensor matches expected tensor")
+        else:
+            raise ValueError("Test failed: Output tensor does not match expected tensor")
+    # Issue a barrier to ensure all processes have completed the test
+    ttnn.distributed_context_barrier()
+    ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    run_multiprocess_workload()

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -12,6 +12,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
+#include <nanobind/operators.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/shared_ptr.h>
@@ -77,7 +78,35 @@ public:
 };
 
 // NOLINTBEGIN(bugprone-unused-raii)
+// NOLINTBEGIN(misc-redundant-expression)
 void py_module_types(nb::module_& mod) {
+    using namespace tt::tt_metal::distributed::multihost;
+
+    // Bind strong types for Rank and Size
+    nb::class_<Rank>(mod, "Rank", "Rank of a process in the distributed context")
+        .def(nb::init<int>())
+        .def("__int__", [](const Rank& r) { return *r; })
+        .def("__repr__", [](const Rank& r) { return nb::str("Rank({})").format(*r); })
+        .def("__str__", [](const Rank& r) { return nb::str("{}").format(*r); })
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
+        .def(nb::self < nb::self)
+        .def(nb::self <= nb::self)
+        .def(nb::self > nb::self)
+        .def(nb::self >= nb::self);
+
+    nb::class_<Size>(mod, "Size", "Size (number of processes) in the distributed context")
+        .def(nb::init<int>())
+        .def("__int__", [](const Size& s) { return *s; })
+        .def("__repr__", [](const Size& s) { return nb::str("Size({})").format(*s); })
+        .def("__str__", [](const Size& s) { return nb::str("{}").format(*s); })
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
+        .def(nb::self < nb::self)
+        .def(nb::self <= nb::self)
+        .def(nb::self > nb::self)
+        .def(nb::self >= nb::self);
+
     nb::class_<MeshToTensor>(mod, "CppMeshToTensor");
     nb::class_<TensorToMesh>(mod, "CppTensorToMesh");
 
@@ -96,6 +125,7 @@ void py_module_types(nb::module_& mod) {
     nb::class_<DistributedHostBuffer>(mod, "DistributedHostBuffer");
     nb::class_<TensorTopology>(mod, "TensorTopology");
 }
+// NOLINTEND(misc-redundant-expression)
 // NOLINTEND(bugprone-unused-raii)
 
 void py_module(nb::module_& mod) {
@@ -835,6 +865,125 @@ void py_module(nb::module_& mod) {
                 Tensor: The combined tensor.
             )doc");
     mod.def("using_distributed_env", &tt::tt_metal::distributed::UsingDistributedEnvironment);
+
+    // Distributed context bindings (moved from distributed_context.cpp)
+    using namespace tt::tt_metal::distributed::multihost;
+
+    // Initialize the distributed context
+    mod.def(
+        "init_distributed_context",
+        []() {
+            // In Python context, we typically don't have argc/argv in the same way
+            // This is a simplified initialization that works with default MPI settings
+            static char prog_name[] = "python";
+            static char* argv[] = {prog_name, nullptr};
+            DistributedContext::create(1, argv);
+        },
+        R"doc(
+            Initialize the distributed context with default settings.
+
+            This is a convenience function for Python that initializes the distributed
+            context without requiring command-line arguments.
+
+            Example:
+                >>> import ttnn
+                >>> ttnn.init_distributed_context()
+                >>> rank = ttnn.distributed_context_get_rank()
+                >>> size = ttnn.distributed_context_get_size()
+                >>> print(f"Rank {int(rank)} of {int(size)}")
+        )doc");
+
+    // Check if distributed context is initialized
+    mod.def(
+        "is_initialized",
+        &DistributedContext::is_initialized,
+        R"doc(
+            Check if the distributed context has been initialized.
+
+            Returns:
+                bool: True if initialized, False otherwise.
+
+            Example:
+                >>> import ttnn
+                >>> if ttnn.distributed_context_is_initialized():
+                >>>     rank = ttnn.distributed_context_get_rank()
+        )doc");
+
+    // Get the rank of the current process
+    mod.def(
+        "get_rank",
+        []() -> Rank {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
+            }
+            return DistributedContext::get_current_world()->rank();
+        },
+        R"doc(
+            Get the rank of the current process.
+
+            Returns:
+                Rank: The rank of the current process (0-indexed).
+
+            Raises:
+                RuntimeError: If the distributed context has not been initialized.
+
+            Example:
+                >>> import ttnn
+                >>> rank = ttnn.distributed_context_get_rank()
+                >>> print(f"This is rank {rank}")
+                >>> # Convert to int if needed
+                >>> rank_int = int(rank)
+        )doc");
+
+    // Get the total number of processes
+    mod.def(
+        "get_size",
+        []() -> Size {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
+            }
+            return DistributedContext::get_current_world()->size();
+        },
+        R"doc(
+            Get the total number of processes.
+
+            Returns:
+                Size: The total number of processes.
+
+            Raises:
+                RuntimeError: If the distributed context has not been initialized.
+
+            Example:
+                >>> import ttnn
+                >>> size = ttnn.distributed_context_get_size()
+                >>> print(f"Total processes: {size}")
+                >>> # Convert to int if needed
+                >>> size_int = int(size)
+        )doc");
+
+    // Synchronize all processes
+    mod.def(
+        "barrier",
+        []() {
+            if (!DistributedContext::is_initialized()) {
+                throw std::runtime_error("Distributed context not initialized. Call init_distributed_context() first.");
+            }
+            DistributedContext::get_current_world()->barrier();
+        },
+        R"doc(
+            Synchronize all processes.
+
+            This function blocks until all processes have reached this point.
+
+            Raises:
+                RuntimeError: If the distributed context has not been initialized.
+
+            Example:
+                >>> import ttnn
+                >>> # Do some work...
+                >>> ttnn.distributed_context_barrier()
+                >>> # All processes continue from here
+        )doc");
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -120,6 +120,13 @@ from ttnn._ttnn.multi_device import (
     aggregate_tensor,
     distribute_tensor,
     using_distributed_env,
+    Rank,
+    Size,
+    init_distributed_context,
+    is_initialized as distributed_context_is_initialized,
+    get_rank as distributed_context_get_rank,
+    get_size as distributed_context_get_size,
+    barrier as distributed_context_barrier,
 )
 
 from ttnn._ttnn.events import (


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Need `DistributedContext` APIs to be exposed to Python for running multi-process/multi-host inference workloads
- Need a basic programming example of how Multi-Mesh workloads can be run through TTNN

### What's changed
- Add `DistributedContext` nanobind interfaces
   - Currently only exposing the minimal set of APIs that are needed for most workloads (rank, size and barrier)
   - This is primarily done to not pollute the API surface with unused APIs
- Expose `MeshSocket` ctor for multi host workloads
- Add basic TTNN programming example for a Multi-Process + Multi-Mesh workload using sockets
- Minor fix to Galaxy Multi-Mesh MGD

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes