### PR TITLE
Fix bug with --verbosity in tt-triage

### DIFF
--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -366,6 +366,9 @@ def process_arguments(args: ScriptArguments) -> None:
     verbose_level = args["-v"]
     set_verbose_level(verbose_level)
 
+    # Initialize console
+    init_console(args)
+
     # Setting verbosity level
     try:
         verbosity = int(args["--verbosity"])
@@ -373,9 +376,6 @@ def process_arguments(args: ScriptArguments) -> None:
     except:
         utils.WARN("Verbosity level must be an integer. Falling back to default value.")
     utils.VERBOSE(f"Verbosity level: {utils.Verbosity.get().name} ({utils.Verbosity.get().value})")
-
-    # Initialize console
-    init_console(args)
 
 
 def parse_arguments(

--- a/tools/triage/utils.py
+++ b/tools/triage/utils.py
@@ -118,34 +118,49 @@ VERBOSITY_VALUE: Verbosity = Verbosity.INFO
 
 def ERROR(s, **kwargs):
     if Verbosity.supports(Verbosity.ERROR):
-        from triage import console
+        try:
+            from triage import console
 
-        console.print(f"[error]{s}[/]", **kwargs)
+            console.print(f"[error]{s}[/]", **kwargs)
+        except ImportError:
+            print(f"ERROR: {s}", **kwargs)
 
 
 def WARN(s, **kwargs):
     if Verbosity.supports(Verbosity.WARN):
-        from triage import console
+        try:
+            from triage import console
 
-        console.print(f"[warning]{s}[/]", **kwargs)
+            console.print(f"[warning]{s}[/]", **kwargs)
+        except ImportError:
+            print(f"WARNING: {s}", **kwargs)
 
 
 def DEBUG(s, **kwargs):
     if Verbosity.supports(Verbosity.DEBUG):
-        from triage import console
+        try:
+            from triage import console
 
-        console.print(f"[debug]{s}[/]", **kwargs)
+            console.print(f"[debug]{s}[/]", **kwargs)
+        except ImportError:
+            print(f"DEBUG: {s}", **kwargs)
 
 
 def INFO(s, **kwargs):
     if Verbosity.supports(Verbosity.INFO):
-        from triage import console
+        try:
+            from triage import console
 
-        console.print(f"[info]{s}[/]", **kwargs)
+            console.print(f"[info]{s}[/]", **kwargs)
+        except ImportError:
+            print(f"INFO: {s}", **kwargs)
 
 
 def VERBOSE(s, **kwargs):
     if Verbosity.supports(Verbosity.VERBOSE):
-        from triage import console
+        try:
+            from triage import console
 
-        console.print(f"[verbose]{s}[/]", **kwargs)
+            console.print(f"[verbose]{s}[/]", **kwargs)
+        except ImportError:
+            print(f"VERBOSE: {s}", **kwargs)


### PR DESCRIPTION
Using `--verbosity=x` didn't work because `console` was being created after it and it was being used in `utils.VERBOSE()`...

Error output before:
```
> ./tools/tt-triage.py --verbosity=4
--------------------------  -----------------  --------------------------------------------------------------------------------------------------------------
tools/tt-triage.py:18       <module>           main()
tools/triage/triage.py:744  main                 args = parse_arguments(scripts)
tools/triage/triage.py:430  parse_arguments        process_arguments(arguments)
tools/triage/triage.py:375  process_arguments        utils.VERBOSE(f"Verbosity level: {utils.Verbosity.get().name} ({utils.Verbosity.get().value})")
tools/triage/utils.py:149   VERBOSE                    from triage import console
tools/triage/utils.py:149   VERBOSE            ImportError: cannot import name 'console' from 'triage' (/localdev/vjovanovic/tt-metal/tools/triage/triage.py)
--------------------------  -----------------  --------------------------------------------------------------------------------------------------------------
```