### PR TITLE
Add module level device fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -380,6 +380,15 @@ def _device_module_impl(request):
     if marker and marker.args:
         device_params = marker.args[0]
     elif marker and marker.kwargs:
+        # Validate kwargs - only 'device_params' is allowed
+        unexpected_kwargs = set(marker.kwargs.keys()) - {"device_params"}
+        if unexpected_kwargs:
+            raise ValueError(
+                f"@pytest.mark.use_module_device received unexpected keyword argument(s): "
+                f"{unexpected_kwargs}. Only 'device_params' is supported. "
+                f"Usage: @pytest.mark.use_module_device({{'l1_small_size': 16384}}) or "
+                f"@pytest.mark.use_module_device(device_params={{'l1_small_size': 16384}})"
+            )
         device_params = marker.kwargs.get("device_params", {})
     else:
         device_params = {}

--- a/conftest.py
+++ b/conftest.py
@@ -306,7 +306,12 @@ def device_params(request):
 def _device_module_impl(request):
     """
     Internal module-scoped device fixture.
-    Do not use directly - use `device` fixture with @pytest.mark.use_module_device marker.
+
+    Do not request this fixture directly in test function signatures. Instead, use the
+    `device` fixture with @pytest.mark.use_module_device marker. When the marker is
+    present, the `device` fixture automatically delegates to this fixture via
+    request.getfixturevalue(), providing a module-scoped device while keeping test
+    signatures unchanged.
 
     This optimization is intended for test modules where all tests share the same
     device configuration. The device is created once per module and reused across
@@ -328,14 +333,56 @@ def _device_module_impl(request):
     Tests with multiple device configurations via parametrized device_params require
     a fresh device for each parameter set and should continue using the default
     function-scoped `device` fixture.
+
+    STATE SHARING CONSIDERATIONS:
+
+    Since the device is shared across all tests in a module, tests can affect each
+    other through accumulated device state:
+
+    - Program cache: Cached programs from earlier tests may be reused by later tests.
+      If tests require different program configurations (e.g., broadcast vs non-broadcast),
+      this can cause incorrect results. Call device.disable_and_clear_program_cache()
+      at the start of tests that are sensitive to cache state.
+
+    - Memory allocations: Tensors allocated on device persist until explicitly
+      deallocated or garbage collected. For highly parameterized tests, this can
+      exhaust device resources (TLBs, L1 memory). Tests should avoid holding
+      references to device tensors beyond what's needed.
+
+    - Device configuration: Any device configuration changes persist across tests.
+
+    WHEN TO USE MODULE SCOPE:
+
+    Module-scoped devices work best for:
+    - Tests that are stateless or don't depend on program cache state
+    - Tests that properly clean up device state when needed
+    - Test modules with many parameterized test cases (biggest time savings)
+
+    Avoid module scope for:
+    - Tests that assert on program cache entry counts
+    - Tests that require specific device initialization state
+    - Tests that use mesh_device or other multi-device fixtures
+
+    FAILURE HANDLING:
+
+    If a test fails or crashes, subsequent tests in the module will still run with
+    the same device. The device generally remains usable, but may have stale state.
+    For test isolation after failures, prefer function-scoped devices.
     """
     import ttnn
 
     device_id = request.config.getoption("device_id")
 
-    # Get device_params from marker: @pytest.mark.use_module_device({"param": value})
+    # Get device_params from marker - supports both patterns:
+    #   @pytest.mark.use_module_device({"param": value})  # positional
+    #   @pytest.mark.use_module_device(device_params={"param": value})  # keyword
     marker = request.node.get_closest_marker("use_module_device")
-    device_params = marker.args[0] if marker and marker.args else {}
+    if marker and marker.args:
+        device_params = marker.args[0]
+    elif marker and marker.kwargs:
+        device_params = marker.kwargs.get("device_params", {})
+    else:
+        device_params = {}
 
     # When initializing a single device on a TG system, we want to
     # target the first user exposed device, not device 0 (one of the
@@ -360,10 +407,26 @@ def _device_module_impl(request):
 
 @pytest.fixture(scope="function")
 def device(request, device_params):
+    """
+    Primary device fixture - delegates to module-scoped or function-scoped implementation.
+
+    The device_params parameter is required even for the module-scoped path to detect
+    conflicting usage with @pytest.mark.parametrize("device_params", ...).
+    """
     import ttnn
 
     # Check if file/test wants module-scoped device
     if request.node.get_closest_marker("use_module_device"):
+        # device_params will be non-empty if test uses parametrized device_params,
+        # which conflicts with module-scoped device (can't vary device config per test)
+        if device_params:
+            raise ValueError(
+                "Cannot use @pytest.mark.use_module_device with "
+                "@pytest.mark.parametrize('device_params', ...). "
+                "Module-scoped devices are created once per module and cannot "
+                "vary per test. Either remove the marker to use function-scoped "
+                "device, or split tests with different device_params into separate files."
+            )
         yield request.getfixturevalue("_device_module_impl")
         return
 
@@ -984,8 +1047,14 @@ def pytest_runtest_teardown(item, nextitem):
         report = item.stash[phase_report_key]
         test_failed = report.get("call", None) and report["call"].failed
         if test_failed:
-            logger.info(f"In custom teardown, open device ids: {set(item.pci_ids)}")
-            reset_tensix(set(item.pci_ids))
+            # pci_ids may be on the test item (function-scoped device) or on the
+            # parent module node (module-scoped device via use_module_device marker)
+            pci_ids = getattr(item, "pci_ids", None)
+            if pci_ids is None and item.parent is not None:
+                pci_ids = getattr(item.parent, "pci_ids", None)
+            if pci_ids is not None:
+                logger.info(f"In custom teardown, open device ids: {set(pci_ids)}")
+                reset_tensix(set(pci_ids))
 
 
 # Session-scoped watchdog IPC keys

--- a/conftest.py
+++ b/conftest.py
@@ -334,6 +334,7 @@ def _device_module_impl(request):
 
     updated_device_params = get_updated_device_params(device_params)
     device = ttnn.CreateDevice(device_id=device_id, **updated_device_params)
+    request.node.pci_ids = [ttnn.GetPCIeDeviceID(device_id)]
     ttnn.SetDefaultDevice(device)
 
     yield device

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,5 +16,6 @@ markers =
     model_perf_t3000: mark model silicon tests for performance on t3000 bare metal
     model_perf_tg: mark model silicon tests for performance on tg bare metal
     requires_fast_runtime_mode_off: mark tests which require fast runtime mode to be off: validation, logging, tracing
+    use_module_device: use module-scoped device fixture for faster test execution. Optional arg: device_params dict
 filterwarnings =
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,6 @@ markers =
     model_perf_t3000: mark model silicon tests for performance on t3000 bare metal
     model_perf_tg: mark model silicon tests for performance on tg bare metal
     requires_fast_runtime_mode_off: mark tests which require fast runtime mode to be off: validation, logging, tracing
-    use_module_device: use module-scoped device fixture for faster test execution. Optional arg: device_params dict
+    use_module_device(device_params): use module-scoped device fixture for faster test execution. Pass device_params as positional dict or keyword arg.
 filterwarnings =
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -11,6 +11,8 @@ import math
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
+pytestmark = pytest.mark.use_module_device
+
 
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])

--- a/tests/ttnn/unit_tests/base_functionality/test_getitem.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_getitem.py
@@ -10,6 +10,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("batch_sizes", [(), (1,)])
 @pytest.mark.parametrize("height", [32, 64])

--- a/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py
@@ -5,6 +5,8 @@
 from loguru import logger
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_device.py
@@ -8,6 +8,8 @@ import torch
 
 import ttnn
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "shape",

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -9,6 +9,8 @@ import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 def test_from_torch_none():
     assert ttnn.from_torch(None) is None

--- a/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py
@@ -5,6 +5,8 @@
 from loguru import logger
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -17,6 +17,8 @@ from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_f
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.utils_for_testing import assert_allclose, assert_with_ulp
 
+pytestmark = pytest.mark.use_module_device
+
 
 def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY_CONFIG):
     pt = torch.rand(shape, dtype=torch.bfloat16) * (max - min) + min

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast_tcast.py
@@ -11,6 +11,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from models.common.utility_functions import torch_random
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -12,6 +12,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 )
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "ttnn_function",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -8,6 +8,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_equal, assert_with_ulp
 
+pytestmark = pytest.mark.use_module_device
+
 
 def create_full_range_tensor(input_shape, dtype, value_ranges):
     num_elements = torch.prod(torch.tensor(input_shape)).item()

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -11,6 +11,8 @@ from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 binary_fns = {
     "ge",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_scalar.py
@@ -8,6 +8,8 @@ import ttnn
 import random
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "a_shape, b_shape",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint32.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+pytestmark = pytest.mark.use_module_device
+
 
 def create_full_range_tensor(input_shape, dtype, value_ranges):
     num_elements = torch.prod(torch.tensor(input_shape)).item()

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -9,6 +9,8 @@ import random
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -8,6 +8,8 @@ import ttnn
 import pytest
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 def test_sub_fp32(device):
     x_torch = torch.tensor([[1]], dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
@@ -13,6 +13,8 @@ from functools import reduce
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
+pytestmark = pytest.mark.use_module_device
+
 input_bcast_shape_pairs = [
     ((1), (2, 10)),
     ((1, 1, 1, 1), (1, 1, 1, 67000)),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -13,6 +13,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py
@@ -10,6 +10,8 @@ from models.common.utility_functions import torch_random
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "ttnn_function",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_divide.py
@@ -8,6 +8,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 import math
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("val_a, val_b", [(0.5, 0.0), (-0.5, 0.0), (0.0, 0.0)])
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_elt_binary.py
@@ -12,6 +12,8 @@ from math import pi
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
 
+pytestmark = pytest.mark.use_module_device
+
 
 def run_elt_binary_test_range(device, h, w, ttnn_function, low, high, pcc=0.9999):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp_21f.py
@@ -8,6 +8,8 @@ import ttnn
 import numpy as np
 from tests.ttnn.utils_for_testing import assert_with_ulp, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 def test_exp_arange_masking(device):
     # Exp Working range - Overflow from 88.5(inf), Underflow till -87(<0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
@@ -10,6 +10,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_equal
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_gcd.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal, compare_pcc
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py
@@ -9,6 +9,8 @@ import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -13,6 +13,8 @@ from models.common.utility_functions import torch_random
 
 from loguru import logger
 
+pytestmark = pytest.mark.use_module_device
+
 
 def run_math_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
@@ -10,6 +10,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 # fmt: off
 @pytest.mark.parametrize("scalar", [3.0])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -10,6 +10,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 def run_relational_test(device, h, w, ttnn_function, pcc=0.9999):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder.py
@@ -9,6 +9,8 @@ from models.common.utility_functions import torch_random
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_round.py
@@ -10,6 +10,8 @@ from functools import partial
 from models.common.utility_functions import torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "shape",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_silu_row_major.py
@@ -13,6 +13,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
 
+pytestmark = pytest.mark.use_module_device
+
 TILE_WIDTH = 32
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -7,6 +7,8 @@ import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype, atol", [(torch.bfloat16, ttnn.bfloat16, 0.008), (torch.float32, ttnn.float32, 0.003)]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_activation.py
@@ -7,6 +7,8 @@ import pytest
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -8,6 +8,8 @@ import ttnn
 import pytest
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "ttnn_function",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_int32.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -8,6 +8,8 @@ import ttnn
 from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -13,6 +13,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal, assert_with_ulp
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+pytestmark = pytest.mark.use_module_device
+
 
 def _run_unary_uint16_test(torch_input_tensor, ttnn_fn, device, memory_config=None):
     """Helper function to run uint16 unary operation tests with consistent setup"""

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -12,6 +12,8 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 from itertools import product
 from models.common.utility_functions import comp_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -11,6 +11,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_allclose, assert_relative_frobenius
 from dataclasses import dataclass
 
+pytestmark = pytest.mark.use_module_device
+
 
 @dataclass
 class AllCloseThresholds:

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -15,6 +15,8 @@ from tests.ttnn.unit_tests.operations.fused.sharded_test_utils import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt", single_stage_param_sets())
 @pytest.mark.parametrize("use_welford", [True, False])

--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -15,8 +15,6 @@ from tests.ttnn.unit_tests.operations.fused.sharded_test_utils import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-pytestmark = pytest.mark.use_module_device
-
 
 @pytest.mark.parametrize("h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt", single_stage_param_sets())
 @pytest.mark.parametrize("use_welford", [True, False])

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm.py
@@ -10,6 +10,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("h", [32, 384])

--- a/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_rms_norm_sharded.py
@@ -16,6 +16,8 @@ from tests.ttnn.unit_tests.operations.fused.sharded_test_utils import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("h, w, num_cores_h, num_cores_w, block_ht, block_wt, subblock_wt", single_stage_param_sets())
 @pytest.mark.parametrize("two_stage", [False])

--- a/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
@@ -8,6 +8,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
 @pytest.mark.parametrize("matrix_size", [4, 8, 16, 32, 64, 128, 256, 512, 1024])

--- a/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_experimental.py
@@ -15,6 +15,8 @@ from models.common.utility_functions import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -11,6 +11,8 @@ from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.common.utility_functions import torch_random, is_wormhole_b0
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("batch_sizes", [(1,)])
 @pytest.mark.parametrize("m_size", [384])

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
+pytestmark = pytest.mark.use_module_device
+
 import torch
 import ttnn
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_h_interleaved.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 from functools import partial
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_on_batch.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
+pytestmark = pytest.mark.use_module_device
+
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 
 import ttnn

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
+pytestmark = pytest.mark.use_module_device
+
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc

--- a/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_conversion.py
@@ -13,6 +13,8 @@ import numpy as np
 import ttnn
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype, tt_dtype_to_np_dtype
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("convert_to_device", [True, False])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -13,6 +13,8 @@ import numpy as np
 import ttnn
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize(
     "layout",

--- a/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.use_module_device
+
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype, assert_with_pcc

--- a/tests/ttnn/unit_tests/tensor/test_tensor_serialization.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_serialization.py
@@ -13,6 +13,8 @@ import numpy as np
 import ttnn
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("shape", [(2, 3, 64, 96)])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_to_list.py
@@ -8,6 +8,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 
+pytestmark = pytest.mark.use_module_device
+
 
 def get_types_from_binding_framwork():
     if hasattr(ttnn.DataType, "__entries"):


### PR DESCRIPTION
### Ticket
NA

### Problem description
ttnn pytests construct and destroy a device for every parameter set. I suspect this is usually unnecessary overhead.

### What's changed
- Add new pytest scheme to selectively avoid creating and closing device per test.
- Save 28 minutes of CI time per run
- Deploy it for:

| File | Tests |
|------|-------|
| `base_functionality/test_copy.py` | 28 |
| `base_functionality/test_getitem.py` | 56 |
| `base_functionality/test_tilize_untilize_2D.py` | 320 |
| `base_functionality/test_to_and_from_device.py` | 21 |
| `base_functionality/test_to_and_from_torch.py` | 107 |
| `base_functionality/test_untilize_bfloat8_b.py` | 352 |
| `operations/eltwise/test_activation.py` | 114 |
| `operations/eltwise/test_binary_bcast.py` | 475 |
| `operations/eltwise/test_binary_bcast_tcast.py` | 25 |
| `operations/eltwise/test_binary_fp32.py` | 49 |
| `operations/eltwise/test_binary_int32.py` | 816 |
| `operations/eltwise/test_binary_maximum.py` | 67 |
| `operations/eltwise/test_binary_minimum.py` | 72 |
| `operations/eltwise/test_binary_ng_typecast.py` | 1510 |
| `operations/eltwise/test_binary_scalar.py` | 21 |
| `operations/eltwise/test_binary_uint16.py` | 296 |
| `operations/eltwise/test_binary_uint32.py` | 79 |
| `operations/eltwise/test_binaryng_ND.py` | 580 |
| `operations/eltwise/test_binaryng_fp32.py` | 52 |
| `operations/eltwise/test_broadcast_to.py` | 112 |
| `operations/eltwise/test_composite.py` | 179 |
| `operations/eltwise/test_div_ops.py` | 44 |
| `operations/eltwise/test_divide.py` | 24 |
| `operations/eltwise/test_elt_binary.py` | 11 |
| `operations/eltwise/test_exp_21f.py` | 18 |
| `operations/eltwise/test_fill.py` | 20 |
| `operations/eltwise/test_gcd.py` | 31 |
| `operations/eltwise/test_hardtanh.py` | 51 |
| `operations/eltwise/test_math.py` | 30 |
| `operations/eltwise/test_mul.py` | 16 |
| `operations/eltwise/test_pow.py` | 550 |
| `operations/eltwise/test_relational.py` | 312 |
| `operations/eltwise/test_remainder.py` | 56 |
| `operations/eltwise/test_round.py` | 24 |
| `operations/eltwise/test_silu_row_major.py` | 14 |
| `operations/eltwise/test_tanh_accuracy.py` | 92 |
| `operations/eltwise/test_unary.py` | 785 |
| `operations/eltwise/test_unary_activation.py` | 14 |
| `operations/eltwise/test_unary_fp32.py` | 18 |
| `operations/eltwise/test_unary_int32.py` | 30 |
| `operations/eltwise/test_unary_maximum.py` | 82 |
| `operations/eltwise/test_unary_minimum.py` | 76 |
| `operations/eltwise/test_unary_ops_ttnn.py` | 374 |
| `operations/eltwise/test_unary_uint16.py` | 18 |
| `operations/fused/test_batch_norm.py` | 1529 |
| `operations/fused/test_layer_norm.py` | 73 |
| `operations/fused/test_rms_norm.py` | 11 |
| `operations/fused/test_rms_norm_sharded.py` | 74 |
| `operations/matmul/test_addmm.py` | 333 |
| `operations/matmul/test_experimental.py` | 36 |
| `operations/matmul/test_linear.py` | 135 |
| `operations/reduce/test_argmax.py` | 36 |
| `operations/reduce/test_max.py` | 195 |
| `operations/reduce/test_reduction_h_interleaved.py` | 18 |
| `operations/reduce/test_reduction_mean.py` | 170 |
| `operations/reduce/test_reduction_min.py` | 288 |
| `operations/reduce/test_reduction_on_batch.py` | 64 |
| `operations/reduce/test_row_major_reduce.py` | 60 |
| `operations/reduce/test_sum.py` | 383 |
| `operations/reduce/test_topk.py` | 106 |
| `tensor/test_tensor_conversion.py` | 60 |
| `tensor/test_tensor_creation.py` | 231 |
| `tensor/test_tensor_nd_sharding.py` | 480 |
| `tensor/test_tensor_serialization.py` | 15 |
| `tensor/test_tensor_to_list.py` | 192 |

**Total: ~11,700 tests**

### Impact
- Save 28 minutes of CI time per run

| Test Group | New Time | Old Time | Saved |
|------------|----------|----------|-------|
| eltwise group 1 | 16:19 | 17:49 | 1:30 |
| eltwise group 2 | 4:54 | 10:18 | 5:24 |
| eltwise group 3 | 14:29 | 18:28 | 3:59 |
| eltwise group 4 | 13:17 | 16:33 | 3:16 |
| eltwise group 5 | 20:25 | 21:35 | 1:10 |
| fused | 21:54 | 25:58 | 4:04 |
| matmul | 18:55 | 20:17 | 1:22 |
| reduce | 16:16 | 19:17 | 3:01 |
| core | 16:55 | 20:50 | 3:55 |
| **Total** | **143:24** | **171:05** | **27:41** |

### Disclaimer
I am not a `pytest` expert, but I think this is the slickest way we can have both a function scoped and module scoped device, with minimal code changes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20425342087) CI passes
- [x] [APC with few more](https://github.com/tenstorrent/tt-metal/actions/runs/20465194292)
- [x] [APC with lot more](https://github.com/tenstorrent/tt-metal/actions/runs/20471999967)
- [x] [APC final sanity](https://github.com/tenstorrent/tt-metal/actions/runs/20490636056)
- [x] New/Existing tests provide coverage for changes