### PR TITLE
#0: Scatter BF16 dataflow kernel fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -4,7 +4,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "../scatter_bf16_reduction_common.hpp"
-#include "dprint.h"
 
 #include <array>
 
@@ -179,7 +178,6 @@ void kernel_main() {
 
             if (in_bounds<N>(coord, index_dims)) {
                 const uint32_t index_stick_id = to_id<N>(coord, index_strides);
-                // DPRINT << "INSIDE " << index_stick_id << ENDL();
                 // second phase: load index and source data chunk-by-chunk and scatter
                 for (uint32_t index_offset = 0, source_offset = 0; index_offset < ctas.index_stick_size;
                      index_offset += index_chunk_size, source_offset += source_chunk_size) {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 #include "../scatter_bf16_reduction_common.hpp"
 #include "dprint.h"
 

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -4,7 +4,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "../scatter_common.hpp"
-#include "api/debug/dprint.h"
 
 #include <array>
 
@@ -149,7 +148,6 @@ void kernel_main() {
 
             if (in_bounds<N>(coord, index_dims)) {
                 const uint32_t index_stick_id = to_id<N>(coord, index_strides);
-                // DPRINT << "INSIDE " << index_stick_id << ENDL();
                 // second phase: load index and source data chunk-by-chunk and scatter
                 for (uint32_t index_offset = 0, source_offset = 0; index_offset < ctas.index_stick_size;
                      index_offset += index_chunk_size, source_offset += source_chunk_size) {

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dataflow_api.h"
+#include "api/dataflow/dataflow_api.h"
 
 #include "../scatter_bf16_reduction_common.hpp"
 


### PR DESCRIPTION
### Ticket

None: Based on run https://github.com/tenstorrent/tt-metal/actions/runs/20423348095/job/58679326818

### Problem description

Recently added dataflow kernels for scatter BF16 variant used old dataflow API include path causing test crash.

### What's changed
- Updated includes to match new dataflow API path.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)    https://github.com/tenstorrent/tt-metal/actions/runs/20426924970
- [ ] [L2 Nightly](a)  https://github.com/tenstorrent/tt-metal/actions/runs/20427313773 failing on `tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py` but it's unrelated to this