### PR TITLE
Add tests for triage script arguments

### DIFF
--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -180,6 +180,72 @@ class TestTriage:
         )
         assert len(result.stderr) == 0
 
+    def test_triage_verbosity(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "--verbosity=4", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
+    def test_triage_initialize_with_noc1(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "--initialize-with-noc1", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
+    def test_triage_skip_version_check(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "--skip-version-check", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
+    def test_triage_print_script_times(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "--print-script-times", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
+    def test_triage_verbose(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "-vvv", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
+    def test_triage_disable_colors(self):
+        global triage_script
+
+        result = subprocess.run(
+            [triage_script, "--disable-colors", "--run=test_output"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert len(result.stderr) == 0
+
     # Tests below test individual triage scripts
 
     def test_check_arc(self):

--- a/tools/triage/test_output.py
+++ b/tools/triage/test_output.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    test_output
+
+Description:
+    This script does nothing. It is used to test the triage output testing framework.
+"""
+
+from triage import ScriptConfig, run_script
+from ttexalens.context import Context
+
+script_config = ScriptConfig(
+    disabled=True,
+)
+
+
+def run(args, context: Context):
+    pass
+
+
+if __name__ == "__main__":
+    run_script()


### PR DESCRIPTION
We had a problem with `console` not being initialized before processing `--verbosity` argument.
This PR adds simple verification tests that all arguments can be parsed correctly.