### PR TITLE
ci: run perf tests when performing llk uplift

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -363,7 +363,7 @@ jobs:
 
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
-          # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
+          # Special handling for tt-metal-l2-nightly.yaml to pass C++ and unit test configuration flags
           if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
             gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" -f run_cpp_tests=true \
             -f run_metal_iommu_tests=true \

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -227,8 +227,8 @@ jobs:
           </details>
 
           ### 🏗️ Architecture Impact
-          $(if [ "$SHOULD_RUN_WH" = "true" ]; then echo "- ⚠️ **Wormhole** changes detected - will trigger all-post-commit and tt-metal-l2-nightly tests"; fi)
-          $(if [ "$SHOULD_RUN_BH" = "true" ]; then echo "- ⚠️ **Blackhole** changes detected - will trigger blackhole-post-commit and tt-metal-l2-nightly tests"; fi)
+          $(if [ "$SHOULD_RUN_WH" = "true" ]; then echo "- ⚠️ **Wormhole** changes detected - will trigger all-post-commit, tt-metal-l2-nightly, and perf-device-models tests"; fi)
+          $(if [ "$SHOULD_RUN_BH" = "true" ]; then echo "- ⚠️ **Blackhole** changes detected - will trigger blackhole-post-commit, tt-metal-l2-nightly, and perf-device-models tests"; fi)
           $(if [ "$SHOULD_RUN_WH" = "false" ] && [ "$SHOULD_RUN_BH" = "false" ]; then echo "- ℹ️ No architecture-specific changes detected"; fi)
 
           <!-- WORKFLOW_DECISIONS:should-run-wormhole=$SHOULD_RUN_WH,should-run-blackhole=$SHOULD_RUN_BH -->
@@ -282,6 +282,9 @@ jobs:
             should-run: ${{ needs.update-submodule.outputs.should-run-blackhole }}
           - workflow: "tt-metal-l2-nightly.yaml"
             name: "TT-Metal L2 Nightly APC"
+            should-run: ${{ (needs.update-submodule.outputs.should-run-wormhole == 'true' || needs.update-submodule.outputs.should-run-blackhole == 'true') && 'true' || 'false' }}
+          - workflow: "perf-device-models.yaml"
+            name: "Device Perf Regressions"
             should-run: ${{ (needs.update-submodule.outputs.should-run-wormhole == 'true' || needs.update-submodule.outputs.should-run-blackhole == 'true') && 'true' || 'false' }}
     steps:
       - name: Checkout
@@ -362,7 +365,14 @@ jobs:
           echo "Triggering $WORKFLOW..."
           # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
           if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
-            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" -f run_APC_cpp_tests=true
+            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" -f run_cpp_tests=true \
+            -f run_metal_iommu_tests=true \
+            -f run_sd_unit_tests=true \
+            -f run_fd_unit_tests=true \
+            -f run_profiler_regression=true \
+            -f run_tt_train_cpp_unit_tests=true \
+            -f run_models_unit_tests=true \
+            -f run_tt_cnn_unit_tests=true
           else
             gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
           fi
@@ -500,6 +510,13 @@ jobs:
               RESULTS+="- $(check_workflow "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC")"$'\n'
               ALL_PASSED=false
             fi
+
+            if check_workflow "perf-device-models.yaml" "Device Perf Regressions"; then
+              RESULTS+="- $(check_workflow "perf-device-models.yaml" "Device Perf Regressions")"$'\n'
+            else
+              RESULTS+="- $(check_workflow "perf-device-models.yaml" "Device Perf Regressions")"$'\n'
+              ALL_PASSED=false
+            fi
           fi
 
           # Comment with results
@@ -596,6 +613,18 @@ jobs:
             if [ "$L2_RUNS" != "empty" ]; then
               L2_URL=$(echo "$L2_RUNS" | jq -r '.url // ""')
               TEST_STATUS+="- ✅ **TT-Metal L2 Nightly APC** passed: [View run]($L2_URL)"$'\n'
+            fi
+
+            # Get Device Perf Regressions workflow results (filter by PR creation time if not recheck)
+            if [ "${{ inputs.recheck_tests }}" = "true" ]; then
+              PERF_RUNS=$(gh run list --workflow "perf-device-models.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status --jq 'map(select(.status == "completed")) | .[0] // empty' --repo "${{ github.repository }}")
+            else
+              PERF_RUNS=$(gh run list --workflow "perf-device-models.yaml" --branch "${{ env.BRANCH_NAME }}" --limit 5 --json conclusion,url,status,createdAt --jq "map(select(.status == \"completed\" and .createdAt >= \"$PR_CREATED_AT\")) | .[0] // empty" --repo "${{ github.repository }}")
+            fi
+
+            if [ "$PERF_RUNS" != "empty" ]; then
+              PERF_URL=$(echo "$PERF_RUNS" | jq -r '.url // ""')
+              TEST_STATUS+="- ✅ **Device Perf Regressions** passed: [View run]($PERF_URL)"$'\n'
             fi
           fi
 

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -53,6 +53,9 @@ on:
       tt-metal-l2-nightly-result:
         description: 'Result of All post-commit C++ tests (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.tt-metal-l2-nightly-result }}
+      perf-device-models-result:
+        description: 'Result of Device perf regressions (status:url format)'
+        value: ${{ jobs.setup-and-test.outputs.perf-device-models-result }}
 
 concurrency:
   group: llk-integration-${{ inputs.mirrored_branch }}
@@ -86,9 +89,11 @@ jobs:
       all-post-commit-run-id: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
       blackhole-run-id: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
       tt-metal-l2-nightly-run-id: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
+      perf-device-models-run-id: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
       all-post-commit-result: ${{ steps.monitor-workflows.outputs.all-post-commit-result }}
       blackhole-result: ${{ steps.monitor-workflows.outputs.blackhole-result }}
       tt-metal-l2-nightly-result: ${{ steps.monitor-workflows.outputs.tt-metal-l2-nightly-result }}
+      perf-device-models-result: ${{ steps.monitor-workflows.outputs.perf-device-models-result }}
     steps:
       - name: Setup
         uses: actions/checkout@v4
@@ -179,6 +184,7 @@ jobs:
           workflows["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
           workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
           workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
+          workflows["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
 
           declare -A run_ids
 
@@ -189,7 +195,14 @@ jobs:
 
             # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
             if [ "$workflow_file" = "tt-metal-l2-nightly.yaml" ]; then
-              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" -f run_APC_cpp_tests=true
+              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" -f run_cpp_tests=true \
+              -f run_metal_iommu_tests=true \
+              -f run_sd_unit_tests=true \
+              -f run_fd_unit_tests=true \
+              -f run_profiler_regression=true \
+              -f run_tt_train_cpp_unit_tests=true \
+              -f run_models_unit_tests=true \
+              -f run_tt_cnn_unit_tests=true
             else
               gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
             fi
@@ -235,6 +248,14 @@ jobs:
                     echo "✅ All post-commit C++ tests run: $run_url"
                   fi
                   ;;
+                "perf-device-models.yaml")
+                  run_data=$(trigger_and_get_id "$workflow" "Device Perf Regressions")
+                  if [ -n "$run_data" ]; then
+                    run_ids["perf-device-models"]=$(echo "$run_data" | cut -d'|' -f1)
+                    run_url=$(echo "$run_data" | cut -d'|' -f2)
+                    echo "✅ Device perf regressions run: $run_url"
+                  fi
+                  ;;
               esac
             fi
           done
@@ -243,6 +264,7 @@ jobs:
           echo "all-post-commit-run-id=${run_ids[all-post-commit]}" >> $GITHUB_OUTPUT
           echo "blackhole-run-id=${run_ids[blackhole]}" >> $GITHUB_OUTPUT
           echo "tt-metal-l2-nightly-run-id=${run_ids[tt-metal-l2-nightly]}" >> $GITHUB_OUTPUT
+          echo "perf-device-models-run-id=${run_ids[perf-device-models]}" >> $GITHUB_OUTPUT
       - name: Monitor triggered workflows
         id: monitor-workflows
         if: |
@@ -256,6 +278,7 @@ jobs:
           ALL_POST_COMMIT_RUN_ID: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
           BLACKHOLE_RUN_ID: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
           TT_METAL_L2_NIGHTLY_RUN_ID: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
+          PERF_DEVICE_MODELS_RUN_ID: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
         run: |
           # Helper function for workflow monitoring
           monitor_workflow() {
@@ -325,6 +348,7 @@ jobs:
           workflow_configs["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}:$ALL_POST_COMMIT_RUN_ID:all-post-commit-result"
           workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
           workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
+          workflow_configs["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$PERF_DEVICE_MODELS_RUN_ID:perf-device-models-result"
           exit_code=0
           for workflow_file in "${!workflow_configs[@]}"; do
             IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"
@@ -344,7 +368,7 @@ jobs:
         run: |
           echo "🔄 Parent workflow cancelled - cleaning up spawned workflows..."
           # Workflows spawned by this job
-          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml")
+          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml" "perf-device-models.yaml")
           # Consider both queued and in_progress runs
           STATUSES=("queued" "in_progress")
           for workflow in "${SPAWNED_WORKFLOWS[@]}"; do
@@ -418,6 +442,7 @@ jobs:
             test_configs["All Post-Commit Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.all-post-commit-result }}"
             test_configs["Blackhole Post-Commit Tests"]="${{ inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.blackhole-result }}"
             test_configs["TT-Metal L2 Nightly APC Tests"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
+            test_configs["Device Perf Regressions"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.perf-device-models-result }}"
 
             # Function to display test result
             display_test_result() {

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -193,7 +193,7 @@ jobs:
             local workflow_file="$1"
             local display_name="$2"
 
-            # Special handling for tt-metal-l2-nightly.yaml to pass run_APC_cpp_tests parameter
+            # Special handling for tt-metal-l2-nightly.yaml to pass C++ and other test configuration flags
             if [ "$workflow_file" = "tt-metal-l2-nightly.yaml" ]; then
               gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" -f run_cpp_tests=true \
               -f run_metal_iommu_tests=true \


### PR DESCRIPTION
### Ticket
None

### Problem description
We recently had 2 escapes from llk level when changes were functionally correct, and yet they introduced perf regressions.
Adding perf regression testing to the uplift process should prevent that.

### What's changed
- With this change, LLK uplift will test LLK changes against single device perf workflow, too.
- Additionally, after https://github.com/tenstorrent/tt-metal/pull/34805 got merged, our workflow stopped working for L2 Nightly tests. This is also addressed in this PR.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes