### PR TITLE
#34667: Add CI check to ensure new ttnn operations are documented

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -56,7 +56,7 @@ on:
         type: boolean
         default: false
       additional_test_categories:
-        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,bos,eltwise,matmul,experimental,docs_examples,misc,moreh,fused,data_movement,transformers)'
+        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,bos,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,data_movement,transformers)'
         required: false
         type: string
         default: ''
@@ -113,6 +113,24 @@ jobs:
       run_data_movement_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',data_movement,') }}
       run_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',fused,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
+  ttnn-ops-docs-check:
+    if: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',ops_docs_check,') }}
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-ops-docs-check.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N150 }
+        ]
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      timeout: ${{ (github.event_name == 'schedule' && 150) || fromJSON(inputs.timeout) }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   didt-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_didt_tests }}
     needs: build-artifact

--- a/.github/workflows/ttnn-ops-docs-check.yaml
+++ b/.github/workflows/ttnn-ops-docs-check.yaml
@@ -93,7 +93,7 @@ jobs:
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
-          prefix: "test_reports_"
+          prefix: "ttnn_ops_docs_check_"
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         # Only notify during failed scheduled runs
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/ttnn-ops-docs-check.yaml
+++ b/.github/workflows/ttnn-ops-docs-check.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'P100' && 'tt-ubuntu-2204-p100a-viommu-stable') || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label))
+        ((format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label))
       }}
     steps:
       - name: 🧬 Checkout Repository

--- a/.github/workflows/ttnn-ops-docs-check.yaml
+++ b/.github/workflows/ttnn-ops-docs-check.yaml
@@ -1,0 +1,104 @@
+name: "TTNN registered ops documentation check"
+
+# This workflow checks that all registered TTNN operations are documented in the API reference.
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 30
+
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - wormhole_b0
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 30
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+
+jobs:
+  ttnn-ops-docs-check:
+    name: TTNN Ops Docs Check on ${{ inputs.runner-label }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P100' && 'tt-ubuntu-2204-p100a-viommu-stable') || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label))
+      }}
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ttnn nightly check OPs docs
+        timeout-minutes: ${{ inputs.timeout }}
+        run: python3 scripts/detect_undocumented_ttnn_ops.py
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: U08DCK9MA1E # Miłosz Gajewski
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/ttnn-ops-docs-check.yaml
+++ b/.github/workflows/ttnn-ops-docs-check.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     runs-on: >-
       ${{
-        ((format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label))
+        (format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label))
       }}
     steps:
       - name: 🧬 Checkout Repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,12 +76,6 @@ repos:
       name: Convert .ipynb to .py for ttnn basic examples
       entry: python3 scripts/convert_notebooks_to_python.py
       language: system
-# - repo: local
-#   hooks:
-#     - id: detect-undocumented-ttnn-ops
-#       name: Detect ttnn registered ops missing documentation in api.rst
-#       entry: python3 scripts/detect_undocumented_ttnn_ops.py
-#       language: system
 - repo: local
   hooks:
     - id: detect-legacy-device-op

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,12 @@ repos:
       name: Convert .ipynb to .py for ttnn basic examples
       entry: python3 scripts/convert_notebooks_to_python.py
       language: system
+# - repo: local
+#   hooks:
+#     - id: detect-undocumented-ttnn-ops
+#       name: Detect ttnn registered ops missing documentation in api.rst
+#       entry: python3 scripts/detect_undocumented_ttnn_ops.py
+#       language: system
 - repo: local
   hooks:
     - id: detect-legacy-device-op

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -17,8 +17,8 @@ import ttnn
 # Constants
 # Skipped operations should not be included in the documentation check
 SKIPPED_OPS = [
-    "ttnn.allocate_tensor_on_device",  # Missing docs for OP causing docs build crash, need to create documentation and add do docs page, GH issue: #34681
-    "ttnn.allocate_tensor_on_host",  # Missing docs for OP causing docs build crash, need to create documentation and add do docs page, GH issue: #34681
+    "ttnn.allocate_tensor_on_device",  # Missing docs for OP causing docs build crash, need to create documentation and add to docs page, GH issue: #34681
+    "ttnn.allocate_tensor_on_host",  # Missing docs for OP causing docs build crash, need to create documentation and add to docs page, GH issue: #34681
     "ttnn.composite_example",  # Example operation.
     "ttnn.composite_example_multiple_return",  # Example operation.
     "ttnn.fused_rms_1_1_32_8192",  # Internal operation only.
@@ -99,7 +99,7 @@ def get_registered_operations(include_experimental=False) -> set:
     return registered_ops
 
 
-def extract_ops_from_docs_rst_file(api_rst_path: str) -> set:
+def extract_ops_from_docs_rst_file(api_rst_path: str | Path) -> set:
     """
     Extract all ttnn operations from docs file by checking each line
 

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script compares the list of registered ttnn operations from ttnn.query_registered_operations(include_experimental=False)
+with the documented operations in docs/source/ttnn/ttnn/api.rst. It identifies any operations that are registered
+but missing from the documentation file.
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+import ttnn
+
+# Constants
+# Skipped operations should not be included in the documentation check
+SKIPPED_OPS = [
+    "ttnn.allocate_tensor_on_device",  # Missing docs for OP causing docs build crash, need to create documentation and add do docs page, GH issue: #34681
+    "ttnn.allocate_tensor_on_host",  # Missing docs for OP causing docs build crash, need to create documentation and add do docs page, GH issue: #34681
+    "ttnn.composite_example",  # Example operation.
+    "ttnn.composite_example_multiple_return",  # Example operation.
+    "ttnn.fused_rms_1_1_32_8192",  # Internal operation only.
+    "ttnn.matmul_batched_weights",  # Internal operation only.
+    "ttnn.moreh_abs_pow",  # Moreh operation.
+    "ttnn.moreh_adam",  # Moreh operation.
+    "ttnn.moreh_adamw",  # Moreh operation.
+    "ttnn.moreh_arange",  # Moreh operation.
+    "ttnn.moreh_bmm",  # Moreh operation.
+    "ttnn.moreh_bmm_backward",  # Moreh operation.
+    "ttnn.moreh_clip_grad_norm",  # Moreh operation.
+    "ttnn.moreh_cumsum",  # Moreh operation.
+    "ttnn.moreh_cumsum_backward",  # Moreh operation.
+    "ttnn.moreh_dot",  # Moreh operation.
+    "ttnn.moreh_dot_backward",  # Moreh operation.
+    "ttnn.moreh_fold",  # Moreh operation.
+    "ttnn.moreh_full",  # Moreh operation.
+    "ttnn.moreh_full_like",  # Moreh operation.
+    "ttnn.moreh_getitem",  # Moreh operation.
+    "ttnn.moreh_group_norm",  # Moreh operation.
+    "ttnn.moreh_group_norm_backward",  # Moreh operation.
+    "ttnn.moreh_layer_norm",  # Moreh operation.
+    "ttnn.moreh_layer_norm_backward",  # Moreh operation.
+    "ttnn.moreh_linear",  # Moreh operation.
+    "ttnn.moreh_linear_backward",  # Moreh operation.
+    "ttnn.moreh_logsoftmax",  # Moreh operation.
+    "ttnn.moreh_logsoftmax_backward",  # Moreh operation.
+    "ttnn.moreh_matmul",  # Moreh operation.
+    "ttnn.moreh_matmul_backward",  # Moreh operation.
+    "ttnn.moreh_mean",  # Moreh operation.
+    "ttnn.moreh_mean_backward",  # Moreh operation.
+    "ttnn.moreh_nll_loss",  # Moreh operation.
+    "ttnn.moreh_nll_loss_backward",  # Moreh operation.
+    "ttnn.moreh_nll_loss_unreduced_backward",  # Moreh operation.
+    "ttnn.moreh_norm",  # Moreh operation.
+    "ttnn.moreh_norm_backward",  # Moreh operation.
+    "ttnn.moreh_sgd",  # Moreh operation.
+    "ttnn.moreh_softmax",  # Moreh operation.
+    "ttnn.moreh_softmax_backward",  # Moreh operation.
+    "ttnn.moreh_softmin",  # Moreh operation.
+    "ttnn.moreh_softmin_backward",  # Moreh operation.
+    "ttnn.moreh_sum",  # Moreh operation.
+    "ttnn.moreh_sum_backward",  # Moreh operation.
+    "ttnn.padded_slice",  # Experimental operation, but wrongly registered without ttnn.experimental.
+    "ttnn.pearson_correlation_coefficient",  # Internal operation only.
+    "ttnn.plus_one",  # Experimental operation, but wrongly registered without ttnn.experimental.
+    "ttnn.prim.example",  # Example operation.
+    "ttnn.prim.example_multiple_return",  # Example operation.
+    "ttnn.prim.test_hang_device_operation",  # Internal operation only.
+    "ttnn.slice_write",  # Experimental operation, but wrongly registered without ttnn.experimental.
+    "ttnn.tosa_gather",  # TOSA operation omitted for docs.
+    "ttnn.tosa_scatter",  # TOSA operation omitted for docs.
+]
+TTNN_PREFIX = "ttnn."
+DOCS_OP_LIST_PATH = "docs/source/ttnn/ttnn/api.rst"
+
+
+# Helper functions
+def get_registered_operations(include_experimental=False) -> set:
+    """
+    Get all registered operations from ttnn.query_registered_operations()
+
+    :param include_experimental: Whether to include experimental operations.
+
+    :return: Set of registered operation names.
+    """
+    # Prepare set to hold registered operations
+    registered_ops = set()
+
+    # Get registered operations from ttnn
+    all_ops = ttnn.query_registered_operations(include_experimental)
+    for op in all_ops:
+        if op.python_fully_qualified_name in SKIPPED_OPS:
+            # Skip operations that are in the SKIPPED_OPS list
+            continue
+        registered_ops.add(op.python_fully_qualified_name)
+
+    return registered_ops
+
+
+def extract_ops_from_docs_rst_file(api_rst_path: str) -> set:
+    """
+    Extract all ttnn operations from docs file by checking each line
+
+    :param api_rst_path: Path to the api.rst file.
+
+    :return: Set of operation names found in the file.
+    """
+    # Prepare set to hold operations found in the file
+    api_ops = set()
+
+    with open(api_rst_path, "r") as f:
+        for line in f:
+            # Remove leading and trailing spaces
+            stripped_line = line.strip()
+
+            # Check if the line starts with ttnn. (after stripping)
+            if stripped_line.startswith(TTNN_PREFIX):
+                api_ops.add(stripped_line)
+
+    return api_ops
+
+
+# Main processing function
+def main() -> None:
+    # Define file path
+    script_dir = Path(__file__).parent
+    api_rst_path = script_dir / DOCS_OP_LIST_PATH
+
+    # Check if file exists
+    if not api_rst_path.exists():
+        print(f"Error: Could not find docs OPs list at {api_rst_path}")
+        sys.exit(1)
+
+    # Get registered operations from ttnn
+    registered_ops = get_registered_operations()
+
+    # Extract operations from docs file
+    api_ops = extract_ops_from_docs_rst_file(api_rst_path)
+
+    # Find operations that are registered but missing from docs file
+    # For each registered operation, check if it exists in api_ops
+    missing_ops = set()
+    for registered_op in registered_ops:
+        if registered_op not in api_ops:
+            missing_ops.add(registered_op)
+
+    # Report results
+    if missing_ops:
+        print("The following registered ttnn operations are missing from the documentation:")
+        for op in sorted(missing_ops):
+            print(f" - {op}")
+        print(f"\nTotal missing operations: {len(missing_ops)}")
+        print(
+            f"Please update the documentation file ({api_rst_path}) to include these operations or add them to the SKIPPED_OPS with reason list if they should be excluded in {__file__}."
+        )
+        sys.exit(1)
+    else:
+        print(f"All registered ttnn operations are documented in {api_rst_path}!")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -9,8 +9,6 @@ with the documented operations in docs/source/ttnn/ttnn/api.rst. It identifies a
 but missing from the documentation file.
 """
 
-import ast
-import os
 import sys
 from pathlib import Path
 

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -127,7 +127,7 @@ def extract_ops_from_docs_rst_file(api_rst_path: str) -> set:
 # Main processing function
 def main() -> None:
     # Define file path
-    script_dir = Path(__file__).parent
+    script_dir = Path(__file__).parent.parent  # Assume script is in scripts/ directory
     api_rst_path = script_dir / DOCS_OP_LIST_PATH
 
     # Check if file exists


### PR DESCRIPTION
### Ticket

#34667

### Problem description
There is currently no automated check ensuring that newly added TTNN operations are also documented. As a result, new operations can be registered without being added to the TTNN docs (`api.rst`), leading to missing or incomplete documentation.

### What's changed
- Added script to query all registered operations in ttnn and compare it to OPs in `api.rst` file,
- Added check for ttnn OPS docs in L2 Nightly pipeline.

### Checklist
- [x] [L2 Nightly](.github/workflows/tt-metal-l2-nightly.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/20434198843