### PR TITLE
#34706: Add separate profiler CI to shrink APC and make jobs more efficient

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ METALIUM_GUIDE.md @davorchap @tenstorrent/codeowner-bypass
 
 # CI/CD
 .github/ @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+.github/workflows/profiler-ci-selector.yaml @mo-tenstorrent @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/ttnn-run-sweeps.yaml @stevendae @cmaryanTT @sjameelTT @pavlejosipovic @bbradelTT @ntarafdar @tenstorrent/codeowner-bypass
 .github/workflows/galaxy-deepseek-tests.yaml @yieldthought @kpaigwar @pprajapatiTT @esmalTT @johanna-rock-tt @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 .github/workflows/galaxy-deepseek-tests-impl.yaml @yieldthought @kpaigwar @pprajapatiTT @esmalTT @johanna-rock-tt @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -60,6 +60,7 @@ on:
       - "(Galaxy) DeepSeek tests"
       - "(TM-DM) Data Movement Test Suite"
       - "(TM-Fabric) Fabric Tests"
+      - "Profiler CI"
 
     types:
       - completed

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -180,6 +180,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      post_commit: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -180,7 +180,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      post_commit: true
+      post_commit_only: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -241,7 +241,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      post_commit: true
+      post_commit_only: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -241,6 +241,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      post_commit: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -128,6 +128,7 @@ jobs:
     with:
       arch: "blackhole"
       runner-label: ${{ matrix.test-group }}
+      post_commit: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -128,7 +128,7 @@ jobs:
     with:
       arch: "blackhole"
       runner-label: ${{ matrix.test-group }}
-      post_commit: true
+      post_commit_only: true
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -1,6 +1,15 @@
 name: "Profiler CI"
+run-name: >-
+  ${{
+    github.event_name == 'push' &&
+    'Profiler CI (push → N150)' ||
+    'Profiler CI'
+  }}
 
 on:
+  push:
+    branches:
+      - mo/34706_profiler_ci
   workflow_dispatch:
     inputs:
       run_t3k_profiler:
@@ -79,6 +88,7 @@ jobs:
   build-artifact-profiler:
     if: >-
       ${{
+        github.event_name == 'push' ||
         inputs.run_t3k_profiler ||
         inputs.run_galaxy_profiler ||
         inputs.run_blackhole_profiler ||
@@ -95,7 +105,7 @@ jobs:
       version: "22.04"
 
   t3k-profiler-tests:
-    if: ${{ inputs.run_t3k_profiler }}
+    if: ${{ github.event_name != 'push' && inputs.run_t3k_profiler }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/profiler-tests-impl.yaml
@@ -107,7 +117,7 @@ jobs:
       test-script: ./tests/scripts/t3000/run_t3000_profiler_tests.sh
 
   galaxy-profiler-tests:
-    if: ${{ inputs.run_galaxy_profiler }}
+    if: ${{ github.event_name != 'push' && inputs.run_galaxy_profiler }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/profiler-tests-impl.yaml
@@ -119,7 +129,7 @@ jobs:
       test-script: ./tests/scripts/wh_6u/run_wh_6u_profiler_tests.sh
 
   blackhole-profiler:
-    if: ${{ inputs.run_blackhole_profiler }}
+    if: ${{ github.event_name != 'push' && inputs.run_blackhole_profiler }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -134,7 +144,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
 
   n300-profiler:
-    if: ${{ inputs.run_n300_profiler }}
+    if: ${{ github.event_name != 'push' && inputs.run_n300_profiler }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -149,7 +159,7 @@ jobs:
       enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
 
   n150-profiler:
-    if: ${{ inputs.run_n150_profiler }}
+    if: ${{ github.event_name == 'push' || inputs.run_n150_profiler }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -1,15 +1,7 @@
 name: "Profiler CI"
-run-name: >-
-  ${{
-    github.event_name == 'push' &&
-    'Profiler CI (push → all)' ||
-    'Profiler CI'
-  }}
+run-name: "Profiler CI"
 
 on:
-  push:
-    branches:
-      - mo/34706_profiler_ci
   workflow_call:
     inputs:
       run_t3k_profiler:
@@ -54,14 +46,11 @@ jobs:
   build-artifact-profiler:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && (
-          inputs.run_t3k_profiler ||
-          inputs.run_galaxy_profiler ||
-          inputs.run_blackhole_profiler ||
-          inputs.run_n300_profiler ||
-          inputs.run_n150_profiler
-        ))
+        inputs.run_t3k_profiler ||
+        inputs.run_galaxy_profiler ||
+        inputs.run_blackhole_profiler ||
+        inputs.run_n300_profiler ||
+        inputs.run_n150_profiler
       }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -75,8 +64,7 @@ jobs:
   t3k-profiler-tests:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && inputs.run_t3k_profiler)
+        inputs.run_t3k_profiler
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -91,8 +79,7 @@ jobs:
   galaxy-profiler-tests:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && inputs.run_galaxy_profiler)
+        inputs.run_galaxy_profiler
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -107,8 +94,7 @@ jobs:
   blackhole-profiler:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && inputs.run_blackhole_profiler)
+        inputs.run_blackhole_profiler
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -121,15 +107,14 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
-      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
-      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
 
   n300-profiler:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && inputs.run_n300_profiler)
+        inputs.run_n300_profiler
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -142,15 +127,14 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
-      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
-      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
 
   n150-profiler:
     if: >-
       ${{
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_call' && inputs.run_n150_profiler)
+        inputs.run_n150_profiler
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -163,6 +147,6 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
-      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
-      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -2,7 +2,7 @@ name: "Profiler CI"
 run-name: >-
   ${{
     github.event_name == 'push' &&
-    'Profiler CI (push → N150)' ||
+    'Profiler CI (push → all)' ||
     'Profiler CI'
   }}
 
@@ -107,7 +107,7 @@ jobs:
   t3k-profiler-tests:
     if: >-
       ${{
-        github.event_name != 'push' &&
+        github.event_name == 'push' ||
         (github.event.inputs.run_t3k_profiler == 'true' || github.event.inputs.run_t3k_profiler == true)
       }}
     needs: build-artifact-profiler
@@ -123,7 +123,7 @@ jobs:
   galaxy-profiler-tests:
     if: >-
       ${{
-        github.event_name != 'push' &&
+        github.event_name == 'push' ||
         (github.event.inputs.run_galaxy_profiler == 'true' || github.event.inputs.run_galaxy_profiler == true)
       }}
     needs: build-artifact-profiler
@@ -139,7 +139,7 @@ jobs:
   blackhole-profiler:
     if: >-
       ${{
-        github.event_name != 'push' &&
+        github.event_name == 'push' ||
         (github.event.inputs.run_blackhole_profiler == 'true' || github.event.inputs.run_blackhole_profiler == true)
       }}
     needs: build-artifact-profiler
@@ -158,7 +158,7 @@ jobs:
   n300-profiler:
     if: >-
       ${{
-        github.event_name != 'push' &&
+        github.event_name == 'push' ||
         (github.event.inputs.run_n300_profiler == 'true' || github.event.inputs.run_n300_profiler == true)
       }}
     needs: build-artifact-profiler
@@ -167,6 +167,8 @@ jobs:
     with:
       arch: wormhole_b0
       runner-label: N300
+      # Full profiler regression (non post-commit)
+      post_commit: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -148,6 +148,8 @@ jobs:
     with:
       arch: blackhole
       runner-label: P150b
+      # Full profiler regression (non post-commit)
+      post_commit: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -188,6 +190,8 @@ jobs:
     with:
       arch: wormhole_b0
       runner-label: N150
+      # Full profiler regression (non post-commit)
+      post_commit: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - mo/34706_profiler_ci
-  workflow_dispatch:
+  workflow_call:
     inputs:
       run_t3k_profiler:
         description: "T3K profiler"
@@ -39,48 +39,14 @@ on:
         default: false
       enable-watcher:
         description: "Enable watcher (profiler regressions only)"
-        required: false
-        type: boolean
         default: false
+        type: boolean
       enable-lightweight-kernel-asserts:
         description: "Enable lightweight kernel asserts (profiler regressions only)"
-        required: false
-        type: boolean
         default: false
+        type: boolean
       enable-llk-asserts:
         description: "Enable LLK asserts (profiler regressions only)"
-        required: false
-        type: boolean
-        default: false
-  workflow_call:
-    inputs:
-      run_t3k_profiler:
-        required: false
-        type: boolean
-        default: false
-      run_galaxy_profiler:
-        required: false
-        type: boolean
-        default: false
-      run_blackhole_profiler:
-        required: false
-        type: boolean
-        default: false
-      run_n300_profiler:
-        required: false
-        type: boolean
-        default: false
-      run_n150_profiler:
-        required: false
-        type: boolean
-        default: false
-      enable-watcher:
-        default: false
-        type: boolean
-      enable-lightweight-kernel-asserts:
-        default: false
-        type: boolean
-      enable-llk-asserts:
         default: false
         type: boolean
 
@@ -89,11 +55,13 @@ jobs:
     if: >-
       ${{
         github.event_name == 'push' ||
-        github.event.inputs.run_t3k_profiler == 'true' || github.event.inputs.run_t3k_profiler == true ||
-        github.event.inputs.run_galaxy_profiler == 'true' || github.event.inputs.run_galaxy_profiler == true ||
-        github.event.inputs.run_blackhole_profiler == 'true' || github.event.inputs.run_blackhole_profiler == true ||
-        github.event.inputs.run_n300_profiler == 'true' || github.event.inputs.run_n300_profiler == true ||
-        github.event.inputs.run_n150_profiler == 'true' || github.event.inputs.run_n150_profiler == true
+        (github.event_name == 'workflow_call' && (
+          inputs.run_t3k_profiler ||
+          inputs.run_galaxy_profiler ||
+          inputs.run_blackhole_profiler ||
+          inputs.run_n300_profiler ||
+          inputs.run_n150_profiler
+        ))
       }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -108,7 +76,7 @@ jobs:
     if: >-
       ${{
         github.event_name == 'push' ||
-        (github.event.inputs.run_t3k_profiler == 'true' || github.event.inputs.run_t3k_profiler == true)
+        (github.event_name == 'workflow_call' && inputs.run_t3k_profiler)
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -124,7 +92,7 @@ jobs:
     if: >-
       ${{
         github.event_name == 'push' ||
-        (github.event.inputs.run_galaxy_profiler == 'true' || github.event.inputs.run_galaxy_profiler == true)
+        (github.event_name == 'workflow_call' && inputs.run_galaxy_profiler)
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -140,7 +108,7 @@ jobs:
     if: >-
       ${{
         github.event_name == 'push' ||
-        (github.event.inputs.run_blackhole_profiler == 'true' || github.event.inputs.run_blackhole_profiler == true)
+        (github.event_name == 'workflow_call' && inputs.run_blackhole_profiler)
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -149,19 +117,19 @@ jobs:
       arch: blackhole
       runner-label: P150b
       # Full profiler regression (non post-commit)
-      post_commit: false
+      post_commit_only: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
-      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
-      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}
+      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
+      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
+      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}
 
   n300-profiler:
     if: >-
       ${{
         github.event_name == 'push' ||
-        (github.event.inputs.run_n300_profiler == 'true' || github.event.inputs.run_n300_profiler == true)
+        (github.event_name == 'workflow_call' && inputs.run_n300_profiler)
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -170,19 +138,19 @@ jobs:
       arch: wormhole_b0
       runner-label: N300
       # Full profiler regression (non post-commit)
-      post_commit: false
+      post_commit_only: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
-      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
-      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}
+      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
+      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
+      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}
 
   n150-profiler:
     if: >-
       ${{
         github.event_name == 'push' ||
-        (github.event.inputs.run_n150_profiler == 'true' || github.event.inputs.run_n150_profiler == true)
+        (github.event_name == 'workflow_call' && inputs.run_n150_profiler)
       }}
     needs: build-artifact-profiler
     secrets: inherit
@@ -191,10 +159,10 @@ jobs:
       arch: wormhole_b0
       runner-label: N150
       # Full profiler regression (non post-commit)
-      post_commit: false
+      post_commit_only: false
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
-      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
-      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}
+      enable-watcher: ${{ (github.event_name == 'workflow_call' && inputs.enable-watcher) || false }}
+      enable-lightweight-kernel-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-lightweight-kernel-asserts) || false }}
+      enable-llk-asserts: ${{ (github.event_name == 'workflow_call' && inputs.enable-llk-asserts) || false }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -89,11 +89,11 @@ jobs:
     if: >-
       ${{
         github.event_name == 'push' ||
-        inputs.run_t3k_profiler ||
-        inputs.run_galaxy_profiler ||
-        inputs.run_blackhole_profiler ||
-        inputs.run_n300_profiler ||
-        inputs.run_n150_profiler
+        github.event.inputs.run_t3k_profiler == 'true' || github.event.inputs.run_t3k_profiler == true ||
+        github.event.inputs.run_galaxy_profiler == 'true' || github.event.inputs.run_galaxy_profiler == true ||
+        github.event.inputs.run_blackhole_profiler == 'true' || github.event.inputs.run_blackhole_profiler == true ||
+        github.event.inputs.run_n300_profiler == 'true' || github.event.inputs.run_n300_profiler == true ||
+        github.event.inputs.run_n150_profiler == 'true' || github.event.inputs.run_n150_profiler == true
       }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
@@ -105,7 +105,11 @@ jobs:
       version: "22.04"
 
   t3k-profiler-tests:
-    if: ${{ github.event_name != 'push' && inputs.run_t3k_profiler }}
+    if: >-
+      ${{
+        github.event_name != 'push' &&
+        (github.event.inputs.run_t3k_profiler == 'true' || github.event.inputs.run_t3k_profiler == true)
+      }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/profiler-tests-impl.yaml
@@ -117,7 +121,11 @@ jobs:
       test-script: ./tests/scripts/t3000/run_t3000_profiler_tests.sh
 
   galaxy-profiler-tests:
-    if: ${{ github.event_name != 'push' && inputs.run_galaxy_profiler }}
+    if: >-
+      ${{
+        github.event_name != 'push' &&
+        (github.event.inputs.run_galaxy_profiler == 'true' || github.event.inputs.run_galaxy_profiler == true)
+      }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/profiler-tests-impl.yaml
@@ -129,7 +137,11 @@ jobs:
       test-script: ./tests/scripts/wh_6u/run_wh_6u_profiler_tests.sh
 
   blackhole-profiler:
-    if: ${{ github.event_name != 'push' && inputs.run_blackhole_profiler }}
+    if: >-
+      ${{
+        github.event_name != 'push' &&
+        (github.event.inputs.run_blackhole_profiler == 'true' || github.event.inputs.run_blackhole_profiler == true)
+      }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -139,12 +151,16 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher }}
-      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
-      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
+      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
+      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}
 
   n300-profiler:
-    if: ${{ github.event_name != 'push' && inputs.run_n300_profiler }}
+    if: >-
+      ${{
+        github.event_name != 'push' &&
+        (github.event.inputs.run_n300_profiler == 'true' || github.event.inputs.run_n300_profiler == true)
+      }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -154,12 +170,16 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher }}
-      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
-      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
+      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
+      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}
 
   n150-profiler:
-    if: ${{ github.event_name == 'push' || inputs.run_n150_profiler }}
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (github.event.inputs.run_n150_profiler == 'true' || github.event.inputs.run_n150_profiler == true)
+      }}
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/run-profiler-regression.yaml
@@ -169,6 +189,6 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher }}
-      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
-      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+      enable-watcher: ${{ github.event.inputs['enable-watcher'] == 'true' || github.event.inputs['enable-watcher'] == true }}
+      enable-lightweight-kernel-asserts: ${{ github.event.inputs['enable-lightweight-kernel-asserts'] == 'true' || github.event.inputs['enable-lightweight-kernel-asserts'] == true }}
+      enable-llk-asserts: ${{ github.event.inputs['enable-llk-asserts'] == 'true' || github.event.inputs['enable-llk-asserts'] == true }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -1,0 +1,164 @@
+name: "Profiler CI"
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_t3k_profiler:
+        description: "T3K profiler"
+        required: false
+        type: boolean
+        default: false
+      run_galaxy_profiler:
+        description: "Galaxy profiler"
+        required: false
+        type: boolean
+        default: false
+      run_blackhole_profiler:
+        description: "Blackhole profiler"
+        required: false
+        type: boolean
+        default: false
+      run_n300_profiler:
+        description: "N300 profiler"
+        required: false
+        type: boolean
+        default: false
+      run_n150_profiler:
+        description: "N150 profiler"
+        required: false
+        type: boolean
+        default: false
+      enable-watcher:
+        description: "Enable watcher (profiler regressions only)"
+        required: false
+        type: boolean
+        default: false
+      enable-lightweight-kernel-asserts:
+        description: "Enable lightweight kernel asserts (profiler regressions only)"
+        required: false
+        type: boolean
+        default: false
+      enable-llk-asserts:
+        description: "Enable LLK asserts (profiler regressions only)"
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      run_t3k_profiler:
+        required: false
+        type: boolean
+        default: false
+      run_galaxy_profiler:
+        required: false
+        type: boolean
+        default: false
+      run_blackhole_profiler:
+        required: false
+        type: boolean
+        default: false
+      run_n300_profiler:
+        required: false
+        type: boolean
+        default: false
+      run_n150_profiler:
+        required: false
+        type: boolean
+        default: false
+      enable-watcher:
+        default: false
+        type: boolean
+      enable-lightweight-kernel-asserts:
+        default: false
+        type: boolean
+      enable-llk-asserts:
+        default: false
+        type: boolean
+
+jobs:
+  build-artifact-profiler:
+    if: >-
+      ${{
+        inputs.run_t3k_profiler ||
+        inputs.run_galaxy_profiler ||
+        inputs.run_blackhole_profiler ||
+        inputs.run_n300_profiler ||
+        inputs.run_n150_profiler
+      }}
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      tracy: true
+      build-wheel: true
+      version: "22.04"
+
+  t3k-profiler-tests:
+    if: ${{ inputs.run_t3k_profiler }}
+    needs: build-artifact-profiler
+    secrets: inherit
+    uses: ./.github/workflows/profiler-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      topology: config-t3000
+      test-script: ./tests/scripts/t3000/run_t3000_profiler_tests.sh
+
+  galaxy-profiler-tests:
+    if: ${{ inputs.run_galaxy_profiler }}
+    needs: build-artifact-profiler
+    secrets: inherit
+    uses: ./.github/workflows/profiler-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      topology: topology-6u
+      test-script: ./tests/scripts/wh_6u/run_wh_6u_profiler_tests.sh
+
+  blackhole-profiler:
+    if: ${{ inputs.run_blackhole_profiler }}
+    needs: build-artifact-profiler
+    secrets: inherit
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    with:
+      arch: blackhole
+      runner-label: P150b
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+
+  n300-profiler:
+    if: ${{ inputs.run_n300_profiler }}
+    needs: build-artifact-profiler
+    secrets: inherit
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    with:
+      arch: wormhole_b0
+      runner-label: N300
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+
+  n150-profiler:
+    if: ${{ inputs.run_n150_profiler }}
+    needs: build-artifact-profiler
+    secrets: inherit
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    with:
+      arch: wormhole_b0
+      runner-label: N150
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
+      enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
+      enable-llk-asserts: ${{ inputs.enable-llk-asserts }}

--- a/.github/workflows/profiler-ci-selector.yaml
+++ b/.github/workflows/profiler-ci-selector.yaml
@@ -4,6 +4,11 @@ run-name: "Profiler CI"
 on:
   workflow_call:
     inputs:
+      debug_build:
+        description: "Run ALL profiler jobs using a debug build (RelWithDebInfo) instead of Release."
+        required: false
+        type: boolean
+        default: false
       run_t3k_profiler:
         description: "T3K profiler"
         required: false
@@ -46,6 +51,7 @@ jobs:
   build-artifact-profiler:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_t3k_profiler ||
         inputs.run_galaxy_profiler ||
         inputs.run_blackhole_profiler ||
@@ -57,6 +63,7 @@ jobs:
       packages: write
     secrets: inherit
     with:
+      build-type: ${{ inputs.debug_build && 'RelWithDebInfo' || 'Release' }}
       tracy: true
       build-wheel: true
       version: "22.04"
@@ -64,6 +71,7 @@ jobs:
   t3k-profiler-tests:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_t3k_profiler
       }}
     needs: build-artifact-profiler
@@ -79,6 +87,7 @@ jobs:
   galaxy-profiler-tests:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_galaxy_profiler
       }}
     needs: build-artifact-profiler
@@ -94,6 +103,7 @@ jobs:
   blackhole-profiler:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_blackhole_profiler
       }}
     needs: build-artifact-profiler
@@ -114,6 +124,7 @@ jobs:
   n300-profiler:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_n300_profiler
       }}
     needs: build-artifact-profiler
@@ -134,6 +145,7 @@ jobs:
   n150-profiler:
     if: >-
       ${{
+        inputs.debug_build ||
         inputs.run_n150_profiler
       }}
     needs: build-artifact-profiler

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -9,6 +9,11 @@ on:
       runner-label:
         required: true
         type: string
+      post_commit:
+        description: "If true, run in post-commit mode (exclude @skip_post_commit). If false, run full profiler regression."
+        required: false
+        type: boolean
+        default: true
       timeout:
         required: false
         type: number
@@ -49,6 +54,11 @@ on:
           - N150
           - N300
           - BH
+      post_commit:
+        description: "Run in post-commit mode (exclude @skip_post_commit)"
+        required: false
+        type: boolean
+        default: true
       timeout:
         required: false
         type: number
@@ -120,7 +130,11 @@ jobs:
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          ./tests/scripts/run_profiler_regressions.sh
+          if [[ "${{ inputs.post_commit }}" == "true" ]]; then
+            ./tests/scripts/run_profiler_regressions.sh --post-commit
+          else
+            ./tests/scripts/run_profiler_regressions.sh --full
+          fi
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -9,8 +9,8 @@ on:
       runner-label:
         required: true
         type: string
-      post_commit:
-        description: "If true, run in post-commit mode (exclude @skip_post_commit). If false, run full profiler regression."
+      post_commit_only:
+        description: "If true, run post-commit-only (exclude @pytest.mark.skip_post_commit). If false, run full profiler regression."
         required: false
         type: boolean
         default: true
@@ -54,8 +54,8 @@ on:
           - N150
           - N300
           - BH
-      post_commit:
-        description: "Run in post-commit mode (exclude @skip_post_commit)"
+      post_commit_only:
+        description: "Run post-commit-only (exclude @pytest.mark.skip_post_commit)"
         required: false
         type: boolean
         default: true
@@ -130,7 +130,7 @@ jobs:
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |
-          if [[ "${{ inputs.post_commit }}" == "true" ]]; then
+          if [[ "${{ inputs.post_commit_only }}" == "true" ]]; then
             ./tests/scripts/run_profiler_regressions.sh --post-commit
           else
             ./tests/scripts/run_profiler_regressions.sh --full

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     post_commit: mark tests to run on post-commit
     frequent: mark tests to run every couple of hours
     slow: marks tests as slow and long
+    skip_post_commit: mark tests excluded by default in profiler regression script (use -m / --include-skip-post-commit to include)
     frequently_hangs: mark tests that frequently hang cards
     eager_host_side: mark tests meant for host-side eager release builds
     eager_package_silicon: mark silicon tests meant for eager release builds

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -11,18 +11,28 @@ usage() {
 Usage: run_profiler_regressions.sh [options]
 
 Options:
-  --include-skip-post-commit   Include tests marked with @pytest.mark.skip_post_commit
-                              (default: exclude them)
+  --post-commit                Post-commit mode: exclude tests marked with @pytest.mark.skip_post_commit (default)
+  --full                       Full mode: include tests marked with @pytest.mark.skip_post_commit
+  --include-skip-post-commit   Alias for --full (backwards compatible)
   -h, --help                   Show this help
 EOF
 }
 
-INCLUDE_SKIP_POST_COMMIT=0
+# Default to post-commit behavior to preserve existing CI behavior.
+MODE="post_commit" # or "full"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --post-commit)
+            MODE="post_commit"
+            shift
+            ;;
+        --full)
+            MODE="full"
+            shift
+            ;;
         --include-skip-post-commit)
-            INCLUDE_SKIP_POST_COMMIT=1
+            MODE="full"
             shift
             ;;
         -h|--help)
@@ -50,7 +60,7 @@ run_profiling_test() {
     run_mid_run_data_dump
 
     device_profiler_marker_args=()
-    if [[ "$INCLUDE_SKIP_POST_COMMIT" -eq 0 ]]; then
+    if [[ "$MODE" == "post_commit" ]]; then
         device_profiler_marker_args=(-m "not skip_post_commit")
     fi
 

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -6,6 +6,37 @@ source scripts/tools_setup_common.sh
 
 set -eo pipefail
 
+usage() {
+    cat <<'EOF'
+Usage: run_profiler_regressions.sh [options]
+
+Options:
+  --include-skip-post-commit   Include tests marked with @pytest.mark.skip_post_commit
+                              (default: exclude them)
+  -h, --help                   Show this help
+EOF
+}
+
+INCLUDE_SKIP_POST_COMMIT=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --include-skip-post-commit)
+            INCLUDE_SKIP_POST_COMMIT=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" 1>&2
+            usage 1>&2
+            exit 2
+            ;;
+    esac
+done
+
 run_mid_run_data_dump() {
     echo "Smoke test, checking mid-run device data dump for hangs"
     remove_default_log_locations
@@ -18,7 +49,12 @@ run_profiling_test() {
 
     run_mid_run_data_dump
 
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py --noconftest --timeout 360
+    device_profiler_marker_args=()
+    if [[ "$INCLUDE_SKIP_POST_COMMIT" -eq 0 ]]; then
+        device_profiler_marker_args=(-m "not skip_post_commit")
+    fi
+
+    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py --noconftest --timeout 360 "${device_profiler_marker_args[@]}"
 
     TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/tracy/test_perf_op_report.py --noconftest -k "not TestOpSupportCount"
 

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -476,17 +476,6 @@ def test_dispatch_cores():
         refCountDict=REF_COUNT_DICT,
     )
 
-    verify_stats(
-        run_device_profiler_test(
-            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py",
-            setupAutoExtract=False,
-            doDispatchCores=True,
-        ),
-        statTypes=["dispatch_total_cq_cmd_op_time", "dispatch_go_send_wait_time"],
-        allowedRange=0,  # This test is basically counting ops and should be exact regardless of changes to dispatch code or harvesting.
-        refCountDict=REF_COUNT_DICT,
-    )
-
 
 @skip_for_blackhole()
 @pytest.mark.skip_post_commit
@@ -494,6 +483,8 @@ def test_dispatch_cores_extended_worker():
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch*": [600, 760, 1310, 2330, 3558, 4915, 6383, 7422, 8570],
         "Tensix CQ Prefetch": [900, 1440, 2012, 3870, 5000, 7752],
+        "dispatch_total_cq_cmd_op_time": [223],
+        "dispatch_go_send_wait_time": [223],
     }
 
     verify_stats(
@@ -517,6 +508,17 @@ def test_dispatch_cores_extended_worker():
         ),
         statTypes=["Dispatch", "Prefetch"],
         allowedRange=9260,
+        refCountDict=REF_COUNT_DICT,
+    )
+
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py",
+            setupAutoExtract=False,
+            doDispatchCores=True,
+        ),
+        statTypes=["dispatch_total_cq_cmd_op_time", "dispatch_go_send_wait_time"],
+        allowedRange=0,  # This test is basically counting ops and should be exact regardless of changes to dispatch code or harvesting.
         refCountDict=REF_COUNT_DICT,
     )
 

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -461,7 +461,7 @@ def test_device_trace_run():
 
 
 @skip_for_blackhole()
-def test_dispatch_cores_smoke():
+def test_dispatch_cores():
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch*": [9325],
         "Tensix CQ Prefetch": [9325],
@@ -494,8 +494,6 @@ def test_dispatch_cores_extended_worker():
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch*": [600, 760, 1310, 2330, 3558, 4915, 6383, 7422, 8570],
         "Tensix CQ Prefetch": [900, 1440, 2012, 3870, 5000, 7752],
-        "dispatch_total_cq_cmd_op_time": [223],
-        "dispatch_go_send_wait_time": [223],
     }
 
     verify_stats(

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -465,8 +465,6 @@ def test_dispatch_cores():
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch*": [9325],
         "Tensix CQ Prefetch": [9325],
-        "dispatch_total_cq_cmd_op_time": [223],
-        "dispatch_go_send_wait_time": [223],
     }
 
     verify_stats(
@@ -481,8 +479,8 @@ def test_dispatch_cores():
 @pytest.mark.skip_post_commit
 def test_dispatch_cores_extended_worker():
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch*": [600, 760, 1310, 2330, 3558, 4915, 6383, 7422, 8570],
-        "Tensix CQ Prefetch": [900, 1440, 2012, 3870, 5000, 7752],
+        "Tensix CQ Dispatch*": [9325],
+        "Tensix CQ Prefetch": [9325],
         "dispatch_total_cq_cmd_op_time": [223],
         "dispatch_go_send_wait_time": [223],
     }

--- a/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-
-# SPDX-License-Identifier: Apache-2.0
-
-from tests.tt_metal.tools.profiler import test_device_profiler
-
-
-def test_multi_op_gs_no_reset():
-    test_device_profiler.test_multi_op()

--- a/tools/tracy/device_post_proc_config.py
+++ b/tools/tracy/device_post_proc_config.py
@@ -435,6 +435,10 @@ class test_dispatch_cores(default_setup):
     detectOps = False
 
 
+class test_dispatch_cores_extended_worker(test_dispatch_cores):
+    pass
+
+
 class test_ethernet_dispatch_cores(default_setup):
     timerAnalysis = {
         "Ethernet CQ Dispatch": {


### PR DESCRIPTION
### Ticket
#34706 

### Problem description
Post commit needed to shrink and N300 Nightly was gonna be yet another profiler job. 

### What's changed
Consolidate all profiler jobs in one workflow. 

 
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20727001215)
- [x] [BH Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20576387441)
- [x] [Profiler CI](https://github.com/tenstorrent/tt-metal/actions/runs/20576373688)