### PR TITLE
Sampling - Update Docs, Create Example

### DIFF
--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -337,6 +337,7 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     "ttnn.var": reduction.test_var,
     "ttnn.argmax": reduction.test_argmax,
     "ttnn.prod": reduction.test_prod,
+    "ttnn.sampling": reduction.test_sampling,
     "ttnn.topk": reduction.test_topk,
     "ttnn.cumsum": reduction.test_cumsum,
     "ttnn.ema": reduction.test_ema,

--- a/tests/ttnn/docs_examples/test_reduction_examples.py
+++ b/tests/ttnn/docs_examples/test_reduction_examples.py
@@ -116,6 +116,29 @@ def test_prod(device):
     logger.info(f"Prod result: {output}")
 
 
+def test_sampling(device):
+    # Input values tensor for N*C*H = 32 users
+    input_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Input indices tensor: this example uses sequential indices [0, 1, 2, ..., W-1] for each of the 32 users
+    # Resulting in a final shape of [1, 1, 32, 64]
+    indices_1d = ttnn.arange(0, 64, dtype=ttnn.int32, device=device)
+    indices_reshaped = ttnn.reshape(indices_1d, [1, 1, 1, 64])
+    input_indices_tensor = ttnn.repeat(indices_reshaped, (1, 1, 32, 1))
+
+    # k tensor: 32 values in range (0, 32] for top-k sampling
+    k_tensor = ttnn.full([32], fill_value=10, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    # p tensor: 32 values in range [0.0, 1.0] for top-p sampling
+    p_tensor = ttnn.full([32], fill_value=0.9, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    # temp tensor: 32 temperature values in range [0.0, 1.0]
+    temp_tensor = ttnn.ones([32], dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
+    logger.info(f"Sampling result: {output}")
+
+
 def test_topk(device):
     # Create tensor
     tensor_input = ttnn.rand([1, 1, 32, 64], device=device)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_nanobind.cpp
@@ -122,7 +122,7 @@ void bind_normalization_layernorm_operation(nb::module_& mod) {
 
         Memory Support:
             - Interleaved: DRAM and L1
-            - Sharded (L1): Block sharded
+            - Sharded (L1): Width and Block sharded
 
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
@@ -79,6 +79,7 @@ void bind_normalization_rms_norm(nb::module_& mod) {
 
         Memory Support:
             - Interleaved: DRAM and L1
+            - Sharded (L1): Width and Block sharded
 
         Limitations:
             - All input tensors must be on-device and have a rank >= 1.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -37,19 +37,6 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
 
         Currently, this operation supports inputs and outputs with specific memory layout and data type constraints.
 
-        Equivalent PyTorch code:
-            .. code-block:: python
-
-               return torch.sampling(
-                      input_values_tensor,
-                      input_indices_tensor,
-                      k=k,
-                      p=p,
-                      temp=temp,
-                      seed=seed,
-                      optional_output_tensor=optional_output_tensor,
-                  )
-
         Args:
             input_values_tensor (ttnn.Tensor): The input tensor containing values to sample from.
             input_indices_tensor (ttnn.Tensor): The input tensor containing indices to assist with sampling.
@@ -130,18 +117,6 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                 - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
                 - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
                 - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
-
-        Example:
-            .. code-block:: python
-
-                input_tensor = ttnn.rand([1, 1, 32, 64], layout=ttnn.TILE_LAYOUT, device=device)
-                input_indices_tensor = ttnn.rand([1, 1, 32, 64], dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                k_tensor = ttnn.rand([32], dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                p_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-                temp_tensor = ttnn.rand([32], layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-
-                output = ttnn.sampling(input_tensor, input_indices_tensor, k=k_tensor, p=p_tensor, temp=temp_tensor)
-
         )doc";
 
     using OperationType = decltype(ttnn::sampling);


### PR DESCRIPTION
### Ticket
Closes #34688

### Problem description
Sampling docs listed PyTorch code and didn't have a proper example linked into to the sampling tests

Layernorm and RMS norm docs didn't explicitly state that they support width sharding (only that they didn't support height sharding)

### What's changed
Created an example for Sampling and linked it to the docs

Update LN docs to explicitly state width sharding support

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/20437465508) [Rebase](https://github.com/tenstorrent/tt-metal/actions/runs/20575591521)
- [x] [L2 Example Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job [pass](https://github.com/tenstorrent/tt-metal/actions/runs/20437474134) [Rebase](https://github.com/tenstorrent/tt-metal/actions/runs/20575596895)