### PR TITLE
Allow selecting which BH multi-card systems to run on BH nightly

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -15,6 +15,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      runner-label:
+        required: false
+        type: string
+        default: "BH-LLMBox"
 
 jobs:
   multi-card-unit-tests:
@@ -23,17 +27,6 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        runner-group:
-          - name: LLMBox unit tests
-            runner-label: BH-LLMBox
-          - name: DeskBox unit tests
-            runner-label: BH-DeskBox
-          - name: LoudBox unit tests
-            runner-label: BH-LoudBox
-          - name: P300 unit tests
-            runner-label: P300-viommu
-          - name: QuietBox Global Edition unit tests
-            runner-label: BH-QB-GE
         test-group:
           - name: fabric 1D unit tests
             cmd: |
@@ -75,11 +68,11 @@ jobs:
             timeout: 15
           # - name: t3000 fast fabric tests
           #   cmd: "source tests/scripts/t3000/run_t3000_unit_tests.sh && run_t3000_ttfabric_tests"
-    name: ${{ inputs.arch }} ${{ matrix.runner-group.runner-label }} ${{ matrix.test-group.name }}
+    name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service
       - arch-blackhole
-      - ${{ matrix.runner-group.runner-label }}
+      - ${{ inputs.runner-label }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
       env:
@@ -112,11 +105,11 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
         with:
-          runner-label: ${{ matrix.runner-group.runner-label }}
+          runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          if [[ "${{ matrix.test-group.name }}" == "fabric system health tests" && "${{ matrix.runner-group.runner-label }}" == "BH-DeskBox" ]]; then
+          if [[ "${{ matrix.test-group.name }}" == "fabric system health tests" && "${{ inputs.runner-label }}" == "BH-DeskBox" ]]; then
             ${{ matrix.test-group.cmd }} --min-connections 4
           else
             ${{ matrix.test-group.cmd }}

--- a/.github/workflows/blackhole-multi-card-unit-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests.yaml
@@ -18,8 +18,23 @@ jobs:
     needs: build-artifact-profiler
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group:
+          - name: LLMBox unit tests
+            runner-label: BH-LLMBox
+          - name: DeskBox unit tests
+            runner-label: BH-DeskBox
+          - name: LoudBox unit tests
+            runner-label: BH-LoudBox
+          - name: P300 unit tests
+            runner-label: P300-viommu
+          - name: QuietBox Global Edition unit tests
+            runner-label: BH-QB-GE
     with:
       arch: blackhole
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      runner-label: ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -115,7 +115,9 @@ jobs:
 
           # If schedule, include all systems
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "matrix={\"test-group\": $all_systems}" >> $GITHUB_OUTPUT
+            matrix_output=$(echo "{\"test-group\": $all_systems}" | jq -c .)
+            echo "Matrix output: $matrix_output"
+            echo "matrix=$matrix_output" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -127,10 +129,13 @@ jobs:
           [[ "${{ inputs.run_bh_p300 }}" == "true" ]] && selected_keys+=("p300")
           [[ "${{ inputs.run_bh_quietbox_2 }}" == "true" ]] && selected_keys+=("quietbox_2")
 
-          # Filter all_systems by selected keys using jq
-          keys_json=$(printf '%s\n' "${selected_keys[@]}" | jq -R . | jq -s .)
-          filtered=$(echo "$all_systems" | jq --argjson keys "$keys_json" '[.[] | select(.key as $k | $keys | index($k))]')
-          echo "matrix={\"test-group\": $filtered}" >> $GITHUB_OUTPUT
+          # Filter all_systems by selected keys using jq (-c for compact single-line output)
+          keys_json=$(printf '%s\n' "${selected_keys[@]}" | jq -R . | jq -sc .)
+          echo "Selected keys: $keys_json"
+          filtered=$(echo "$all_systems" | jq -c --argjson keys "$keys_json" '[.[] | select(.key as $k | $keys | index($k))]')
+          matrix_output="{\"test-group\": $filtered}"
+          echo "Matrix output: $matrix_output"
+          echo "matrix=$matrix_output" >> $GITHUB_OUTPUT
   blackhole-multi-card-demo-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_demo_tests }}
     needs: [build-artifact, blackhole-multi-card-tests-matrix ]

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -34,7 +34,7 @@ on:
         description: 'Run multi-card tests on Quietbox (4xP150)'
         required: false
         type: boolean
-        default: false
+        default: true
       run_bh_deskbox:
         description: 'Run multi-card tests on DeskBox (2xP150)'
         required: false
@@ -44,7 +44,7 @@ on:
         description: 'Run multi-card tests on LoudBox (8xP150)'
         required: false
         type: boolean
-        default: false
+        default: true
       run_bh_p300:
         description: 'Run multi-card tests on P300 (1xP300)'
         required: false
@@ -54,7 +54,7 @@ on:
         description: 'Run multi-card tests on QuietBox 2 (2xP300)'
         required: false
         type: boolean
-        default: false
+        default: true
   workflow_call:
   schedule:
     - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -51,7 +51,7 @@ on:
         type: boolean
         default: false
       run_bh_quietbox_2:
-        description: 'Run multi-card tests on QuietBox 2 (2xP300)'
+        description: 'Run multi-card tests on QuietBox 2 (2xP300) (formerly called BH QB GE)'
         required: false
         type: boolean
         default: true

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -129,6 +129,11 @@ jobs:
           [[ "${{ inputs.run_bh_p300 }}" == "true" ]] && selected_keys+=("p300")
           [[ "${{ inputs.run_bh_quietbox_2 }}" == "true" ]] && selected_keys+=("quietbox_2")
 
+          # If no systems were selected, fail fast with a clear error message.
+          if [ ${#selected_keys[@]} -eq 0 ]; then
+            echo "Error: No systems selected for blackhole-multi-card-tests-matrix. At least one of the following inputs must be set to true: run_bh_llmbox, run_bh_deskbox, run_bh_loudbox, run_bh_p300, run_bh_quietbox_2." >&2
+            exit 1
+          fi
           # Filter all_systems by selected keys using jq (-c for compact single-line output)
           keys_json=$(printf '%s\n' "${selected_keys[@]}" | jq -R . | jq -sc .)
           echo "Selected keys: $keys_json"

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -30,6 +30,31 @@ on:
         required: false
         type: boolean
         default: false
+      run_bh_llmbox:
+        description: 'Run multi-card tests on Quietbox (4xP150)'
+        required: false
+        type: boolean
+        default: false
+      run_bh_deskbox:
+        description: 'Run multi-card tests on DeskBox (2xP150)'
+        required: false
+        type: boolean
+        default: false
+      run_bh_loudbox:
+        description: 'Run multi-card tests on LoudBox (8xP150)'
+        required: false
+        type: boolean
+        default: false
+      run_bh_p300:
+        description: 'Run multi-card tests on P300 (1xP300)'
+        required: false
+        type: boolean
+        default: false
+      run_bh_quietbox_2:
+        description: 'Run multi-card tests on QuietBox 2 (2xP300)'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
   schedule:
     - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC
@@ -72,35 +97,57 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  blackhole-multi-card-tests-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          all_systems='[
+            {"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox"},
+            {"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"},
+            {"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-perf", "num_devices": 8, "key": "loudbox"},
+            {"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"},
+            {"name": "QuietBox 2 (2xP300) tests", "runner-label": "BH-QB-GE", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox_2"}
+          ]'
+
+          # If schedule, include all systems
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "matrix={\"test-group\": $all_systems}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Build filtered list based on individual inputs
+          selected=()
+          if [[ "${{ inputs.run_bh_quietbox }}" == "true" ]]; then
+            selected+=('{"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox"}')
+          fi
+          if [[ "${{ inputs.run_bh_deskbox }}" == "true" ]]; then
+            selected+=('{"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"}')
+          fi
+          if [[ "${{ inputs.run_bh_loudbox }}" == "true" ]]; then
+            selected+=('{"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-perf", "num_devices": 8, "key": "loudbox"}')
+          fi
+          if [[ "${{ inputs.run_bh_p300 }}" == "true" ]]; then
+            selected+=('{"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"}')
+          fi
+          if [[ "${{ inputs.run_bh_quietbox_2 }}" == "true" ]]; then
+            selected+=('{"name": "QuietBox 2 (2xP300) tests", "runner-label": "BH-QB-GE", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox_2"}')
+          fi
+
+          # Join array into JSON
+          json_array=$(printf '%s\n' "${selected[@]}" | jq -s '.')
+          echo "matrix={\"test-group\": $json_array}" >> $GITHUB_OUTPUT
   blackhole-multi-card-demo-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_demo_tests }}
-    needs: build-artifact
+    needs: [build-artifact, blackhole-multi-card-tests-matrix ]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
     strategy:
       fail-fast: false
-      matrix:
-        test-group:
-          - name: LLMBox Demo tests
-            runner-label: BH-LLMBox
-            extra-tag: pipeline-perf
-            num_devices: 4
-          - name: DeskBox Demo tests
-            runner-label: BH-DeskBox
-            extra-tag: pipeline-functional
-            num_devices: 2
-          - name: LoudBox Demo tests
-            runner-label: BH-LoudBox
-            extra-tag: pipeline-perf
-            num_devices: 8
-          - name: P300 Demo tests
-            runner-label: P300-viommu
-            extra-tag: pipeline-yyz2-lfc
-            num_devices: 2
-          - name: QuietBox Global Edition tests
-            runner-label: BH-QB-GE
-            extra-tag: pipeline-perf
-            num_devices: 4
+      matrix: ${{ fromJSON(needs.blackhole-multi-card-tests-matrix.outputs.matrix) }}
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
@@ -110,14 +157,18 @@ jobs:
       num_devices: ${{ matrix.test-group.num_devices }}
   blackhole-multi-card-unit-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, blackhole-multi-card-tests-matrix]
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.blackhole-multi-card-tests-matrix.outputs.matrix) }}
     with:
       arch: blackhole
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   blackhole-ttnn-stress-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_ttnn_stress_tests }}
     needs: build-artifact

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -106,7 +106,7 @@ jobs:
         id: set-matrix
         run: |
           all_systems='[
-            {"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox"},
+            {"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "llmbox"},
             {"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"},
             {"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-perf", "num_devices": 8, "key": "loudbox"},
             {"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"},
@@ -119,27 +119,18 @@ jobs:
             exit 0
           fi
 
-          # Build filtered list based on individual inputs
-          selected=()
-          if [[ "${{ inputs.run_bh_quietbox }}" == "true" ]]; then
-            selected+=('{"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox"}')
-          fi
-          if [[ "${{ inputs.run_bh_deskbox }}" == "true" ]]; then
-            selected+=('{"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"}')
-          fi
-          if [[ "${{ inputs.run_bh_loudbox }}" == "true" ]]; then
-            selected+=('{"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-perf", "num_devices": 8, "key": "loudbox"}')
-          fi
-          if [[ "${{ inputs.run_bh_p300 }}" == "true" ]]; then
-            selected+=('{"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"}')
-          fi
-          if [[ "${{ inputs.run_bh_quietbox_2 }}" == "true" ]]; then
-            selected+=('{"name": "QuietBox 2 (2xP300) tests", "runner-label": "BH-QB-GE", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox_2"}')
-          fi
+          # Build list of selected keys based on inputs
+          selected_keys=()
+          [[ "${{ inputs.run_bh_llmbox }}" == "true" ]] && selected_keys+=("llmbox")
+          [[ "${{ inputs.run_bh_deskbox }}" == "true" ]] && selected_keys+=("deskbox")
+          [[ "${{ inputs.run_bh_loudbox }}" == "true" ]] && selected_keys+=("loudbox")
+          [[ "${{ inputs.run_bh_p300 }}" == "true" ]] && selected_keys+=("p300")
+          [[ "${{ inputs.run_bh_quietbox_2 }}" == "true" ]] && selected_keys+=("quietbox_2")
 
-          # Join array into JSON
-          json_array=$(printf '%s\n' "${selected[@]}" | jq -s '.')
-          echo "matrix={\"test-group\": $json_array}" >> $GITHUB_OUTPUT
+          # Filter all_systems by selected keys using jq
+          keys_json=$(printf '%s\n' "${selected_keys[@]}" | jq -R . | jq -s .)
+          filtered=$(echo "$all_systems" | jq --argjson keys "$keys_json" '[.[] | select(.key as $k | $keys | index($k))]')
+          echo "matrix={\"test-group\": $filtered}" >> $GITHUB_OUTPUT
   blackhole-multi-card-demo-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_demo_tests }}
     needs: [build-artifact, blackhole-multi-card-tests-matrix ]


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently BH nightly multi-card demo and unit tests run all tests on all multi-card system types.

### What's changed
Allow selecting the system type in BH nightly (by default QB, LB, QB2 are selected).
For scheduled runs on main, all system types are selected.
Move the system test-group for multi-card unit tests out of the impl to alllow re-using the generated matrix.

### Checklist
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/20438150528