### PR TITLE
Introduce ttnn.narrow operation

### DIFF
--- a/tests/ttnn/docs_examples/examples_mapping.py
+++ b/tests/ttnn/docs_examples/examples_mapping.py
@@ -390,6 +390,7 @@ FUNCTION_TO_EXAMPLES_MAPPING_DICT = {
     "ttnn.indexed_fill": data_movement.test_indexed_fill,
     "ttnn.gather": data_movement.test_gather,
     "ttnn.sort": data_movement.test_sort,
+    "ttnn.narrow": data_movement.test_narrow,
     # Normalization
     "ttnn.group_norm": normalization.test_group_norm,
     "ttnn.layer_norm": normalization.test_layer_norm,

--- a/tests/ttnn/docs_examples/test_data_movement_examples.py
+++ b/tests/ttnn/docs_examples/test_data_movement_examples.py
@@ -261,3 +261,9 @@ def test_sort(device):
     input_tensor_2d_ttnn = ttnn.from_torch(input_tensor_2d, dtype=ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
     sorted_tensor_dim, indices_dim = ttnn.sort(input_tensor_2d_ttnn, dim=1)
     logger.info(f"Sorted Tensor along dim 1: {sorted_tensor_dim}, Indices: {indices_dim}")
+
+
+def test_narrow(device):
+    input_tensor = ttnn.rand((32, 16, 16, 4), dtype=ttnn.bfloat16, device=device)
+    narrowed_tensor = ttnn.narrow(input_tensor, 0, 12, 8)
+    logger.info("Narrowed Tensor Shape:", narrowed_tensor.shape)

--- a/tests/ttnn/unit_tests/base_functionality/test_narrow.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_narrow.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, tt_dtype_to_torch_dtype
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.uint8, ttnn.uint16, ttnn.int32, ttnn.uint32, ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b],
+)
+@pytest.mark.parametrize(
+    "input_shape, dim, start, length, memory_config, layout",
+    [
+        ((32, 32, 17, 32), 0, 12, 16, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.TILE_LAYOUT),
+        ((1, 32, 12, 16), 1, 5, 8, ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.ROW_MAJOR_LAYOUT),
+        (
+            (1, 8, 64, 128),
+            1,
+            4,
+            4,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+                    (32, 128),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.TILE_LAYOUT,
+        ),
+        (
+            (1, 8, 64, 128),
+            3,
+            32,
+            32,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+                    (32, 128),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.TILE_LAYOUT,
+        ),
+        (
+            (1, 8, 128, 128),
+            2,
+            96,
+            32,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+                    (64, 128),
+                    ttnn.ShardOrientation.COL_MAJOR,
+                ),
+            ),
+            ttnn.ROW_MAJOR_LAYOUT,
+        ),
+        (
+            (1, 1, 32, 576),
+            -1,
+            512,
+            64,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(3, 3))}),
+                    (32, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.TILE_LAYOUT,
+        ),
+        (
+            (1, 1, 8, 576),
+            3,
+            512,
+            64,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(3, 3))}),
+                    (8, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.ROW_MAJOR_LAYOUT,
+        ),
+        (
+            (1, 32, 16, 192),
+            3,
+            128,
+            64,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(6, 7))}),
+                    (128, 32),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.TILE_LAYOUT,
+        ),
+    ],
+    ids=[
+        "dram_dim0_tile",
+        "dram_dim1_rm",
+        "l1_height_sharded_dim1_tile",
+        "l1_height_sharded_dim3_tile",
+        "l1_height_sharded_dim2_rm",
+        "l1_width_sharded_dim3_tile",
+        "l1_width_sharded_dim3_rm",
+        "l1_block_sharded_dim3_tile",
+    ],
+)
+def test_narrow(input_shape, dim, start, length, memory_config, layout, dtype, device):
+    if (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b) and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("Skipping test for bfloat8_b or bfloat4_b with ROW_MAJOR_LAYOUT")
+
+    if dtype in [ttnn.uint8, ttnn.uint16, ttnn.int32, ttnn.uint32]:
+        torch_input_tensor = torch.randint(0, 128, input_shape, dtype=tt_dtype_to_torch_dtype[dtype])
+    else:
+        torch_input_tensor = torch.randn(input_shape, dtype=tt_dtype_to_torch_dtype[dtype])
+    torch_result = torch.narrow(torch_input_tensor, dim, start, length)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=layout, dtype=dtype, device=device, memory_config=memory_config
+    )
+    ttnn_output = ttnn.narrow(input_tensor, dim, start, length)
+
+    assert layout == ttnn_output.layout
+    assert memory_config.buffer_type == ttnn_output.memory_config().buffer_type
+    assert memory_config.memory_layout == ttnn_output.memory_config().memory_layout
+    output = ttnn.to_torch(ttnn_output)
+    if dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b:
+        target_pcc = 0.95 if dtype == ttnn.bfloat4_b else 0.99
+        assert_with_pcc(torch_result, output, target_pcc)
+    else:
+        assert_equal(torch_result, output)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, start, length, memory_config, layout",
+    [
+        (
+            (8, 4, 128, 128),
+            3,
+            32,
+            32,
+            ttnn.MemoryConfig(
+                buffer_type=ttnn.BufferType.L1,
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+                    (32, 128),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            ),
+            ttnn.TILE_LAYOUT,
+        ),
+    ],
+    ids=["l1_height_sharded"],
+)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+def test_narrow_mesh(input_shape, dim, start, length, memory_config, layout, mesh_device):
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_result = torch.narrow(torch_input_tensor, dim, start, length)
+    mesh_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], mesh_device.shape)
+
+    input_tensor_mesh = ttnn.from_torch(
+        torch_input_tensor,
+        device=mesh_device,
+        layout=layout,
+        dtype=ttnn.bfloat16,
+        memory_config=memory_config,
+        mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_config),
+    )
+    ttnn_output = ttnn.narrow(input_tensor_mesh, dim, start, length)
+
+    output = ttnn.to_torch(
+        ttnn_output, mesh_composer=ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(dims=[0, 1]))
+    )
+    assert_equal(torch_result, output)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -226,6 +226,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/indexed_fill/indexed_fill_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/moe_routing_remap/moe_routing_remap_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/move/move_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -394,6 +394,7 @@ target_sources(
         move/device/move_overlap_program_factory.cpp
         move/device/move_sharded_program_factory.cpp
         move/move.cpp
+        narrow/narrow.cpp
         non_zero_indices/device/non_zero_indices_device_operation.cpp
         non_zero_indices/device/non_zero_indices_program_factory.cpp
         non_zero_indices/non_zero_indices.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_nanobind.cpp
@@ -22,6 +22,7 @@
 #include "ttnn/operations/data_movement/moe_expert_token_remap/moe_expert_token_remap_nanobind.hpp"
 #include "ttnn/operations/data_movement/moe_routing_remap/moe_routing_remap_nanobind.hpp"
 #include "ttnn/operations/data_movement/move/move_nanobind.hpp"
+#include "ttnn/operations/data_movement/narrow/narrow_nanobind.hpp"
 #include "ttnn/operations/data_movement/non_zero_indices/non_zero_indices_nanobind.hpp"
 #include "ttnn/operations/data_movement/pad/pad_nanobind.hpp"
 #include "ttnn/operations/data_movement/permute/permute_nanobind.hpp"
@@ -84,6 +85,7 @@ void py_module(nb::module_& mod) {
     bind_expand(mod);
     bind_interleaved_to_sharded(mod);
     bind_interleaved_to_sharded_partial(mod);
+    bind_narrow(mod);
     bind_repeat(mod);
     bind_reshape_enum(mod);
     bind_reshape(mod);

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "narrow.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+namespace ttnn {
+
+ttnn::Tensor narrow(
+    const ttnn::Tensor& input_tensor, const int32_t narrow_dim, const int32_t narrow_start, const uint32_t length) {
+    auto input_tensor_shape = input_tensor.padded_shape();
+    uint32_t dim = input_tensor_shape.get_normalized_index(narrow_dim);
+    uint32_t start = operations::data_movement::wrap_index(narrow_start, input_tensor_shape[dim]);
+
+    // Early return if no narrowing needed
+    if (start == 0 && length == input_tensor_shape[dim]) {
+        return input_tensor;
+    }
+
+    // Validate input parameters
+    TT_FATAL(
+        start < input_tensor_shape[dim],
+        "Narrow start index {} out of bounds for dimension {} with size {}",
+        start,
+        dim,
+        input_tensor_shape[dim]);
+    TT_FATAL(
+        length > 0 && start + length <= input_tensor_shape[dim],
+        "Narrow length {} out of bounds for dimension {} with start index {} and size {}",
+        length,
+        dim,
+        start,
+        input_tensor_shape[dim]);
+
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "NarrowOperation currently only supports DEVICE tensors, got {}",
+        input_tensor.storage_type());
+
+    auto output_tensor_shape = input_tensor.logical_shape();
+    output_tensor_shape[dim] = length;
+    bool narrow_width = dim == input_tensor_shape.size() - 1;
+    bool narrow_height = dim == input_tensor_shape.size() - 2;
+    const auto& storage = input_tensor.device_storage();
+    Buffer* buffer = storage.get_buffer();
+
+    TT_FATAL(
+        input_tensor.layout() != ttnn::TILE_LAYOUT || !narrow_width ||
+            (start % tt::constants::TILE_WIDTH == 0 && length % tt::constants::TILE_WIDTH == 0),
+        "Narrowing on width for TILE layout requires start and length to be multiples of TILE_WIDTH ({}), "
+        "got start {} and length {}",
+        tt::constants::TILE_WIDTH,
+        start,
+        length);
+    TT_FATAL(
+        input_tensor.layout() != ttnn::TILE_LAYOUT || !narrow_height ||
+            (start % tt::constants::TILE_HEIGHT == 0 && length % tt::constants::TILE_HEIGHT == 0),
+        "Narrowing on height for TILE layout requires start and length to be multiples of TILE_HEIGHT ({}), "
+        "got start {} and length {}",
+        tt::constants::TILE_HEIGHT,
+        start,
+        length);
+    TT_FATAL(
+        input_tensor.layout() != ttnn::ROW_MAJOR_LAYOUT || !narrow_width || start % buffer->alignment() == 0,
+        "Narrowing on width for ROW_MAJOR layout requires start ({}) to be aligned to buffer alignment ({})",
+        start,
+        buffer->alignment());
+
+    // Update global config for narrowed tensor
+    // Note: ShardedBufferConfig variant is not supported due to lack of examples
+    TT_FATAL(
+        storage.get_mesh_buffer().global_layout() == tt::tt_metal::distributed::MeshBufferLayout::REPLICATED,
+        "NarrowOperation currently only supports REPLICATED global layouts");
+
+    tt::tt_metal::distributed::ReplicatedBufferConfig replicated_config =
+        std::get<tt::tt_metal::distributed::ReplicatedBufferConfig>(storage.get_mesh_buffer().global_config());
+    uint32_t reduction_factor = input_tensor_shape[dim] / length;
+    replicated_config.size /= reduction_factor;
+    tt::tt_metal::distributed::MeshBufferConfig narrowed_global_config = replicated_config;
+
+    // Handle INTERLEAVED DRAM buffers
+    if (input_tensor.memory_config().buffer_type() == ttnn::BufferType::DRAM &&
+        input_tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED) {
+        // For DRAM interleaved, narrowing is only supported on the first non-trivial dimension
+        // (dimensions with size > 1). All preceding dimensions must be of size 1.
+        bool all_preceding_dims_trivial = true;
+        for (uint32_t i = 0; i < dim; ++i) {
+            if (input_tensor_shape[i] != 1) {
+                all_preceding_dims_trivial = false;
+                break;
+            }
+        }
+        TT_FATAL(
+            all_preceding_dims_trivial,
+            "Narrowing on dimension {} for DRAM INTERLEAVED tensors requires all preceding dimensions to be trivial "
+            "(size 1). Got non-trivial dimensions before dimension {}.",
+            dim,
+            dim);
+
+        // Compute internal block size (product of dimensions after narrowing dimension)
+        uint64_t elements_per_block = 1;
+        for (uint32_t i = dim + 1; i < input_tensor_shape.size(); ++i) {
+            elements_per_block *= input_tensor_shape[i];
+        }
+
+        uint64_t element_size_bytes = input_tensor.element_size();
+        uint32_t num_banks = buffer->allocator()->get_num_banks(buffer->buffer_type());
+
+        // Calculate starting page ID and verify bank alignment
+        uint64_t logical_page_size = (input_tensor.layout() == ttnn::TILE_LAYOUT)
+                                         ? tt::constants::TILE_HW * element_size_bytes
+                                         : buffer->page_size();
+        uint64_t start_page_id = start * element_size_bytes * elements_per_block / logical_page_size;
+
+        TT_FATAL(
+            start_page_id % num_banks == 0,
+            "Start page ID must be aligned with number of banks for INTERLEAVED DRAM buffer");
+
+        uint64_t offset_bytes = (start_page_id / num_banks) * buffer->aligned_page_size();
+        auto device_local_config = storage.get_mesh_buffer().device_local_config();
+
+        auto subtensor_mesh = tt::tt_metal::distributed::MeshBuffer::create(
+            narrowed_global_config,
+            device_local_config,
+            storage.get_mesh_buffer().device(),
+            storage.get_mesh_buffer().address() + offset_bytes);
+
+        tt::tt_metal::DeviceStorage subtensor_storage(subtensor_mesh, storage.coords, storage.get_root_mesh_buffer());
+        TensorSpec subtensor_spec = TensorSpec(
+            output_tensor_shape,
+            tt::tt_metal::TensorLayout(
+                input_tensor.dtype(),
+                input_tensor.tensor_spec().page_config(),
+                input_tensor.tensor_spec().memory_config()));
+
+        return Tensor(subtensor_storage, subtensor_spec, input_tensor.tensor_topology());
+    }
+
+    // Handle sharded L1 buffers
+    if (input_tensor.memory_config().buffer_type() == ttnn::BufferType::L1 && input_tensor.is_sharded()) {
+        // Compute internal block size for non-last dimensions
+        uint64_t elements_per_row = 1;
+        for (uint32_t i = dim + 1; i < input_tensor_shape.size() - 1; ++i) {
+            elements_per_row *= input_tensor_shape[i];
+        }
+
+        auto current_shard_shape = input_tensor.shard_spec()->shape;
+        auto narrowed_shard_shape = current_shard_shape;
+        uint32_t page_offset = 0;
+
+        // Extract device-local configuration early to get page_shape
+        auto device_local_config = storage.get_mesh_buffer().device_local_config();
+        auto& sharding_args = device_local_config.sharding_args;
+        auto shard_spec_buffer = sharding_args.shard_spec().value();
+        auto page_shape = shard_spec_buffer.page_shape;
+
+        // Process narrowing based on dimension
+        if (narrow_width) {
+            // Narrowing on last dimension
+            if (current_shard_shape[0] == page_shape[0] &&
+                (start % current_shard_shape[1] + length) <= current_shard_shape[1]) {
+                // Splitting shard on last dimension
+                narrowed_shard_shape[1] = length;
+                page_offset = (start % current_shard_shape[1]) / page_shape[1];
+            } else if (start % current_shard_shape[1] == 0 && length % current_shard_shape[1] == 0) {
+                // Using full shards on last dimension (no-op for shard shape)
+            } else {
+                TT_FATAL(
+                    false,
+                    "Narrowing on last dimension for L1 sharded tensor only supports full shards or splitting "
+                    "within single shard. Got start {} and length {} with shard shape ({}, {})",
+                    start,
+                    length,
+                    current_shard_shape[0],
+                    current_shard_shape[1]);
+            }
+        } else {
+            // Narrowing on non-last dimension
+            uint64_t start_offset = start * elements_per_row;
+            uint64_t length_offset = length * elements_per_row;
+
+            if ((start_offset % current_shard_shape[0] + length_offset) <= current_shard_shape[0]) {
+                // Splitting shard on non-last dimension
+                narrowed_shard_shape[0] = length_offset;
+                page_offset =
+                    (start_offset % current_shard_shape[0]) / page_shape[0] * current_shard_shape[1] / page_shape[1];
+            } else if (start_offset % current_shard_shape[0] == 0 && length_offset % current_shard_shape[0] == 0) {
+                // Using full shards on non-last dimension (no-op for shard shape)
+            } else {
+                TT_FATAL(
+                    false,
+                    "Narrowing on non-last dimension for L1 sharded tensor only supports full shards or splitting "
+                    "within single shard. Got start {} and length {} with shard shape ({}, {})",
+                    start,
+                    length,
+                    current_shard_shape[0],
+                    current_shard_shape[1]);
+            }
+        }
+
+        // Extract device-local configuration
+        auto buffer_distribution_spec = sharding_args.buffer_distribution_spec().value();
+        const auto& cores_with_data = buffer_distribution_spec.cores_with_data();
+        auto tensor_pages_shape = shard_spec_buffer.tensor2d_shape_in_pages;
+        auto shard_pages_shape = shard_spec_buffer.shape_in_pages();
+
+        uint32_t grid_width = tensor_pages_shape[1] / shard_pages_shape[1];
+
+        // Filter cores that contain needed pages
+        std::vector<CoreCoord> filtered_cores;
+        filtered_cores.reserve(cores_with_data.size());
+
+        for (uint32_t core_id = 0; core_id < cores_with_data.size(); ++core_id) {
+            bool is_in_range = false;
+
+            if (narrow_width) {
+                // Last dimension narrowing: check page ID based on width
+                uint32_t core_width = core_id % grid_width;
+                uint64_t page_id = (core_width * current_shard_shape[1] / page_shape[1]) + page_offset;
+                is_in_range = (page_id >= (start / page_shape[1])) && (page_id < ((start + length) / page_shape[1]));
+            } else {
+                // Non-last dimension narrowing: check page ID based on height
+                uint32_t core_height = core_id / grid_width;
+                uint64_t page_id = (core_height * current_shard_shape[0] / page_shape[0] +
+                                    page_offset / (current_shard_shape[1] / page_shape[1])) %
+                                   (input_tensor_shape[dim] * elements_per_row / page_shape[0]);
+                uint64_t start_page = start * elements_per_row / page_shape[0];
+                uint64_t end_page = (start + length) * elements_per_row / page_shape[0];
+                is_in_range = (page_id >= start_page) && (page_id < end_page);
+            }
+
+            if (is_in_range) {
+                filtered_cores.push_back(cores_with_data[core_id]);
+            }
+        }
+
+        // Create new core grid
+        CoreRangeSet new_core_grid;
+        if (shard_spec_buffer.orientation() == ShardOrientation::ROW_MAJOR) {
+            new_core_grid = CoreRangeSet(filtered_cores);
+        } else {
+            std::vector<CoreRange> core_ranges;
+            core_ranges.reserve(filtered_cores.size());
+            for (const auto& core : filtered_cores) {
+                core_ranges.push_back(CoreRange(core));
+            }
+            new_core_grid = CoreRangeSet(core_ranges);
+        }
+
+        // Update tensor shape in pages
+        auto narrowed_pages_shape = tensor_pages_shape;
+        if (narrow_width) {
+            narrowed_pages_shape[1] /= reduction_factor;
+        } else {
+            narrowed_pages_shape[0] /= reduction_factor;
+        }
+
+        // Create new shard specifications
+        tt::tt_metal::ShardSpec narrowed_shard_spec(new_core_grid, narrowed_shard_shape, ShardOrientation::ROW_MAJOR);
+        tt::tt_metal::ShardSpecBuffer narrowed_shard_spec_buffer =
+            tt::tt_metal::ShardSpecBuffer(narrowed_shard_spec, shard_spec_buffer.page_shape, narrowed_pages_shape);
+
+        tt::tt_metal::Shape tensor_shape_pages(narrowed_pages_shape);
+        tt::tt_metal::Shape shard_shape_pages(narrowed_shard_spec_buffer.shape_in_pages());
+        tt::tt_metal::BufferDistributionSpec narrowed_buffer_dist_spec =
+            tt::tt_metal::BufferDistributionSpec(tensor_shape_pages, shard_shape_pages, filtered_cores);
+
+        tt::tt_metal::BufferShardingArgs narrowed_sharding_args(
+            narrowed_buffer_dist_spec, narrowed_shard_spec_buffer, sharding_args.buffer_layout());
+
+        // Create new device-local configuration
+        tt::tt_metal::distributed::DeviceLocalBufferConfig narrowed_device_config = {
+            .page_size = device_local_config.page_size,
+            .buffer_type = device_local_config.buffer_type,
+            .sharding_args = narrowed_sharding_args,
+            .bottom_up = device_local_config.bottom_up};
+
+        auto subtensor_mesh = tt::tt_metal::distributed::MeshBuffer::create(
+            narrowed_global_config,
+            narrowed_device_config,
+            storage.get_mesh_buffer().device(),
+            storage.get_mesh_buffer().address() + (page_offset * buffer->aligned_page_size()));
+
+        tt::tt_metal::DeviceStorage subtensor_storage(subtensor_mesh, storage.coords, storage.get_root_mesh_buffer());
+
+        auto narrowed_memory_config =
+            MemoryConfig(input_tensor.memory_config().memory_layout(), BufferType::L1, narrowed_shard_spec);
+
+        TensorSpec subtensor_spec = TensorSpec(
+            output_tensor_shape,
+            tt::tt_metal::TensorLayout(
+                input_tensor.dtype(), input_tensor.tensor_spec().page_config(), narrowed_memory_config));
+
+        return Tensor(subtensor_storage, subtensor_spec, input_tensor.tensor_topology());
+    }
+
+    // Unsupported tensor configuration
+    TT_FATAL(
+        false,
+        "Narrowing for the given tensor configuration is not yet implemented."
+        "Supported: DRAM INTERLEAVED tensors on first non-trivial dimension, L1 sharded tensors with restrictions.");
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+
+ttnn::Tensor narrow(const ttnn::Tensor& input_tensor, int32_t narrow_dim, int32_t narrow_start, uint32_t length);
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "narrow_nanobind.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include <nanobind/nanobind.h>
+
+#include "narrow.hpp"
+
+namespace ttnn::operations::data_movement {
+
+void bind_narrow(nb::module_& mod) {
+    const auto* doc = R"doc(
+        This is a zero-cost narrow operation that returns the narrowed version of the tensor. The returned tensor shares the same data buffer as the input tensor, but dimension dim will have the specified length, starting from the start index.
+
+        Note:
+            * Input tensor must be stored on the device.
+            * Currently supports only DRAM INTERLEAVED or L1 sharded tensors.
+            * For DRAM INTERLEAVED tensors, narrow can only be performed on the first non-trivial dimension, with start pointing to the first bank.
+            * For L1 sharded tensors, narrow is supported only in specific cases: when the narrowed region consists of complete full shards, or when the narrowed region spans multiple shards with the same page offset.
+            * Supports all pairs of layout and data types that are supported by ttnn.
+
+        Args:
+            * input_tensor: Input Tensor.
+            * dim: Dimension to narrow.
+            * start: Starting index of the narrow operation.
+            * length: Length of the narrow dimension.
+
+        Returns:
+            ttnn.Tensor: a reference to the narrowed tensor but with the new shape.
+
+        Example:
+
+            >>> tensor = ttnn.rand((32, 16, 16, 4), dtype=ttnn.bfloat16, device=device)
+            >>> output = ttnn.narrow(tensor, 0, 12, 8)
+
+        )doc";
+
+    ttnn::bind_function<"narrow">(
+        mod, doc, &ttnn::narrow, nb::arg("input_tensor"), nb::arg("dim"), nb::arg("start"), nb::arg("length"));
+}
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow_nanobind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::data_movement {
+namespace nb = nanobind;
+void bind_narrow(nb::module_& mod);
+}  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Introduce ttnn.narrow operation for efficient sub-tensor extraction. This zero-copy slicing primitive enables memory optimizations in models like Deepseek by allowing direct sub-tensor view operations without data duplication.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes