### PR TITLE
Add HF mixtral MoE as reference to mixtral moe test

### DIFF
--- a/models/tt_transformers/tests/mixtral/test_mixtral_moe.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_moe.py
@@ -129,7 +129,7 @@ def test_mixtral_moe_inference(t3k_mesh_device, reset_seeds, mode, device_params
             .view(seqlen, batch, -1)
         )
         # Reference Model Output
-        logger.info(f"Starting Reeference MOE {mode}")
+        logger.info(f"Starting Reference MOE {mode}")
         ref_output, _ = reference_model(pt_decode_input)
         passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc)
 


### PR DESCRIPTION
### Ticket
Close [#30101](https://github.com/tenstorrent/tt-metal/issues/30101)

### Problem description
The references for models tests are being changed to HF.

### What's changed
Just using the HF Mixtral MoE module, as well as the required config object for Mixtral model as it's required to instantiate the MoE.

Weights loading is not modified.

### Checklist
- [x]  [All  post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20465276592) CI running
- [x]  [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20465302816) CI running