### PR TITLE
Fix ttnn.topk doc defaults

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -37,8 +37,8 @@ void bind_reduction_topk_operation(nb::module_& mod) {
                 input_tensor (ttnn.Tensor): the input tensor.
                 k (number): the number of top elements to look for.
                 dim (number): the dimension to reduce.
-                largest (bool): whether to return the largest or the smallest elements. Defaults to `False`.
-                sorted (bool): whether to return the elements in sorted order. Defaults to `False`.
+                largest (bool): whether to return the largest or the smallest elements. Defaults to `True`.
+                sorted (bool): whether to return the elements in sorted order. Defaults to `True`.
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -37,8 +37,8 @@ void bind_reduction_topk_operation(py::module& module) {
                 input_tensor (ttnn.Tensor): the input tensor.
                 k (number): the number of top elements to look for.
                 dim (number): the dimension to reduce.
-                largest (bool): whether to return the largest or the smallest elements. Defaults to `False`.
-                sorted (bool): whether to return the elements in sorted order. Defaults to `False`.
+                largest (bool): whether to return the largest or the smallest elements. Defaults to `True`.
+                sorted (bool): whether to return the elements in sorted order. Defaults to `True`.
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.cpp
@@ -37,8 +37,8 @@ void bind_reduction_topk_operation(py::module& module) {
                 input_tensor (ttnn.Tensor): the input tensor.
                 k (number): the number of top elements to look for.
                 dim (number): the dimension to reduce.
-                largest (bool): whether to return the largest or the smallest elements. Defaults to `True`.
-                sorted (bool): whether to return the elements in sorted order. Defaults to `True`.
+                largest (bool): whether to return the largest or the smallest elements. Defaults to `False`.
+                sorted (bool): whether to return the elements in sorted order. Defaults to `False`.
 
             Keyword Args:
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.


### PR DESCRIPTION
`ttnn.topk` docstrings claims that:

> If largest is True, the k largest elements are returned. Otherwise, the k smallest elements are returned.

I think this is a lie and have created this glorious PR to set the record straight and return peace and joy to the mankind in this small and humble way.