### PR TITLE
Fix Llama8B-N150 max seq len assertion and note in TTT readme

### DIFF
--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -316,7 +316,7 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and batch
 
 ### Implementation notes
 
-**Chunked prefill (text-only)**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 64k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below.
+**Chunked prefill (text-only)**: All of the compatible model/device combinations support a max prefill context-length of 128k, with the exception of Llama3.1-8B and Llama3.2-11B on N150 which have a max of 32k (due to a lack of memory). To support these large max context-lengths, chunked prefill is performed with different max chunk sizes as shown in the table below.
 
 Max Prefill Chunk Sizes (text-only):
 |              |      N150     |      N300     |      T3K       |      TG     |

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -374,7 +374,7 @@ class LlamaForCausalLM(Generator):
             and mesh_device.get_num_devices() == 1
             and is_wormhole_b0()
         ):
-            MAX_PROMPT_LEN = 65536
+            MAX_PROMPT_LEN = 32768
             if max_seq_len > MAX_PROMPT_LEN:
                 raise ValueError(
                     f"TT-LLama8B and TT-Llama11B do not support max_model_len greater than {MAX_PROMPT_LEN} on N150 "


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/vllm/issues/285

### Problem description
- 64K tokens in kv cache for Llama8B-N150 causes OOM for short ISL (1K). Not a recent regression, has been occurring for over a month in vLLM. Not exposed by demo test since demo sets `{"page_block_size": 32, "page_max_num_blocks_per_dp": 1024}`. Max chunk size cannot be lowered further (already at 4k, cannot be below 2k). 

### What's changed
- In vLLM, lowering max tokens for llama8b-n150 in kv cache to 32k until the model can support more blocks - https://github.com/tenstorrent/vllm/pull/289.
- Updated TTT readme to indicate actual max context len (32k instead of 64k) for Llama8B-N150.

### Checklist
- vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/20440472321