### PR TITLE
Put whole prefill processing under trace

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -107,7 +107,7 @@ class Generator:
 
     def prepare_slice_tensors(self, last_token_idx, embed_shape, model_id):
         start_slice_tensor = ttnn.from_torch(torch.tensor([0, 0, last_token_idx, 0]))
-        end_slice_tensor = ttnn.from_torch(torch.tensor([0, 0, last_token_idx + 32, embed_shape]))
+        end_slice_tensor = ttnn.from_torch(torch.tensor([1, 1, last_token_idx + 32, embed_shape]))
         host_tensors = [start_slice_tensor, end_slice_tensor]
         device_tensors = [self.slice_tensors[model_id][0], self.slice_tensors[model_id][1]]
         copy_host_to_device(host_tensors, device_tensors, mesh_device=self.model_args[model_id].mesh_device)
@@ -362,7 +362,7 @@ class Generator:
                     prefill_ids,
                     page_table=page_table_user,
                     user_id=group_user_id,
-                    last_token_idx=last_token_idx,
+                    last_token_idx=(last_token_idx // 32) * 32,
                     kv_cache=model_kv_cache,
                     model_id=model_id,
                     prefill_seq_len=prefill_seq_len,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -129,7 +129,6 @@ class Generator:
         enable_trace,
         sampling_params=None,
     ):
-        return
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1318,6 +1318,9 @@ class ModelArgs:
         }
 
         max_seq_len_to_warmup = model_specific_ceil_warmup_lengths.get(self.base_model_name, DEFAULT_VALUE)
+        if max_seq_len_to_warmup > self.capped_warmup_seq_len:
+            max_seq_len_to_warmup = self.capped_warmup_seq_len
+
         to_warmup_seq_lens = calculate_prefill_warmup_seq_lens(
             max_seq_len_to_warmup, self.trace_prefill_supported_seq_lens
         )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34601)

### Problem description
Currently, some last steps of prefill are not captured under trace and with these changes they will be captured within the trace.

https://github.com/tenstorrent/tt-metal/issues/35100

### Checklist
- [ ] vllm nightly - https://github.com/tenstorrent/tt-metal/actions/runs/20445059841
- [x] models-ci llama8b - https://github.com/tenstorrent/tt-shield/actions/runs/20445078615
- [x] [All post commit] - https://github.com/tenstorrent/tt-metal/actions/runs/20445089333
- [x] (For models and ops writers) [Single-card demo tests] - https://github.com/tenstorrent/tt-metal/actions/runs/20445101596
- [ ] [Galaxy demo tests, for Llama] - https://github.com/tenstorrent/tt-metal/actions/runs/20445116140
- [x] (For runtime and ops writers) [T3000 unit tests] - https://github.com/tenstorrent/tt-metal/actions/runs/20445127911
- [ ] (For models and ops writers) [T3000 demo tests] - https://github.com/tenstorrent/tt-metal/actions/runs/20445138898
- [x] blackhole demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/20445152120