### PR TITLE
Improve accuracy of tanh on float32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -7,9 +7,59 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_sigmoid.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
+
+/*
+ * Accurate tanh for fp32 using sigmoid: tanh(x) = 2*sigmoid(2x) - 1
+ * For small |x| < 0.6, uses minimax polynomial for better accuracy
+ *
+ * Algorithm:
+ * - For |x| < 0.6: Use minimax polynomial (Sollya-optimized)
+ * - For |x| >= 0.6: Use 2*sigmoid(2x) - 1
+ *
+ * Target accuracy: < 5 ULP for float32 (0.5 ULP for bfloat16)
+ */
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
+
+    sfpi::vFloat abs_val = sfpi::abs(val);
+
+    v_if(abs_val < POLYNOMIAL_THRESHOLD) {
+        // Small |x|: Use minimax polynomial for better accuracy
+        // Polynomial coefficients found with Sollya using the following command:
+        // fpminimax(tanh(x)/x, [|0,2,4,6,8|], [|single...|], [-0.6; -2^(-40)] + [2^(-40); 0.6], relative);
+        sfpi::vFloat x2 = val * val;
+
+        sfpi::vFloat p = PolynomialEvaluator::eval(
+            x2,
+            0.999999940395355224609375f,
+            -0.33332359790802001953125f,
+            0.13310669362545013427734375f,
+            -5.21197654306888580322265625e-2f,
+            1.5497927553951740264892578125e-2f);
+
+        result = val * p;
+    }
+    v_else {
+        // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
+        sfpi::vFloat two_x = 2.f * val;
+
+        // Perform sigmoid manually as 1/(1+exp(-x))
+        // (TODO: https://github.com/tenstorrent/tt-metal/pull/34862#discussion_r2639909601)
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
+
+        // Compute 2*sigmoid(2x) - 1
+        result = 2.f * sig - sfpi::vConst1;
+    }
+    v_endif;
+
+    return result;
+}
 
 template <bool is_fp32_acc_to_dest_mode = true>
 sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
@@ -35,10 +85,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     sfpi::vec_min_max(result, threshold_value);
 
     result = sfpi::setsgn(result, val);  // restore sign (i.e. tanh(-x) = -tanh(x))
-
-    if constexpr (!is_fp32_acc_to_dest_mode) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
 
     return result;
 }
@@ -68,10 +114,6 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     sfpi::vec_min_max(result, threshold_value);
 
     result = sfpi::setsgn(result, x);  // restore sign (i.e. tanh(-x) = -tanh(x))
-
-    if constexpr (!is_fp32_acc_to_dest_mode) {
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
-    }
 
     return result;
 }
@@ -104,9 +146,11 @@ inline void calculate_tanh() {
             sfpi::vFloat result;
 
             if constexpr (is_fp32_dest_acc_en) {
-                result = _sfpu_tanh_continued_fraction_<is_fp32_dest_acc_en>(val);
+                // Use accurate sigmoid-based tanh for fp32
+                result = _sfpu_tanh_fp32_accurate_<is_fp32_dest_acc_en>(val);
             } else {
                 result = _sfpu_tanh_polynomial_<is_fp32_dest_acc_en>(val);
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
             }
 
             sfpi::dst_reg[0] = result;
@@ -126,8 +170,8 @@ inline void tanh_init() {
         _sfpu_load_imm16_(2, imm2);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
-            // Continued fraction
-            ckernel::sfpu::_init_sfpu_reciprocal_<false>();
+            // Accurate tanh uses sigmoid which requires reciprocal
+            _init_reciprocal_<false, false>();
         } else {
             // Polynomial approximation
             // Store some polynomial coefficients in programmable registers
@@ -138,5 +182,4 @@ inline void tanh_init() {
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -48,9 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
     v_else {
         // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
         sfpi::vFloat two_x = 2.f * val;
-
-        // Perform sigmoid manually as 1/(1+exp(-x))
-        sfpi::vFloat sig = _sfpu_sigmoid_(two_x);
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
         // Compute 2*sigmoid(2x) - 1
         result = 2.f * sig - sfpi::vConst1;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -10,12 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -23,7 +23,7 @@ namespace ckernel::sfpu {
  */
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
-    sfpi::vFloat result;
+    sfpi::vFloat result = sfpi::vConst0;
 
     constexpr float POLYNOMIAL_THRESHOLD = 0.6f;
 
@@ -48,9 +48,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
     v_else {
         // Normal region: Use tanh(x) = 2*sigmoid(2x) - 1
         sfpi::vFloat two_x = 2.f * val;
-
-        // Perform sigmoid manually as 1/(1+exp(-x))
-        sfpi::vFloat sig = _sfpu_sigmoid_(two_x);
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(two_x);
 
         // Compute 2*sigmoid(2x) - 1
         result = 2.f * sig - sfpi::vConst1;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -50,10 +50,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
         sfpi::vFloat two_x = 2.f * val;
 
         // Perform sigmoid manually as 1/(1+exp(-x))
-        // (TODO: https://github.com/tenstorrent/tt-metal/pull/34862#discussion_r2639909601)
-        sfpi::vFloat exp_neg_x = _sfpu_exp_f32_accurate_(-two_x);
-        sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
-        sfpi::vFloat sig = _sfpu_reciprocal_<2>(denominator);
+        sfpi::vFloat sig = _sfpu_sigmoid_(two_x);
 
         // Compute 2*sigmoid(2x) - 1
         result = 2.f * sig - sfpi::vConst1;
@@ -63,7 +60,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_fp32_accurate_(sfpi::vFloat val) {
     return result;
 }
 
-template <bool is_fp32_acc_to_dest_mode = true>
+template <bool is_fp32_acc_to_dest_mode>
 sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     // Formula found at
     // https://varietyofsound.wordpress.com/2011/02/14/efficient-tanh-computation-using-lamberts-continued-fraction/
@@ -89,7 +86,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_continued_fraction_(sfpi::vFloat val) {
     return result;
 }
 
-template <bool is_fp32_acc_to_dest_mode = true>
+template <bool is_fp32_acc_to_dest_mode>
 sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     // For negative numbers, we compute tanh(-x) = -tanh(x)
     sfpi::vFloat val = sfpi::abs(x);  // set positive
@@ -118,7 +115,7 @@ sfpi_inline sfpi::vFloat _sfpu_tanh_polynomial_(sfpi::vFloat x) {
     return result;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
         // SFPU microcode
@@ -159,7 +156,7 @@ inline void calculate_tanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
     if constexpr (APPROXIMATION_MODE) {
         uint imm0 = 0x1DFF;  // 0.90625*x
@@ -170,8 +167,7 @@ inline void tanh_init() {
         _sfpu_load_imm16_(2, imm2);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
-            // Accurate tanh uses sigmoid which requires reciprocal
-            _init_reciprocal_<false, false>();
+            sigmoid_init<false>();
         } else {
             // Polynomial approximation
             // Store some polynomial coefficients in programmable registers

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -10,12 +10,12 @@
 
 namespace ckernel {
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>(sfpu::tanh_init<APPROXIMATE, is_fp32_dest_acc_en>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_tanh.h
@@ -18,7 +18,7 @@ inline void llk_math_eltwise_unary_sfpu_tanh_init() {
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_tanh(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_tanh<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_tanh<APPROXIMATE, is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
#33718

### Problem description
We would like tanh to be accurate within a few ULPs of torch on float32 data types. 

### What's changed

This PR improves the accuracy of tanh for float32.

#### Accuracy improvements

New tanh implementation is accurate within ~4 ULPs of torch

<img width="562" height="378" alt="tanh-accurate-float32" src="https://github.com/user-attachments/assets/a8392d3e-e0fb-499b-a3ed-8637739495a3" />

<img width="549" height="378" alt="tanh-accurate-zoom-float32" src="https://github.com/user-attachments/assets/fcb019bf-f4cd-4475-9940-61590905d0a9" />


#### Performance

On Wormhole:

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
float32 | main | 2.47 | 2532
float32 | new | 4.26 | 4363


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20660465020)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20660467424)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20664443081)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20664444607)
- [x] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20664446236)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes
- [x] L2 Nightly [OK, unrelated hang](https://github.com/tenstorrent/tt-metal/actions/runs/20664484137)