### PR TITLE
[skip ci] Skip link status retrain count checks if eth port is unused

### DIFF
--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -101,6 +101,10 @@ class EthCore(ABC):
                 output.port_status = port_status_str
             log_check_location(self.location, port_status_str != "Down", "port is down")
 
+        # if the port is unused the rest of these checks are not relevant
+        if output.port_status in ("Unused", "Unknown", "Undefined", None):
+            return output
+
         # RETRAIN COUNT
         output.retrain_count = int(
             read_word_from_device(self.location, self.eth_core_definitions.retrain_count, context=self.context)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
False tt-triage failures coming from the eth status check script

### What's changed
Retrain count, link status, etc. are not relevant when the ethernet port is unused. We should skip these checks in this case.

### Checklist
Tested locally and confirmed the issue is resolved
https://github.com/tenstorrent/tt-metal/actions/runs/20447057913/job/58752713378