### PR TITLE
Pool2D Fix for openpdn_mnist

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avgpool2d.py
@@ -171,13 +171,13 @@ def run_avg_pool2d(
     torch.manual_seed(1e3)
     torch_input = randomize_tensor(tensor_map, input_shape)
     torch_input_permuted = torch.permute(torch_input, (0, 2, 3, 1))  # N, H, W, C
+    ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
+    torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
     if in_dtype == ttnn.bfloat8_b:
-        ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
-        torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
         ttnn_input = ttnn.from_torch(torch_input_reshaped, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
     else:
         ttnn_input = ttnn.from_torch(
-            torch_input_permuted, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+            torch_input_reshaped, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
         )
 
     # run ttnn avg_pool2d

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -486,7 +486,7 @@ def test_run_max_pool_mem_config(
         device,
         tensor_map,
         ttnn.bfloat16,
-        out_memory_config=memory_config,
+        out_memory_config=out_memory_config,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -51,6 +51,7 @@ def run_max_pool2d(
     nightly_skips=True,
     out_dtype=ttnn.bfloat16,
     output_layout=ttnn.ROW_MAJOR_LAYOUT,
+    use_reshaped_tensor=True,
 ):
     in_n, in_c, in_h, in_w = input_shape
     kernel_h, kernel_w = kernel_size
@@ -124,13 +125,27 @@ def run_max_pool2d(
     ttnn_input_shape = (1, 1, in_n * in_h * in_w, in_c)
     torch_input_reshaped = torch_input_permuted.reshape(ttnn_input_shape)  # NHW, C
     if in_dtype == ttnn.bfloat8_b:
+        assert use_reshaped_tensor == True
         ttnn_input = ttnn.from_torch(
             torch_input_reshaped, in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_memory_config
         )
     else:
-        ttnn_input = ttnn.from_torch(
-            torch_input_reshaped, in_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=in_memory_config
-        )
+        if use_reshaped_tensor:
+            ttnn_input = ttnn.from_torch(
+                torch_input_reshaped,
+                in_dtype,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=in_memory_config,
+            )
+        else:
+            ttnn_input = ttnn.from_torch(
+                torch_input_permuted,
+                in_dtype,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=in_memory_config,
+            )
     # run ttnn maxpool2d
     ttnn_output = ttnn.max_pool2d(
         input_tensor=ttnn_input,
@@ -563,6 +578,7 @@ def test_run_max_pool_squeeze_net_model(
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("use_reshaped_tensor", [True, False])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
 @pytest.mark.parametrize("output_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
@@ -595,11 +611,27 @@ def test_run_max_pool_squeeze_net_model(
     ],
 )
 def test_max_pool2d_output_formats_and_layouts(
-    device, tensor_map, input_shape, shard_startegy, kernel_size, out_dtype, output_layout, in_dtype
+    device,
+    tensor_map,
+    input_shape,
+    shard_startegy,
+    kernel_size,
+    use_reshaped_tensor,
+    out_dtype,
+    output_layout,
+    in_dtype,
 ):
     padding = (0, 0)
     stride = (1, 1)
     dilation = (1, 1)
+
+    if not use_reshaped_tensor:
+        if in_dtype == ttnn.bfloat8_b:
+            pytest.skip("BFLOAT8_B input data format is not supported without reshaped tensor")
+        if out_dtype == ttnn.bfloat8_b or out_dtype == ttnn.bfloat4_b:
+            pytest.skip("skip BFLOAT8_B/BFLOAT4_B output data format for non-reshaped tensor")
+        if output_layout == ttnn.TILE_LAYOUT:
+            pytest.skip("skip TILE_LAYOUT output layout for non-reshaped tensor")
 
     run_max_pool2d(
         input_shape,

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -66,21 +66,8 @@ parameters = {
     "in_mem_config_tests": {
         "cores": [[8, 7]],  # N300 core grid
         "input_specs": [
-            [
-                2,
-                32,
-                78,
-                78,
-                3,
-                3,
-                3,
-                3,
-                0,
-                0,
-                1,
-                1,
-                False,
-            ],  # trace from openpdn_mnist test, no work on core 47 for 8x7 N300 grid
+            # trace from openpdn_mnist test, no work on core 47 for 8x7 N300 grid
+            [2, 32, 78, 78, 3, 3, 3, 3, 0, 0, 1, 1, False],
         ],
     },
     "out_mem_config_tests": {

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+import math
 import pytest
 from tests.ttnn.nightly.unit_tests.operations.pool.test_maxpool2d import run_max_pool2d
 
@@ -62,7 +63,27 @@ parameters = {
             [1, 512, 25, 25, 12, 12, 1, 1, 6, 6, 1, 1, False],  # 12x12 kernel
         ],
     },
-    "mem_config_tests": {
+    "in_mem_config_tests": {
+        "cores": [[8, 7]],  # N300 core grid
+        "input_specs": [
+            [
+                2,
+                32,
+                78,
+                78,
+                3,
+                3,
+                3,
+                3,
+                0,
+                0,
+                1,
+                1,
+                False,
+            ],  # trace from openpdn_mnist test, no work on core 47 for 8x7 N300 grid
+        ],
+    },
+    "out_mem_config_tests": {
         "in_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_specs": [
             [1, 32, 224, 224, 3, 3, 2, 2, 1, 1, 1, 1, False],
@@ -183,11 +204,11 @@ def test_max_pool2d_block_shard(device, in_dtype, input_spec, tensor_map):
     )
 
 
-@pytest.mark.parametrize("input_spec", parameters["mem_config_tests"]["input_specs"])
-@pytest.mark.parametrize("in_dtype", parameters["mem_config_tests"]["in_dtype"])
-@pytest.mark.parametrize("memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("input_spec", parameters["out_mem_config_tests"]["input_specs"])
+@pytest.mark.parametrize("in_dtype", parameters["out_mem_config_tests"]["in_dtype"])
+@pytest.mark.parametrize("out_memory_config", [ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_max_pool2d_mem_config(device, in_dtype, input_spec, memory_config, tensor_map):
+def test_max_pool2d_mem_config(device, in_dtype, input_spec, out_memory_config, tensor_map):
     (
         in_n,
         in_c,
@@ -213,7 +234,7 @@ def test_max_pool2d_mem_config(device, in_dtype, input_spec, memory_config, tens
         device,
         tensor_map,
         in_dtype,
-        memory_config=memory_config,
+        out_memory_config=out_memory_config,
         shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ceil_mode=ceil_mode,
         nightly_skips=False,
@@ -256,5 +277,61 @@ def test_max_pool2d_tiled_out(device, in_dtype, input_spec, out_dtype, tensor_ma
         ceil_mode=ceil_mode,
         output_layout=output_layout,
         out_dtype=out_dtype,
+        nightly_skips=False,
+    )
+
+
+@pytest.mark.parametrize("input_spec", parameters["in_mem_config_tests"]["input_specs"])
+@pytest.mark.parametrize("cores", parameters["in_mem_config_tests"]["cores"])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_max_pool2d_in_mem_config(device, input_spec, cores, tensor_map):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ceil_mode,
+    ) = input_spec
+
+    (cores_x, cores_y) = cores
+
+    # shard shape calculations are only accurate for height sharded tensors
+    shard_scheme = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    shard_orientation = ttnn.ShardOrientation.ROW_MAJOR
+    in_nhw = in_n * in_h * in_w
+    num_cores = cores_x * cores_y
+    # we use tile shape to mimic tile based tensors passed from other ops like conv2d
+    shard_height = math.ceil(math.ceil(in_nhw / num_cores) / 32) * 32
+    shard_width = math.ceil(in_c / 32) * 32
+
+    in_memory_config = ttnn.MemoryConfig(
+        memory_layout=shard_scheme,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(cores_x - 1, cores_y - 1))}),
+            [shard_height, shard_width],
+            shard_orientation,
+        ),
+    )
+
+    run_max_pool2d(
+        [in_n, in_c, in_h, in_w],
+        (kernel_h, kernel_w),
+        (pad_h, pad_w),
+        (stride_h, stride_w),
+        (dilation_h, dilation_w),
+        device,
+        tensor_map,
+        ttnn.bfloat16,
+        in_memory_config=in_memory_config,
+        ceil_mode=ceil_mode,
         nightly_skips=False,
     )

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -519,18 +519,6 @@ void kernel_main() {
     uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
     bool first_row_value = reader_id == 0 || !use_split_reader;
 
-    uint32_t reader_indices_on_core = 0;
-
-    if (use_split_reader) {
-        if (reader_id == 0) {
-            reader_indices_on_core = (reader_nindices + 1) / 2;
-        } else {
-            reader_indices_on_core = reader_nindices / 2;
-        }
-    } else {
-        reader_indices_on_core = reader_nindices;
-    }
-
     while (num_segments--) {
         uint32_t start_end_segment = reader_indices_ptr[segments_counter++];
         uint16_t start = start_end_segment & 0xffff;
@@ -551,7 +539,6 @@ void kernel_main() {
                     use_split_reader,
                     multi_buffering_factor>(scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
-            reader_indices_on_core--;
             read_kernel_with_top_left_index<
                 in_nblocks_c,
                 in_cb_id,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -722,7 +722,9 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         } else {
             total_out_nhw_processed = core_i * max_out_nhw_per_core;
         }
-        uint32_t out_nhw_this_core = std::min(max_out_nhw_per_core, total_out_nhw - total_out_nhw_processed);
+        uint32_t remaining_out_nhw =
+            total_out_nhw_processed < total_out_nhw ? total_out_nhw - total_out_nhw_processed : 0;
+        uint32_t out_nhw_this_core = std::min(max_out_nhw_per_core, remaining_out_nhw);
         std::vector<uint32_t> args = {out_nhw_this_core};
 
         if (return_indices) {


### PR DESCRIPTION
### Ticket
Fixing regression from https://github.com/tenstorrent/tt-metal/pull/34186

### Problem description
Pool2D hangs for the openpdn_mnist unit test.

### What's changed
The out nhw per core has been adjusted for grids which don't use all rectangular cores such that unused cores process 0 out nhw rather than the max out nhw per core.

A new input memory config test has been added.

All pool tests have been adjusted to reshape the tensor before passing it to pool for all data formats where before this was only done for Bfloat8, not Bfloat16.

Some related dead code was removed from the pool reader kernel.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20490041318
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20492031738
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/20490049688
failing on main, this PR hits same unrelated error, and passes the openpdn_mnist test whose failure motivated this PR