### PR TITLE
#0: Add skip to `ttnn_tracer_model` tutorial

### DIFF
--- a/tests/ttnn/notebook_tests/test_tutorials.py
+++ b/tests/ttnn/notebook_tests/test_tutorials.py
@@ -48,7 +48,6 @@ TUTORIALS_DATA_PATHS = {
 EXCLUDED_TUTORIALS = [
     "train_and_export_mlp.py",
     "train_and_export_cnn.py",
-    "ttnn_tracer_model.py",
     "ttnn_tracer_model.ipynb",  # GH issue: #34947
     "ttnn_tracer_model.py",  # GH issue: #34947
     # NOTE: Add tutorial file names here that should be excluded from tests

--- a/tests/ttnn/notebook_tests/test_tutorials.py
+++ b/tests/ttnn/notebook_tests/test_tutorials.py
@@ -48,7 +48,9 @@ TUTORIALS_DATA_PATHS = {
 EXCLUDED_TUTORIALS = [
     "train_and_export_mlp.py",
     "train_and_export_cnn.py",
-    "ttnn_tracer_model.py"
+    "ttnn_tracer_model.py",
+    "ttnn_tracer_model.ipynb",  # GH issue: #34947
+    "ttnn_tracer_model.py",  # GH issue: #34947
     # NOTE: Add tutorial file names here that should be excluded from tests
 ]
 


### PR DESCRIPTION
### Ticket
#0 - respond to failing CI

### Problem description
`ttnn_tracer_model` fail on CI. Run: https://github.com/tenstorrent/tt-metal/actions/runs/20457026807/job/58781616793

### What's changed
- Added skip to `test_tutorials.py` for this test,
- Created an issue: #34947

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/20457749667