### PR TITLE
Split DeepSeek V3 tests into separate unit and module test jobs

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -35,8 +35,8 @@ jobs:
         id: generate
         run: |
           all_tests=$(jq -n '[
-            { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 20, "owner_id": "U03HY7MK4BT" },
-            { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 140, "owner_id": "U03HY7MK4BT" }
+            { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 15, "owner_id": "U03HY7MK4BT" },
+            { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 150, "owner_id": "U03HY7MK4BT" }
           ]')
 
           # Filter matrix based on test-type selection
@@ -102,31 +102,19 @@ jobs:
         if: ${{ matrix.test-group.test-type == 'unit' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          fail=0
-          echo "LOG_METAL: Running DeepSeek unit tests"
-          start_time=$(date +%s)
-
           pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests/unit --timeout 10 --durations=0 || fail=1
-
-          end_time=$(date +%s)
-          duration=$((end_time - start_time))
-          echo "LOG_METAL: DeepSeek unit tests took $duration seconds to complete"
-
-          if (( fail )); then
-            exit 1
-          fi
+          pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
       - name: Validate weight cache
         if: ${{ matrix.test-group.test-type == 'module' }}
         timeout-minutes: 10
         run: |
-          python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/test_cache" || true
+          python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache" || true
       - name: Run DeepSeek module tests
         if: ${{ matrix.test-group.test-type == 'module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --timeout 10 --durations=0
+          pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --timeout 600  --durations=0
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -20,15 +20,46 @@ on:
         required: false
         type: string
         default: "topology-6u"
+      test-type:
+        required: false
+        type: string
+        default: "all"
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate test matrix
+        id: generate
+        run: |
+          all_tests=$(jq -n '[
+            { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 20, "owner_id": "U03HY7MK4BT" },
+            { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 140, "owner_id": "U03HY7MK4BT" }
+          ]')
+
+          # Filter matrix based on test-type selection
+          if [ "${{ inputs.test-type }}" = "all" ]; then
+            matrix="$all_tests"
+          else
+            matrix=$(echo "$all_tests" | jq -c "[.[] | select(.\"test-type\" == \"${{ inputs.test-type }}\")]")
+          fi
+
+          # Fail fast if the matrix is empty (invalid test-type selected)
+          if [ "$(echo "$matrix" | jq length)" -eq 0 ]; then
+            echo "Error: Invalid test-type selected: '${{ inputs.test-type }}'"
+            exit 1
+          fi
+          echo "matrix=$(echo "$matrix" | jq -c .)" >> $GITHUB_OUTPUT
+
   galaxy-deepseek-tests:
+    needs: generate-matrix
+    name: ${{ matrix.test-group.name }}
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { name: "(Galaxy) DeepSeek tests", arch: wormhole_b0, model: deepseek, timeout: 120, owner_id: U03HY7MK4BT}, # Mark O'Connor
-        ]
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     runs-on:
       - arch-wormhole_b0
       - ${{ inputs.topology }}
@@ -49,7 +80,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -67,7 +98,8 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run DeepSeek tests
+      - name: Run DeepSeek unit tests
+        if: ${{ matrix.test-group.test-type == 'unit' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           fail=0
@@ -75,7 +107,7 @@ jobs:
           start_time=$(date +%s)
 
           pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests --timeout 10 --durations=0 || fail=1
+          pytest models/demos/deepseek_v3/tests/unit --timeout 10 --durations=0 || fail=1
 
           end_time=$(date +%s)
           duration=$((end_time - start_time))
@@ -84,6 +116,17 @@ jobs:
           if (( fail )); then
             exit 1
           fi
+      - name: Validate weight cache
+        if: ${{ matrix.test-group.test-type == 'module' }}
+        timeout-minutes: 10
+        run: |
+          python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/test_cache" || true
+      - name: Run DeepSeek module tests
+        if: ${{ matrix.test-group.test-type == 'module' }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+          pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --timeout 10 --durations=0
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -2,6 +2,16 @@ name: "(Galaxy) DeepSeek tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      test-type:
+        description: 'Select which tests to run'
+        required: false
+        type: choice
+        options:
+          - all
+          - unit
+          - module
+        default: 'all'
   schedule:
     - cron: "0 3 * * *" # Run at 3:00 AM UTC (11:00 PM EST) every day
 
@@ -23,3 +33,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       topology: topology-6u
+      test-type: ${{ inputs.test-type || 'all' }}


### PR DESCRIPTION
### Summary
This PR changes the following:
- Split the DeepSeek V3 workflow into two separate jobs using matrix strategy:
  * Unit tests: runs tests in tests/unit/ directory
  * Module tests: runs tests in tests/ root directory (excluding unit/)
- Changed MLPerf mount from read-write (rw) to read-only (ro) for security
- Added manual workflow_dispatch input to select test type:
  * 'all' - runs both unit and module tests (default)
  * 'unit' - runs only unit tests
  * 'module' - runs only module tests
- Added generate-matrix job to dynamically filter test matrix based on selection
- Added weight cache validation step before module tests:
  * Validates cache directories using `validate_weight_cache.py` script
  * Output is printed but does not fail the workflow (return code ignored)
  * Uses `DEEPSEEK_V3_CACHE`/test_cache as the validation root
- Updated timeouts: unit tests (20 min), module tests (140 min)
- Maintains backward compatibility with scheduled runs (defaults to 'all')

### Checklist
- [x] DeepSeekV3 Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/20461066596