### PR TITLE
Fix perf counters hitting device side asserts

### DIFF
--- a/tt_metal/tools/profiler/perf_counters.hpp
+++ b/tt_metal/tools/profiler/perf_counters.hpp
@@ -118,6 +118,10 @@ uint32_t get_flag_for_counter_group(PerfCounterGroup counter_group) {
     uint32_t flag = 0;
     switch (counter_group) {
         case PerfCounterGroup::FPU: flag = PROFILE_PERF_COUNTERS_FPU; break;
+        case PerfCounterGroup::PACK: flag = PROFILE_PERF_COUNTERS_PACK; break;
+        case PerfCounterGroup::UNPACK: flag = PROFILE_PERF_COUNTERS_UNPACK; break;
+        case PerfCounterGroup::L1: flag = PROFILE_PERF_COUNTERS_L1; break;
+        case PerfCounterGroup::INSTRN: flag = PROFILE_PERF_COUNTERS_INSTRN; break;
         default: {
             ASSERT(false);
             break;


### PR DESCRIPTION
### Problem description
Perf counters hit device side asserts when they are enabled. 

### What's changed
Change get_flag_for_counter_group to not assert for unsupported groups (since this is used to check which groups are enabled). We can assert later if the user has actually enabled this unsupported group.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable)
- [ ] [Galaxy quick](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml) CI passes (if applicable)
- [ ] [Galaxy demo tests, for Llama](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) CI passes, if applicable, because of current Llama work
- [ ] (For runtime and ops writers) [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml) CI passes (if applicable, since this is run on push to main)
- [ ] (For models and ops writers) [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) CI passes (if applicable, since this is required for release)
- [ ] [cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) job passes
- [ ] New/Existing tests provide coverage for changes