### PR TITLE
Kp/qwen stable

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
@@ -161,6 +161,7 @@ def test_qwen_attention_ttt_inference(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_decoder_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_decoder_ttt.py
@@ -147,6 +147,7 @@ def test_qwen_decoder_ttt_inference(
         mesh_device,
         n_tensors=5,  # More tensors needed for decoder (attention + MLP)
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head.py
@@ -64,6 +64,7 @@ def test_qwen_lm_head_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=0,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
 
     mesh_device.set_sub_device_stall_group(

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_lm_head_ttt.py
@@ -77,6 +77,7 @@ def test_qwen_lm_head_ttt_inference(seq_len, batch_size, mesh_device, reset_seed
         mesh_device,
         n_tensors=0,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
 
     mesh_device.set_sub_device_stall_group(

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_mlp_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_mlp_ttt.py
@@ -77,6 +77,7 @@ def test_qwen_mlp_ttt_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=3,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_qk_norm.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_qk_norm.py
@@ -51,6 +51,7 @@ def test_qwen3_tg_qk_norm(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_qwen_accuracy.py
@@ -295,7 +295,7 @@ def test_qwen_model_acc(
         )
 
         # Sampling
-        tt_out_tok = tt_sampling(tt_out[0])
+        tt_out_tok, _ = tt_sampling(tt_out[0])
 
         # Update the idxs
         ttnn.plus_one(

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
@@ -141,6 +141,7 @@ def test_qwen_attention_inference(
         mesh_device,
         n_tensors=2,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
@@ -82,6 +82,7 @@ def test_llama_decoder_inference(
         mesh_device,
         n_tensors=5,
         n_layers=model_args.n_layers,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
@@ -84,6 +84,7 @@ def test_qwen_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds):
         mesh_device,
         n_tensors=3,
         n_layers=1,
+        is_qwen=True,
     )
     mesh_device.set_sub_device_stall_group(
         [prefetcher_setup.prefetcher_sub_device_id, prefetcher_setup.worker_sub_device_id]

--- a/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_decoder.py
@@ -134,6 +134,7 @@ class TtTransformerBlock(LightweightModule):
     ) -> ttnn.Tensor:
         # x contains input in layer 0 and ffout of previous layer thereafter, x should be dealocated
         # h contains 0 in layer 0 and h_prev+x_prev+attn_out_prev thereafter, h is persistent
+        residual_dtype = ttnn.bfloat16
         skip_mem_cfg = self.model_config["DECODE_RESIDUAL_MEMCFG"] if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
         assert (
             x.memory_config() == skip_mem_cfg
@@ -150,7 +151,7 @@ class TtTransformerBlock(LightweightModule):
         else:
             # In subsequent Layers we take the h tensor from before and modify it in place
             if self.unfuse_res_add:
-                h = ttnn.add(x, h)
+                h = ttnn.add(x, h, dtype=residual_dtype)
                 attn_in_sharded, _ = self.attention_norm(h, None, mode)
             else:
                 attn_in_sharded, _ = self.attention_norm(x, h, mode)
@@ -173,7 +174,7 @@ class TtTransformerBlock(LightweightModule):
             ff_in_sharded, _ = self.ff_norm(h, None, mode)
         if mode == "decode":
             if self.unfuse_res_add:
-                h = ttnn.add(attn_out, h)
+                h = ttnn.add(attn_out, h, dtype=residual_dtype)
                 ff_in_sharded, _ = self.ff_norm(h, None, mode)
             else:
                 ff_in_sharded, _ = self.ff_norm(attn_out, h, mode)

--- a/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_mlp.py
@@ -63,7 +63,7 @@ class TtLlamaMLP(LightweightModule):
         ]  # args.create_dram_sharded_mem_config(args.hidden_dim // args.num_devices, args.dim)
         as_sharded_tensor = lambda name, type, dim: ttnn.as_tensor(
             torch_weight(name[:2]).unsqueeze(0).unsqueeze(0),  # Grab only the wX part of the name
-            dtype=type if not args.is_qwen else ttnn.bfloat16,
+            dtype=type if not args.is_qwen else ttnn.bfloat8_b,
             device=self.mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dim, mesh_shape=args.cluster_shape),
             layout=ttnn.TILE_LAYOUT,

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -146,6 +146,7 @@ class TtTransformer(LightweightModule):
             mode="prefill",
             mesh_sub_device_manager_id_prefill=mesh_sub_device_manager_id_prefill,
             save_tensor_addresses=True,
+            is_qwen=self.args.is_qwen,
         )
         self.mesh_sub_device_manager_id_prefill = self.prefetcher_setup.mesh_sub_device_manager_id_prefill
         self.mesh_device.set_sub_device_stall_group([self.prefetcher_setup.worker_sub_device_id])
@@ -168,6 +169,7 @@ class TtTransformer(LightweightModule):
             n_layers=self.n_layers,
             mesh_sub_device_manager_id_decode=mesh_sub_device_manager_id_decode,
             save_tensor_addresses=True,
+            is_qwen=self.args.is_qwen,
         )
         self.mesh_sub_device_manager_id_decode = self.prefetcher_setup.mesh_sub_device_manager_id_decode
         self.mesh_device.set_sub_device_stall_group(

--- a/models/demos/llama3_70b_galaxy/tt/prefetcher_common.py
+++ b/models/demos/llama3_70b_galaxy/tt/prefetcher_common.py
@@ -80,7 +80,7 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             # To fit entire MLP we'd need ~742 * 1088 but using block-wise prefetching and 732 tiles this is sufficient for now
             # Note: For Qwen3-32B on Galaxy, we are seeing bad PCC when using 728 tiles, investigation is ongoing for why 728 tiles is not sufficient
             # We are using 800 tiles as a workaround for now (Issue: https://github.com/tenstorrent/tt-metal/issues/34413)
-            self.global_cb_size = 800 * 1088 if is_qwen else 728 * 1088
+            self.global_cb_size = 800 * 1024 if is_qwen else 728 * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
             # self.global_circular_buffer = ttnn.create_global_circular_buffer(
             #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -33,7 +33,6 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;
@@ -63,6 +62,10 @@ inline void calculate_sigmoid() {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -4,36 +4,31 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_polyval.h"
-#include "sfpi.h"
+#include "ckernel_sfpu_sigmoid.h"
 
 namespace ckernel::sfpu {
 
-inline sfpi::vFloat silu_sigmoid_piecewise_linear_positive(sfpi::vFloat val) {
-    sfpi::vFloat result = 1.0f;
-    v_if(val <= 1.0f) {
-        result = 0.2415f * val + 0.5f;  // linear appx as y = 0.2415f + 0.5
-    }
-    v_elseif(val < 7.7f) {
-        result = POLYVAL5<sfpi::vFloat>(
-            -3.82558889e-04f, 9.22008486e-03f, -8.34694910e-02f, 3.39967832e-01f, 4.66254244e-01f, val);
-    }
-    v_endif;
-    return result;
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
-    // SFPU microcode
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = sfpi::abs(val);
-        result = silu_sigmoid_piecewise_linear_positive(result);
-        v_if(val < 0.0f) { result = 1.0f - result; }
-        v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+
+        // silu(x) = x * sigmoid(x)
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+
+        // Round to bfloat16 if not in fp32 accumulation mode
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
+}
+
+inline void silu_init() {
+    _init_reciprocal_<false, false>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -34,7 +34,6 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
         result = _sfpu_reciprocal_<2>(denominator);
     } else {
         result = _sfpu_reciprocal_<1>(denominator);
-        result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
     }
 
     return result;
@@ -65,6 +64,10 @@ inline void calculate_sigmoid() {
             sfpi::vFloat val = sfpi::dst_reg[0];
 
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+
+            if constexpr (!is_fp32_dest_acc_en) {
+                result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+            }
 
             sfpi::dst_reg[0] = result;
             sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -4,36 +4,31 @@
 
 #pragma once
 
-#include "sfpu/ckernel_sfpu_polyval.h"
-#include "sfpi.h"
+#include "ckernel_sfpu_sigmoid.h"
 
 namespace ckernel::sfpu {
 
-inline sfpi::vFloat silu_sigmoid_piecewise_linear_positive(sfpi::vFloat val) {
-    sfpi::vFloat result = 1.0f;
-    v_if(val <= 1.0f) {
-        result = 0.2415f * val + 0.5f;  // linear appx as y = 0.2415f + 0.5
-    }
-    v_elseif(val < 7.7f) {
-        result = POLYVAL5<sfpi::vFloat>(
-            -3.82558889e-04f, 9.22008486e-03f, -8.34694910e-02f, 3.39967832e-01f, 4.66254244e-01f, val);
-    }
-    v_endif;
-    return result;
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_silu() {
-    // SFPU microcode
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat val = sfpi::dst_reg[0];
-        sfpi::vFloat result = sfpi::abs(val);
-        result = silu_sigmoid_piecewise_linear_positive(result);
-        v_if(val < 0.0f) { result = 1.0f - result; }
-        v_endif;
-        sfpi::dst_reg[0] = val * result;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+
+        // silu(x) = x * sigmoid(x)
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+
+        // Round to bfloat16 if not in fp32 accumulation mode
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
+}
+
+inline void silu_init() {
+    _init_reciprocal_<false, false>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,13 +12,13 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>();
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
 }
 
-template <bool APPROXIMATE, int ITERATIONS = 8>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<APPROXIMATE, ITERATIONS>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -439,11 +439,22 @@ ALWI void expm1_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_expm1<tr
  */
 ALWI void expm1_tile_init() { MATH((llk_math_eltwise_unary_sfpu_expm1_init<true>())); }
 
-// silu
-// Function SILU (same as Swish)
-// use activation Silu[x] = x*Sigmoid[x]
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.SiLU.html?highlight=silu#torch.nn.SiLU
-ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX>(idst))); }
+// clang-format off
+/**
+ * Performs SILU (same as Swish) operation on each element of a tile
+ * in DST register at index tile_index. Uses the following implementation:
+ * Silu[x] = x*Sigmoid[x]
+ *
+ * Ref: https://pytorch.org/docs/stable/generated/torch.nn.SiLU.html?highlight=silu#torch.nn.SiLU
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst))); }
 
 ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>())); }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -309,7 +309,7 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
         tt::tt_metal::ComputeConfig{.compile_args = compute_args_final});
 
     uint32_t core_w = 0;
-    bool ascending = !args.largest;
+    bool direction_init = !args.largest;
     for (auto core : local_cores) {
         if (input_indices_tensor.has_value()) {
             SetRuntimeArgs(
@@ -342,15 +342,8 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
                 core_w,
             });
 
-        SetRuntimeArgs(
-            program,
-            topk_compute_kernel_id,
-            core,
-            {
-                ascending,
-            });
+        SetRuntimeArgs(program, topk_compute_kernel_id, core, {direction_init});
         core_w++;
-        ascending = !ascending;
     }
     SetRuntimeArgs(
         program,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -343,6 +343,7 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
             });
 
         SetRuntimeArgs(program, topk_compute_kernel_id, core, {direction_init});
+        direction_init = !direction_init;
         core_w++;
     }
     SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -137,7 +137,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
     const auto pad_amount = std::max(
         static_cast<int>(topk::constants::min_dim_per_core) - static_cast<int>(transformed_tensor.logical_shape()[-1]),
         0);
-    const auto pad_val = largest ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
+    const auto pad_val = largest ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
     if (pad_amount > 0) {
         ttnn::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
         padded_tensor = ttnn::pad(transformed_tensor, padding, pad_val);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -137,7 +137,7 @@ std::vector<Tensor> ExecuteTopK::invoke(
     const auto pad_amount = std::max(
         static_cast<int>(topk::constants::min_dim_per_core) - static_cast<int>(transformed_tensor.logical_shape()[-1]),
         0);
-    const auto pad_val = largest ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max();
+    const auto pad_val = largest ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
     if (pad_amount > 0) {
         ttnn::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
         padded_tensor = ttnn::pad(transformed_tensor, padding, pad_val);


### PR DESCRIPTION
### Description
tt-metal and model changes for Qwen3-32b delievery


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs