### PR TITLE
add explicit torch dtype

### DIFF
--- a/ttnn/tutorials/basic_python/ttnn_tracer_model.py
+++ b/ttnn/tutorials/basic_python/ttnn_tracer_model.py
@@ -20,7 +20,7 @@ def main():
 
     with trace():
         # Create a random integer tensor of shape (1, 64) with values between 0-99
-        tensor = torch.randint(0, 100, (1, 64))
+        tensor = torch.randint(0, 100, (1, 64), dtype=torch.int32)
         # Apply exponential function element-wise
         # This demonstrates how mathematical operations are captured
         tensor = torch.exp(tensor)
@@ -31,7 +31,7 @@ def main():
 
     with trace():
         # Create a PyTorch tensor with shape (4, 64)
-        tensor = torch.randint(0, 100, (4, 64))
+        tensor = torch.randint(0, 100, (4, 64), dtype=torch.int32)
 
         # Convert PyTorch tensor to TT-NN format
         # This operation moves data to the TT-NN representation


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ttnn tutorials were failing CI, likely due to an undefined torch dtype. https://github.com/tenstorrent/tt-metal/actions/runs/20452861358/job/58769456452#step:8:908

### What's changed
Added explicit dtypes
Fixed broken pipeline

### Checklist

- [x] ttnn tutorials https://github.com/tenstorrent/tt-metal/actions/runs/20472838149/job/58832050864