### PR TITLE
SDXL refiner and img_to_img seed issue fix

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
@@ -438,8 +438,8 @@ class TtSDXLCombinedPipeline:
                 refiner_add_text_embeds,
             ) = self.refiner_pipeline.generate_input_tensors(
                 all_prompt_embeds_torch=torch.randn(
-                    self.batch_size, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER
-                ),
+                    1, 2, MAX_SEQUENCE_LENGTH, CONCATENATED_TEXT_EMBEDINGS_SIZE_REFINER
+                ).repeat(self.batch_size, 1, 1, 1),
                 torch_add_text_embeds=torch_add_text_embeds,
                 torch_image=base_latents,
                 fixed_seed_for_batch=True,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py
@@ -96,8 +96,6 @@ class TtSDXLImg2ImgPipeline(TtSDXLPipeline):
         ), "start_latent_seed must be an integer or None"
 
         # Encode image to latents (standard img2img case)
-        if start_latent_seed is not None:
-            torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed)
         add_noise = True if denoising_start is None else False
         img_latents = prepare_image_latents(
             self.torch_pipeline,
@@ -112,6 +110,8 @@ class TtSDXLImg2ImgPipeline(TtSDXLPipeline):
             False,  # No max strength path in ref img2img implementation
             add_noise,
             None,  # passed in latents
+            start_latent_seed,
+            fixed_seed_for_batch,
         )
 
         if isinstance(img_latents, ttnn.Tensor):


### PR DESCRIPTION
### Ticket
SDXL Img2Img and SDXL+Refiner encoder seed #34486
Different images for different DP (data parallel) config for img_to_img and sdxl base+refiner pipelines.


### Problem description
- `models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py` `torch.randn(batch_size, ...)` created different random embeddings for each item in the batch
- `models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py` Previously, the seed was set before calling `prepare_image_latents`, which caused incorrect RNG state when DP > 1.

### What's changed
- `models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py` Use `.repeat()` instead of creating a larger random tensor to ensure all images in the batch share the same prompt embedding.
- `models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_img2img_pipeline.py` start_latent_seed is passed to prepare_image_latents

## Checklist
- [x] [accuracy_test, --num-prompts=100 -k "device_vae and with_trace and device_encoders"](https://github.com/tenstorrent/tt-shield/actions/runs/20508220561)




