### PR TITLE
Device ops text refactor

### DIFF
--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -138,26 +138,26 @@
 [ ] ./ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/full/device/full_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+[/] ./ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp

--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -157,7 +157,7 @@
 [x] ./ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
 [x] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
 [x] ./ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
-[/] ./ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -104,13 +105,17 @@ tt::stl::hash::hash_t AllBroadcastDeviceOperation::compute_program_hash(
         input_memory_config);
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> AllBroadcastDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl::all_broadcast
+
+namespace ttnn::prim {
+std::vector<ttnn::Tensor> all_broadcast(
     const ttnn::Tensor& input_tensor,
     std::optional<uint32_t> cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     const ttnn::MemoryConfig& output_mem_config,
     uint32_t num_links,
     tt::tt_fabric::Topology topology) {
+    using OperationType = ttnn::operations::ccl::all_broadcast::AllBroadcastDeviceOperation;
     const auto& tensor_topology = input_tensor.tensor_topology();
     const auto& tensor_topology_shape = tensor_topology.distribution_shape();
 
@@ -131,15 +136,14 @@ std::tuple<operation_attributes_t, tensor_args_t> AllBroadcastDeviceOperation::i
     log_debug(tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", num_devices, num_links);
     log_debug(tt::LogOp, "DEBUG: line_fabric is created");
 
-    return {
-        operation_attributes_t{
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .num_links = num_links,
             .ring_size = num_devices,
             .output_mem_config = output_mem_config,
             .cluster_axis = cluster_axis,
             .sub_device_id = sub_device_id,
             .topology = topology},
-        tensor_args_t{.input_tensor = input_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor});
 }
-
-}  // namespace ttnn::operations::ccl::all_broadcast
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
@@ -36,20 +36,16 @@ struct AllBroadcastDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        std::optional<uint32_t> cluster_axis,
-        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-        const ttnn::MemoryConfig& output_mem_config,
-        uint32_t num_links,
-        tt::tt_fabric::Topology topology);
 };
 
 }  // namespace ttnn::operations::ccl::all_broadcast
 
 namespace ttnn::prim {
-constexpr auto all_broadcast = ttnn::register_operation<
-    "ttnn::prim::all_broadcast",
-    ttnn::operations::ccl::all_broadcast::AllBroadcastDeviceOperation>();
+std::vector<ttnn::Tensor> all_broadcast(
+    const ttnn::Tensor& input_tensor,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const ttnn::MemoryConfig& output_mem_config,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "all_gather_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::ccl {
@@ -163,8 +164,10 @@ ttsl::hash::hash_t AllGatherDeviceOperation::compute_program_hash(
         input_tensor);
 }
 
-std::tuple<AllGatherDeviceOperation::operation_attributes_t, AllGatherDeviceOperation::tensor_args_t>
-AllGatherDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::Tensor all_gather(
     const ttnn::Tensor& input_tensor,
     uint32_t dim,
     std::optional<uint32_t> cluster_axis,
@@ -174,8 +177,9 @@ AllGatherDeviceOperation::invoke(
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
     const std::optional<CoreRangeSet>& sub_core_grid) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::ccl::AllGatherDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .memory_config = memory_config,
             .dim = dim,
             .cluster_axis = cluster_axis,
@@ -183,7 +187,6 @@ AllGatherDeviceOperation::invoke(
             .topology = topology,
             .num_links = num_links,
             .sub_core_grid = sub_core_grid},
-        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor});
 }
-
-}  // namespace ttnn::operations::ccl
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
@@ -83,22 +83,19 @@ struct AllGatherDeviceOperation {
     static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        uint32_t dim,
-        std::optional<uint32_t> cluster_axis,
-        const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
-        const ttnn::MemoryConfig& memory_config,
-        const std::optional<ttnn::Tensor>& optional_output_tensor,
-        uint32_t num_links,
-        tt::tt_fabric::Topology topology,
-        const std::optional<CoreRangeSet>& sub_core_grid);
 };
 
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {
-constexpr auto all_gather =
-    ttnn::register_operation<"ttnn::prim::all_gather", ttnn::operations::ccl::AllGatherDeviceOperation>();
+ttnn::Tensor all_gather(
+    const ttnn::Tensor& input_tensor,
+    uint32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology,
+    const std::optional<CoreRangeSet>& sub_core_grid);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "all_to_all_combine_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
 
@@ -157,8 +158,10 @@ AllToAllCombineDeviceOperation::tensor_return_value_t AllToAllCombineDeviceOpera
         create_device_tensor(output_spec, tensor_args.input_tensor.device()));
 }
 
-std::tuple<AllToAllCombineDeviceOperation::operation_attributes_t, AllToAllCombineDeviceOperation::tensor_args_t>
-AllToAllCombineDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::Tensor all_to_all_combine(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& expert_mapping_tensor,
     const ttnn::Tensor& expert_metadata_tensor,
@@ -170,8 +173,9 @@ AllToAllCombineDeviceOperation::invoke(
     const bool locally_reduced,
     const CoreRangeSet& worker_core_range_set,
     uint32_t output_shard_dim) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::ccl::AllToAllCombineDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_mem_config = memory_config,
             .axis = axis,
             .num_links = num_links,
@@ -180,11 +184,10 @@ AllToAllCombineDeviceOperation::invoke(
             .worker_core_range_set = worker_core_range_set,
             .output_shard_dim = output_shard_dim,
         },
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .mapping_tensor = expert_mapping_tensor,
             .metadata_tensor = expert_metadata_tensor,
-            .optional_output_tensor = optional_output_tensor}};
+            .optional_output_tensor = optional_output_tensor});
 }
-
-}  // namespace ttnn::operations::ccl
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
@@ -102,24 +102,20 @@ struct AllToAllCombineDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& expert_mapping_tensor,
-        const ttnn::Tensor& expert_metadata_tensor,
-        uint32_t num_links,
-        tt::tt_fabric::Topology topology,
-        const ttnn::MemoryConfig& memory_config,
-        const std::optional<uint32_t>& axis,
-        const std::optional<ttnn::Tensor>& optional_output_tensor,
-        bool locally_reduced,
-        const CoreRangeSet& worker_core_range_set,
-        uint32_t output_shard_dim);
 };
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-constexpr auto all_to_all_combine =
-    ttnn::register_operation<"ttnn::prim::all_to_all_combine", ttnn::operations::ccl::AllToAllCombineDeviceOperation>();
+ttnn::Tensor all_to_all_combine(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    const ttnn::Tensor& expert_metadata_tensor,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<uint32_t>& axis,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    bool locally_reduced,
+    const CoreRangeSet& worker_core_range_set,
+    uint32_t output_shard_dim);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -98,20 +98,22 @@ MeshPartitionDeviceOperation::tensor_return_value_t MeshPartitionDeviceOperation
     return tensor;
 }
 
-std::tuple<MeshPartitionDeviceOperation::operation_attributes_t, MeshPartitionDeviceOperation::tensor_args_t>
-MeshPartitionDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::Tensor mesh_partition(
     const ttnn::Tensor& input_tensor,
     int32_t dim,
     std::optional<uint32_t> cluster_axis,
     const ttnn::MemoryConfig& memory_config,
     const std::optional<ttnn::Tensor>& optional_output_tensor) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::ccl::MeshPartitionDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .dim = (dim < 0 ? uint32_t(input_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
             .cluster_axis = cluster_axis,
             .output_mem_config = memory_config,
         },
-        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor});
 }
-
-}  // namespace ttnn::operations::ccl
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "mesh_partition_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
 

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
@@ -88,13 +88,6 @@ struct MeshPartitionDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        int32_t dim,
-        std::optional<uint32_t> cluster_axis,
-        const ttnn::MemoryConfig& memory_config,
-        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt);
 };
 
 namespace detail {
@@ -104,7 +97,10 @@ uint32_t get_cluster_axis_size(const ttnn::Tensor& input_tensor, const std::opti
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-constexpr auto mesh_partition =
-    ttnn::register_operation<"ttnn::prim::mesh_partition", ttnn::operations::ccl::MeshPartitionDeviceOperation>();
+ttnn::Tensor mesh_partition(
+    const ttnn::Tensor& input_tensor,
+    int32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
 
@@ -98,27 +99,27 @@ EmbeddingBackwardDeviceOperation::tensor_return_value_t EmbeddingBackwardDeviceO
     return create_device_tensor(output_spec, tensor_args.grad_tensor.device());
 }
 
-std::tuple<EmbeddingBackwardDeviceOperation::operation_attributes_t, EmbeddingBackwardDeviceOperation::tensor_args_t>
-EmbeddingBackwardDeviceOperation::invoke(
+}  // namespace ttnn::operations::embedding_backward
+
+namespace ttnn::prim {
+ttnn::Tensor embedding_backward(
     const Tensor& index_tensor,
     const Tensor& grad_tensor,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype,
     uint32_t num_embeddings,
     const std::optional<Tensor>& preallocated_output) {
-    operation_attributes_t operation_attributes{
-        .output_mem_config = output_mem_config,
-        .output_dtype = output_dtype,
-        .num_embeddings = num_embeddings,
-    };
-
-    tensor_args_t tensor_args{
-        .index_tensor = index_tensor,
-        .grad_tensor = grad_tensor,
-        .preallocated_output = preallocated_output,
-    };
-
-    return {operation_attributes, tensor_args};
+    using OperationType = ttnn::operations::embedding_backward::EmbeddingBackwardDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            .output_mem_config = output_mem_config,
+            .output_dtype = output_dtype,
+            .num_embeddings = num_embeddings,
+        },
+        OperationType::tensor_args_t{
+            .index_tensor = index_tensor,
+            .grad_tensor = grad_tensor,
+            .preallocated_output = preallocated_output,
+        });
 }
-
-}  // namespace ttnn::operations::embedding_backward
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
@@ -29,22 +29,16 @@ struct EmbeddingBackwardDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& index_tensor,
-        const Tensor& grad_tensor,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype,
-        uint32_t num_embeddings,
-        const std::optional<Tensor>& preallocated_output);
 };
 
 }  // namespace ttnn::operations::embedding_backward
 
 namespace ttnn::prim {
-
-constexpr auto embedding_backward = ttnn::register_operation<
-    "ttnn::prim::embedding_backward",
-    ttnn::operations::embedding_backward::EmbeddingBackwardDeviceOperation>();
-
+ttnn::Tensor embedding_backward(
+    const Tensor& index_tensor,
+    const Tensor& grad_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    uint32_t num_embeddings,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "index_fill_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -47,13 +48,18 @@ IndexFillOperation::tensor_return_value_t IndexFillOperation::create_output_tens
     const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
-std::tuple<IndexFillOperation::operation_attributes_t, IndexFillOperation::tensor_args_t> IndexFillOperation::invoke(
+}  // namespace ttnn::operations::index_fill
+
+namespace ttnn::prim {
+ttnn::Tensor index_fill(
     const Tensor& input,
     const uint32_t dim,
     const Tensor& index,
     const std::variant<float, int> value,
     const std::optional<MemoryConfig>& memory_config) {
-    return {
-        operation_attributes_t{dim, value, memory_config.value_or(input.memory_config())}, tensor_args_t{input, index}};
+    using OperationType = ttnn::operations::index_fill::IndexFillOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{dim, value, memory_config.value_or(input.memory_config())},
+        OperationType::tensor_args_t{input, index});
 }
-}  // namespace ttnn::operations::index_fill
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
@@ -48,15 +48,13 @@ struct IndexFillOperation {
     static void validate(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        uint32_t dim,
-        const Tensor& index,
-        std::variant<float, int> value,
-        const std::optional<MemoryConfig>& memory_config);
 };
 }  // namespace ttnn::operations::index_fill
 namespace ttnn::prim {
-constexpr auto index_fill =
-    ttnn::register_operation<"ttnn::prim::index_fill", ttnn::operations::index_fill::IndexFillOperation>();
+ttnn::Tensor index_fill(
+    const Tensor& input,
+    uint32_t dim,
+    const Tensor& index,
+    std::variant<float, int> value,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pool_op.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <tt-metalium/math.hpp>
 #include <utility>
@@ -210,10 +211,13 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t
     return result;
 }
 
-std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke(
+}  // namespace ttnn::operations::pool
+
+namespace ttnn::prim {
+std::vector<ttnn::Tensor> pool2d(
     const Tensor& input_tensor,
-    const sliding_window::SlidingWindowConfig& sliding_window_config,
-    Pool2DType pool_type,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    ttnn::operations::pool::Pool2DType pool_type,
     DataType output_dtype,
     Layout output_layout,
     MemoryConfig memory_config,
@@ -222,8 +226,9 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
     std::optional<int32_t> divisor_override,
     bool return_indices,
     uint32_t memory_used) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::pool::Pool2D;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .sliding_window_config_ = sliding_window_config,
             .pool_type_ = pool_type,
             .output_dtype_ = output_dtype,
@@ -234,7 +239,6 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
             .divisor_override_ = divisor_override,
             .return_indices_ = return_indices,
             .memory_used = memory_used},
-        tensor_args_t{input_tensor}};
+        OperationType::tensor_args_t{input_tensor});
 }
-
-}  // namespace ttnn::operations::pool
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -90,23 +90,21 @@ struct Pool2D {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const sliding_window::SlidingWindowConfig& sliding_window_config,
-        Pool2DType pool_type,
-        DataType output_dtype,
-        Layout output_layout,
-        MemoryConfig memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-        bool count_include_pad,
-        std::optional<int32_t> divisor_override,
-        bool return_indices,
-        uint32_t memory_used);
 };
 
 }  // namespace ttnn::operations::pool
 
 namespace ttnn::prim {
-constexpr auto pool2d = ttnn::register_operation<"ttnn::prim::pool2d", ttnn::operations::pool::Pool2D>();
+std::vector<ttnn::Tensor> pool2d(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
+    ttnn::operations::pool::Pool2DType pool_type,
+    DataType output_dtype,
+    Layout output_layout,
+    MemoryConfig memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
+    bool count_include_pad,
+    std::optional<int32_t> divisor_override,
+    bool return_indices,
+    uint32_t memory_used);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
@@ -33,21 +33,18 @@ struct GridSampleOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const Tensor& grid,
-        const std::string& mode = "bilinear",
-        const std::string& padding_mode = "zeros",
-        bool align_corners = false,
-        bool use_precomputed_grid = false,
-        bool batch_output_channels = false,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
 }  // namespace ttnn::operations::pool::grid_sample
 
 namespace ttnn::prim {
-constexpr auto grid_sample =
-    ttnn::register_operation<"ttnn::prim::grid_sample", ttnn::operations::pool::grid_sample::GridSampleOperation>();
+ttnn::Tensor grid_sample(
+    const Tensor& input_tensor,
+    const Tensor& grid,
+    const std::string& mode = "bilinear",
+    const std::string& padding_mode = "zeros",
+    bool align_corners = false,
+    bool use_precomputed_grid = false,
+    bool batch_output_channels = false,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/pool/upsample/device/upsample_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp"
@@ -123,20 +124,24 @@ UpsampleOperation::tensor_return_value_t UpsampleOperation::create_output_tensor
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-std::tuple<UpsampleOperation::operation_attributes_t, UpsampleOperation::tensor_args_t> UpsampleOperation::invoke(
+}  // namespace ttnn::operations::pool::upsample
+
+namespace ttnn::prim {
+ttnn::Tensor upsample(
     const ttnn::Tensor& input_tensor,
     const int scale_factor_h,
     const int scale_factor_w,
     const std::string& mode,
     const MemoryConfig& output_mem_config,
     const DeviceComputeKernelConfig& compute_kernel_config) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::pool::upsample::UpsampleOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .scale_factor_h = scale_factor_h,
             .scale_factor_w = scale_factor_w,
             .mode = mode,
             .output_mem_config = output_mem_config,
             .compute_kernel_config = compute_kernel_config},
-        tensor_args_t{.input_tensor = input_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor});
 }
-}  // namespace ttnn::operations::pool::upsample
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
@@ -35,19 +35,16 @@ struct UpsampleOperation {
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        int scale_factor_h,
-        int scale_factor_w,
-        const std::string& mode,
-        const MemoryConfig& output_mem_config,
-        const DeviceComputeKernelConfig& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::pool::upsample
 
 namespace ttnn::prim {
-constexpr auto upsample =
-    ttnn::register_operation<"ttnn::prim::upsample", ttnn::operations::pool::upsample::UpsampleOperation>();
+ttnn::Tensor upsample(
+    const ttnn::Tensor& input_tensor,
+    int scale_factor_h,
+    int scale_factor_w,
+    const std::string& mode,
+    const MemoryConfig& output_mem_config,
+    const DeviceComputeKernelConfig& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "accumulation_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include <enchantum/enchantum.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
@@ -110,16 +111,20 @@ operation::Hash AccumulationDeviceOperation::compute_program_hash(
         tensor_args.opt_output.has_value() ? tensor_args.opt_output.value().dtype() : DataType{});
 }
 
-AccumulationDeviceOperation::invocation_result_t AccumulationDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::accumulation
+
+namespace ttnn::prim {
+ttnn::Tensor accumulation(
     const Tensor& input_tensor,
     const int32_t& dim,
     const std::optional<DataType>& dtype,
     const bool& reverse_order,
     std::optional<Tensor> optional_out,
     const std::optional<MemoryConfig>& memory_config,
-    AccumulationOp op) {
-    return {
-        operation_attributes_t{
+    ttnn::operations::reduction::accumulation::AccumulationOp op) {
+    using OperationType = ttnn::operations::reduction::accumulation::AccumulationDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             (dim < 0) ? (dim + input_tensor.logical_shape().rank()) : dim,
             dtype.has_value() ? dtype.value()
                               : (optional_out.has_value() ? optional_out->dtype() : input_tensor.dtype()),
@@ -128,7 +133,6 @@ AccumulationDeviceOperation::invocation_result_t AccumulationDeviceOperation::in
                 : (optional_out.has_value() ? optional_out->memory_config() : input_tensor.memory_config()),
             reverse_order,
             op},
-        tensor_args_t{input_tensor, std::move(optional_out)}};
+        OperationType::tensor_args_t{input_tensor, std::move(optional_out)});
 }
-
-}  // namespace ttnn::operations::reduction::accumulation
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
@@ -43,21 +43,17 @@ struct AccumulationDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static invocation_result_t invoke(
-        const Tensor& input_tensor,
-        const int32_t& dim,
-        const std::optional<DataType>& dtype,
-        const bool& reverse_order,
-        std::optional<Tensor> optional_out,
-        const std::optional<MemoryConfig>& memory_config,
-        AccumulationOp op);
 };
 
 }  // namespace ttnn::operations::reduction::accumulation
 
 namespace ttnn::prim {
-constexpr auto accumulation = ttnn::register_operation<
-    "ttnn::prim::accumulation",
-    ttnn::operations::reduction::accumulation::AccumulationDeviceOperation>();
+ttnn::Tensor accumulation(
+    const Tensor& input_tensor,
+    const int32_t& dim,
+    const std::optional<DataType>& dtype,
+    const bool& reverse_order,
+    std::optional<Tensor> optional_out,
+    const std::optional<MemoryConfig>& memory_config,
+    ttnn::operations::reduction::accumulation::AccumulationOp op);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ema_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <tt_stl/assert.hpp>
 
@@ -85,24 +86,27 @@ tensor_return_value_t EmaDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<EmaDeviceOperation::operation_attributes_t, EmaDeviceOperation::tensor_args_t> EmaDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::ema
+
+namespace ttnn::prim {
+ttnn::Tensor ema_device(
     const Tensor& input,
     float alpha,
     CoreCoord grid_size,
-    const MemoryConfig& output_mem_config,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<Tensor> optional_output_tensor) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::reduction::ema::EmaDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .alpha = alpha,
             .grid_size = grid_size,
             .output_mem_config = output_mem_config,
             .compute_kernel_config = compute_kernel_config,
         },
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .input = input,
             .optional_output_tensor = std::move(optional_output_tensor),
-        }};
+        });
 }
-
-}  // namespace ttnn::operations::reduction::ema
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
@@ -27,19 +27,16 @@ struct EmaDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        float alpha,
-        CoreCoord grid_size,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const DeviceComputeKernelConfig& compute_kernel_config,
-        std::optional<Tensor> optional_output_tensor);
 };
 
 }  // namespace ttnn::operations::reduction::ema
 
 namespace ttnn::prim {
-constexpr auto ema_device =
-    ttnn::register_operation<"ttnn::prim::ema_device", ttnn::operations::reduction::ema::EmaDeviceOperation>();
+ttnn::Tensor ema_device(
+    const Tensor& input,
+    float alpha,
+    CoreCoord grid_size,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "argmax_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "argmax_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -180,8 +181,10 @@ tensor_return_value_t ArgMaxDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<ArgMaxDeviceOperation::operation_attributes_t, ArgMaxDeviceOperation::tensor_args_t>
-ArgMaxDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::argmax
+
+namespace ttnn::prim {
+ttnn::Tensor argmax(
     const Tensor& input,
     tt::tt_metal::DataType output_dtype,
     std::optional<int> dim,
@@ -190,8 +193,9 @@ ArgMaxDeviceOperation::invoke(
     bool use_multicore,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::optional<Tensor> optional_output_tensor) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::reduction::argmax::ArgMaxDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_dtype = output_dtype,
             .dim = dim,
             .keepdim = keepdim,
@@ -199,7 +203,6 @@ ArgMaxDeviceOperation::invoke(
             .use_multicore = use_multicore,
             .output_mem_config = output_mem_config,
         },
-        tensor_args_t{.input = input, .optional_output_tensor = std::move(optional_output_tensor)}};
+        OperationType::tensor_args_t{.input = input, .optional_output_tensor = std::move(optional_output_tensor)});
 }
-
-}  // namespace ttnn::operations::reduction::argmax
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
@@ -29,21 +29,18 @@ struct ArgMaxDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        tt::tt_metal::DataType output_dtype,
-        std::optional<int> dim,
-        bool keepdim,
-        const std::optional<CoreRangeSet>& sub_core_grids,
-        bool use_multicore,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        std::optional<Tensor> optional_output_tensor);
 };
 
 }  // namespace ttnn::operations::reduction::argmax
 
 namespace ttnn::prim {
-constexpr auto argmax =
-    ttnn::register_operation<"ttnn::prim::argmax", ttnn::operations::reduction::argmax::ArgMaxDeviceOperation>();
+ttnn::Tensor argmax(
+    const Tensor& input,
+    tt::tt_metal::DataType output_dtype,
+    std::optional<int> dim,
+    bool keepdim,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool use_multicore,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::optional<Tensor> optional_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reduce_op_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/common.hpp"
 
 namespace ttnn::operations::reduction::generic {
 
-std::tuple<ReduceDeviceOperation::operation_attributes_t, ReduceDeviceOperation::tensor_args_t>
-ReduceDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::generic
+
+namespace ttnn::prim {
+ttnn::Tensor reduce(
     const Tensor& input_tensor,
     tt::tt_metal::ReduceOpMath reduce_math,
     tt::tt_metal::ReduceOpDim reduce_dim,
@@ -17,8 +20,9 @@ ReduceDeviceOperation::invoke(
     const std::optional<DataType>& output_dtype,
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::reduction::generic::ReduceDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             reduce_math,
             reduce_dim,
             scaler,
@@ -26,8 +30,11 @@ ReduceDeviceOperation::invoke(
             output_dtype.value_or(input_tensor.dtype()),
             compute_kernel_config,
             sub_core_grids},
-        tensor_args_t{input_tensor}};
+        OperationType::tensor_args_t{input_tensor});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::reduction::generic {
 
 ReduceDeviceOperation::program_factory_t ReduceDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -30,16 +30,6 @@ struct ReduceDeviceOperation {
     static program_factory_t select_program_factory(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        tt::tt_metal::ReduceOpMath reduce_math,
-        tt::tt_metal::ReduceOpDim reduce_dim,
-        float scaler,
-        const MemoryConfig& output_mem_config,
-        const std::optional<DataType>& output_dtype,
-        const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
-        const std::optional<CoreRangeSet>& sub_core_grids);
-
     static void validate_on_program_cache_miss(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
@@ -59,6 +49,13 @@ struct ReduceDeviceOperation {
 }  // namespace ttnn::operations::reduction::generic
 
 namespace ttnn::prim {
-constexpr auto reduce =
-    ttnn::register_operation<"ttnn::prim::reduce", ttnn::operations::reduction::generic::ReduceDeviceOperation>();
+ttnn::Tensor reduce(
+    const Tensor& input_tensor,
+    tt::tt_metal::ReduceOpMath reduce_math,
+    tt::tt_metal::ReduceOpDim reduce_dim,
+    float scaler,
+    const MemoryConfig& output_mem_config,
+    const std::optional<DataType>& output_dtype,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "manual_seed_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include "manual_seed/device/manual_seed_device_operation_types.hpp"
 
@@ -117,19 +118,20 @@ ManualSeedDeviceOperation::tensor_return_value_t ManualSeedDeviceOperation::crea
     return create_device_tensor(output_specs, operation_attributes.device);
 }
 
-std::tuple<ManualSeedDeviceOperation::operation_attributes_t, ManualSeedDeviceOperation::tensor_args_t>
-ManualSeedDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::manual_seed
+
+namespace ttnn::prim {
+ttnn::Tensor manual_seed(
     const std::variant<uint32_t, Tensor>& seeds,
     std::optional<std::reference_wrapper<MeshDevice>> device,
     const std::optional<std::variant<uint32_t, Tensor>>& user_ids,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // Check if device is provided when seeds is uint32_t
     if (std::holds_alternative<uint32_t>(seeds)) {
         TT_FATAL(device.has_value(), "Device must be provided when seeds is a uint32_t value.");
     }
 
-    // Prepare operation attributes
-    operation_attributes_t operation_attributes{};
+    using OperationType = ttnn::operations::reduction::manual_seed::ManualSeedDeviceOperation;
+    OperationType::operation_attributes_t operation_attributes{};
     if (device.has_value()) {
         operation_attributes.device = std::addressof(device.value().get());
     } else {
@@ -144,15 +146,15 @@ ManualSeedDeviceOperation::invoke(
         operation_attributes.user_ids = std::get<uint32_t>(user_ids.value());
     }
     operation_attributes.sub_core_grids = sub_core_grids;
-    // Prepare tensor arguments
-    tensor_args_t tensor_args{};
+
+    OperationType::tensor_args_t tensor_args{};
     if (std::holds_alternative<Tensor>(seeds)) {
         tensor_args.seeds = std::get<Tensor>(seeds);
     }
     if (user_ids.has_value() && std::holds_alternative<Tensor>(user_ids.value())) {
         tensor_args.user_ids = std::get<Tensor>(user_ids.value());
     }
-    // Return prepared arguments
-    return {operation_attributes, tensor_args};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::reduction::manual_seed
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
@@ -32,20 +32,14 @@ struct ManualSeedDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::variant<uint32_t, Tensor>& seeds,
-        std::optional<std::reference_wrapper<MeshDevice>> device,
-        const std::optional<std::variant<uint32_t, Tensor>>& user_ids,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::reduction::manual_seed
 
 namespace ttnn::prim {
-
-constexpr auto manual_seed = ttnn::register_operation<
-    "ttnn::prim::manual_seed",
-    ttnn::operations::reduction::manual_seed::ManualSeedDeviceOperation>();
-
+ttnn::Tensor manual_seed(
+    const std::variant<uint32_t, Tensor>& seeds,
+    std::optional<std::reference_wrapper<MeshDevice>> device,
+    const std::optional<std::variant<uint32_t, Tensor>>& user_ids,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/reduction/moe/device/moe_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <optional>
 
@@ -83,21 +84,24 @@ tensor_return_value_t MoeDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<MoeDeviceOperation::operation_attributes_t, MoeDeviceOperation::tensor_args_t> MoeDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::moe
+
+namespace ttnn::prim {
+ttnn::Tensor moe(
     const Tensor& input_tensor,
     const Tensor& expert_mask_tensor,
     const Tensor& topk_mask_tensor,
     uint16_t k,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
     const std::optional<Tensor>& preallocated_output_tensor) {
-    return {
-        operation_attributes_t{
-            .k = k, .output_memory_config = memory_config.value_or(operation::DEFAULT_OUTPUT_MEMORY_CONFIG)},
-        tensor_args_t{
+    using OperationType = ttnn::operations::reduction::moe::MoeDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            .k = k, .output_memory_config = memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG)},
+        OperationType::tensor_args_t{
             .input = input_tensor,
             .expert_mask = expert_mask_tensor,
             .topk_mask = topk_mask_tensor,
-            .preallocated_output = preallocated_output_tensor}};
+            .preallocated_output = preallocated_output_tensor});
 }
-
-}  // namespace ttnn::operations::reduction::moe
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
@@ -28,21 +28,16 @@ struct MoeDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const Tensor& expert_mask_tensor,
-        const Tensor& topk_mask_tensor,
-        uint16_t k,
-        const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
 };
 
 }  // namespace ttnn::operations::reduction::moe
 
 namespace ttnn::prim {
-
-constexpr auto moe =
-    ttnn::register_operation<"ttnn::prim::moe", ttnn::operations::reduction::moe::MoeDeviceOperation>();
-
+ttnn::Tensor moe(
+    const Tensor& input_tensor,
+    const Tensor& expert_mask_tensor,
+    const Tensor& topk_mask_tensor,
+    uint16_t k,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod_all_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
 
@@ -52,9 +53,13 @@ ProdAllDeviceOperation::tensor_return_value_t ProdAllDeviceOperation::create_out
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<ProdAllDeviceOperation::operation_attributes_t, ProdAllDeviceOperation::tensor_args_t>
-ProdAllDeviceOperation::invoke(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
-    return {operation_attributes_t{.output_mem_config = output_mem_config}, tensor_args_t{.input = input}};
-}
-
 }  // namespace ttnn::operations::reduction::prod_all
+
+namespace ttnn::prim {
+ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
+    using OperationType = ttnn::operations::reduction::prod_all::ProdAllDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{.output_mem_config = output_mem_config},
+        OperationType::tensor_args_t{.input = input});
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
@@ -27,14 +27,10 @@ struct ProdAllDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
 };
 
 }  // namespace ttnn::operations::reduction::prod_all
 
 namespace ttnn::prim {
-constexpr auto prod_all =
-    ttnn::register_operation<"ttnn::prim::prod_all", ttnn::operations::reduction::prod_all::ProdAllDeviceOperation>();
+ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prod_nc_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::reduction::prod_nc {
 
@@ -59,9 +60,13 @@ ProdNcDeviceOperation::tensor_return_value_t ProdNcDeviceOperation::create_outpu
     return tensor_args.output;
 }
 
-std::tuple<ProdNcDeviceOperation::operation_attributes_t, ProdNcDeviceOperation::tensor_args_t>
-ProdNcDeviceOperation::invoke(const Tensor& input, const Tensor& output, int64_t dim) {
-    return {operation_attributes_t{.dim = dim}, tensor_args_t{.input = input, .output = output}};
-}
-
 }  // namespace ttnn::operations::reduction::prod_nc
+
+namespace ttnn::prim {
+ttnn::Tensor prod_nc(const ttnn::Tensor& input, const ttnn::Tensor& output, int64_t dim) {
+    using OperationType = ttnn::operations::reduction::prod_nc::ProdNcDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{.dim = dim},
+        OperationType::tensor_args_t{.input = input, .output = output});
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
@@ -28,14 +28,10 @@ struct ProdNcDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input, const Tensor& output, int64_t dim);
 };
 
 }  // namespace ttnn::operations::reduction::prod_nc
 
 namespace ttnn::prim {
-constexpr auto prod_nc =
-    ttnn::register_operation<"ttnn::prim::prod_nc", ttnn::operations::reduction::prod_nc::ProdNcDeviceOperation>();
+ttnn::Tensor prod_nc(const ttnn::Tensor& input, const ttnn::Tensor& output, int64_t dim);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <optional>
 
@@ -109,8 +110,10 @@ tensor_return_value_t SamplingDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_values.device());
 }
 
-std::tuple<SamplingDeviceOperation::operation_attributes_t, SamplingDeviceOperation::tensor_args_t>
-SamplingDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::sampling
+
+namespace ttnn::prim {
+ttnn::Tensor sampling(
     const Tensor& input_values_tensor,
     const Tensor& input_indices_tensor,
     const Tensor& k,
@@ -119,15 +122,15 @@ SamplingDeviceOperation::invoke(
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& preallocated_output_tensor) {
-    return {
-        operation_attributes_t{.seed = seed, .sub_core_grids = sub_core_grids},
-        tensor_args_t{
+    using OperationType = ttnn::operations::reduction::sampling::SamplingDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{.seed = seed, .sub_core_grids = sub_core_grids},
+        OperationType::tensor_args_t{
             .input_values = input_values_tensor,
             .input_indices = input_indices_tensor,
             .k = k,
             .p = p,
             .temp = temp,
-            .preallocated_output = preallocated_output_tensor}};
+            .preallocated_output = preallocated_output_tensor});
 }
-
-}  // namespace ttnn::operations::reduction::sampling
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
@@ -28,23 +28,18 @@ struct SamplingDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_values_tensor,
-        const Tensor& input_indices_tensor,
-        const Tensor& k,
-        const Tensor& p,
-        const Tensor& temp,
-        const std::optional<uint32_t>& seed = std::nullopt,
-        const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
-        const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
 };
 
 }  // namespace ttnn::operations::reduction::sampling
 
 namespace ttnn::prim {
-
-constexpr auto sampling =
-    ttnn::register_operation<"ttnn::prim::sampling", ttnn::operations::reduction::sampling::SamplingDeviceOperation>();
-
+ttnn::Tensor sampling(
+    const Tensor& input_values_tensor,
+    const Tensor& input_indices_tensor,
+    const Tensor& k,
+    const Tensor& p,
+    const Tensor& temp,
+    const std::optional<uint32_t>& seed = std::nullopt,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/reduction/topk/device/topk_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <optional>
 #include <tuple>
@@ -193,7 +194,10 @@ tensor_return_value_t TopKDeviceOperation::create_output_tensors(
     };
 }
 
-std::tuple<TopKDeviceOperation::operation_attributes_t, TopKDeviceOperation::tensor_args_t> TopKDeviceOperation::invoke(
+}  // namespace ttnn::operations::reduction::topk
+
+namespace ttnn::prim {
+std::tuple<ttnn::Tensor, ttnn::Tensor> topk(
     const Tensor& input_tensor,
     uint32_t k,
     int8_t dim,
@@ -203,16 +207,17 @@ std::tuple<TopKDeviceOperation::operation_attributes_t, TopKDeviceOperation::ten
     const tt::tt_metal::CoreRangeSet& sub_core_grids,
     const std::optional<Tensor>& indices_tensor,
     const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::reduction::topk::TopKDeviceOperation;
+    auto outputs = ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .k = k,
             .dim = dim,
             .largest = largest,
             .sorted = sorted,
             .output_memory_config = memory_config,
             .sub_core_grids = sub_core_grids},
-        tensor_args_t{
-            .input = input_tensor, .indices = indices_tensor, .preallocated_outputs = preallocated_output_tensors}};
+        OperationType::tensor_args_t{
+            .input = input_tensor, .indices = indices_tensor, .preallocated_outputs = preallocated_output_tensors});
+    return {outputs[0], outputs[1]};
 }
-
-}  // namespace ttnn::operations::reduction::topk
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.hpp
@@ -28,24 +28,19 @@ struct TopKDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        uint32_t k,
-        int8_t dim,
-        bool largest,
-        bool sorted,
-        const tt::tt_metal::MemoryConfig& memory_config,
-        const tt::tt_metal::CoreRangeSet& sub_core_grids,
-        const std::optional<Tensor>& indices_tensor = std::nullopt,
-        const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors = std::nullopt);
 };
 
 }  // namespace ttnn::operations::reduction::topk
 
 namespace ttnn::prim {
-
-constexpr auto topk =
-    ttnn::register_operation<"ttnn::prim::topk", ttnn::operations::reduction::topk::TopKDeviceOperation>();
-
+std::tuple<ttnn::Tensor, ttnn::Tensor> topk(
+    const Tensor& input_tensor,
+    uint32_t k,
+    int8_t dim,
+    bool largest,
+    bool sorted,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const tt::tt_metal::CoreRangeSet& sub_core_grids,
+    const std::optional<Tensor>& indices_tensor = std::nullopt,
+    const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "uniform_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::uniform {
 
@@ -49,22 +50,24 @@ tt::stl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operati
     return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
-std::tuple<UniformDeviceOperation::operation_attributes_t, UniformDeviceOperation::tensor_args_t>
-UniformDeviceOperation::invoke(
+}  // namespace ttnn::operations::uniform
+
+namespace ttnn::prim {
+ttnn::Tensor uniform(
     const Tensor& input,
     const float from,
     const float to,
     const uint32_t seed,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::uniform::UniformDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             from,
             to,
             seed,
             memory_config.value_or(input.memory_config()),
             init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{input}};
+        OperationType::tensor_args_t{input});
 }
-
-}  // namespace ttnn::operations::uniform
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -55,20 +55,17 @@ struct UniformDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        float from,
-        float to,
-        uint32_t seed,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::uniform
 
 namespace ttnn::prim {
-constexpr auto uniform =
-    ttnn::register_operation<"ttnn::prim::uniform", ttnn::operations::uniform::UniformDeviceOperation>();
+ttnn::Tensor uniform(
+    const Tensor& input,
+    float from,
+    float to,
+    uint32_t seed,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This PR refactors 20 device operations to align with a new pattern for defining and launching `ttnn` device operations. The previous `ttnn::register_operation` mechanism, which relied on a static `invoke` method, is being replaced by explicit global function declarations in the `ttnn::prim` namespace and direct calls to `ttnn::device_operation::detail::launch_on_device` for implementation. This change improves clarity, consistency, and maintainability of the device operation definitions.

### What's changed
The following 20 device operations have been refactored:
1.  **Uniform:** `ttnn::prim::uniform`
2.  **Index Fill:** `ttnn::prim::index_fill`
3.  **Upsample:** `ttnn::prim::upsample`
4.  **Grid Sample:** `ttnn::prim::grid_sample`
5.  **Pool2D:** `ttnn::prim::pool2d`
6.  **Embedding Backward:** `ttnn::prim::embedding_backward`
7.  **Sampling:** `ttnn::prim::sampling`
8.  **Reduce:** `ttnn::prim::reduce`
9.  **MOE:** `ttnn::prim::moe`
10. **Manual Seed:** `ttnn::prim::manual_seed`
11. **Accumulation:** `ttnn::prim::accumulation`
12. **EMA Device:** `ttnn::prim::ema_device`
13. **Prod All:** `ttnn::prim::prod_all`
14. **Prod NC:** `ttnn::prim::prod_nc`
15. **ArgMax:** `ttnn::prim::argmax`
16. **TopK:** `ttnn::prim::topk`
17. **All Broadcast:** `ttnn::prim::all_broadcast`
18. **All To All Combine:** `ttnn::prim::all_to_all_combine`
19. **All Gather:** `ttnn::prim::all_gather`
20. **Mesh Partition:** `ttnn::prim::mesh_partition`

**Summary of changes:**
*   **Header Files (`.hpp`):** Removed `ttnn::register_operation` instantiations and the `invoke` static member functions. Added corresponding global function declarations in the `ttnn::prim` namespace.
*   **Implementation Files (`.cpp`):** Moved the logic from the former `invoke` functions into the new global functions, using `ttnn::device_operation::detail::launch_on_device` for dispatch. Included `ttnn/api/ttnn/device_operation.hpp` where necessary.
*   **Tracking:** Updated `device_ops_to_process.txt` to mark these operations as completed `[x]`.

This refactoring standardizes the definition of device operations, making them more explicit and easier to trace.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ay/agent/device-ops-text-refactor-4889)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ay/agent/device-ops-text-refactor-4889)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
<a href="https://cursor.com/background-agent?bcId=bc-49b04c0f-847f-491a-9467-c845f1c3adee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49b04c0f-847f-491a-9467-c845f1c3adee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

