### PR TITLE
Device ops refactoring process

### DIFF
--- a/REFACTORING_GUIDE.md
+++ b/REFACTORING_GUIDE.md
@@ -99,7 +99,7 @@ ttml::metal::ops::layernorm_bw::device::LayerNormBackwardDeviceOperation::tensor
 ### 3.2 Required Includes
 Ensure the `.cpp` file includes the header for `launch_on_device`:
 ```cpp
-#include "ttnn/api/ttnn/device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 ```
 
 ---

--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -182,26 +182,26 @@
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -3,270 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "bcast_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include <tt-logger/tt-logger.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-namespace ttnn::operations::data_movement::bcast {
-
-using namespace tt::constants;
-using namespace tt::tt_metal;
-
-BcastDeviceOperation::program_factory_t BcastDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const Tensor& input_tensor_a = tensor_args.input_a;
-    const Tensor& input_tensor_b = tensor_args.input_b;
-
-    program_factory_t selected_factory;
-    [[maybe_unused]] const char* factory_name = nullptr;
-
-    if (operation_attributes.dim == BcastOpDim::H) {
-        if (input_tensor_a.is_sharded()) {
-            if (input_tensor_a.padded_shape()[0] == input_tensor_b.padded_shape()[0] ||
-                (input_tensor_a.padded_shape()[0] > 1 && input_tensor_b.padded_shape()[0] == 1)) {
-                selected_factory = program::BcastShardedHOptimisedProgramFactory{};
-                factory_name = "BcastShardedHOptimisedProgramFactory";
-            } else {
-                selected_factory = program::BcastShardedHProgramFactory{};
-                factory_name = "BcastShardedHProgramFactory";
-            }
-        } else {
-            selected_factory = program::BcastMultiCoreHProgramFactory{};
-            factory_name = "BcastMultiCoreHProgramFactory";
-        }
-    } else if (operation_attributes.dim == BcastOpDim::W) {
-        selected_factory = program::BcastMultiCoreWProgramFactory{};
-        factory_name = "BcastMultiCoreWProgramFactory";
-    } else if (operation_attributes.dim == BcastOpDim::HW) {
-        selected_factory = program::BcastMultiCoreHWProgramFactory{};
-        factory_name = "BcastMultiCoreHWProgramFactory";
-    } else {
-        TT_THROW("Unsupported Bcast Dim");
-    }
-
-    log_debug(tt::LogOp, "Selected bcast factory: {}", factory_name);
-    return selected_factory;
-}
-
-void BcastDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(operation_attributes, tensor_args);
-}
-
-void BcastDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const Tensor& input_tensor_a = tensor_args.input_a;
-    const Tensor& input_tensor_b = tensor_args.input_b;
-
-    TT_FATAL(
-        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
-        "Operands to bcast need to be allocated in buffers on device!");
-    TT_FATAL(
-        input_tensor_a.device() != nullptr and input_tensor_b.device() != nullptr,
-        "Operands to bcast need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to bcast need to be on the same device!");
-
-    const auto& input_shape_a = input_tensor_a.padded_shape();
-    const auto& input_shape_b = input_tensor_b.padded_shape();
-
-    TT_FATAL(
-        input_tensor_a.layout() == Layout::TILE,
-        "Input tensor A layout must be TILE but got {}",
-        input_tensor_a.layout());
-    TT_FATAL(
-        input_tensor_b.layout() == Layout::TILE,
-        "Input tensor B layout must be TILE but got {}",
-        input_tensor_b.layout());
-    TT_FATAL(is_floating_point(input_tensor_a.dtype()), "Unsupported data format");
-    if (tensor_args.preallocated_output.has_value()) {
-        TT_FATAL(is_floating_point(tensor_args.preallocated_output->dtype()), "Unsupported data format");
-        const auto output_spec_required = compute_output_specs(operation_attributes, tensor_args);
-        const auto& out_tensor = tensor_args.preallocated_output.value();
-        TT_FATAL(
-            out_tensor.logical_shape() == output_spec_required.logical_shape(),
-            "The input tensors need a shape of {}, however the output tensor is only {}",
-            output_spec_required.logical_shape(),
-            out_tensor.padded_shape());
-    }
-    if (operation_attributes.in_place) {
-        TT_FATAL(
-            input_tensor_a.memory_config().memory_layout() == operation_attributes.output_mem_config.memory_layout(),
-            "Input tensor A memory layout ({}) must match output memory config layout ({})",
-            input_tensor_a.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.memory_layout());
-        TT_FATAL(
-            input_tensor_a.memory_config().buffer_type() == operation_attributes.output_mem_config.buffer_type(),
-            "Input tensor A buffer type ({}) must match output memory config buffer type ({})",
-            input_tensor_a.memory_config().buffer_type(),
-            operation_attributes.output_mem_config.buffer_type());
-    }
-    const MemoryConfig& out_mem_config = tensor_args.preallocated_output.has_value()
-                                             ? tensor_args.preallocated_output->memory_config()
-                                             : operation_attributes.output_mem_config;
-    if (operation_attributes.dim == BcastOpDim::W) {
-        TT_FATAL(
-            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                out_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
-            "Bcast does not currently support input0 sharding, except if dim is W");
-    } else if (operation_attributes.dim == BcastOpDim::H) {
-        if (input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED) {
-            TT_FATAL(
-                input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
-                    out_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                "Bcast does not currently support input0 sharding, except if dim is HW");
-        } else {
-            TT_FATAL(
-                input_tensor_a.memory_config().is_sharded() && out_mem_config.is_sharded(),
-                "Input and output mem layouts must be the same for bcast H op!");
-        }
-    } else {
-        TT_FATAL(
-            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED ||
-                input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-            "HW bcast in0 supports Height Sharding or Interleaving");
-        TT_FATAL(
-            input_tensor_a.memory_config().memory_layout() == out_mem_config.memory_layout(),
-            "Input and output mem layouts must be the same for bcast HW op!");
-    }
-
-    const uint32_t height_a = input_shape_a[-2];
-    const uint32_t width_a = input_shape_a[-1];
-    const uint32_t height_b = input_shape_b[-2];
-    const uint32_t width_b = input_shape_b[-1];
-    if (!(input_tensor_a.is_sharded() && operation_attributes.dim == BcastOpDim::H)) {
-        const uint32_t batch_size_b = get_batch_size(input_shape_b);
-        if (batch_size_b != 1) {
-            TT_FATAL(
-                input_shape_a.rank() == input_shape_b.rank(),
-                "Broadcast with batch is currently only supported when input tensor ranks are the same",
-                "Error");
-            for (auto i = 0; i < input_shape_a.rank() - 2; i++) {
-                TT_FATAL(
-                    input_shape_a[i] == input_shape_b[i],
-                    "Broadcast with batch is currently only supported when bN*bC=1 or N & C match or equivalent");  // for H multi-batch weight is supported
-            }
-        }
-    }
-
-    // validate input dimensions
-    if (operation_attributes.dim == BcastOpDim::W) {
-        TT_FATAL(
-            height_a == height_b && width_b == TILE_WIDTH,
-            "For width broadcast: height_a ({}) must equal height_b ({}) and width_b ({}) must equal TILE_WIDTH ({})",
-            height_a,
-            height_b,
-            width_b,
-            TILE_WIDTH);
-    }
-    if (operation_attributes.dim == BcastOpDim::H) {
-        TT_FATAL(
-            width_a == width_b && height_b == TILE_HEIGHT,
-            "For height broadcast: width_a ({}) must equal width_b ({}) and height_b ({}) must equal TILE_HEIGHT ({})",
-            width_a,
-            width_b,
-            height_b,
-            TILE_HEIGHT);
-    }
-    if (operation_attributes.dim == BcastOpDim::HW) {
-        TT_FATAL(
-            width_b == TILE_WIDTH && height_b == TILE_HEIGHT,
-            "For HW broadcast: width_b ({}) must equal TILE_WIDTH ({}) and height_b ({}) must equal TILE_HEIGHT ({})",
-            width_b,
-            TILE_WIDTH,
-            height_b,
-            TILE_HEIGHT);
-    }
-}
-
-spec_return_value_t BcastDeviceOperation::compute_output_specs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output->tensor_spec();
-    }
-    if (operation_attributes.in_place) {
-        return tensor_args.input_a.tensor_spec();
-    }
-    const Tensor& input_tensor = tensor_args.input_a;
-    if (operation_attributes.output_mem_config.is_sharded()) {
-        ShardSpec shard_spec{CoreRangeSet(), {0, 0}};
-        if (input_tensor.memory_config().is_sharded()) {
-            // Derive output shard_spec based on input
-            shard_spec = input_tensor.shard_spec().value();
-        }
-        const MemoryConfig mem_config = operation_attributes.output_mem_config.with_shard_spec(shard_spec);
-        return TensorSpec(
-            input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                input_tensor.dtype(),
-                PageConfig(Layout::TILE),
-                mem_config,
-                input_tensor.logical_shape(),
-                input_tensor.padded_shape()));
-    }
-
-    return TensorSpec(
-        input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
-            input_tensor.dtype(),
-            PageConfig(Layout::TILE),
-            operation_attributes.output_mem_config,
-            input_tensor.logical_shape(),
-            input_tensor.padded_shape()));
-}
-
-tensor_return_value_t BcastDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output.value();
-    }
-    if (operation_attributes.in_place) {
-        return tensor_args.input_a;
-    }
-    const spec_return_value_t spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, tensor_args.input_a.device());
-}
-
-tt::stl::hash::hash_t BcastDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const program_factory_t program_factory = select_program_factory(operation_attributes, tensor_args);
-    const bool bcast_scalar = (tensor_args.input_b.padded_shape()[-2] * tensor_args.input_b.padded_shape()[-1] == 1) &&
-                              operation_attributes.dim == BcastOpDim::HW;
-    return operation::hash_operation<BcastDeviceOperation>(
-        operation_attributes,
-        program_factory.index(),
-        tensor_args.input_a.memory_config(),
-        tensor_args.input_a.dtype(),
-        tensor_args.input_b.memory_config(),
-        tensor_args.input_b.dtype(),
-        bcast_scalar,
-        operation_attributes.in_place);
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
-BcastDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const Tensor& input_tensor0 = tensor_args.input_a;
-    const Tensor& input_tensor1 = tensor_args.input_b;
-    const Tensor& output_tensor = tensor_return_value;
-    const bool output_is_dram = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    const bool output_is_sharded = output_tensor.memory_config().is_sharded();
-    const bool input_is_dram = input_tensor0.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    const bool input_is_sharded = input_tensor0.memory_config().is_sharded();
-    const bool is_local = input_is_sharded && !input_is_dram && output_is_sharded && !output_is_dram &&
-                          (output_tensor.memory_config().shard_spec().value().grid ==
-                           input_tensor0.memory_config().shard_spec().value().grid);
-    const int ideal_dev_clock_cycles =
-        common_tm_bw_model(input_tensor1, output_tensor, false, 0, false, false, is_local);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {input_tensor0, input_tensor1}, tensor_return_value, ideal_dev_clock_cycles);
-    return result;
-}
-
-std::tuple<BcastDeviceOperation::operation_attributes_t, BcastDeviceOperation::tensor_args_t>
-BcastDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::bcast::BcastDeviceOperation::tensor_return_value_t bcast(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     ttnn::BcastOpMath bcast_op,
@@ -274,11 +18,15 @@ BcastDeviceOperation::invoke(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     bool in_place,
     const std::optional<Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::bcast::BcastDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .math_op = bcast_op, .dim = bcast_dim, .output_mem_config = output_mem_config, .in_place = in_place},
-        tensor_args_t{
-            .input_a = input_tensor_a, .input_b = input_tensor_b, .preallocated_output = preallocated_output}};
+        OperationType::tensor_args_t{
+            .input_a = input_tensor_a, .input_b = input_tensor_b, .preallocated_output = preallocated_output});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::bcast {
 
 }  // namespace ttnn::operations::data_movement::bcast

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -49,20 +49,17 @@ struct BcastDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        ttnn::BcastOpMath bcast_op,
-        ttnn::BcastOpDim bcast_dim,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        bool in_place,
-        const std::optional<Tensor>& preallocated_output);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast
 
 namespace ttnn::prim {
-constexpr auto bcast =
-    ttnn::register_operation<"ttnn::prim::bcast", ttnn::operations::data_movement::bcast::BcastDeviceOperation>();
+ttnn::operations::data_movement::bcast::BcastDeviceOperation::tensor_return_value_t bcast(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    ttnn::BcastOpMath bcast_op,
+    ttnn::BcastOpDim bcast_dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool in_place,
+    const std::optional<Tensor>& preallocated_output);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "concat_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "concat_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
@@ -187,22 +188,23 @@ ConcatDeviceOperation::create_op_performance_model(
     return result;
 }
 
-std::tuple<ConcatDeviceOperation::operation_attributes_t, ConcatDeviceOperation::tensor_args_t>
-ConcatDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::concat::ConcatDeviceOperation::tensor_return_value_t concat(
     const std::vector<Tensor>& input_tensors,
     std::int64_t dim,
     unsigned int groups,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
+    using OperationType = ttnn::operations::data_movement::concat::ConcatDeviceOperation;
     uint32_t normalized_dim = input_tensors[0].padded_shape().get_normalized_index(dim);
-
-    return {
-        operation_attributes_t{
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .dim = normalized_dim,
             .groups = groups,
             .output_mem_config = output_mem_config,
         },
-        tensor_args_t{.input_tensors = input_tensors}};
+        OperationType::tensor_args_t{.input_tensors = input_tensors});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::concat
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -45,19 +45,16 @@ struct ConcatDeviceOperation {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::vector<Tensor>& input_tensors,
-        std::int64_t dim,
-        unsigned int groups,
-        const tt::tt_metal::MemoryConfig& output_mem_config);
 };
 
 }  // namespace ttnn::operations::data_movement::concat
 
 namespace ttnn::prim {
-constexpr auto concat =
-    ttnn::register_operation<"ttnn::prim::concat", ttnn::operations::data_movement::concat::ConcatDeviceOperation>();
+ttnn::operations::data_movement::concat::ConcatDeviceOperation::tensor_return_value_t concat(
+    const std::vector<Tensor>& input_tensors,
+    std::int64_t dim,
+    unsigned int groups,
+    const tt::tt_metal::MemoryConfig& output_mem_config);
 }  // namespace ttnn::prim
 
 namespace ttnn::operations::data_movement {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -3,22 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "copy_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "copy_program_factory.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"  // common_tm_bw_model
 
-namespace ttnn::operations::data_movement::copy {
-
-using namespace tt::tt_metal;
-
-std::tuple<CopyDeviceOperation::operation_attributes_t, CopyDeviceOperation::tensor_args_t> CopyDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::copy::CopyDeviceOperation::tensor_return_value_t copy(
     const Tensor& input,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype,
     const std::optional<Tensor>& preallocated_output,
     bool backwards) {
-    return {
-        operation_attributes_t{output_mem_config, output_dtype, backwards}, tensor_args_t{input, preallocated_output}};
+    using OperationType = ttnn::operations::data_movement::copy::CopyDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{output_mem_config, output_dtype, backwards},
+        OperationType::tensor_args_t{input, preallocated_output});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::copy {
 
 CopyDeviceOperation::program_factory_t CopyDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.hpp
@@ -38,18 +38,15 @@ struct CopyDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype,
-        const std::optional<Tensor>& preallocated_output,
-        bool backwards = false);
 };
 
 }  // namespace ttnn::operations::data_movement::copy
 
 namespace ttnn::prim {
-constexpr auto copy =
-    ttnn::register_operation<"ttnn::prim::copy", ttnn::operations::data_movement::copy::CopyDeviceOperation>();
+ttnn::operations::data_movement::copy::CopyDeviceOperation::tensor_return_value_t copy(
+    const Tensor& input,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    const std::optional<Tensor>& preallocated_output,
+    bool backwards = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -71,23 +72,25 @@ IndexedFillDeviceOperation::create_op_performance_model(
     return result;
 }
 
-std::tuple<IndexedFillDeviceOperation::operation_attributes_t, IndexedFillDeviceOperation::tensor_args_t>
-IndexedFillDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation::tensor_return_value_t indexed_fill(
     const Tensor& batch_id,
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     int64_t dim) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .dim = dim,
         },
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .batch_id = batch_id,
             .input_tensor_a = input_tensor_a,
             .input_tensor_b = input_tensor_b,
-        }};
+        });
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::indexed_fill

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
@@ -28,19 +28,15 @@ struct IndexedFillDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& batch_id,
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        int64_t dim);
 };
 
 }  // namespace ttnn::operations::data_movement::indexed_fill
 
 namespace ttnn::prim {
-constexpr auto indexed_fill = ttnn::register_operation<
-    "ttnn::prim::indexed_fill",
-    ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation>();
+ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation::tensor_return_value_t indexed_fill(
+    const Tensor& batch_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    int64_t dim);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "moe_routing_remap_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -68,23 +69,25 @@ MoeRoutingRemapDeviceOperation::tensor_return_value_t MoeRoutingRemapDeviceOpera
         create_device_tensor(output_spec, tensor_args.input_routing_weights.device()));
 }
 
-std::tuple<MoeRoutingRemapDeviceOperation::operation_attributes_t, MoeRoutingRemapDeviceOperation::tensor_args_t>
-MoeRoutingRemapDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation::tensor_return_value_t moe_routing_remap(
     const ttnn::Tensor& routing_weights,
     uint32_t non_zero_weight_size,
     uint32_t expert_parallel_size,
     uint32_t cluster_axis,
     const std::optional<ttnn::MemoryConfig>& output_mem_config,
     const std::optional<ttnn::Tensor>& optional_output_routing_weights) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .non_zero_weight_size = non_zero_weight_size,
             .expert_parallel_size = expert_parallel_size,
             .cluster_axis = cluster_axis,
             .output_mem_config = output_mem_config},
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .input_routing_weights = routing_weights,
-            .optional_output_routing_weights = optional_output_routing_weights}};
+            .optional_output_routing_weights = optional_output_routing_weights});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.hpp
@@ -83,19 +83,15 @@ struct MoeRoutingRemapDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& routing_weights,
-        uint32_t non_zero_weight_size,
-        uint32_t expert_parallel_size,
-        uint32_t cluster_axis,
-        const std::optional<ttnn::MemoryConfig>& output_mem_config = std::nullopt,
-        const std::optional<ttnn::Tensor>& optional_output_routing_weights = std::nullopt);
 };
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto moe_routing_remap = ttnn::register_operation<
-    "ttnn::prim::moe_routing_remap",
-    ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation>();
+ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation::tensor_return_value_t moe_routing_remap(
+    const ttnn::Tensor& routing_weights,
+    uint32_t non_zero_weight_size,
+    uint32_t expert_parallel_size,
+    uint32_t cluster_axis,
+    const std::optional<ttnn::MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<ttnn::Tensor>& optional_output_routing_weights = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -3,61 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "move_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-namespace ttnn::operations::data_movement::move {
-
-MoveDeviceOperation::program_factory_t MoveDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    switch (operation_attributes.move_op_parallelization_strategy) {
-        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED: return program::MoveShardedProgramFactory{};
-        case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP: return program::MoveOverlapProgramFactory{};
-        case MoveOpParallelizationStrategy::MULTI_CORE: return program::MoveProgramFactory{};
-        default: TT_FATAL(false, "Invalid move operation parallelization strategy");
-    }
-}
-
-void MoveDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // TODO: #33357
-}
-
-void MoveDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // TODO: #33357
-}
-
-MoveDeviceOperation::spec_return_value_t MoveDeviceOperation::compute_output_specs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Output spec is same as output tensor spec
-    return tensor_args.output_tensor.tensor_spec();
-}
-
-MoveDeviceOperation::tensor_return_value_t MoveDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Output tensor is already created and passed in tensor_args
-    return tensor_args.output_tensor;
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<MoveDeviceOperation::tensor_return_value_t>
-MoveDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    const auto& output_tensor = tensor_return_value;
-    const int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output_tensor);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
-    return result;
-}
-
-std::tuple<MoveDeviceOperation::operation_attributes_t, MoveDeviceOperation::tensor_args_t> MoveDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::move::MoveDeviceOperation::tensor_return_value_t move(
     const Tensor& input_tensor,
     const Tensor& output_tensor,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const MoveOpParallelizationStrategy& move_op_parallelization_strategy) {
+    using OperationType = ttnn::operations::data_movement::move::MoveDeviceOperation;
     bool backwards = false;
     if (move_op_parallelization_strategy == MoveOpParallelizationStrategy::MULTI_CORE) {
         Buffer* src_buffer = input_tensor.buffer();
@@ -70,12 +26,15 @@ std::tuple<MoveDeviceOperation::operation_attributes_t, MoveDeviceOperation::ten
         const bool ranges_overlap = (src_base < dst_base + copy_size_bytes) && (dst_base < src_base + copy_size_bytes);
         backwards = src_and_dst_in_l1 && ranges_overlap && (dst_base > src_base);
     }
-    return {
-        operation_attributes_t{
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .move_op_parallelization_strategy = move_op_parallelization_strategy,
             .backwards = backwards},
-        tensor_args_t{.input_tensor = input_tensor, .output_tensor = output_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .output_tensor = output_tensor});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::move {
 
 }  // namespace ttnn::operations::data_movement::move

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -44,18 +44,14 @@ struct MoveDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const Tensor& output_tensor,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const MoveOpParallelizationStrategy& move_op_parallelization_strategy);
 };
 
 }  // namespace ttnn::operations::data_movement::move
 
-// Register the operation in ttnn::prim namespace
 namespace ttnn::prim {
-constexpr auto move =
-    ttnn::register_operation<"ttnn::prim::move", ttnn::operations::data_movement::move::MoveDeviceOperation>();
+ttnn::operations::data_movement::move::MoveDeviceOperation::tensor_return_value_t move(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const MoveOpParallelizationStrategy& move_op_parallelization_strategy);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp"
-
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation_types.hpp"
 #include "ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_program_factory.hpp"
 
@@ -52,9 +52,14 @@ tensor_return_value_t NonZeroIndicesDeviceOperation::create_output_tensors(
     };
 }
 
-std::tuple<NonZeroIndicesDeviceOperation::operation_attributes_t, NonZeroIndicesDeviceOperation::tensor_args_t>
-NonZeroIndicesDeviceOperation::invoke(const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& memory_config) {
-    return {operation_attributes_t{.output_memory_config = memory_config}, tensor_args_t{.input = input_tensor}};
+namespace ttnn::prim {
+ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation::tensor_return_value_t nonzero(
+    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& memory_config) {
+    using OperationType = ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{.output_memory_config = memory_config},
+        OperationType::tensor_args_t{.input = input_tensor});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::nonzero

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.hpp
@@ -27,17 +27,13 @@ struct NonZeroIndicesDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& memory_config);
 };
 
 }  // namespace ttnn::operations::data_movement::nonzero
 
 namespace ttnn::prim {
 
-constexpr auto nonzero = ttnn::register_operation<
-    "ttnn::prim::nonzero",
-    ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation>();
+ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation::tensor_return_value_t nonzero(
+    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& memory_config);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include "pad_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/full/device/full_device_operation.hpp"
 #include "ttnn/operations/creation.hpp"
@@ -184,19 +185,22 @@ Tensor PadDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
-std::tuple<PadDeviceOperation::operation_attributes_t, PadDeviceOperation::tensor_args_t> PadDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::pad::PadDeviceOperation::tensor_return_value_t pad(
     const Tensor& input,
     const ttnn::Shape& output_logical_shape,
     const ttnn::Shape& output_padded_shape,
     const ttnn::Shape& input_tensor_start,
-    const float pad_value,
+    float pad_value,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    const bool use_multicore,
+    bool use_multicore,
     const std::optional<ttnn::Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::pad::PadDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             output_logical_shape, output_padded_shape, input_tensor_start, pad_value, output_mem_config, use_multicore},
-        tensor_args_t{input, preallocated_output}};
+        OperationType::tensor_args_t{input, preallocated_output});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::pad

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
@@ -51,19 +51,17 @@ struct PadDeviceOperation {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const ttnn::Shape& output_logical_shape,
-        const ttnn::Shape& output_padded_shape,
-        const ttnn::Shape& input_tensor_start,
-        float pad_value,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        bool use_multicore,
-        const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt);
 };
 }  // namespace ttnn::operations::data_movement::pad
 
 namespace ttnn::prim {
-constexpr auto pad =
-    ttnn::register_operation<"ttnn::prim::pad", ttnn::operations::data_movement::pad::PadDeviceOperation>();
+ttnn::operations::data_movement::pad::PadDeviceOperation::tensor_return_value_t pad(
+    const Tensor& input,
+    const ttnn::Shape& output_logical_shape,
+    const ttnn::Shape& output_padded_shape,
+    const ttnn::Shape& input_tensor_start,
+    float pad_value,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_multicore,
+    const std::optional<ttnn::Tensor>& preallocated_output = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -6,99 +6,27 @@
 #include <utility>
 
 #include "ttnn/tensor/types.hpp"
-#include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "permute_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-namespace ttnn::operations::data_movement {
-
-PermuteDeviceOperation::program_factory_t PermuteDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& dims = operation_attributes.dims;
-    if (tensor_args.input_tensor.layout() == Layout::ROW_MAJOR) {
-        // If the last dimension is not permuted, we can use the row-invariant kernel
-        if (dims.back() == tensor_args.input_tensor.logical_shape().rank() - 1) {
-            return MultiCoreRowInvariant{};
-        }
-        // Otherwise, we need to use the blocked generic, row moving kernel
-        return MultiCoreBlockedGeneric{};
-    } else {
-        // If the input tensor is not row-major, we need to use the tiled kernels
-        uint32_t rank = tensor_args.input_tensor.logical_shape().rank();
-        // When the tiled dimensions are not moved, we use this kernel
-        if ((dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2) ||
-            (dims[rank - 1] == rank - 2 && dims[rank - 2] == rank - 1)) {
-            return MultiCoreTileInvariant{};
-        } else if (dims[rank - 1] == rank - 1 || dims[rank - 1] == rank - 2) {  // When only one of the tiled dimensions
-                                                                                // is moved
-            return MultiCoreTileRowInvariant{};
-        } else {
-            return MultiCoreTiledGeneric{};  // When both the tiled dimensions are moved
-        }
-    }
-}
-
-void PermuteDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    TT_FATAL(
-        attributes.dims.size() == tensor_args.input_tensor.logical_shape().rank(),
-        "Permute dimensions must match input tensor rank");
-}
-
-void PermuteDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
-
-PermuteDeviceOperation::spec_return_value_t PermuteDeviceOperation::compute_output_specs(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.optional_output_tensor.has_value()) {
-        return tensor_args.optional_output_tensor->tensor_spec();
-    }
-
-    SmallVector<uint32_t> shape;
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto input_shape = input_tensor.logical_shape();
-    shape.reserve(input_shape.rank());
-    for (auto dim : attributes.dims) {
-        shape.push_back(input_shape[dim]);
-    }
-
-    return TensorSpec(
-        Shape(std::move(shape)),
-        tt::tt_metal::TensorLayout(
-            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), attributes.output_mem_config));
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<PermuteDeviceOperation::tensor_return_value_t>
-PermuteDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& op_attr, const tensor_args_t& inputs, const Tensor& output) {
-    const auto& input_tensor = inputs.input_tensor;
-    int ideal_dev_clock_cycles = common_tm_bw_model(input_tensor, output, false, 0, true);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {input_tensor}, {output}, ideal_dev_clock_cycles);
-    return result;
-}
-
-PermuteDeviceOperation::tensor_return_value_t PermuteDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.optional_output_tensor.has_value()) {
-        return tensor_args.optional_output_tensor.value();
-    }
-    return create_device_tensor(
-        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
-}
-
-std::tuple<PermuteDeviceOperation::operation_attributes_t, PermuteDeviceOperation::tensor_args_t>
-PermuteDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::PermuteDeviceOperation::tensor_return_value_t permute(
     const Tensor& input_tensor,
     const SmallVector<uint32_t>& dims,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
     const std::optional<float>& pad_value) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::PermuteDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .dims = dims,
             .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
             .pad_value = pad_value},
-        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = std::move(optional_output_tensor)}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = std::move(optional_output_tensor)});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement {
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -171,22 +171,14 @@ struct PermuteDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
-
-    // API call to map user arguments to operation attributes and tensor args.
-    // This is the only method that is called by the user
-    // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const SmallVector<uint32_t>& dims,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        const std::optional<float>& pad_value = std::nullopt);
 };
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-constexpr auto permute =
-    ttnn::register_operation<"ttnn::prim::permute", ttnn::operations::data_movement::PermuteDeviceOperation>();
+ttnn::operations::data_movement::PermuteDeviceOperation::tensor_return_value_t permute(
+    const Tensor& input_tensor,
+    const SmallVector<uint32_t>& dims,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor,
+    const std::optional<float>& pad_value = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -7,91 +7,22 @@
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
-namespace ttnn::operations::data_movement::repeat {
-
-RepeatDeviceOperation::program_factory_t RepeatDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    bool is_last_dim = operation_attributes.m_is_last_dim;
-    if (is_last_dim) {
-        return program::RepeatProgramFactoryLastDim{};
-    } else {
-        return program::RepeatProgramFactoryHigherDim{};
-    }
-}
-
-void RepeatDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Validate the input tensor
-    const Tensor& input_tensor_a = tensor_args.input;
-    TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE,
-        "Operands to reshape need to be on device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "This function is for RM->RM");
-    TT_FATAL(
-        input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Can only work with UINT16, BFLOAT16, UINT32, INT32, FLOAT32 data types");
-    // is this relevant?
-    TT_FATAL(
-        operation_attributes.m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),
-        "Output tensor must have the same memory layout as input tensor");
-}
-
-void RepeatDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(operation_attributes, tensor_args);
-}
-
-RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output_specs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
-    const auto& input_tensor_a = input_tensors.input;
-    auto output_shape = input_tensor_a.logical_shape();
-    output_shape[operation_attributes.m_is_last_dim ? -1 : 1] *= operation_attributes.m_num_repeats;
-
-    auto mem_config = operation_attributes.m_output_mem_config;
-    if (input_tensor_a.memory_config().is_sharded()) {
-        auto shard_spec = input_tensor_a.shard_spec().value();
-        shard_spec.shape[0] = output_shape[0];
-        mem_config = mem_config.with_shard_spec(shard_spec);
-    }
-    return TensorSpec(
-        output_shape,
-        tt::tt_metal::TensorLayout(
-            input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config));
-}
-
-RepeatDeviceOperation::tensor_return_value_t RepeatDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
-    return create_device_tensor(
-        compute_output_specs(operation_attributes, input_tensors), input_tensors.input.device());
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
-RepeatDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-    int ideal_dev_clock_cycles = operations::data_movement::common_tm_bw_model(input_tensor, output_tensor);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {input_tensor}, output_tensor, ideal_dev_clock_cycles);
-    return result;
-}
-
-std::tuple<operation_attributes_t, tensor_args_t> RepeatDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::repeat::RepeatDeviceOperation::tensor_return_value_t repeat(
     const Tensor& input,
     uint32_t m_num_repeats,
     bool m_is_last_dim,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::repeat::RepeatDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .m_num_repeats = m_num_repeats, .m_is_last_dim = m_is_last_dim, .m_output_mem_config = output_mem_config},
-        tensor_args_t{.input = input}};
+        OperationType::tensor_args_t{.input = input});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::repeat {
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -37,16 +37,13 @@ struct RepeatDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output_tensor);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        uint32_t m_num_repeats,
-        bool m_is_last_dim,
-        const tt::tt_metal::MemoryConfig& output_mem_config);
 };
 }  // namespace ttnn::operations::data_movement::repeat
 
 namespace ttnn::prim {
-constexpr auto repeat =
-    ttnn::register_operation<"ttnn::prim::repeat", ttnn::operations::data_movement::repeat::RepeatDeviceOperation>();
+ttnn::operations::data_movement::repeat::RepeatDeviceOperation::tensor_return_value_t repeat(
+    const Tensor& input,
+    uint32_t m_num_repeats,
+    bool m_is_last_dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "reshape_op.hpp"
+#include "ttnn/device_operation.hpp"
 #include <tt-metalium/constants.hpp>
 
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -100,15 +101,17 @@ tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
         input_tensor.padded_shape());
 }
 
-std::tuple<ReshapeDeviceOperation::operation_attributes_t, ReshapeDeviceOperation::tensor_args_t>
-ReshapeDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation::tensor_return_value_t reshape_on_device(
     const Tensor& input_tensor,
-    const ttnn::Shape& logical_output_shape,
-    const ttnn::Shape& padded_output_shape,
+    const tt::tt_metal::Shape& logical_output_shape,
+    const tt::tt_metal::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
-    return {
-        operation_attributes_t{logical_output_shape, padded_output_shape, output_mem_config},
-        tensor_args_t{input_tensor}};
+    using OperationType = ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{logical_output_shape, padded_output_shape, output_mem_config},
+        OperationType::tensor_args_t{input_tensor});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::reshape_on_device

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -37,18 +37,14 @@ struct ReshapeDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const tt::tt_metal::Shape& logical_output_shape,
-        const tt::tt_metal::Shape& padded_output_shape,
-        const tt::tt_metal::MemoryConfig& output_mem_config);
 };
 
 }  // namespace ttnn::operations::data_movement::reshape_on_device
 
 namespace ttnn::prim {
-constexpr auto reshape_on_device = ttnn::register_operation<
-    "ttnn::prim::reshape_on_device",
-    ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation>();
-}
+ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation::tensor_return_value_t reshape_on_device(
+    const Tensor& input_tensor,
+    const tt::tt_metal::Shape& logical_output_shape,
+    const tt::tt_metal::Shape& padded_output_shape,
+    const tt::tt_metal::MemoryConfig& output_mem_config);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 namespace ttnn::operations::data_movement::reshape {
@@ -84,18 +85,20 @@ tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
                                                        : CoreRangeSet(CoreRange({0, 0}, {0, 0})));
 }
 
-std::tuple<ReshapeDeviceOperation::operation_attributes_t, ReshapeDeviceOperation::tensor_args_t>
-ReshapeDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::reshape::ReshapeDeviceOperation::tensor_return_value_t reshape(
     const Tensor& input,
     const ttnn::Shape& logical_output_shape,
     const ttnn::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::reshape::ReshapeDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             logical_output_shape, padded_output_shape, output_mem_config, recreate_mapping_tensor, sub_core_grid},
-        tensor_args_t{input}};
+        OperationType::tensor_args_t{input});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -35,19 +35,16 @@ struct ReshapeDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const ttnn::Shape& logical_output_shape,
-        const ttnn::Shape& padded_output_shape,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        bool recreate_mapping_tensor,
-        const std::optional<CoreRangeSet>& sub_core_grid);
 };
 
 }  // namespace ttnn::operations::data_movement::reshape
 
 namespace ttnn::prim {
-constexpr auto reshape =
-    ttnn::register_operation<"ttnn::prim::reshape", ttnn::operations::data_movement::reshape::ReshapeDeviceOperation>();
-}
+ttnn::operations::data_movement::reshape::ReshapeDeviceOperation::tensor_return_value_t reshape(
+    const Tensor& input,
+    const ttnn::Shape& logical_output_shape,
+    const ttnn::Shape& padded_output_shape,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool recreate_mapping_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grid);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -3,117 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "interleaved_to_sharded_op.hpp"
+#include "ttnn/device_operation.hpp"
 #include <tt-metalium/hal.hpp>
 #include <ttnn/operation.hpp>
 
-namespace ttnn::operations::data_movement {
-
-InterleavedToShardedDeviceOperation::program_factory_t InterleavedToShardedDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return interleaved_to_sharded::InterleavedToShardedProgramFactory{};
-}
-
-void InterleavedToShardedDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    const auto& output_mem_config = operation_attributes.output_mem_config;
-    const auto& output_dtype = operation_attributes.output_dtype;
-
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-
-    if (tensor_args.output_tensor.has_value()) {
-        const auto& output_tensor = tensor_args.output_tensor.value();
-        TT_FATAL(output_tensor.logical_shape() == input_tensor.logical_shape(), "Mismatched output shape");
-        TT_FATAL(output_tensor.memory_config() == output_mem_config, "Mismatched output memory config");
-        TT_FATAL(output_tensor.dtype() == output_dtype, "Mismatched output dtype");
-        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-        TT_FATAL(output_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-        TT_FATAL(output_tensor.device() == input_tensor.device(), "Operands to shard need to be on the same device!");
-    }
-
-    TT_FATAL(
-        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Input tensor memory layout must be INTERLEAVED but got {}",
-        input_tensor.memory_config().memory_layout());
-    TT_FATAL(output_mem_config.is_sharded(), "Output memory config must be sharded");
-    if (output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        TT_FATAL(output_mem_config.buffer_type() == BufferType::L1, "We don't support DRAM block sharding");
-    }
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(
-            0 == (*output_mem_config.shard_spec()).shape[1] * input_tensor.element_size() %
-                     tt::tt_metal::hal::get_l1_alignment(),
-            "Shard page size must currently have L1 aligned page size");
-    }
-    if (input_tensor.dtype() != output_dtype) {
-        TT_FATAL(
-            input_tensor.layout() == Layout::TILE,
-            "Input tensor layout must be TILE when dtype conversion is needed but got {}",
-            input_tensor.layout());
-    }
-}
-
-void InterleavedToShardedDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(operation_attributes, tensor_args);
-}
-
-InterleavedToShardedDeviceOperation::spec_return_value_t InterleavedToShardedDeviceOperation::compute_output_specs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.output_tensor.has_value()) {
-        return tensor_args.output_tensor.value().tensor_spec();
-    }
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    return tt::tt_metal::TensorSpec(
-        input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
-            operation_attributes.output_dtype,
-            tt::tt_metal::PageConfig(input_tensor.layout()),
-            operation_attributes.output_mem_config,
-            input_tensor.logical_shape(),
-            input_tensor.padded_shape()));
-}
-
-InterleavedToShardedDeviceOperation::tensor_return_value_t InterleavedToShardedDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.output_tensor.has_value()) {
-        return tensor_args.output_tensor.value();
-    }
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(spec, input_tensor.device());
-}
-
-tt::stl::hash::hash_t InterleavedToShardedDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-    return tt::tt_metal::operation::hash_operation<InterleavedToShardedDeviceOperation>(
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        operation_attributes.keep_l1_aligned,
-        program_factory.index(),
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_tensor.layout(),
-        input_tensor.padded_shape());
-}
-
-std::tuple<
-    InterleavedToShardedDeviceOperation::operation_attributes_t,
-    InterleavedToShardedDeviceOperation::tensor_args_t>
-InterleavedToShardedDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::InterleavedToShardedDeviceOperation::tensor_return_value_t interleaved_to_sharded(
     const Tensor& input_tensor,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype,
     bool keep_l1_aligned,
     const std::optional<Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{output_mem_config, output_dtype, keep_l1_aligned},
-        tensor_args_t{input_tensor, preallocated_output}};
+    using OperationType = ttnn::operations::data_movement::InterleavedToShardedDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{output_mem_config, output_dtype, keep_l1_aligned},
+        OperationType::tensor_args_t{input_tensor, preallocated_output});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement {
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -39,19 +39,15 @@ struct InterleavedToShardedDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype,
-        bool keep_l1_aligned,
-        const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto interleaved_to_sharded = ttnn::register_operation<
-    "ttnn::prim::interleaved_to_sharded",
-    ttnn::operations::data_movement::InterleavedToShardedDeviceOperation>();
-}
+ttnn::operations::data_movement::InterleavedToShardedDeviceOperation::tensor_return_value_t interleaved_to_sharded(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    bool keep_l1_aligned,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 #include <tt-metalium/buffer_types.hpp>
@@ -11,6 +12,20 @@
 #include <enchantum/enchantum.hpp>
 
 using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+ttnn::operations::data_movement::reshard::ReshardDeviceOperation::tensor_return_value_t reshard(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    using OperationType = ttnn::operations::data_movement::reshard::ReshardDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            .output_mem_config = memory_config,
+        },
+        OperationType::tensor_args_t{.input = input_tensor, .preallocated_output = optional_output_tensor});
+}
+}  // namespace ttnn::prim
 
 namespace ttnn::operations::data_movement::reshard {
 
@@ -218,18 +233,6 @@ ReshardDeviceOperation::create_op_performance_model(
     tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
         {tensor_args.input}, {output_tensor}, ideal_dev_clock_cycles);
     return result;
-}
-
-std::tuple<ReshardDeviceOperation::operation_attributes_t, ReshardDeviceOperation::tensor_args_t>
-ReshardDeviceOperation::invoke(
-    const Tensor& input_tensor,
-    const tt::tt_metal::MemoryConfig& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    return {
-        operation_attributes_t{
-            .output_mem_config = memory_config,
-        },
-        tensor_args_t{.input = input_tensor, .preallocated_output = optional_output_tensor}};
 }
 
 }  // namespace ttnn::operations::data_movement::reshard

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.hpp
@@ -44,16 +44,13 @@ struct ReshardDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output_tensor) const;
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const tt::tt_metal::MemoryConfig& memory_config,
-        const std::optional<Tensor>& optional_output_tensor);
 };
 
 }  // namespace ttnn::operations::data_movement::reshard
 
 namespace ttnn::prim {
-constexpr auto reshard =
-    ttnn::register_operation<"ttnn::prim::reshard", ttnn::operations::data_movement::reshard::ReshardDeviceOperation>();
+ttnn::operations::data_movement::reshard::ReshardDeviceOperation::tensor_return_value_t reshard(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const std::optional<Tensor>& optional_output_tensor);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -3,117 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement {
-
-ShardedToInterleavedDeviceOperation::program_factory_t ShardedToInterleavedDeviceOperation::select_program_factory(
-    const operation_attributes_t&, const tensor_args_t&) {
-    return program::ShardedToInterleavedProgramFactory{};
-}
-
-void ShardedToInterleavedDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto shard_spec = input_tensor.shard_spec().value();
-
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor.memory_config().is_sharded(), "Input tensor must be sharded");
-    TT_FATAL(input_tensor.memory_config().buffer_type() == BufferType::L1, "Input tensor must be in L1");
-
-    if (tensor_args.preallocated_output.has_value()) {
-        const auto& output_tensor = tensor_args.preallocated_output.value();
-        TT_FATAL(output_tensor.memory_config() == args.output_mem_config, "Mismatched output memory config");
-        TT_FATAL(output_tensor.dtype() == args.output_dtype, "Mismatched output dtype");
-        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-        TT_FATAL(output_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-        TT_FATAL(output_tensor.device() == input_tensor.device(), "Operands to shard need to be on the same device!");
-    }
-
-    TT_FATAL(
-        args.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Output memory config must be Interleaved");
-
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        uint32_t l1_alignment = hal::get_l1_alignment();
-        TT_FATAL(
-            (*input_tensor.memory_config().shard_spec()).shape[1] * input_tensor.element_size() % (l1_alignment) == 0,
-            "Shard page size must be aligned to {}B for L1 Tensor",
-            l1_alignment);
-    }
-
-    if (input_tensor.dtype() != args.output_dtype) {
-        TT_FATAL(input_tensor.layout() == Layout::TILE, "If diff output type, tensor must be TILED");
-    }
-}
-
-void ShardedToInterleavedDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(args, tensor_args);
-}
-
-ShardedToInterleavedDeviceOperation::spec_return_value_t ShardedToInterleavedDeviceOperation::compute_output_specs(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output->tensor_spec();
-    }
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    return TensorSpec(
-        input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
-            args.output_dtype,
-            PageConfig(input_tensor.layout()),
-            args.output_mem_config,
-            input_tensor.logical_shape(),
-            input_tensor.padded_shape()));
-}
-
-ShardedToInterleavedDeviceOperation::tensor_return_value_t ShardedToInterleavedDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output.value();
-    }
-
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto spec = compute_output_specs(args, tensor_args);
-    return create_device_tensor(spec, input_tensor.device());
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<ShardedToInterleavedDeviceOperation::tensor_return_value_t>
-ShardedToInterleavedDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) const {
-    int ideal_dev_clock_cycles = common_tm_bw_model(tensor_args.input_tensor, output_tensor);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {tensor_args.input_tensor}, {output_tensor}, ideal_dev_clock_cycles);
-    return result;
-}
-
-std::tuple<
-    ShardedToInterleavedDeviceOperation::operation_attributes_t,
-    ShardedToInterleavedDeviceOperation::tensor_args_t>
-ShardedToInterleavedDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation::tensor_return_value_t sharded_to_interleaved(
     const Tensor& input_tensor,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype,
     const std::optional<Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .output_dtype = output_dtype,
             .num_slices = 1,
-            .slice_index = 0,
-        },
-        tensor_args_t{
+            .slice_index = 0},
+        OperationType::tensor_args_t{
             .input_tensor = input_tensor,
-            .preallocated_output = preallocated_output,
-        }};
+            .preallocated_output = preallocated_output});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement {
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.hpp
@@ -30,18 +30,14 @@ struct ShardedToInterleavedDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output_tensor) const;
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype,
-        const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto sharded_to_interleaved = ttnn::register_operation<
-    "ttnn::prim::sharded_to_interleaved",
-    ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation>();
+ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation::tensor_return_value_t sharded_to_interleaved(
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -3,108 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "interleaved_to_sharded_partial_op.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <ttnn/operation.hpp>
 
-namespace ttnn::operations::data_movement {
-
-InterleavedToShardedPartialDeviceOperation::program_factory_t
-InterleavedToShardedPartialDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return detail::InterleavedToShardedPartialProgramFactory{};
-}
-
-void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    const auto& num_slices = operation_attributes.num_slices;
-    const auto& slice_index = operation_attributes.slice_index;
-    const auto& grid_size = operation_attributes.grid_size;
-    const auto& output_dtype = operation_attributes.output_dtype;
-
-    // Validate output tensor
-    TT_FATAL(
-        slice_index >= 0 && slice_index < num_slices,
-        "Slice index and num_slices don't match! Index = {} num_slices = {}",
-        slice_index,
-        num_slices);
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
-    TT_FATAL(
-        (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % num_slices == 0,
-        "Total height of a tensor must be divisible by num_slices!");
-
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-
-    TT_FATAL(
-        input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Input tensor must be Interleaved");
-    if (input_tensor.dtype() != output_dtype) {
-        TT_FATAL(
-            input_tensor.layout() == Layout::TILE,
-            "Input tensor layout must be TILE but got {}",
-            input_tensor.layout());
-    }
-    auto device_grid = input_tensor.device()->compute_with_storage_grid_size();
-    TT_FATAL(
-        grid_size.x <= device_grid.x && grid_size.y <= device_grid.y,
-        "Grid size for sharding must be less than or equal to total grid available");
-}
-
-void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(operation_attributes, tensor_args);
-}
-
-InterleavedToShardedPartialDeviceOperation::spec_return_value_t
-InterleavedToShardedPartialDeviceOperation::compute_output_specs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto shape = input_tensor.padded_shape();
-
-    uint32_t total_height = input_tensor.physical_volume() / shape[-1];
-    uint32_t new_height = total_height / operation_attributes.num_slices;
-
-    shape[0] = 1;
-    shape[1] = 1;
-    shape[2] = new_height;
-
-    auto mem_config = operation_attributes.output_mem_config.with_shard_spec(operation_attributes.shard_spec);
-
-    return TensorSpec(
-        shape,
-        tt::tt_metal::TensorLayout(
-            operation_attributes.output_dtype, tt::tt_metal::PageConfig(input_tensor.layout()), mem_config));
-}
-
-InterleavedToShardedPartialDeviceOperation::tensor_return_value_t
-InterleavedToShardedPartialDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
-}
-
-tt::stl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-    return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(
-        operation_attributes.grid_size,
-        operation_attributes.shard_spec,
-        operation_attributes.num_slices,
-        operation_attributes.slice_index,
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        program_factory.index(),
-        tensor_args.input_tensor.dtype(),
-        tensor_args.input_tensor.layout());
-}
-
-std::tuple<
-    InterleavedToShardedPartialDeviceOperation::operation_attributes_t,
-    InterleavedToShardedPartialDeviceOperation::tensor_args_t>
-InterleavedToShardedPartialDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::InterleavedToShardedPartialDeviceOperation::tensor_return_value_t
+interleaved_to_sharded_partial(
     const Tensor& input_tensor,
     const CoreCoord& grid_size,
     const tt::tt_metal::ShardSpec& shard_spec,
@@ -112,15 +19,19 @@ InterleavedToShardedPartialDeviceOperation::invoke(
     uint32_t slice_index,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::InterleavedToShardedPartialDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .grid_size = grid_size,
             .shard_spec = shard_spec,
             .num_slices = num_slices,
             .slice_index = slice_index,
             .output_mem_config = output_mem_config,
             .output_dtype = output_dtype},
-        tensor_args_t{.input_tensor = input_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement {
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -34,21 +34,18 @@ struct InterleavedToShardedPartialDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const CoreCoord& grid_size,
-        const tt::tt_metal::ShardSpec& shard_spec,
-        uint32_t num_slices,
-        uint32_t slice_index,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto interleaved_to_sharded_partial = ttnn::register_operation<
-    "ttnn::prim::interleaved_to_sharded_partial",
-    ttnn::operations::data_movement::InterleavedToShardedPartialDeviceOperation>();
+ttnn::operations::data_movement::InterleavedToShardedPartialDeviceOperation::tensor_return_value_t
+interleaved_to_sharded_partial(
+    const Tensor& input_tensor,
+    const CoreCoord& grid_size,
+    const tt::tt_metal::ShardSpec& shard_spec,
+    uint32_t num_slices,
+    uint32_t slice_index,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
@@ -3,107 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement {
-
-ShardedToInterleavedPartialDeviceOperation::program_factory_t
-ShardedToInterleavedPartialDeviceOperation::select_program_factory(
-    const operation_attributes_t&, const tensor_args_t&) {
-    return program::ShardedToInterleavedPartialProgramFactory{};
-}
-
-void ShardedToInterleavedPartialDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    const auto& cache_tensor = tensor_args.cache_tensor;
-    auto shard_spec = input_tensor.shard_spec().value();
-
-    // Validate output tensor
-    TT_FATAL(
-        args.slice_index >= 0 && args.slice_index < args.num_slices,
-        "Slice index and num_slices don't match! Index = {} num_slices = {}",
-        args.slice_index,
-        args.num_slices);
-    TT_FATAL(input_tensor.layout() == Layout::TILE, "Currently, only tile layout is supported for partial S->I");
-    TT_FATAL(
-        (cache_tensor.physical_volume() / cache_tensor.padded_shape()[-1]) % args.num_slices == 0,
-        "Total height of a tensor must be divisible by num_slices!");
-
-    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
-    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
-
-    TT_FATAL(input_tensor.memory_config().is_sharded(), "Input tensor must be sharded");
-    if (input_tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
-        if (input_tensor.padded_shape()[-1] % shard_spec.shape[1] != 0 ||
-            ((input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % shard_spec.shape[0]) != 0) {
-            TT_FATAL(
-                input_tensor.shard_spec().value().grid.ranges().size() == 1,
-                "Input tensor shard spec must have exactly 1 grid range but got {}",
-                input_tensor.shard_spec().value().grid.ranges().size());
-        }
-    }
-    if (input_tensor.dtype() != args.output_dtype) {
-        TT_FATAL(
-            input_tensor.layout() == Layout::TILE,
-            "Input tensor layout must be TILE but got {}",
-            input_tensor.layout());
-    }
-}
-
-void ShardedToInterleavedPartialDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(args, tensor_args);
-}
-
-ShardedToInterleavedPartialDeviceOperation::spec_return_value_t
-ShardedToInterleavedPartialDeviceOperation::compute_output_specs(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {
-    // Return the spec of the cache tensor since we're writing to it
-    return tensor_args.cache_tensor.tensor_spec();
-}
-
-ShardedToInterleavedPartialDeviceOperation::tensor_return_value_t
-ShardedToInterleavedPartialDeviceOperation::create_output_tensors(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {
-    // Return the cache tensor itself - it's preallocated
-    return tensor_args.cache_tensor;
-}
-
-tt::tt_metal::operation::OpPerformanceModelGeneral<ShardedToInterleavedPartialDeviceOperation::tensor_return_value_t>
-ShardedToInterleavedPartialDeviceOperation::create_op_performance_model(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) const {
-    int ideal_dev_clock_cycles = common_tm_bw_model(tensor_args.input_tensor, output_tensor);
-    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
-        {tensor_args.input_tensor}, {output_tensor}, ideal_dev_clock_cycles);
-    return result;
-}
-
-std::tuple<
-    ShardedToInterleavedPartialDeviceOperation::operation_attributes_t,
-    ShardedToInterleavedPartialDeviceOperation::tensor_args_t>
-ShardedToInterleavedPartialDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::ShardedToInterleavedPartialDeviceOperation::tensor_return_value_t
+sharded_to_interleaved_partial(
     const Tensor& input_tensor,
     const Tensor& cache_tensor,
     uint32_t num_slices,
     uint32_t slice_index,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::ShardedToInterleavedPartialDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .num_slices = num_slices,
             .slice_index = slice_index,
             .output_mem_config = output_mem_config,
-            .output_dtype = output_dtype,
-        },
-        tensor_args_t{
+            .output_dtype = output_dtype},
+        OperationType::tensor_args_t{
             .input_tensor = input_tensor,
-            .cache_tensor = cache_tensor,
-        }};
+            .cache_tensor = cache_tensor});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement {
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.hpp
@@ -32,20 +32,17 @@ struct ShardedToInterleavedPartialDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output_tensor) const;
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const Tensor& cache_tensor,
-        uint32_t num_slices,
-        uint32_t slice_index,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const tt::tt_metal::DataType& output_dtype);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto sharded_to_interleaved_partial = ttnn::register_operation<
-    "ttnn::prim::sharded_to_interleaved_partial",
-    ttnn::operations::data_movement::ShardedToInterleavedPartialDeviceOperation>();
+ttnn::operations::data_movement::ShardedToInterleavedPartialDeviceOperation::tensor_return_value_t
+sharded_to_interleaved_partial(
+    const Tensor& input_tensor,
+    const Tensor& cache_tensor,
+    uint32_t num_slices,
+    uint32_t slice_index,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const tt::tt_metal::DataType& output_dtype);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp"
@@ -85,7 +86,31 @@ uint32_t get_rm_start_offset(const Tensor& tensor, const ttnn::Shape& slice_star
     return start_offset;
 }
 
-namespace slice {
+}  // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+ttnn::operations::data_movement::slice::SliceDeviceOperation::tensor_return_value_t slice(
+    const Tensor& input,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& step,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_tensor_args,
+    std::optional<Tensor> start_tensor,
+    std::optional<Tensor> end_tensor,
+    const std::optional<uint32_t>& slice_dim,
+    const std::optional<uint32_t>& num_devices,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<Tensor>& preallocated_output) {
+    using OperationType = ttnn::operations::data_movement::slice::SliceDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            slice_start, slice_end, step, output_mem_config, use_tensor_args, slice_dim, num_devices, sub_core_grids},
+        OperationType::tensor_args_t{input, std::move(start_tensor), std::move(end_tensor), preallocated_output});
+}
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::slice {
 
 void SliceDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
@@ -220,7 +245,7 @@ SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_s
         tt::tt_metal::TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), args.output_mem_config));
 }
 
-SliceDeviceOperation::tensor_return_value_t SliceDeviceOperation::create_output_tensors(
+tensor_return_value_t SliceDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();
@@ -268,25 +293,4 @@ SliceDeviceOperation::create_op_performance_model(
     return result;
 }
 
-std::tuple<SliceDeviceOperation::operation_attributes_t, SliceDeviceOperation::tensor_args_t>
-SliceDeviceOperation::invoke(
-    const Tensor& input,
-    const ttnn::Shape& slice_start,
-    const ttnn::Shape& slice_end,
-    const ttnn::Shape& step,
-    const tt::tt_metal::MemoryConfig& output_mem_config,
-    bool use_tensor_args,
-    std::optional<Tensor> start_tensor,
-    std::optional<Tensor> end_tensor,
-    const std::optional<uint32_t>& slice_dim,
-    const std::optional<uint32_t>& num_devices,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{
-            slice_start, slice_end, step, output_mem_config, use_tensor_args, slice_dim, num_devices, sub_core_grids},
-        tensor_args_t{input, std::move(start_tensor), std::move(end_tensor), preallocated_output}};
-}
-
-}  // namespace slice
-}  // namespace ttnn::operations::data_movement
+}  // namespace ttnn::operations::data_movement::slice

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -49,27 +49,23 @@ struct SliceDeviceOperation {
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const ttnn::Shape& slice_start,
-        const ttnn::Shape& slice_end,
-        const ttnn::Shape& step,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        bool use_tensor_args,
-        std::optional<Tensor> start_tensor = std::nullopt,
-        std::optional<Tensor> end_tensor = std::nullopt,
-        const std::optional<uint32_t>& slice_dim = std::nullopt,
-        const std::optional<uint32_t>& num_devices = std::nullopt,
-        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-        const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
 }  // namespace slice
 }  // namespace ttnn::operations::data_movement
 
-// Register the operation with ttnn::register_operation API to make it available as ttnn::prim::slice
 namespace ttnn::prim {
-constexpr auto slice =
-    ttnn::register_operation<"ttnn::prim::slice", ttnn::operations::data_movement::slice::SliceDeviceOperation>();
+ttnn::operations::data_movement::slice::SliceDeviceOperation::tensor_return_value_t slice(
+    const Tensor& input,
+    const ttnn::Shape& slice_start,
+    const ttnn::Shape& slice_end,
+    const ttnn::Shape& step,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    bool use_tensor_args,
+    std::optional<Tensor> start_tensor = std::nullopt,
+    std::optional<Tensor> end_tensor = std::nullopt,
+    const std::optional<uint32_t>& slice_dim = std::nullopt,
+    const std::optional<uint32_t>& num_devices = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
@@ -3,160 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sort_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::data_movement::sort {
-
-constexpr uint32_t WT_THRESHOLD = 64;
-
-SortDeviceOperation::program_factory_t SortDeviceOperation::select_program_factory(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto input_tensor_shape = tensor_args.input_tensor.padded_shape();
-    const auto tile_width = tensor_args.input_tensor.tensor_spec().tile().get_width();
-    const uint32_t Wt = input_tensor_shape[3] / tile_width;
-
-    // Device number of cores
-    auto* const device = tensor_args.input_tensor.device();
-    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    const uint32_t total_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
-
-    const auto input_dtype = tensor_args.input_tensor.dtype();
-    const auto output_specs = compute_output_specs(attributes, tensor_args);
-    const auto index_dtype = output_specs[1].data_type();
-
-    const uint32_t total_number_of_tiles_for_hybrid_approach =
-        total_number_of_cores * program::SortProgramFactoryCrossCoreDataExchange::get_number_of_tiles_per_core(
-                                    total_number_of_cores,
-                                    Wt,
-                                    input_dtype,
-                                    index_dtype,
-                                    program::SortProgramFactoryCrossCoreDataExchange::
-                                        CrossCoreDataExchangeSortSlicingStrategy::USE_AS_MANY_CORES);
-
-    if (Wt <= WT_THRESHOLD) {
-        // Single-core implementation
-        return program::SortProgramFactorySingleRowSingleCore{};
-    } else if (Wt <= total_number_of_tiles_for_hybrid_approach) {
-        // Hybrid implementation
-        return program::SortProgramFactoryCrossCoreDataExchange{};
-    }
-    // DRAM implementation
-    return program::SortProgramFactorySingleRowMultiCore{};
-}
-
-void SortDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(attributes, tensor_args);
-}
-
-void SortDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // Validate shapes of input and output tensors
-    const auto input_tensor_shape = tensor_args.input_tensor.padded_shape();
-
-    TT_FATAL(
-        tensor_args.input_tensor.buffer() != nullptr,
-        "Operands need to be allocated in buffers on the device. Buffer is null.");
-    TT_FATAL(
-        tensor_args.input_tensor.storage_type() == StorageType::DEVICE,
-        "Operation requires input to be on Device. Input storage type: {}",
-        static_cast<int>(tensor_args.input_tensor.storage_type()));
-
-    TT_FATAL(input_tensor_shape.rank() == 4, "Input shape must be 4D, got {}", input_tensor_shape.rank());
-
-    TT_FATAL(
-        input_tensor_shape[-1] % 64 == 0,
-        "Input shape inner dim {} must be a multiple of 64, pad with +/-infinity if necessary",
-        input_tensor_shape[-1]);
-    TT_FATAL(
-        (input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]) % 32 == 0,
-        "Input height (combined input_shape[0-3]) {} must be a multiple of 32",
-        input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]);
-
-    TT_FATAL(attributes.output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
-
-    TT_FATAL(tensor_args.input_tensor.layout() == Layout::TILE, "The input must be in tiled format");
-
-    if (tensor_args.output_tensors.size() == 2) {
-        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
-            const auto output_tensor_shape = tensor_args.output_tensors.at(0)->padded_shape();
-            TT_FATAL(
-                output_tensor_shape == input_tensor_shape,
-                "Output tensor shape must be the same as input tensor shape. Got output tensor shape: {} and input "
-                "tensor shape: {}",
-                output_tensor_shape,
-                input_tensor_shape);
-            const auto output_indices_shape = tensor_args.output_tensors.at(1)->padded_shape();
-            TT_FATAL(
-                output_indices_shape == input_tensor_shape,
-                "Output tensor indices shape must be the same as input tensor shape. Got output indices tensor shape: "
-                "{} and "
-                "input tensor shape: {}",
-                output_indices_shape,
-                input_tensor_shape);
-            TT_FATAL(
-                tensor_args.output_tensors.at(0)->dtype() == tensor_args.input_tensor.dtype(),
-                "Output values tensor dtype must be the same as input tensor dtype. Got output values tensor dtype: {} "
-                "and input tensor dtype: {}",
-                tensor_args.output_tensors.at(0)->dtype(),
-                tensor_args.input_tensor.dtype());
-            TT_FATAL(
-                tensor_args.output_tensors.at(1)->dtype() == DataType::UINT16 ||
-                    tensor_args.output_tensors.at(1)->dtype() == DataType::UINT32,
-                "Output indices tensor dtype must be UINT16 or UINT32. Got output indices tensor dtype: {}",
-                tensor_args.output_tensors.at(1)->dtype());
-        }
-    }
-}
-
-SortDeviceOperation::spec_return_value_t SortDeviceOperation::compute_output_specs(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.output_tensors.size() == 2) {
-        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
-            return {tensor_args.output_tensors[0]->tensor_spec(), tensor_args.output_tensors[1]->tensor_spec()};
-        }
-    }
-    // Create output tensors specs
-    auto output_shape = tensor_args.input_tensor.logical_shape();
-    auto values_spec = TensorSpec(
-        output_shape,
-        TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(Layout::TILE), attributes.output_mem_config));
-
-    DataType index_dtype = DataType::UINT16;
-    if (output_shape[-1] >= std::numeric_limits<uint16_t>::max()) {
-        index_dtype = DataType::UINT32;
-    }
-    auto index_spec =
-        TensorSpec(output_shape, TensorLayout(index_dtype, PageConfig(Layout::TILE), attributes.output_mem_config));
-
-    return {values_spec, index_spec};
-}
-
-SortDeviceOperation::tensor_return_value_t SortDeviceOperation::create_output_tensors(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.output_tensors.size() == 2) {
-        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
-            return {tensor_args.output_tensors[0].value(), tensor_args.output_tensors[1].value()};
-        }
-    }
-    auto output_specs = compute_output_specs(attributes, tensor_args);
-    return {
-        create_device_tensor(output_specs[0], tensor_args.input_tensor.device()),  // Value tensor
-        create_device_tensor(output_specs[1], tensor_args.input_tensor.device()),  // Index tensor
-    };
-}
-
-std::tuple<SortDeviceOperation::operation_attributes_t, SortDeviceOperation::tensor_args_t> SortDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::sort::SortDeviceOperation::tensor_return_value_t sort(
     const Tensor& input_tensor,
-    const int8_t dim,
-    const bool descending,
-    const bool stable,
+    int8_t dim,
+    bool descending,
+    bool stable,
     const MemoryConfig& output_memory_config,
     const std::vector<std::optional<Tensor>>& output_tensors) {
-    return {
-        operation_attributes_t{dim, descending, stable, output_memory_config},
-        tensor_args_t{input_tensor, output_tensors}};
+    using OperationType = ttnn::operations::data_movement::sort::SortDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{dim, descending, stable, output_memory_config},
+        OperationType::tensor_args_t{input_tensor, output_tensors});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::data_movement::sort {
 
 }  // namespace ttnn::operations::data_movement::sort

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.hpp
@@ -31,19 +31,16 @@ struct SortDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        int8_t dim,
-        bool descending,
-        bool stable,
-        const MemoryConfig& output_memory_config,
-        const std::vector<std::optional<Tensor>>& output_tensors);
 };
 
 }  // namespace ttnn::operations::data_movement::sort
 
 namespace ttnn::prim {
-constexpr auto sort =
-    ttnn::register_operation<"ttnn::prim::sort", ttnn::operations::data_movement::sort::SortDeviceOperation>();
+ttnn::operations::data_movement::sort::SortDeviceOperation::tensor_return_value_t sort(
+    const Tensor& input_tensor,
+    int8_t dim,
+    bool descending,
+    bool stable,
+    const MemoryConfig& output_memory_config,
+    const std::vector<std::optional<Tensor>>& output_tensors);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
 
@@ -140,21 +141,20 @@ TilizeWithValPaddingDeviceOperation::tensor_return_value_t TilizeWithValPaddingD
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-std::tuple<
-    TilizeWithValPaddingDeviceOperation::operation_attributes_t,
-    TilizeWithValPaddingDeviceOperation::tensor_args_t>
-TilizeWithValPaddingDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation::tensor_return_value_t tilize_with_val_padding(
     const Tensor& input_tensor,
     const ttnn::Shape& output_padded_shape,
     const PadValue& pad_value,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<DataType>& output_dtype,
-    const bool use_multicore,
-    const bool enough_space_width,
-    const bool enough_space_height,
+    bool use_multicore,
+    bool enough_space_width,
+    bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    return {
-        TilizeWithValPaddingDeviceOperation::operation_attributes_t{
+    using OperationType = ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .output_padded_shape = output_padded_shape,
             .pad_value = pad_value,
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
@@ -164,7 +164,8 @@ TilizeWithValPaddingDeviceOperation::invoke(
             .enough_space_height = enough_space_height,
             .sub_core_grids = sub_core_grids,
         },
-        TilizeWithValPaddingDeviceOperation::tensor_args_t{.input_tensor = input_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.hpp
@@ -40,23 +40,19 @@ struct TilizeWithValPaddingDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const ttnn::Shape& output_padded_shape,
-        const tt::tt_metal::PadValue& pad_value,
-        const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
-        const std::optional<tt::tt_metal::DataType>& output_dtype,
-        bool use_multicore,
-        bool enough_space_width,
-        bool enough_space_height,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto tilize_with_val_padding = ttnn::register_operation<
-    "ttnn::prim::tilize_with_val_padding",
-    ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation>();
+ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation::tensor_return_value_t tilize_with_val_padding(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_padded_shape,
+    const tt::tt_metal::PadValue& pad_value,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
+    const std::optional<tt::tt_metal::DataType>& output_dtype,
+    bool use_multicore,
+    bool enough_space_width,
+    bool enough_space_height,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp
@@ -67,6 +67,14 @@ struct UntilizeDeviceOperation {
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto untilize =
-    ttnn::register_operation<"ttnn::prim::untilize", ttnn::operations::data_movement::UntilizeDeviceOperation>();
+ttnn::operations::data_movement::UntilizeDeviceOperation::tensor_return_value_t untilize(
+    const Tensor& input,
+    tt::tt_metal::MemoryConfig output_mem_config,
+    bool use_multicore,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    std::optional<CoreRangeSet> sub_core_grids,
+    bool enough_space_width,
+    bool enough_space_height,
+    uint32_t pf_type);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "untilize_with_unpadding_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -201,10 +202,8 @@ UntilizeWithUnpaddingDeviceOperation::create_op_performance_model(
     return result;
 }
 
-std::tuple<
-    UntilizeWithUnpaddingDeviceOperation::operation_attributes_t,
-    UntilizeWithUnpaddingDeviceOperation::tensor_args_t>
-UntilizeWithUnpaddingDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingDeviceOperation::tensor_return_value_t untilize_with_unpadding(
     const Tensor& input_tensor,
     const ttnn::Shape& output_tensor_end,
     const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
@@ -214,19 +213,19 @@ UntilizeWithUnpaddingDeviceOperation::invoke(
     bool enough_space_width,
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    operation_attributes_t operation_attributes{
-        .output_tensor_end = output_tensor_end,
-        .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
-        .use_multicore = use_multicore,
-        .use_pack_untilize = use_pack_untilize,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .enough_space_width = enough_space_width,
-        .enough_space_height = enough_space_height,
-        .sub_core_grids = sub_core_grids};
-
-    tensor_args_t tensor_args{.input_tensor = input_tensor};
-
-    return std::make_tuple(operation_attributes, tensor_args);
+    using OperationType = ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            .output_tensor_end = output_tensor_end,
+            .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
+            .use_multicore = use_multicore,
+            .use_pack_untilize = use_pack_untilize,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .enough_space_width = enough_space_width,
+            .enough_space_height = enough_space_height,
+            .sub_core_grids = sub_core_grids},
+        OperationType::tensor_args_t{.input_tensor = input_tensor});
 }
+}  // namespace ttnn::prim
 
 }  // namespace ttnn::operations::data_movement::untilize_with_unpadding

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
@@ -48,23 +48,19 @@ struct UntilizeWithUnpaddingDeviceOperation {
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output_tensor);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const ttnn::Shape& output_tensor_end,
-        const std::optional<MemoryConfig>& output_mem_config,
-        bool use_multicore,
-        bool use_pack_untilize,
-        bool fp32_dest_acc_en,
-        bool enough_space_width,
-        bool enough_space_height,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::data_movement::untilize_with_unpadding
 
 namespace ttnn::prim {
-constexpr auto untilize_with_unpadding = ttnn::register_operation<
-    "ttnn::prim::untilize_with_unpadding",
-    ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingDeviceOperation>();
+ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingDeviceOperation::tensor_return_value_t untilize_with_unpadding(
+    const Tensor& input_tensor,
+    const ttnn::Shape& output_tensor_end,
+    const std::optional<MemoryConfig>& output_mem_config,
+    bool use_multicore,
+    bool use_pack_untilize,
+    bool fp32_dest_acc_en,
+    bool enough_space_width,
+    bool enough_space_height,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -3,181 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "update_cache_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
-namespace ttnn::operations::kv_cache {
-
-using namespace tt::constants;
-
-UpdateKVCacheOperation::program_factory_t UpdateKVCacheOperation::select_program_factory(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (args.op_type == UpdateCacheOpType::FILL) {
-        return program::FillCacheMultiCoreProgramFactory{};
-    } else {
-        return program::UpdateCacheMultiCoreProgramFactory{};
-    }
-}
-
-void UpdateKVCacheOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& cache_tensor = tensor_args.cache;
-    const auto& input_tensor = tensor_args.input;
-    TT_FATAL(
-        input_tensor.storage_type() == StorageType::DEVICE and cache_tensor.storage_type() == StorageType::DEVICE,
-        "Operands to update_cache need to be on device!");
-    TT_FATAL(input_tensor.device() == cache_tensor.device(), "Operands to update_cache need to be on the same device!");
-    TT_FATAL(
-        input_tensor.buffer() != nullptr and cache_tensor.buffer() != nullptr,
-        "Operands to update_cache need to be allocated in buffers on device!");
-    TT_FATAL(
-        (input_tensor.layout() == Layout::TILE && cache_tensor.layout() == Layout::TILE),
-        "Inputs to update_cache must be tilized");
-    TT_FATAL(
-        input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
-            input_tensor.dtype() == DataType::BFLOAT8_B,
-        "Input tensor dtype must be FLOAT32, BFLOAT16, or BFLOAT8_B but got {}",
-        input_tensor.dtype());
-    TT_FATAL(
-        cache_tensor.dtype() == DataType::FLOAT32 || cache_tensor.dtype() == DataType::BFLOAT16 ||
-            cache_tensor.dtype() == DataType::BFLOAT8_B,
-        "Cache tensor dtype must be FLOAT32, BFLOAT16, or BFLOAT8_B but got {}",
-        cache_tensor.dtype());
-
-    TT_FATAL(
-        input_tensor.padded_shape()[-1] == cache_tensor.padded_shape()[-1],
-        "Input tensor width ({}) must equal cache tensor width ({})",
-        input_tensor.padded_shape()[-1],
-        cache_tensor.padded_shape()[-1]);
-    TT_FATAL(
-        input_tensor.padded_shape()[0] == 1,
-        "Input tensor batch size must be 1 but got {}",
-        input_tensor.padded_shape()[0]);
-    TT_FATAL(
-        input_tensor.padded_shape()[1] == cache_tensor.padded_shape()[1],
-        "Input tensor height ({}) must equal cache tensor height ({})",
-        input_tensor.padded_shape()[1],
-        cache_tensor.padded_shape()[1]);
-    TT_FATAL(
-        cache_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Cache tensor memory layout must be INTERLEAVED but got {}",
-        cache_tensor.memory_config().memory_layout());
-    if (args.op_type == UpdateCacheOpType::FILL) {
-        // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
-        TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
-
-        // TODO: For interleaved, assume each core handles 1 tile of seq_len if kv_heads > 1
-        // For 56 cores and 2 heads, this effectively caps max seq len at 56 / 2 * 32 = 896
-        // Can generalize interleaved to infer and check arbitrary number of tiles along seq_len per core; or, add more
-        // robust logic in reader/writer loops to handle generic blocking of work For sharded, we infer number of tiles
-        // each core handles from shard so no issues there
-        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED and
-            input_tensor.padded_shape()[1] > 1) {
-            const uint32_t num_blocks_of_work =
-                input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
-            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-            TT_FATAL(
-                (num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y),
-                "Number of work blocks ({}) must be <= total grid size ({})",
-                num_blocks_of_work,
-                compute_with_storage_grid_size.x * compute_with_storage_grid_size.y);
-        }
-
-        if (input_tensor.is_sharded()) {
-            TT_FATAL(
-                input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "Input tensor memory layout must not be WIDTH_SHARDED but got {}",
-                input_tensor.memory_config().memory_layout());
-            TT_FATAL(
-                input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Input tensor shard width ({}) must equal padded width ({})",
-                input_tensor.shard_spec().value().shape[1],
-                input_tensor.padded_shape()[-1]);
-            // Require even work division along seq_len and also only 1 head per core
-            TT_FATAL(
-                input_tensor.padded_shape()[-2] % input_tensor.shard_spec().value().shape[0] == 0,
-                "Seq len must be divisible by shard height!");
-        }
-
-        TT_FATAL(
-            args.batch_idx < cache_tensor.padded_shape()[0],
-            "Batch index ({}) must be less than cache tensor batch size ({})",
-            args.batch_idx,
-            cache_tensor.padded_shape()[0]);
-        TT_FATAL(
-            input_tensor.padded_shape()[-2] <= cache_tensor.padded_shape()[-2],
-            "Input tensor height ({}) must be <= cache tensor height ({})",
-            input_tensor.padded_shape()[-2],
-            cache_tensor.padded_shape()[-2]);
-    } else if (args.op_type == UpdateCacheOpType::UPDATE) {
-        if (input_tensor.device()->arch() == tt::ARCH::GRAYSKULL) {
-            TT_FATAL(
-                cache_tensor.dtype() == DataType::BFLOAT16,
-                "#12931: Update Cache currently produces non-deterministic output on GS when converting data types for "
-                "cache tensor");
-        }
-        if (input_tensor.is_sharded()) {
-            TT_FATAL(
-                input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
-                "Input tensor memory layout must not be WIDTH_SHARDED but got {}",
-                input_tensor.memory_config().memory_layout());
-            TT_FATAL(
-                input_tensor.shard_spec().value().shape[1] == input_tensor.padded_shape()[-1],
-                "Input tensor shard width ({}) must equal padded width ({})",
-                input_tensor.shard_spec().value().shape[1],
-                input_tensor.padded_shape()[-1]);
-            // Require even work division for now
-            TT_FATAL(
-                (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) %
-                        input_tensor.shard_spec().value().shape[0] ==
-                    0,
-                "Error");
-        } else {
-            TT_FATAL(
-                input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-                "Input tensor memory layout must be INTERLEAVED but got {}",
-                input_tensor.memory_config().memory_layout());
-        }
-        TT_FATAL(
-            cache_tensor.padded_shape()[0] <= input_tensor.padded_shape()[-2],
-            "Cache tensor batch size ({}) must be <= input tensor height ({})",
-            cache_tensor.padded_shape()[0],
-            input_tensor.padded_shape()[-2]);
-        // batch offset is only valid if num_user less than 32 and batch_offset + num_user <= 32
-        if (cache_tensor.padded_shape()[0] < 32) {
-            TT_FATAL(
-                args.batch_offset + cache_tensor.padded_shape()[0] <= 32,
-                "Batch offset ({}) + cache tensor batch size ({}) must be <= 32",
-                args.batch_offset,
-                cache_tensor.padded_shape()[0]);
-        } else {
-            TT_FATAL(args.batch_offset == 0, "Batch offset must be 0 when cache tensor batch size >= 32");
-        }
-    }
-}
-
-void UpdateKVCacheOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    validate_on_program_cache_miss(args, tensor_args);
-}
-
-spec_return_value_t UpdateKVCacheOperation::compute_output_specs(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Do nothing because it's an in-place operation. Cache Tensor is the output tensor.
-    return tensor_args.cache.tensor_spec();
-}
-
-tensor_return_value_t UpdateKVCacheOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Do nothing because it's an in-place operation. Cache Tensor is the output tensor.
-    return tensor_args.cache;
-}
-
-tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<UpdateKVCacheOperation>(
-        args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
-}
-
-std::tuple<operation_attributes_t, tensor_args_t> UpdateKVCacheOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::kv_cache::UpdateKVCacheOperation::tensor_return_value_t update_cache(
     const Tensor& cache,
     const Tensor& input,
     const uint32_t batch_idx,
@@ -185,16 +14,19 @@ std::tuple<operation_attributes_t, tensor_args_t> UpdateKVCacheOperation::invoke
     const uint32_t batch_offset,
     const UpdateCacheOpType op_type,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::kv_cache::UpdateKVCacheOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .batch_idx = batch_idx,
             .update_idx = update_index,
             .batch_offset = batch_offset,
             .op_type = op_type,
             .compute_kernel_config = compute_kernel_config},
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .cache = cache,
-            .input = input,
-        }};
+            .input = input});
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::kv_cache {
 }  // namespace ttnn::operations::kv_cache

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -33,19 +33,17 @@ struct UpdateKVCacheOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& cache,
-        const Tensor& input,
-        uint32_t batch_idx,
-        uint32_t update_index,
-        uint32_t batch_offset,
-        UpdateCacheOpType op_type,
-        std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
 }  // namespace ttnn::operations::kv_cache
 
 namespace ttnn::prim {
-constexpr auto update_cache =
-    ttnn::register_operation<"ttnn::prim::update_cache", ttnn::operations::kv_cache::UpdateKVCacheOperation>();
+ttnn::operations::kv_cache::UpdateKVCacheOperation::tensor_return_value_t update_cache(
+    const Tensor& cache,
+    const Tensor& input,
+    uint32_t batch_idx,
+    uint32_t update_index,
+    uint32_t batch_offset,
+    UpdateCacheOpType op_type,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This PR continues the ongoing refactoring effort to standardize device operations in `ttnn`. Previously, `ttnn::register_operation` was used with a static `invoke` method, which is being replaced by direct function declarations in `ttnn::prim` that utilize `ttnn::device_operation::detail::launch_on_device`. This change aims to improve consistency, maintainability, and enable better integration with the `ttnn` operation dispatch mechanism.

### What's changed
This PR refactors 23 device operations from `device_ops_to_process.txt` (lines 168-191) to align with the new `ttnn::device_operation::detail::launch_on_device` pattern.

The changes for each operation include:
1.  **Removal of `static auto invoke(...)`**: The static `invoke` member function from the Operation Class in the `.hpp` file has been removed.
2.  **Removal of `ttnn::register_operation`**: The `ttnn::register_operation` call in the `.hpp` file has been replaced.
3.  **Direct Function Declaration**: A direct function is now declared in the `ttnn::prim` namespace in the `.hpp` file.
4.  **Implementation with `launch_on_device`**: The new function is implemented in the corresponding `.cpp` file using `ttnn::device_operation::detail::launch_on_device`.
5.  **Include Path Update**: The implementation files now correctly include `#include "ttnn/device_operation.hpp"`.

**Refactored Operations**:
*   `pad`
*   `indexed_fill`
*   `non_zero_indices`
*   `moe_routing_remap`
*   `tilize_with_val_padding`
*   `reshape_on_device`
*   `reshape` (from `reshape_view`)
*   `untilize_with_unpadding`
*   `concat`
*   `untilize`
*   `copy`
*   `slice`
*   `interleaved_to_sharded_partial`
*   `sharded_to_interleaved_partial`
*   `move`
*   `bcast`
*   `sort`
*   `permute`
*   `sharded_to_interleaved`
*   `interleaved_to_sharded`
*   `reshard`
*   `repeat`
*   `update_cache`

Additionally, `REFACTORING_GUIDE.md` has been updated to reflect the correct include path for `ttnn/device_operation.hpp`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4fb8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ay/agent/device-ops-refactoring-process-4fb8)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
<a href="https://cursor.com/background-agent?bcId=bc-1873b13e-8302-4add-ba23-f3d440513b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1873b13e-8302-4add-ba23-f3d440513b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

