### PR TITLE
Device ops refactoring process

### DIFF
--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -116,28 +116,28 @@
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/full/device/full_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/full/device/full_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -56,20 +56,17 @@ struct BernoulliDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        uint32_t seed,
-        const std::optional<Tensor>& output,
-        const std::optional<DataType>& dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::bernoulli
 
 namespace ttnn::prim {
-constexpr auto bernoulli =
-    ttnn::register_operation<"ttnn::prim::bernoulli", ttnn::operations::bernoulli::BernoulliDeviceOperation>();
+ttnn::operations::bernoulli::BernoulliDeviceOperation::tensor_return_value_t bernoulli(
+    const Tensor& input,
+    uint32_t seed,
+    const std::optional<Tensor>& output = std::nullopt,
+    const std::optional<DataType>& dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -240,31 +240,30 @@ struct BinaryDeviceOperation {
         tensor_return_value_t& tensor_return_value);
 
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        const Tensor& input_tensor_b_arg,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        std::optional<unary::EltwiseFusedActivations> activations,
-        std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        float scalar,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        std::optional<unary::EltwiseFusedActivations> activations,
-        std::optional<unary::EltwiseUnaryWithParam> input_tensor_a_activation);
 };
 
 }  // namespace ttnn::operations::binary
 
 namespace ttnn::prim {
-constexpr auto binary =
-    ttnn::register_operation<"ttnn::prim::binary", ttnn::operations::binary::BinaryDeviceOperation>();
+
+ttnn::operations::binary::BinaryDeviceOperation::tensor_return_value_t binary(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    ttnn::operations::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<Tensor> optional_output_tensor = std::nullopt,
+    std::optional<ttnn::operations::unary::EltwiseFusedActivations> activations = std::nullopt,
+    std::optional<ttnn::operations::unary::EltwiseUnaryWithParam> input_tensor_a_activation = std::nullopt);
+
+ttnn::operations::binary::BinaryDeviceOperation::tensor_return_value_t binary(
+    const Tensor& input_tensor_a_arg,
+    float scalar,
+    ttnn::operations::binary::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    std::optional<Tensor> optional_output_tensor = std::nullopt,
+    std::optional<ttnn::operations::unary::EltwiseFusedActivations> activations = std::nullopt,
+    std::optional<ttnn::operations::unary::EltwiseUnaryWithParam> input_tensor_a_activation = std::nullopt);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "binary_ng_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "binary_ng_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -430,11 +431,14 @@ bool BinaryNgDeviceOperation::skip_launch(
     return tensor_return_value.logical_shape().volume() == 0;
 }
 
-std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
-BinaryNgDeviceOperation::invoke(
+}  // namespace ttnn::operations::binary_ng
+
+namespace ttnn::prim {
+
+ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
-    BinaryOpType binary_op_type,
+    ttnn::operations::binary_ng::BinaryOpType binary_op_type,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
@@ -442,8 +446,9 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    std::optional<unary::ScalarVariant> scalar_value,
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    using OperationType = ttnn::operations::binary_ng::BinaryNgDeviceOperation;
     // Validate storage type for input tensors
     TT_FATAL(
         input_tensor_a.storage_type() == StorageType::DEVICE,
@@ -455,7 +460,7 @@ BinaryNgDeviceOperation::invoke(
         "Input tensor B must be on device, got storage type: {}",
         input_tensor_b.storage_type());
 
-    auto subtile_broadcast_type = get_subtile_broadcast_type(
+    auto subtile_broadcast_type = ttnn::operations::binary_ng::get_subtile_broadcast_type(
         input_tensor_a.logical_shape()[-2],
         input_tensor_a.logical_shape()[-1],
         input_tensor_b.logical_shape()[-2],
@@ -464,70 +469,72 @@ BinaryNgDeviceOperation::invoke(
     DataType dtype_a = input_tensor_a.dtype();
     DataType dtype_b = input_tensor_b.dtype();
     bool is_sfpu_op =
-        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
-    bool is_quant_op = utils::is_quant_op(binary_op_type);
-    bool is_where_op = (binary_op_type == BinaryOpType::WHERE_TTS || binary_op_type == BinaryOpType::WHERE_TST);
-    return {
-        operation_attributes_t{
-            binary_op_type,
-            {lhs_activations.begin(), lhs_activations.end()},
-            {rhs_activations.begin(), rhs_activations.end()},
-            {post_activations.begin(), post_activations.end()},
-            scalar_value,
-            memory_config.value_or(
-                output_tensor.has_value()                     ? output_tensor->memory_config()
-                : input_tensor_a.memory_config().is_sharded() ? input_tensor_a.memory_config()
-                                                              : input_tensor_b.memory_config()),
-            is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
-                                              // dtype depending on which LLK is meant to be used.
-            output_dtype,
-            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor, sub_core_grids),
-            std::nullopt,
-            sub_core_grids,
-            subtile_broadcast_type,
-            is_sfpu_op,
-            is_quant_op,
-            is_where_op},
-        tensor_args_t{input_tensor_a, input_tensor_b, output_tensor}};
+        (ttnn::operations::binary_ng::utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = ttnn::operations::binary_ng::utils::is_quant_op(binary_op_type);
+    bool is_where_op = (binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TTS || binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TST);
+    auto operation_attributes = OperationType::operation_attributes_t{
+        binary_op_type,
+        {lhs_activations.begin(), lhs_activations.end()},
+        {rhs_activations.begin(), rhs_activations.end()},
+        {post_activations.begin(), post_activations.end()},
+        scalar_value,
+        memory_config.value_or(
+            output_tensor.has_value()                     ? output_tensor->memory_config()
+            : input_tensor_a.memory_config().is_sharded() ? input_tensor_a.memory_config()
+                                                          : input_tensor_b.memory_config()),
+        is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
+                                          // dtype depending on which LLK is meant to be used.
+        output_dtype,
+        ttnn::operations::binary_ng::get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor, sub_core_grids),
+        std::nullopt,
+        sub_core_grids,
+        subtile_broadcast_type,
+        is_sfpu_op,
+        is_quant_op,
+        is_where_op};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
 
-std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
-BinaryNgDeviceOperation::invoke(
+ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
     const Tensor& input_tensor_a,
     float scalar,
-    BinaryOpType binary_op_type,
+    ttnn::operations::binary_ng::BinaryOpType binary_op_type,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor,
     const std::optional<bool>& fast_and_approximate_mode,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-    tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-    std::optional<unary::ScalarVariant> scalar_value,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    using OperationType = ttnn::operations::binary_ng::BinaryNgDeviceOperation;
     DataType dtype_a = input_tensor_a.dtype();
     bool is_sfpu_op =
-        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
-    bool is_quant_op = utils::is_quant_op(binary_op_type);
-    return {
-        operation_attributes_t{
-            binary_op_type,
-            {lhs_activations.begin(), lhs_activations.end()},
-            {rhs_activations.begin(), rhs_activations.end()},
-            {post_activations.begin(), post_activations.end()},
-            scalar,
-            memory_config.value_or(
-                output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config()),
-            input_tensor_a.dtype(),
-            output_dtype,
-            get_worker_grid(input_tensor_a, nullptr, output_tensor, sub_core_grids),
-            std::nullopt,
-            sub_core_grids,
-            SubtileBroadcastType::NONE,
-            is_sfpu_op,
-            is_quant_op,
-            false},
-        tensor_args_t{input_tensor_a, std::nullopt, output_tensor}};
+        (ttnn::operations::binary_ng::utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = ttnn::operations::binary_ng::utils::is_quant_op(binary_op_type);
+    auto operation_attributes = OperationType::operation_attributes_t{
+        binary_op_type,
+        {lhs_activations.begin(), lhs_activations.end()},
+        {rhs_activations.begin(), rhs_activations.end()},
+        {post_activations.begin(), post_activations.end()},
+        scalar,
+        memory_config.value_or(
+            output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config()),
+        input_tensor_a.dtype(),
+        output_dtype,
+        ttnn::operations::binary_ng::get_worker_grid(input_tensor_a, nullptr, output_tensor, sub_core_grids),
+        std::nullopt,
+        sub_core_grids,
+        ttnn::operations::binary_ng::SubtileBroadcastType::NONE,
+        is_sfpu_op,
+        is_quant_op,
+        false};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
 
-}  // namespace ttnn::operations::binary_ng
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -89,41 +89,38 @@ struct BinaryNgDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    // tensor-tensor invocation
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        const Tensor& input_tensor_b_arg,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<bool>& fast_and_approximate_mode,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-        std::optional<unary::ScalarVariant> scalar_value,
-        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
-
-    // tensor-scalar invocation
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        float scalar,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<bool>& fast_and_approximate_mode,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> lhs_activations,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
-        tt::stl::Span<const unary::EltwiseUnaryWithParam> post_activations,
-        std::optional<unary::ScalarVariant> scalar_value,
-        const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 };
 
 }  // namespace ttnn::operations::binary_ng
 
 namespace ttnn::prim {
-constexpr auto binary_ng =
-    ttnn::register_operation<"ttnn::prim::binary_ng", ttnn::operations::binary_ng::BinaryNgDeviceOperation>();
+
+ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a_arg,
+    const Tensor& input_tensor_b_arg,
+    ttnn::operations::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+    const Tensor& input_tensor_a_arg,
+    float scalar,
+    ttnn::operations::binary_ng::BinaryOpType binary_op_type,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<bool>& fast_and_approximate_mode = std::nullopt,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations = {},
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations = {},
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations = {},
+    std::optional<ttnn::operations::unary::ScalarVariant> scalar_value = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ternary_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ternary_op_utils.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
@@ -495,9 +496,12 @@ bool TernaryDeviceOperation::skip_launch(
     return tensor_return_value.logical_shape().volume() == 0;
 }
 
-std::tuple<TernaryDeviceOperation::operation_attributes_t, TernaryDeviceOperation::tensor_args_t>
-TernaryDeviceOperation::invoke(
-    TernaryOpType op_type,
+}  // namespace ttnn::operations::ternary
+
+namespace ttnn::prim {
+
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
     const Tensor& input_a,
     const Tensor& input_b,
     const Tensor& input_c,
@@ -505,17 +509,19 @@ TernaryDeviceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // Detect broadcast type for TTT variant
-    TernaryBroadcastType broadcast_type =
-        get_broadcast_type(input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());
+    using OperationType = ttnn::operations::ternary::TernaryDeviceOperation;
 
-    operation_attributes_t attributes{
+    // Detect broadcast type for TTT variant
+    ttnn::operations::ternary::TernaryBroadcastType broadcast_type =
+        ttnn::operations::ternary::get_broadcast_type(input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());
+
+    OperationType::operation_attributes_t attributes{
         .ternary_op_type = op_type,
-        .ternary_variant = TernaryVariant::TTT,
+        .ternary_variant = ttnn::operations::ternary::TernaryVariant::TTT,
         .broadcast_type = broadcast_type,
         .memory_config = memory_config.value_or(input_b.memory_config()),
         .input_dtype = input_a.dtype(),
-        .worker_grid = get_worker_grid(input_a, &input_b, &input_c, optional_output_tensor, sub_core_grids),
+        .worker_grid = ttnn::operations::ternary::get_worker_grid(input_a, &input_b, &input_c, optional_output_tensor, sub_core_grids),
         .dtype = output_dtype.value_or(input_b.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
@@ -523,18 +529,17 @@ TernaryDeviceOperation::invoke(
         .scalar_input_b = std::nullopt,
     };
 
-    tensor_args_t args{
+    OperationType::tensor_args_t args{
         .input_tensor_a = input_a,
         .input_tensor_b = input_b,
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return {attributes, args};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
 }
 
-std::tuple<TernaryDeviceOperation::operation_attributes_t, TernaryDeviceOperation::tensor_args_t>
-TernaryDeviceOperation::invoke(
-    TernaryOpType op_type,
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
     const Tensor& input_a,
     const Tensor& input_b,
     const Tensor& input_c,
@@ -543,22 +548,24 @@ TernaryDeviceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // This invoke variant is only for operations that need a scalar parameter with TTT variant
+    using OperationType = ttnn::operations::ternary::TernaryDeviceOperation;
+
+    // This variant is only for operations that need a scalar parameter with TTT variant
     TT_FATAL(
-        op_type == TernaryOpType::ADDCMUL,
-        "This invoke variant with scalar parameter is only supported for ADDCMUL operation");
+        op_type == ttnn::operations::ternary::TernaryOpType::ADDCMUL,
+        "This variant with scalar parameter is only supported for ADDCMUL operation");
 
     // Detect broadcast type for TTT variant
-    TernaryBroadcastType broadcast_type =
-        get_broadcast_type(input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());
+    ttnn::operations::ternary::TernaryBroadcastType broadcast_type =
+        ttnn::operations::ternary::get_broadcast_type(input_a.logical_shape(), input_b.logical_shape(), input_c.logical_shape());
 
-    operation_attributes_t attributes{
+    OperationType::operation_attributes_t attributes{
         .ternary_op_type = op_type,
-        .ternary_variant = TernaryVariant::TTT,
+        .ternary_variant = ttnn::operations::ternary::TernaryVariant::TTT,
         .broadcast_type = broadcast_type,
         .memory_config = memory_config.value_or(input_b.memory_config()),
         .input_dtype = input_a.dtype(),
-        .worker_grid = get_worker_grid(input_a, &input_b, &input_c, optional_output_tensor, sub_core_grids),
+        .worker_grid = ttnn::operations::ternary::get_worker_grid(input_a, &input_b, &input_c, optional_output_tensor, sub_core_grids),
         .dtype = output_dtype.value_or(input_b.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
@@ -566,18 +573,17 @@ TernaryDeviceOperation::invoke(
         .scalar_input_b = std::nullopt,
     };
 
-    tensor_args_t args{
+    OperationType::tensor_args_t args{
         .input_tensor_a = input_a,
         .input_tensor_b = input_b,
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return {attributes, args};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
 }
 
-std::tuple<TernaryDeviceOperation::operation_attributes_t, TernaryDeviceOperation::tensor_args_t>
-TernaryDeviceOperation::invoke(
-    TernaryOpType op_type,
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
     const Tensor& input_a,
     const Tensor& input_b,
     float scalar_c,
@@ -585,34 +591,35 @@ TernaryDeviceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    // Detect broadcast type for TTS variant
-    TernaryBroadcastType broadcast_type = get_broadcast_type(input_a.logical_shape(), input_b.logical_shape());
+    using OperationType = ttnn::operations::ternary::TernaryDeviceOperation;
 
-    operation_attributes_t attributes{
+    // Detect broadcast type for TTS variant
+    ttnn::operations::ternary::TernaryBroadcastType broadcast_type = ttnn::operations::ternary::get_broadcast_type(input_a.logical_shape(), input_b.logical_shape());
+
+    OperationType::operation_attributes_t attributes{
         .ternary_op_type = op_type,
-        .ternary_variant = TernaryVariant::TTS,
+        .ternary_variant = ttnn::operations::ternary::TernaryVariant::TTS,
         .broadcast_type = broadcast_type,
         .memory_config = memory_config.value_or(input_b.memory_config()),
         .input_dtype = input_a.dtype(),
-        .worker_grid = get_worker_grid(input_a, &input_b, nullptr, optional_output_tensor, sub_core_grids),
+        .worker_grid = ttnn::operations::ternary::get_worker_grid(input_a, &input_b, nullptr, optional_output_tensor, sub_core_grids),
         .dtype = output_dtype.value_or(input_b.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
         .scalar_input_b = scalar_c,
     };
 
-    tensor_args_t args{
+    OperationType::tensor_args_t args{
         .input_tensor_a = input_a,
         .input_tensor_b = input_b,
         .input_tensor_c = std::nullopt,
         .optional_output_tensor = optional_output_tensor};
 
-    return {attributes, args};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
 }
 
-std::tuple<TernaryDeviceOperation::operation_attributes_t, TernaryDeviceOperation::tensor_args_t>
-TernaryDeviceOperation::invoke(
-    TernaryOpType op_type,
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
     const Tensor& input_a,
     float scalar_b,
     const Tensor& input_c,
@@ -620,28 +627,30 @@ TernaryDeviceOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    TernaryBroadcastType broadcast_type = get_broadcast_type(input_a.logical_shape(), input_c.logical_shape());
+    using OperationType = ttnn::operations::ternary::TernaryDeviceOperation;
 
-    operation_attributes_t attributes{
+    ttnn::operations::ternary::TernaryBroadcastType broadcast_type = ttnn::operations::ternary::get_broadcast_type(input_a.logical_shape(), input_c.logical_shape());
+
+    OperationType::operation_attributes_t attributes{
         .ternary_op_type = op_type,
-        .ternary_variant = TernaryVariant::TST,
+        .ternary_variant = ttnn::operations::ternary::TernaryVariant::TST,
         .broadcast_type = broadcast_type,
         .memory_config = memory_config.value_or(input_c.memory_config()),
         .input_dtype = input_a.dtype(),
-        .worker_grid = get_worker_grid(input_a, nullptr, &input_c, optional_output_tensor, sub_core_grids),
+        .worker_grid = ttnn::operations::ternary::get_worker_grid(input_a, nullptr, &input_c, optional_output_tensor, sub_core_grids),
         .dtype = output_dtype.value_or(input_c.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
         .scalar_input_a = scalar_b,
     };
 
-    tensor_args_t args{
+    OperationType::tensor_args_t args{
         .input_tensor_a = input_a,
         .input_tensor_b = std::nullopt,
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return {attributes, args};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
 }
 
-}  // namespace ttnn::operations::ternary
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -72,57 +72,51 @@ struct TernaryDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    // tensor-tensor-tensor invocation (TTT)
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        TernaryOpType op_type,
-        const Tensor& input_a,
-        const Tensor& input_b,
-        const Tensor& input_c,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<CoreRangeSet>& sub_core_grids);
-
-    // tensor-tensor-tensor invocation (TTT) with additional scalar
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        TernaryOpType op_type,
-        const Tensor& input_a,
-        const Tensor& input_b,
-        const Tensor& input_c,
-        float scalar,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<CoreRangeSet>& sub_core_grids);
-
-    // tensor-tensor-scalar invocation (TTS)
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        TernaryOpType op_type,
-        const Tensor& input_a,
-        const Tensor& input_b,
-        float scalar_c,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<CoreRangeSet>& sub_core_grids);
-
-    // tensor-scalar-tensor invocation (TST)
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        TernaryOpType op_type,
-        const Tensor& input_a,
-        float scalar_b,
-        const Tensor& input_c,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<Tensor>& optional_output_tensor,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::ternary
 
 namespace ttnn::prim {
-constexpr auto ternary =
-    ttnn::register_operation<"ttnn::prim::ternary", ttnn::operations::ternary::TernaryDeviceOperation>();
+
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const Tensor& input_c,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const Tensor& input_c,
+    float scalar,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float scalar_c,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+
+ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
+    ttnn::operations::ternary::TernaryOpType op_type,
+    const Tensor& input_a,
+    float scalar_b,
+    const Tensor& input_c,
+    const std::optional<const DataType>& output_dtype = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "tools/profiler/op_profiler.hpp"
@@ -181,10 +182,12 @@ bool UnaryDeviceOperation::skip_launch(
     return tensor_return_value.logical_shape().volume() == 0;
 }
 
-std::tuple<UnaryDeviceOperation::operation_attributes_t, UnaryDeviceOperation::tensor_args_t>
-UnaryDeviceOperation::invoke(
+}  // namespace ttnn::operations::unary
+
+namespace ttnn::prim {
+ttnn::operations::unary::UnaryDeviceOperation::tensor_return_value_t unary(
     const Tensor& input,
-    const std::vector<EltwiseUnaryWithParam>& op_chain,
+    const std::vector<ttnn::operations::unary::EltwiseUnaryWithParam>& op_chain,
     DataType output_dtype,
     const MemoryConfig& output_memory_config,
     bool fp32_dest_acc_en,
@@ -192,17 +195,18 @@ UnaryDeviceOperation::invoke(
     bool bfp8_pack_precise,
     const std::optional<Tensor>& preallocated_output,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    return {
-        operation_attributes_t{
-            .op_chain = op_chain,
-            .output_dtype = output_dtype,
-            .output_memory_config = output_memory_config,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .preserve_fp32_precision = preserve_fp32_precision,
-            .bfp8_pack_precise = bfp8_pack_precise,
-            .sub_core_grids = sub_core_grids,
-        },
-        tensor_args_t{.input = input, .preallocated_output = preallocated_output}};
-}
+    using OperationType = ttnn::operations::unary::UnaryDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .op_chain = op_chain,
+        .output_dtype = output_dtype,
+        .output_memory_config = output_memory_config,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .preserve_fp32_precision = preserve_fp32_precision,
+        .bfp8_pack_precise = bfp8_pack_precise,
+        .sub_core_grids = sub_core_grids,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-}  // namespace ttnn::operations::unary
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+} // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -40,21 +40,19 @@ struct UnaryDeviceOperation {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const std::vector<EltwiseUnaryWithParam>& op_chain,
-        DataType output_dtype,
-        const MemoryConfig& output_memory_config,
-        bool fp32_dest_acc_en,
-        bool preserve_fp32_precision,
-        bool bfp8_pack_precise,
-        const std::optional<Tensor>& preallocated_output,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::unary
 
 namespace ttnn::prim {
-constexpr auto unary = ttnn::register_operation<"ttnn::prim::unary", ttnn::operations::unary::UnaryDeviceOperation>();
+ttnn::operations::unary::UnaryDeviceOperation::tensor_return_value_t unary(
+    const Tensor& input,
+    const std::vector<ttnn::operations::unary::EltwiseUnaryWithParam>& op_chain,
+    DataType output_dtype,
+    const MemoryConfig& output_memory_config,
+    bool fp32_dest_acc_en,
+    bool preserve_fp32_precision,
+    bool bfp8_pack_precise,
+    const std::optional<Tensor>& preallocated_output = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 } // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/embedding/device/embedding_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 using namespace tt::constants;
 using namespace std;
@@ -95,28 +96,31 @@ tensor_return_value_t EmbeddingsDeviceOperation::create_output_tensors(
 }
 
 
-std::tuple<EmbeddingsDeviceOperation::operation_attributes_t, EmbeddingsDeviceOperation::tensor_args_t>
-EmbeddingsDeviceOperation::invoke(
+}  // namespace ttnn::operations::embedding
+
+namespace ttnn::prim {
+ttnn::operations::embedding::EmbeddingsDeviceOperation::tensor_return_value_t embedding(
     const Tensor& input_tensor_arg,
     const Tensor& weight_arg,
     bool tilized,
-    EmbeddingsType embeddings_type,
+    ttnn::operations::embedding::EmbeddingsType embeddings_type,
     const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
     const std::optional<uint32_t>& pad_token,
     const std::optional<Tensor>& optional_output_tensor) {
+    using OperationType = ttnn::operations::embedding::EmbeddingsDeviceOperation;
     auto memory_config = output_mem_config.value_or(input_tensor_arg.memory_config());
-    return {
-        operation_attributes_t{
-            .output_mem_config = memory_config,
-            .tilized = tilized,
-            .embeddings_type = embeddings_type,
-            .pad_token = pad_token,
-        },
-        tensor_args_t{
-            .input_tensor_arg = input_tensor_arg,
-            .weight_arg = weight_arg,
-            .optional_output_tensor = optional_output_tensor,
-        }};
-}
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .output_mem_config = memory_config,
+        .tilized = tilized,
+        .embeddings_type = embeddings_type,
+        .pad_token = pad_token,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .input_tensor_arg = input_tensor_arg,
+        .weight_arg = weight_arg,
+        .optional_output_tensor = optional_output_tensor,
+    };
 
-}  // namespace ttnn::operations::embedding
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.hpp
@@ -36,20 +36,17 @@ struct EmbeddingsDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_arg,
-        const Tensor& weight_arg,
-        bool tilized,
-        EmbeddingsType embeddings_type,
-        const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config = std::nullopt,
-        const std::optional<uint32_t>& pad_token = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 }  // namespace ttnn::operations::embedding
 
 namespace ttnn::prim {
-constexpr auto embedding =
-    ttnn::register_operation<"ttnn::prim::embedding", ttnn::operations::embedding::EmbeddingsDeviceOperation>();
+ttnn::operations::embedding::EmbeddingsDeviceOperation::tensor_return_value_t embedding(
+    const Tensor& input_tensor_arg,
+    const Tensor& weight_arg,
+    bool tilized,
+    ttnn::operations::embedding::EmbeddingsType embeddings_type,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<uint32_t>& pad_token = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "example_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::examples {
 
@@ -36,9 +37,14 @@ ExampleDeviceOperation::tensor_return_value_t ExampleDeviceOperation::create_out
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-std::tuple<ExampleDeviceOperation::operation_attributes_t, ExampleDeviceOperation::tensor_args_t>
-ExampleDeviceOperation::invoke(const Tensor& input_tensor) {
-    return {operation_attributes_t{true, 42}, tensor_args_t{input_tensor}};
-}
-
 }  // namespace ttnn::operations::examples
+
+namespace ttnn::prim {
+ttnn::operations::examples::ExampleDeviceOperation::tensor_return_value_t example(const Tensor& input_tensor) {
+    using OperationType = ttnn::operations::examples::ExampleDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{true, 42};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -123,33 +123,10 @@ struct ExampleDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // API call to map user arguments to operation attributes and tensor args.
-    // This is the only method that is called by the user
-    // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
-
-    // Optional methods
-
-    // In case the operation need a custom hash function, the following method can be implemented
-    /* static tt::stl::hash::hash_t compute_program_hash(
-        const operation_attributes_t&, const tensor_args_t&);
-    */
-
-    // In case the operation needs a custom create_op_performance_model, this method can be implemented
-    /*
-    static tt::tt_metal::tt::tt_metal::operation::OpPerformanceModel create_op_performance_model(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&);
-    */
 };
 
 }  // namespace ttnn::operations::examples
 
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
 namespace ttnn::prim {
-constexpr auto example =
-    ttnn::register_operation<"ttnn::prim::example", ttnn::operations::examples::ExampleDeviceOperation>();
+ttnn::operations::examples::ExampleDeviceOperation::tensor_return_value_t example(const Tensor& input_tensor);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "example_multiple_return_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::examples {
 
@@ -57,11 +58,15 @@ ExampleMultipleReturnDeviceOperation::tensor_return_value_t ExampleMultipleRetur
     return ret;
 }
 
-std::tuple<
-    ExampleMultipleReturnDeviceOperation::operation_attributes_t,
-    ExampleMultipleReturnDeviceOperation::tensor_args_t>
-ExampleMultipleReturnDeviceOperation::invoke(const Tensor& input_tensor, bool return_output1, bool return_output2) {
-    return {operation_attributes_t{true, 42, return_output1, return_output2}, tensor_args_t{input_tensor}};
-}
-
 }  // namespace ttnn::operations::examples
+
+namespace ttnn::prim {
+ttnn::operations::examples::ExampleMultipleReturnDeviceOperation::tensor_return_value_t example_multiple_return(
+    const Tensor& input_tensor, bool return_output1, bool return_output2) {
+    using OperationType = ttnn::operations::examples::ExampleMultipleReturnDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{true, 42, return_output1, return_output2};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
@@ -103,36 +103,11 @@ struct ExampleMultipleReturnDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // API call to map user arguments to operation attributes and tensor args.
-    // This is the only method that is called by the user
-    // The user will be able to call the operation using `tensor_return_value_t output =
-    // ttnn::prim::example(input_tensor)` after the op is registered
-    // `tensor_return_value_t output = ttnn::prim::exampleinput_tensor)`
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor, bool return_output1, bool return_output2);
-
-    // Optional methods
-
-    // In case the operation need a custom hash function, the following method can be implemented
-    /* static tt::stl::hash::hash_t compute_program_hash(
-        const operation_attributes_t&, const tensor_args_t&);
-    */
-
-    // In case the operation needs a custom create_op_performance_model, this method can be implemented
-    /*
-    static tt::tt_metal::tt::tt_metal::operation::OpPerformanceModel create_op_performance_model(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&);
-    */
 };
 
 }  // namespace ttnn::operations::examples
 
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
 namespace ttnn::prim {
-constexpr auto example_multiple_return = ttnn::register_operation<
-    "ttnn::prim::example_multiple_return",
-    ttnn::operations::examples::ExampleMultipleReturnDeviceOperation>();
+ttnn::operations::examples::ExampleMultipleReturnDeviceOperation::tensor_return_value_t example_multiple_return(
+    const Tensor& input_tensor, bool return_output1, bool return_output2);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/full/device/full_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "full_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -62,23 +63,27 @@ FullOperation::tensor_return_value_t FullOperation::create_output_tensors(
     return create_device_tensor(output_spec, operation_attributes.mesh_device);
 }
 
-std::tuple<FullOperation::operation_attributes_t, FullOperation::tensor_args_t> FullOperation::invoke(
+}  // namespace ttnn::operations::full
+
+namespace ttnn::prim {
+ttnn::operations::full::FullOperation::tensor_return_value_t full(
     ttnn::SmallVector<uint32_t> shape,
     std::variant<float, int> fill_value,
     ttnn::MeshDevice* mesh_device,
     const DataType& dtype,
     const Layout& layout,
     const MemoryConfig& memory_config) {
-    return {
-        operation_attributes_t{
-            std::move(shape),
-            fill_value,
-            mesh_device,
-            dtype,
-            layout,
-            memory_config,
-        },
-        tensor_args_t{},
+    using OperationType = ttnn::operations::full::FullOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        std::move(shape),
+        fill_value,
+        mesh_device,
+        dtype,
+        layout,
+        memory_config,
     };
+    auto tensor_args = OperationType::tensor_args_t{};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::full
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/full/device/full_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_device_operation.hpp
@@ -55,18 +55,16 @@ struct FullOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        ttnn::SmallVector<uint32_t> shape,
-        std::variant<float, int> fill_value,
-        ttnn::MeshDevice* mesh_device,
-        const DataType& dtype,
-        const Layout& layout,
-        const MemoryConfig& memory_config);
 };
 
 }  // namespace ttnn::operations::full
 
 namespace ttnn::prim {
-constexpr auto full = ttnn::register_operation<"ttnn::prim::full", ttnn::operations::full::FullOperation>();
+ttnn::operations::full::FullOperation::tensor_return_value_t full(
+    ttnn::SmallVector<uint32_t> shape,
+    std::variant<float, int> fill_value,
+    ttnn::MeshDevice* mesh_device,
+    const DataType& dtype,
+    const Layout& layout,
+    const MemoryConfig& memory_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::full_like {
@@ -57,19 +58,23 @@ FullLikeOperation::tensor_return_value_t FullLikeOperation::create_output_tensor
     return create_device_tensor(output_spec, tensor_args.input.device());
 }
 
-std::tuple<FullLikeOperation::operation_attributes_t, FullLikeOperation::tensor_args_t> FullLikeOperation::invoke(
+}  // namespace ttnn::operations::full_like
+
+namespace ttnn::prim {
+ttnn::operations::full_like::FullLikeOperation::tensor_return_value_t moreh_full_like(
     const Tensor& input,
-    const std::variant<float, int> fill_value,
+    std::variant<float, int> fill_value,
     const std::optional<DataType>& dtype,
     const std::optional<Layout>& layout,
     const std::optional<MemoryConfig>& memory_config) {
-    return {
-        operation_attributes_t{
-            fill_value,
-            dtype.value_or(input.dtype()),
-            layout.value_or(input.layout()),
-            memory_config.value_or(input.memory_config())},
-        tensor_args_t{input}};
-}
+    using OperationType = ttnn::operations::full_like::FullLikeOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        fill_value,
+        dtype.value_or(input.dtype()),
+        layout.value_or(input.layout()),
+        memory_config.value_or(input.memory_config())};
+    auto tensor_args = OperationType::tensor_args_t{input};
 
-}  // namespace ttnn::operations::full_like
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.hpp
@@ -57,17 +57,15 @@ struct FullLikeOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        std::variant<float, int> fill_value,
-        const std::optional<DataType>& dtype,
-        const std::optional<Layout>& layout,
-        const std::optional<MemoryConfig>& memory_config);
 };
 
 }  // namespace ttnn::operations::full_like
 
 namespace ttnn::prim {
-constexpr auto moreh_full_like =
-    ttnn::register_operation<"ttnn::prim::moreh_full_like", ttnn::operations::full_like::FullLikeOperation>();
+ttnn::operations::full_like::FullLikeOperation::tensor_return_value_t moreh_full_like(
+    const Tensor& input,
+    std::variant<float, int> fill_value,
+    const std::optional<DataType>& dtype,
+    const std::optional<Layout>& layout,
+    const std::optional<MemoryConfig>& memory_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -63,9 +63,6 @@ struct GenericOpDeviceOperation {
     // Validate the operation when it reuses a program. Usually will have less checks
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::vector<Tensor>& io_tensors, const operation_attributes_t& operation_attributes);
-
     // Note: will either compute a program hash, or simply return user provided custom program hash
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
@@ -74,6 +71,7 @@ struct GenericOpDeviceOperation {
 }  // namespace ttnn::operations::generic
 
 namespace ttnn::prim {
-constexpr auto generic_op =
-    ttnn::register_operation<"ttnn::prim::generic_op", ttnn::operations::generic::GenericOpDeviceOperation>();
+ttnn::operations::generic::GenericOpDeviceOperation::tensor_return_value_t generic_op(
+    const std::vector<Tensor>& io_tensors,
+    const ttnn::operations::generic::GenericOpDeviceOperation::operation_attributes_t& operation_attributes);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "moreh_abs_pow_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -66,19 +67,22 @@ MorehAbsPowOperation::tensor_return_value_t MorehAbsPowOperation::create_output_
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 };
 
-std::tuple<MorehAbsPowOperation::operation_attributes_t, MorehAbsPowOperation::tensor_args_t>
-MorehAbsPowOperation::invoke(
+}  // namespace ttnn::operations::moreh::moreh_abs_pow
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_abs_pow::MorehAbsPowOperation::tensor_return_value_t moreh_abs_pow(
     const Tensor& input,
     const float p,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    const operation_attributes_t operation_attributes{
+    using OperationType = ttnn::operations::moreh::moreh_abs_pow::MorehAbsPowOperation;
+    const OperationType::operation_attributes_t operation_attributes{
         p,
         memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
-    const tensor_args_t tensor_args{input, output};
+    const OperationType::tensor_args_t tensor_args{input, output};
 
-    return {operation_attributes, tensor_args};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_abs_pow
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
@@ -60,17 +60,15 @@ struct MorehAbsPowOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        float p,
-        const std::optional<Tensor>& output,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_abs_pow
 
 namespace ttnn::prim {
-constexpr auto moreh_abs_pow = ttnn::
-    register_operation<"ttnn::prim::moreh_abs_pow", ttnn::operations::moreh::moreh_abs_pow::MorehAbsPowOperation>();
+ttnn::operations::moreh::moreh_abs_pow::MorehAbsPowOperation::tensor_return_value_t moreh_abs_pow(
+    const Tensor& input,
+    float p,
+    const std::optional<Tensor>& output = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -146,10 +147,11 @@ MorehGroupNormBackwardGammaBetaGradOperation::create_output_tensors(
     return result;
 }
 
-std::tuple<
-    MorehGroupNormBackwardGammaBetaGradOperation::operation_attributes_t,
-    MorehGroupNormBackwardGammaBetaGradOperation::tensor_args_t>
-MorehGroupNormBackwardGammaBetaGradOperation::invoke(
+}  // namespace ttnn::operations::moreh::moreh_group_norm_backward
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardGammaBetaGradOperation::tensor_return_value_t
+moreh_group_norm_backward_gamma_beta_grad(
     const Tensor& output_grad,
     const Tensor& input,
     const Tensor& mean,
@@ -161,13 +163,15 @@ MorehGroupNormBackwardGammaBetaGradOperation::invoke(
     const std::optional<MemoryConfig>& gamma_grad_memory_config,
     const std::optional<MemoryConfig>& beta_grad_memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    operation_attributes_t operation_attributes{
+    using OperationType =
+        ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardGammaBetaGradOperation;
+    OperationType::operation_attributes_t operation_attributes{
         num_groups,
         are_required_outputs,
         gamma_grad_memory_config.value_or(output_grad.memory_config()),
         beta_grad_memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
-    tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma_grad, beta_grad};
-    return {operation_attributes, tensor_args};
+    OperationType::tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma_grad, beta_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_group_norm_backward
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -65,23 +65,21 @@ struct MorehGroupNormBackwardGammaBetaGradOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& mean,
-        const Tensor& rstd,
-        uint32_t num_groups,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<const Tensor>& gamma_grad,
-        const std::optional<const Tensor>& beta_grad,
-        const std::optional<MemoryConfig>& gamma_grad_memory_config,
-        const std::optional<MemoryConfig>& beta_grad_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_group_norm_backward_gamma_beta_grad = ttnn::register_operation<
-    "ttnn::prim::moreh_group_norm_backward_gamma_beta",
-    ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardGammaBetaGradOperation>();
-}
+ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardGammaBetaGradOperation::tensor_return_value_t
+moreh_group_norm_backward_gamma_beta_grad(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& mean,
+    const Tensor& rstd,
+    uint32_t num_groups,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<const Tensor>& gamma_grad = std::nullopt,
+    const std::optional<const Tensor>& beta_grad = std::nullopt,
+    const std::optional<MemoryConfig>& gamma_grad_memory_config = std::nullopt,
+    const std::optional<MemoryConfig>& beta_grad_memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "moreh_group_norm_backward_input_grad_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
@@ -91,10 +92,11 @@ MorehGroupNormBackwardInputGradOperation::create_output_tensors(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.output_grad.device());
 }
 
-std::tuple<
-    MorehGroupNormBackwardInputGradOperation::operation_attributes_t,
-    MorehGroupNormBackwardInputGradOperation::tensor_args_t>
-MorehGroupNormBackwardInputGradOperation::invoke(
+}  // namespace ttnn::operations::moreh::moreh_group_norm_backward
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardInputGradOperation::tensor_return_value_t
+moreh_group_norm_backward_input_grad(
     const Tensor& output_grad,
     const Tensor& input,
     const Tensor& mean,
@@ -104,11 +106,13 @@ MorehGroupNormBackwardInputGradOperation::invoke(
     const std::optional<const Tensor>& input_grad,
     const std::optional<MemoryConfig>& input_grad_memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    operation_attributes_t operation_attributes{
+    using OperationType =
+        ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardInputGradOperation;
+    OperationType::operation_attributes_t operation_attributes{
         num_groups,
         input_grad_memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
-    tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma, input_grad};
-    return {operation_attributes, tensor_args};
+    OperationType::tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma, input_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_group_norm_backward
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
@@ -56,21 +56,19 @@ struct MorehGroupNormBackwardInputGradOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& mean,
-        const Tensor& rstd,
-        uint32_t num_groups,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& input_grad,
-        const std::optional<MemoryConfig>& input_grad_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_group_norm_backward_input_grad = ttnn::register_operation<
-    "ttnn::prim::moreh_group_norm_backward_input_grad",
-    ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardInputGradOperation>();
-}
+ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackwardInputGradOperation::tensor_return_value_t
+moreh_group_norm_backward_input_grad(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& mean,
+    const Tensor& rstd,
+    uint32_t num_groups,
+    const std::optional<const Tensor>& gamma = std::nullopt,
+    const std::optional<const Tensor>& input_grad = std::nullopt,
+    const std::optional<MemoryConfig>& input_grad_memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "batch_norm_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "batch_norm_utils.hpp"
@@ -167,22 +168,27 @@ tt::stl::hash::hash_t BatchNormOperation::operation_attributes_t::to_hash() cons
     return tt::stl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype(), compute_kernel_config);
 }
 
-std::tuple<BatchNormOperation::operation_attributes_t, BatchNormOperation::tensor_args_t> BatchNormOperation::invoke(
+}  // namespace ttnn::operations::normalization
+
+namespace ttnn::prim {
+ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch_norm(
     const Tensor& input,
     const Tensor& batch_mean,
     const Tensor& batch_var,
-    const float eps,
+    float eps,
     std::optional<Tensor> weight,
     std::optional<Tensor> bias,
     std::optional<Tensor> output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    operation_attributes_t operation_attributes{
+    using OperationType = ttnn::operations::normalization::BatchNormOperation;
+    OperationType::operation_attributes_t operation_attributes{
         eps,
         memory_config.value_or(input.memory_config()),
-        batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, input),
+        ttnn::operations::normalization::batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, input),
         input.dtype()};
-    tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
-    return {operation_attributes, tensor_args};
+    OperationType::tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::normalization
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -64,20 +64,18 @@ struct BatchNormOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const Tensor& batch_mean,
-        const Tensor& batch_var,
-        float eps,
-        std::optional<Tensor> weight,
-        std::optional<Tensor> bias,
-        std::optional<Tensor> output,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::normalization
 
 namespace ttnn::prim {
-constexpr auto batch_norm =
-    ttnn::register_operation<"ttnn::prim::batch_norm", ttnn::operations::normalization::BatchNormOperation>();
-}
+ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch_norm(
+    const Tensor& input,
+    const Tensor& batch_mean,
+    const Tensor& batch_var,
+    float eps,
+    std::optional<Tensor> weight,
+    std::optional<Tensor> bias,
+    std::optional<Tensor> output,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "running_statistics_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "batch_norm_utils.hpp"
@@ -108,20 +109,25 @@ RunningStatistics::tensor_return_value_t RunningStatistics::create_output_tensor
         compute_output_specs(operation_attributes, tensor_args), tensor_args.batch_mean.device());
 }
 
-std::tuple<RunningStatistics::operation_attributes_t, RunningStatistics::tensor_args_t> RunningStatistics::invoke(
+}  // namespace ttnn::operations::normalization
+
+namespace ttnn::prim {
+ttnn::operations::normalization::RunningStatistics::tensor_return_value_t running_statistics(
     const Tensor& batch_mean,
     const Tensor& batch_var,
-    const float momentum,
+    float momentum,
     std::optional<Tensor> running_mean,
     std::optional<Tensor> running_var,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    operation_attributes_t operation_attributes{
+    using OperationType = ttnn::operations::normalization::RunningStatistics;
+    OperationType::operation_attributes_t operation_attributes{
         momentum,
         memory_config.value_or(batch_mean.memory_config()),
-        batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, batch_mean),
+        ttnn::operations::normalization::batch_norm::utils::resolve_compute_kernel_config(compute_kernel_config, batch_mean),
         batch_mean.dtype()};
-    tensor_args_t tensor_args{batch_mean, batch_var, std::move(running_mean), std::move(running_var)};
-    return {operation_attributes, tensor_args};
+    OperationType::tensor_args_t tensor_args{batch_mean, batch_var, std::move(running_mean), std::move(running_var)};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::normalization
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -60,18 +60,16 @@ struct RunningStatistics {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& batch_mean,
-        const Tensor& batch_var,
-        float momentum,
-        std::optional<Tensor> running_mean,
-        std::optional<Tensor> running_var,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::normalization
 
 namespace ttnn::prim {
-constexpr auto running_statistics =
-    ttnn::register_operation<"ttnn::prim::running_statistics", ttnn::operations::normalization::RunningStatistics>();
-}
+ttnn::operations::normalization::RunningStatistics::tensor_return_value_t running_statistics(
+    const Tensor& batch_mean,
+    const Tensor& batch_var,
+    float momentum,
+    std::optional<Tensor> running_mean,
+    std::optional<Tensor> running_var,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
@@ -32,26 +32,22 @@ struct GroupNormDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        float eps,
-        uint32_t num_groups,
-        const MemoryConfig& output_mem_config,
-        const GroupNormProgramConfig& program_config,
-        const DeviceComputeKernelConfig& compute_kernel_config,
-        bool use_welford,
-        std::optional<Tensor> gamma,
-        std::optional<Tensor> beta,
-        std::optional<Tensor> input_mask,
-        std::optional<Tensor> negative_mask,
-        std::optional<Tensor> reciprocals);
 };
 
 }  // namespace ttnn::operations::normalization::group_norm
 
 namespace ttnn::prim {
-constexpr auto group_norm = ttnn::register_operation<
-    "ttnn::prim::group_norm",
-    ttnn::operations::normalization::group_norm::GroupNormDeviceOperation>();
+ttnn::operations::normalization::group_norm::GroupNormDeviceOperation::tensor_return_value_t group_norm(
+    const Tensor& input,
+    float eps,
+    uint32_t num_groups,
+    const MemoryConfig& output_mem_config,
+    const ttnn::operations::normalization::group_norm::GroupNormProgramConfig& program_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    bool use_welford,
+    std::optional<Tensor> gamma,
+    std::optional<Tensor> beta,
+    std::optional<Tensor> input_mask,
+    std::optional<Tensor> negative_mask,
+    std::optional<Tensor> reciprocals);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "layernorm_device_operation.hpp"
 
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include <tt-metalium/constants.hpp>
@@ -404,37 +405,40 @@ tensor_return_value_t LayerNormDeviceOperation::create_output_tensors(
         operation_attributes.program_config);
 }
 
-std::tuple<LayerNormDeviceOperation::operation_attributes_t, LayerNormDeviceOperation::tensor_args_t>
-LayerNormDeviceOperation::invoke(
+}  // namespace ttnn::operations::normalization::layer_norm
+
+namespace ttnn::prim {
+ttnn::operations::normalization::layer_norm::LayerNormDeviceOperation::tensor_return_value_t layer_norm(
     const Tensor& input_tensor,
     float epsilon,
     const std::optional<const Tensor>& weight,
     const std::optional<const Tensor>& bias,
     const std::optional<const Tensor>& residual_input_tensor,
     const MemoryConfig& output_mem_config,
-    const LayerNormProgramConfig& program_config,
+    const ttnn::operations::normalization::layer_norm::LayerNormProgramConfig& program_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<DataType>& dtype,
-    LayerNormType norm_type,
-    DistributedLayerNormStage distributed_norm_stage,
+    ttnn::operations::normalization::layer_norm::LayerNormType norm_type,
+    ttnn::operations::normalization::layer_norm::DistributedLayerNormStage distributed_norm_stage,
     const std::optional<const Tensor>& stats) {
-    return {
-        operation_attributes_t{
-            .norm_type = norm_type,
-            .distributed_norm_stage = distributed_norm_stage,
-            .eps = epsilon,
-            .output_mem_config = output_mem_config,
-            .program_config = program_config,
-            .compute_kernel_config = compute_kernel_config,
-            .dtype = dtype,
-        },
-        tensor_args_t{
-            .input = input_tensor,
-            .residual_input_tensor = residual_input_tensor,
-            .weight = weight,
-            .bias = bias,
-            .stats = stats,
-        }};
-}
+    using OperationType = ttnn::operations::normalization::layer_norm::LayerNormDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .norm_type = norm_type,
+        .distributed_norm_stage = distributed_norm_stage,
+        .eps = epsilon,
+        .output_mem_config = output_mem_config,
+        .program_config = program_config,
+        .compute_kernel_config = compute_kernel_config,
+        .dtype = dtype,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .input = input_tensor,
+        .residual_input_tensor = residual_input_tensor,
+        .weight = weight,
+        .bias = bias,
+        .stats = stats,
+    };
 
-}  // namespace ttnn::operations::normalization::layer_norm
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
@@ -39,26 +39,24 @@ struct LayerNormDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        float epsilon,
-        const std::optional<const Tensor>& weight,
-        const std::optional<const Tensor>& bias,
-        const std::optional<const Tensor>& residual_input_tensor,
-        const MemoryConfig& output_mem_config,
-        const LayerNormProgramConfig& program_config,
-        const DeviceComputeKernelConfig& compute_kernel_config,
-        const std::optional<DataType>& dtype = std::nullopt,
-        LayerNormType norm_type = LayerNormType::LAYERNORM,
-        DistributedLayerNormStage distributed_norm_stage = DistributedLayerNormStage::NOT_DISTRIBUTED,
-        const std::optional<const Tensor>& stats = std::nullopt);
 };
 
 }  // namespace ttnn::operations::normalization::layer_norm
 
 namespace ttnn::prim {
-constexpr auto layer_norm = ttnn::register_operation<
-    "ttnn::prim::layer_norm",
-    ttnn::operations::normalization::layer_norm::LayerNormDeviceOperation>();
+ttnn::operations::normalization::layer_norm::LayerNormDeviceOperation::tensor_return_value_t layer_norm(
+    const Tensor& input_tensor,
+    float epsilon,
+    const std::optional<const Tensor>& weight,
+    const std::optional<const Tensor>& bias,
+    const std::optional<const Tensor>& residual_input_tensor,
+    const MemoryConfig& output_mem_config,
+    const ttnn::operations::normalization::layer_norm::LayerNormProgramConfig& program_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<DataType>& dtype = std::nullopt,
+    ttnn::operations::normalization::layer_norm::LayerNormType norm_type =
+        ttnn::operations::normalization::layer_norm::LayerNormType::LAYERNORM,
+    ttnn::operations::normalization::layer_norm::DistributedLayerNormStage distributed_norm_stage =
+        ttnn::operations::normalization::layer_norm::DistributedLayerNormStage::NOT_DISTRIBUTED,
+    const std::optional<const Tensor>& stats = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "layernorm_post_all_gather_device_operation.hpp"
-
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 #include <tt-metalium/constants.hpp>
@@ -183,37 +183,40 @@ tensor_return_value_t LayerNormPostAllGatherDeviceOperation::create_output_tenso
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<
-    LayerNormPostAllGatherDeviceOperation::operation_attributes_t,
-    LayerNormPostAllGatherDeviceOperation::tensor_args_t>
-LayerNormPostAllGatherDeviceOperation::invoke(
+}  // namespace ttnn::operations::normalization::layernorm_post_all_gather
+
+namespace ttnn::prim {
+ttnn::operations::normalization::layernorm_post_all_gather::LayerNormPostAllGatherDeviceOperation::tensor_return_value_t
+layernorm_post_all_gather(
     const Tensor& input,
     const Tensor& stats,
     const std::optional<Tensor>& gamma,
     const std::optional<Tensor>& beta,
-    LayerNormDistributedType norm_type,
+    ttnn::operations::normalization::layernorm::LayerNormDistributedType norm_type,
     float eps,
     const tt::tt_metal::MemoryConfig& memory_config,
     const DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     const std::optional<bool>& use_2d_core_grid,
-    const LayerNormDistributedDefaultProgramConfig& program_config) {
-    return {
-        operation_attributes_t{
-            .norm_type = norm_type,
-            .eps = eps,
-            .memory_config = memory_config,
-            .compute_kernel_config = compute_kernel_config,
-            .output_dtype = output_dtype,
-            .use_2d_core_grid = use_2d_core_grid,
-            .program_config = program_config,
-        },
-        tensor_args_t{
-            .input = input,
-            .stats = stats,
-            .gamma = gamma,
-            .beta = beta,
-        }};
-}
+    const ttnn::operations::normalization::layernorm::LayerNormDistributedDefaultProgramConfig& program_config) {
+    using OperationType =
+        ttnn::operations::normalization::layernorm_post_all_gather::LayerNormPostAllGatherDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .norm_type = norm_type,
+        .eps = eps,
+        .memory_config = memory_config,
+        .compute_kernel_config = compute_kernel_config,
+        .output_dtype = output_dtype,
+        .use_2d_core_grid = use_2d_core_grid,
+        .program_config = program_config,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .input = input,
+        .stats = stats,
+        .gamma = gamma,
+        .beta = beta,
+    };
 
-}  // namespace ttnn::operations::normalization::layernorm_post_all_gather
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.hpp
@@ -31,25 +31,22 @@ struct LayerNormPostAllGatherDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const Tensor& stats,
-        const std::optional<Tensor>& gamma,
-        const std::optional<Tensor>& beta,
-        LayerNormDistributedType norm_type,
-        float eps,
-        const tt::tt_metal::MemoryConfig& memory_config,
-        const DeviceComputeKernelConfig& compute_kernel_config,
-        const std::optional<tt::tt_metal::DataType>& output_dtype,
-        const std::optional<bool>& use_2d_core_grid,
-        const LayerNormDistributedDefaultProgramConfig& program_config);
 };
 
 }  // namespace ttnn::operations::normalization::layernorm_post_all_gather
 
 namespace ttnn::prim {
-constexpr auto layernorm_post_all_gather = ttnn::register_operation<
-    "ttnn::prim::layernorm_post_all_gather",
-    ttnn::operations::normalization::layernorm_post_all_gather::LayerNormPostAllGatherDeviceOperation>();
+ttnn::operations::normalization::layernorm_post_all_gather::LayerNormPostAllGatherDeviceOperation::tensor_return_value_t
+layernorm_post_all_gather(
+    const Tensor& input,
+    const Tensor& stats,
+    const std::optional<Tensor>& gamma,
+    const std::optional<Tensor>& beta,
+    ttnn::operations::normalization::layernorm::LayerNormDistributedType norm_type,
+    float eps,
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    const std::optional<tt::tt_metal::DataType>& output_dtype,
+    const std::optional<bool>& use_2d_core_grid,
+    const ttnn::operations::normalization::layernorm::LayerNormDistributedDefaultProgramConfig& program_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "layernorm_pre_all_gather_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/math.hpp"
@@ -69,25 +70,27 @@ LayerNormPreAllGatherDeviceOperation::tensor_return_value_t LayerNormPreAllGathe
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<
-    LayerNormPreAllGatherDeviceOperation::operation_attributes_t,
-    LayerNormPreAllGatherDeviceOperation::tensor_args_t>
-LayerNormPreAllGatherDeviceOperation::invoke(
+}  // namespace ttnn::operations::normalization::layernorm
+
+namespace ttnn::prim {
+ttnn::operations::normalization::layernorm::LayerNormPreAllGatherDeviceOperation::tensor_return_value_t
+layernorm_pre_all_gather(
     const Tensor& input,
-    LayerNormDistributedType norm_type,
+    ttnn::operations::normalization::layernorm::LayerNormDistributedType norm_type,
     DataType dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<bool> use_2d_core_grid,
-    const LayerNormDistributedDefaultProgramConfig& program_config,
+    const ttnn::operations::normalization::layernorm::LayerNormDistributedDefaultProgramConfig& program_config,
     const std::optional<Tensor>& preallocated_output) {
-    return {
-        operation_attributes_t{
-            .norm_type = norm_type,
-            .dtype = dtype,
-            .compute_kernel_config = compute_kernel_config,
-            .use_2d_core_grid = use_2d_core_grid,
-            .program_config = program_config},
-        tensor_args_t{.input = input, .preallocated_output = preallocated_output}};
-}
+    using OperationType = ttnn::operations::normalization::layernorm::LayerNormPreAllGatherDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .norm_type = norm_type,
+        .dtype = dtype,
+        .compute_kernel_config = compute_kernel_config,
+        .use_2d_core_grid = use_2d_core_grid,
+        .program_config = program_config};
+    auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-}  // namespace ttnn::operations::normalization::layernorm
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
@@ -34,21 +34,18 @@ struct LayerNormPreAllGatherDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        LayerNormDistributedType norm_type,
-        DataType dtype,
-        const DeviceComputeKernelConfig& compute_kernel_config,
-        std::optional<bool> use_2d_core_grid,
-        const LayerNormDistributedDefaultProgramConfig& program_config,
-        const std::optional<Tensor>& preallocated_output = std::nullopt);
 };
 
 }  // namespace ttnn::operations::normalization::layernorm
 
 namespace ttnn::prim {
-constexpr auto layernorm_pre_all_gather = ttnn::register_operation<
-    "ttnn::prim::layernorm_pre_all_gather",
-    ttnn::operations::normalization::layernorm::LayerNormPreAllGatherDeviceOperation>();
+ttnn::operations::normalization::layernorm::LayerNormPreAllGatherDeviceOperation::tensor_return_value_t
+layernorm_pre_all_gather(
+    const Tensor& input,
+    ttnn::operations::normalization::layernorm::LayerNormDistributedType norm_type,
+    DataType dtype,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    std::optional<bool> use_2d_core_grid,
+    const ttnn::operations::normalization::layernorm::LayerNormDistributedDefaultProgramConfig& program_config,
+    const std::optional<Tensor>& preallocated_output = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
@@ -38,20 +38,6 @@ struct SoftmaxDeviceOperation {
     static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        SoftmaxOperationType softmax_type,
-        const Tensor& input_tensor,
-        int8_t dim = -1,
-        const std::optional<const Tensor>& mask = std::nullopt,
-        std::optional<float> scale = std::nullopt,
-        bool inplace = false,
-        tt::tt_metal::MemoryConfig output_mem_config = {},
-        SoftmaxProgramConfig program_config = {},
-        bool is_causal_mask = false,
-        DeviceComputeKernelConfig compute_kernel_config = {},
-        bool is_scale_causal_mask_hw_dims_softmax = false,
-        bool numeric_stable = true);
 };
 
 Tensor softmax(
@@ -93,7 +79,18 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
 
 namespace ttnn::prim {
 
-constexpr auto softmax =
-    ttnn::register_operation<"ttnn::prim::softmax", ttnn::operations::normalization::softmax::SoftmaxDeviceOperation>();
+ttnn::operations::normalization::softmax::SoftmaxDeviceOperation::tensor_return_value_t softmax(
+    ttnn::operations::normalization::softmax::SoftmaxOperationType softmax_type,
+    const Tensor& input_tensor,
+    int8_t dim = -1,
+    const std::optional<const Tensor>& mask = std::nullopt,
+    std::optional<float> scale = std::nullopt,
+    bool inplace = false,
+    tt::tt_metal::MemoryConfig output_mem_config = {},
+    ttnn::operations::normalization::softmax::SoftmaxProgramConfig program_config = {},
+    bool is_causal_mask = false,
+    DeviceComputeKernelConfig compute_kernel_config = {},
+    bool is_scale_causal_mask_hw_dims_softmax = false,
+    bool numeric_stable = true);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dram_prefetcher_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include <tt-metalium/constants.hpp>
 #include <optional>
 
@@ -93,19 +94,22 @@ DramPrefetcherOperation::tensor_return_value_t DramPrefetcherOperation::create_o
     return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());
 }
 
-std::tuple<DramPrefetcherOperation::operation_attributes_t, DramPrefetcherOperation::tensor_args_t>
-DramPrefetcherOperation::invoke(
+}  // namespace ttnn::operations::dram_prefetcher
+
+namespace ttnn::prim {
+ttnn::operations::dram_prefetcher::DramPrefetcherOperation::tensor_return_value_t dram_prefetcher(
     std::vector<ttnn::Tensor>& tensors,
     const uint32_t num_layers,
     const std::optional<const GlobalCircularBuffer>& global_cb,
     const bool enable_performance_mode) {
-    return {
-        operation_attributes_t{
-            .num_layers = num_layers,
-            .enable_performance_mode = enable_performance_mode,
-            .global_cb = global_cb,
-        },
-        tensor_args_t{.input_tensors = tensors}};
-}
+    using OperationType = ttnn::operations::dram_prefetcher::DramPrefetcherOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .num_layers = num_layers,
+        .enable_performance_mode = enable_performance_mode,
+        .global_cb = global_cb,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.input_tensors = tensors};
 
-}  // namespace ttnn::operations::dram_prefetcher
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
@@ -27,17 +27,14 @@ struct DramPrefetcherOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        std::vector<ttnn::Tensor>& tensors,
-        uint32_t num_layers,
-        const std::optional<const GlobalCircularBuffer>& global_cb,
-        bool enable_performance_mode);
 };
 
 }  // namespace ttnn::operations::dram_prefetcher
 
 namespace ttnn::prim {
-constexpr auto dram_prefetcher = ttnn::
-    register_operation<"ttnn::prim::dram_prefetcher", ttnn::operations::dram_prefetcher::DramPrefetcherOperation>();
+ttnn::operations::dram_prefetcher::DramPrefetcherOperation::tensor_return_value_t dram_prefetcher(
+    std::vector<ttnn::Tensor>& tensors,
+    uint32_t num_layers,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    bool enable_performance_mode);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This PR addresses the ongoing refactoring effort to transition `ttnn` device operations from using the `ttnn::register_operation` macro and `static invoke` methods to direct global function calls within the `ttnn::prim` namespace. This change aims to simplify the API and standardize the dispatch mechanism for device operations.

### What's changed
This PR refactors 22 device operations, moving them from the `ttnn::register_operation` macro and `static invoke` member functions to direct global function calls in the `ttnn::prim` namespace.

For each of the following operations:
1.  `moreh_abs_pow`
2.  `moreh_group_norm_backward_input_grad`
3.  `moreh_group_norm_backward_gamma_beta_grad`
4.  `ternary`
5.  `binary`
6.  `unary`
7.  `binary_ng`
8.  `running_statistics`
9.  `batch_norm`
10. `softmax`
11. `layernorm_pre_all_gather`
12. `layernorm_post_all_gather`
13. `group_norm`
14. `layer_norm`
15. `example`
16. `example_multiple_return`
17. `generic_op`
18. `embedding`
19. `dram_prefetcher`
20. `moreh_full_like`
21. `bernoulli`
22. `full`

The changes include:
*   **Header (`.hpp`)**: Removed the `ttnn::register_operation` instantiation and the `static invoke` member function. A global function declaration with the same signature as the original `invoke` was added in the `ttnn::prim` namespace.
*   **Implementation (`.cpp`)**: Added `#include "ttnn/api/ttnn/device_operation.hpp"`. The logic from the old `invoke` method was moved into the new global function, mapping arguments to `operation_attributes_t` and `tensor_args_t`, and dispatching using `ttnn::device_operation::detail::launch_on_device`.
*   **Progress Tracking**: The `device_ops_to_process.txt` file has been updated to mark these 22 operations as completed.

This refactoring simplifies the API for these operations and aligns them with the new standardized device operation dispatch pattern.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-4faf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ay/agent/device-ops-refactoring-process-4faf)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
<a href="https://cursor.com/background-agent?bcId=bc-90fea51c-dfd0-4582-889d-f9be0f58df06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90fea51c-dfd0-4582-889d-f9be0f58df06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>