### PR TITLE
Device ops refactoring process

### DIFF
--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -158,22 +158,22 @@
 [ ] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "all_to_all_dispatch_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
 
@@ -156,8 +157,10 @@ AllToAllDispatchDeviceOperation::tensor_return_value_t AllToAllDispatchDeviceOpe
     return {output_tensor, metadata_tensor};
 }
 
-std::tuple<AllToAllDispatchDeviceOperation::operation_attributes_t, AllToAllDispatchDeviceOperation::tensor_args_t>
-AllToAllDispatchDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::operations::ccl::AllToAllDispatchDeviceOperation::tensor_return_value_t all_to_all_dispatch(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& expert_indices_tensor,
     const ttnn::Tensor& expert_mapping_tensor,
@@ -167,10 +170,11 @@ AllToAllDispatchDeviceOperation::invoke(
     tt::tt_fabric::Topology topology,
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
-    AllToAllTransferType impl,
+    ttnn::operations::ccl::AllToAllDispatchDeviceOperation::AllToAllTransferType impl,
     uint32_t output_concat_dim) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::ccl::AllToAllDispatchDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .worker_core_range_set = worker_core_range_set,
             .output_mem_config = memory_config,
             .axis = axis,
@@ -178,11 +182,10 @@ AllToAllDispatchDeviceOperation::invoke(
             .topology = topology,
             .impl = impl,
             .output_concat_dim = output_concat_dim},
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .expert_indices_tensor = expert_indices_tensor,
             .expert_mapping_tensor = expert_mapping_tensor,
-            .optional_output_tensors = optional_output_tensors}};
+            .optional_output_tensors = optional_output_tensors});
 }
-
-}  // namespace ttnn::operations::ccl
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -113,24 +113,20 @@ struct AllToAllDispatchDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& expert_indices_tensor,
-        const ttnn::Tensor& expert_mapping_tensor,
-        std::optional<uint32_t> axis,
-        const std::optional<std::array<ttnn::Tensor, 2>>& optional_output_tensors,
-        uint32_t num_links,
-        tt::tt_fabric::Topology topology,
-        const ttnn::MemoryConfig& memory_config,
-        const CoreRangeSet& worker_core_range_set,
-        AllToAllTransferType impl,
-        uint32_t output_concat_dim);
 };
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-constexpr auto all_to_all_dispatch = ttnn::
-    register_operation<"ttnn::prim::all_to_all_dispatch", ttnn::operations::ccl::AllToAllDispatchDeviceOperation>();
+ttnn::operations::ccl::AllToAllDispatchDeviceOperation::tensor_return_value_t all_to_all_dispatch(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& expert_indices_tensor,
+    const ttnn::Tensor& expert_mapping_tensor,
+    std::optional<uint32_t> axis,
+    const std::optional<std::array<ttnn::Tensor, 2>>& optional_output_tensors,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology,
+    const ttnn::MemoryConfig& memory_config,
+    const CoreRangeSet& worker_core_range_set,
+    ttnn::operations::ccl::AllToAllDispatchDeviceOperation::AllToAllTransferType impl,
+    uint32_t output_concat_dim);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
@@ -35,20 +35,17 @@ struct BroadcastDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        const MeshCoordinate& sender_coord,
-        uint32_t num_links,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        tt::tt_fabric::Topology topology,
-        std::optional<uint32_t> cluster_axis,
-        std::optional<tt::tt_metal::SubDeviceId> sub_device_id);
 };
 
 }  // namespace ttnn::operations::ccl::broadcast
 
 namespace ttnn::prim {
-constexpr auto broadcast =
-    ttnn::register_operation<"ttnn::prim::broadcast", ttnn::operations::ccl::broadcast::BroadcastDeviceOperation>();
+ttnn::operations::ccl::broadcast::BroadcastDeviceOperation::tensor_return_value_t broadcast(
+    const ttnn::Tensor& input_tensor,
+    const MeshCoordinate& sender_coord,
+    uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    tt::tt_fabric::Topology topology,
+    std::optional<uint32_t> cluster_axis,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "reduce_scatter_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 
 namespace ttnn::operations::ccl {
@@ -99,8 +100,10 @@ ttsl::hash::hash_t ReduceScatterDeviceOperation::compute_program_hash(
         input_tensor);
 }
 
-std::tuple<ReduceScatterDeviceOperation::operation_attributes_t, ReduceScatterDeviceOperation::tensor_args_t>
-ReduceScatterDeviceOperation::invoke(
+}  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduce_scatter(
     const ttnn::Tensor& input_tensor,
     uint32_t dim,
     std::optional<uint32_t> cluster_axis,
@@ -109,15 +112,15 @@ ReduceScatterDeviceOperation::invoke(
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     uint32_t num_links,
     tt::tt_fabric::Topology topology) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::ccl::ReduceScatterDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .memory_config = memory_config,
             .dim = dim,
             .cluster_axis = cluster_axis,
             .subdevice_id = subdevice_id,
             .topology = topology,
             .num_links = num_links},
-        tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor}};
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor});
 }
-
-}  // namespace ttnn::operations::ccl
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
@@ -81,20 +81,17 @@ struct ReduceScatterDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        uint32_t dim,
-        std::optional<uint32_t> cluster_axis,
-        const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
-        const ttnn::MemoryConfig& memory_config,
-        const std::optional<ttnn::Tensor>& optional_output_tensor,
-        uint32_t num_links,
-        tt::tt_fabric::Topology topology);
 };
 }  // namespace ttnn::operations::ccl
 
 namespace ttnn::prim {
-constexpr auto reduce_scatter =
-    ttnn::register_operation<"ttnn::prim::reduce_scatter", ttnn::operations::ccl::ReduceScatterDeviceOperation>();
+ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduce_scatter(
+    const ttnn::Tensor& input_tensor,
+    uint32_t dim,
+    std::optional<uint32_t> cluster_axis,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    uint32_t num_links,
+    tt::tt_fabric::Topology topology);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
@@ -4,6 +4,7 @@
 ///
 #include <tt_stl/assert.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -204,3 +205,35 @@ cached_workload_t ReduceToRootOp::ReduceToRoot::create_at(
 }
 
 }  // namespace ttnn::operations::ccl
+
+namespace ttnn::prim {
+ttnn::operations::ccl::ReduceToRootOp::tensor_return_value_t reduce_to_root(
+    const Tensor& input_tensor_l,
+    const Tensor& input_tensor_s,
+    const Tensor& input_tensor_m,
+    const tt::tt_fabric::Topology& topology,
+    const MeshCoordinate& root_coord,
+    float scale_fp32,
+    const std::optional<Tensor>& optional_output_tensor_l,
+    const std::optional<Tensor>& optional_output_tensor_s,
+    const std::optional<Tensor>& optional_output_tensor_m,
+    const std::optional<Tensor>& optional_intermediate_tensor,
+    const std::optional<std::vector<ttnn::CoreCoord>>& input_mux_cores) {
+    using OperationType = ttnn::operations::ccl::ReduceToRootOp;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
+            root_coord,
+            scale_fp32,
+            topology,
+            input_mux_cores,
+            {input_tensor_l.tensor_spec(), input_tensor_s.tensor_spec(), input_tensor_m.tensor_spec()}},
+        OperationType::tensor_args_t{
+            input_tensor_l,
+            input_tensor_s,
+            input_tensor_m,
+            optional_output_tensor_l,
+            optional_output_tensor_s,
+            optional_output_tensor_m,
+            optional_intermediate_tensor});
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.hpp
@@ -101,35 +101,6 @@ struct ReduceToRootOp {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_l,
-        const Tensor& input_tensor_s,
-        const Tensor& input_tensor_m,
-        const tt::tt_fabric::Topology& topology,
-        const MeshCoordinate& root_coord,
-        float scale_fp32,
-        const std::optional<Tensor>& optional_output_tensor_l = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor_s = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor_m = std::nullopt,
-        const std::optional<Tensor>& optional_intermediate_tensor = std::nullopt,
-        const std::optional<std::vector<ttnn::CoreCoord>>& input_mux_cores = std::nullopt) {
-        return std::make_tuple(
-            operation_attributes_t{
-                root_coord,
-                scale_fp32,
-                topology,
-                input_mux_cores,
-                {input_tensor_l.tensor_spec(), input_tensor_s.tensor_spec(), input_tensor_m.tensor_spec()}},
-            tensor_args_t{
-                input_tensor_l,
-                input_tensor_s,
-                input_tensor_m,
-                optional_output_tensor_l,
-                optional_output_tensor_s,
-                optional_output_tensor_m,
-                optional_intermediate_tensor});
-    };
-
 private:
     static void validate(const operation_attributes_t&, const tensor_args_t&);
 };
@@ -147,7 +118,17 @@ device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_variables_t
 }  // namespace operations::ccl
 
 namespace prim {
-constexpr auto reduce_to_root =
-    ttnn::register_operation<"ttnn::prim::reduce_to_root", ttnn::operations::ccl::ReduceToRootOp>();
+ttnn::operations::ccl::ReduceToRootOp::tensor_return_value_t reduce_to_root(
+    const Tensor& input_tensor_l,
+    const Tensor& input_tensor_s,
+    const Tensor& input_tensor_m,
+    const tt::tt_fabric::Topology& topology,
+    const MeshCoordinate& root_coord,
+    float scale_fp32,
+    const std::optional<Tensor>& optional_output_tensor_l = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor_s = std::nullopt,
+    const std::optional<Tensor>& optional_output_tensor_m = std::nullopt,
+    const std::optional<Tensor>& optional_intermediate_tensor = std::nullopt,
+    const std::optional<std::vector<ttnn::CoreCoord>>& input_mux_cores = std::nullopt);
 }  // namespace prim
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "typecast_device_op.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 using namespace tt::tt_metal;
 
@@ -127,8 +128,10 @@ bool TypecastDeviceOperation::skip_launch(
     return tensor_return_value.logical_shape().volume() == 0;
 }
 
-std::tuple<TypecastDeviceOperation::operation_attributes_t, TypecastDeviceOperation::tensor_args_t>
-TypecastDeviceOperation::invoke(
+}  // namespace ttnn::operations::copy
+
+namespace ttnn::prim {
+ttnn::operations::copy::TypecastDeviceOperation::tensor_return_value_t typecast(
     const Tensor& input,
     DataType output_dtype,
     const MemoryConfig& output_memory_config,
@@ -137,8 +140,9 @@ TypecastDeviceOperation::invoke(
     bool bfp8_pack_precise,
     const std::optional<Tensor>& preallocated_output,
     const std::optional<CoreRangeSet>& sub_core_grids) {
-    return {
-        operation_attributes_t{
+    using OperationType = ttnn::operations::copy::TypecastDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .input_dtype = input.dtype(),
             .output_dtype = output_dtype,
             .output_memory_config = output_memory_config,
@@ -147,7 +151,6 @@ TypecastDeviceOperation::invoke(
             .bfp8_pack_precise = bfp8_pack_precise,
             .sub_core_grids = sub_core_grids,
         },
-        tensor_args_t{.input = input, .preallocated_output = preallocated_output}};
+        OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output});
 }
-
-}  // namespace ttnn::operations::copy
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
@@ -40,21 +40,18 @@ struct TypecastDeviceOperation {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        DataType output_dtype,
-        const MemoryConfig& output_memory_config,
-        bool fp32_dest_acc_en,
-        bool preserve_fp32_precision,
-        bool bfp8_pack_precise,
-        const std::optional<Tensor>& preallocated_output,
-        const std::optional<CoreRangeSet>& sub_core_grids);
 };
 
 }  // namespace ttnn::operations::copy
 
 namespace ttnn::prim {
-constexpr auto typecast =
-    ttnn::register_operation<"ttnn::prim::typecast", ttnn::operations::copy::TypecastDeviceOperation>();
+ttnn::operations::copy::TypecastDeviceOperation::tensor_return_value_t typecast(
+    const Tensor& input,
+    DataType output_dtype,
+    const MemoryConfig& output_memory_config,
+    bool fp32_dest_acc_en,
+    bool preserve_fp32_precision,
+    bool bfp8_pack_precise,
+    const std::optional<Tensor>& preallocated_output,
+    const std::optional<CoreRangeSet>& sub_core_grids);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fold_device_op.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -116,7 +117,10 @@ Fold::tensor_return_value_t Fold::create_output_tensors(
     return create_device_tensor(compute_output_specs(op_attr, tensors), tensors.input_tensor.device());
 }
 
-std::tuple<Fold::operation_attributes_t, Fold::tensor_args_t> Fold::invoke(
+}  // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
     const ttnn::Tensor& input_tensor,
     uint32_t stride_h,
     uint32_t stride_w,
@@ -124,15 +128,13 @@ std::tuple<Fold::operation_attributes_t, Fold::tensor_args_t> Fold::invoke(
     uint32_t pad_c,
     uint32_t pad_h,
     uint32_t pad_w) {
+    using OperationType = ttnn::operations::data_movement::Fold;
     bool is_sharded = input_tensor.is_sharded();
     bool is_dram_interleaved =
         input_tensor.storage_type() == StorageType::DEVICE && input_tensor.memory_config().is_dram();
-    Fold::operation_attributes_t op_attr = {
-        .stride_h = stride_h,
-        .stride_w = stride_w,
-        .is_sharded = is_sharded,
-        .is_dram_interleaved = is_dram_interleaved};
-    return {op_attr, Fold::tensor_args_t{.input_tensor = input_tensor}};
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .stride_h = stride_h, .stride_w = stride_w, .is_sharded = is_sharded, .is_dram_interleaved = is_dram_interleaved};
+    auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-
-}  // namespace ttnn::operations::data_movement
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -98,19 +98,17 @@ struct Fold {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        uint32_t stride_h,
-        uint32_t stride_w,
-        const std::optional<const ttnn::Shape>& output_shape,
-        uint32_t pad_c,
-        uint32_t pad_h,
-        uint32_t pad_w);
 };
 
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-constexpr auto fold = ttnn::register_operation<"ttnn::prim::fold", ttnn::operations::data_movement::Fold>();
+ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
+    const ttnn::Tensor& input_tensor,
+    uint32_t stride_h,
+    uint32_t stride_w,
+    const std::optional<const ttnn::Shape>& output_shape,
+    uint32_t pad_c,
+    uint32_t pad_h,
+    uint32_t pad_w);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
@@ -6,8 +6,8 @@
 #include <utility>
 
 #include "ttnn/tensor/types.hpp"
-// #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include "moe_expert_token_remap_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -108,24 +108,25 @@ MoeExpertTokenRemapDeviceOperation::tensor_return_value_t MoeExpertTokenRemapDev
     return {output_mapping_tensor, output_reduced_tensor};
 }
 
-std::
-    tuple<MoeExpertTokenRemapDeviceOperation::operation_attributes_t, MoeExpertTokenRemapDeviceOperation::tensor_args_t>
-    MoeExpertTokenRemapDeviceOperation::invoke(
-        const ttnn::Tensor& topk_tensor,
-        const ttnn::Tensor& mapping_tensor,
-        const ttnn::Tensor& metadata_tensor,
-        const std::optional<ttnn::MemoryConfig>& output_mem_config,
-        const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
-        const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
-        const uint32_t reduction_size) {
-    return {
-        operation_attributes_t{.output_mem_config = output_mem_config, .reduction_size = reduction_size},
-        tensor_args_t{
+}  // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation::tensor_return_value_t moe_expert_token_remap(
+    const ttnn::Tensor& topk_tensor,
+    const ttnn::Tensor& mapping_tensor,
+    const ttnn::Tensor& metadata_tensor,
+    const std::optional<ttnn::MemoryConfig>& output_mem_config,
+    const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
+    const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
+    uint32_t reduction_size) {
+    using OperationType = ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{.output_mem_config = output_mem_config, .reduction_size = reduction_size},
+        OperationType::tensor_args_t{
             .topk_tensor = topk_tensor,
             .mapping_tensor = mapping_tensor,
             .metadata_tensor = metadata_tensor,
             .optional_output_mapping_tensor = optional_output_mapping_tensor,
-            .optional_output_reduced_tensor = optional_output_reduced_tensor}};
+            .optional_output_reduced_tensor = optional_output_reduced_tensor});
 }
-
-}  // namespace ttnn::operations::data_movement
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.hpp
@@ -84,21 +84,16 @@ struct MoeExpertTokenRemapDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& topk_tensor,
-        const ttnn::Tensor& mapping_tensor,
-        const ttnn::Tensor& metadata_tensor,
-        const std::optional<ttnn::MemoryConfig>& output_mem_config,
-        const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
-        const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
-        uint32_t reduction_size = REDUCTION_SIZE);
 };
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
-// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-constexpr auto moe_expert_token_remap = ttnn::register_operation<
-    "ttnn::prim::moe_expert_token_remap",
-    ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation>();
+ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation::tensor_return_value_t moe_expert_token_remap(
+    const ttnn::Tensor& topk_tensor,
+    const ttnn::Tensor& mapping_tensor,
+    const ttnn::Tensor& metadata_tensor,
+    const std::optional<ttnn::MemoryConfig>& output_mem_config,
+    const std::optional<ttnn::Tensor>& optional_output_mapping_tensor,
+    const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
+    uint32_t reduction_size = ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation::REDUCTION_SIZE);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
@@ -4,6 +4,7 @@
 ///
 #include <tt_stl/assert.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -287,3 +288,18 @@ void PointToPointOp::SendReceive::override_runtime_arguments(
 };
 
 }  // namespace ttnn::operations::point_to_point
+
+namespace ttnn::prim {
+ttnn::operations::point_to_point::PointToPointOp::tensor_return_value_t point_to_point(
+    const Tensor& input_tensor,
+    const ::ttnn::ccl::Topology& topology,
+    const MeshCoordinate& receiver_coord,
+    const MeshCoordinate& sender_coord,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    const std::optional<ttnn::Tensor>& optional_intermediate_tensor) {
+    using OperationType = ttnn::operations::point_to_point::PointToPointOp;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{receiver_coord, sender_coord, topology, input_tensor.tensor_spec()},
+        OperationType::tensor_args_t{input_tensor, optional_output_tensor, optional_intermediate_tensor});
+}
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
@@ -101,18 +101,6 @@ struct PointToPointOp {
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const ::ttnn::ccl::Topology& topology,
-        const MeshCoordinate& receiver_coord,
-        const MeshCoordinate& sender_coord,
-        const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
-        const std::optional<ttnn::Tensor>& optional_intermediate_tensor = std::nullopt) {
-        return std::make_tuple(
-            operation_attributes_t{receiver_coord, sender_coord, topology, input_tensor.tensor_spec()},
-            tensor_args_t{input_tensor, optional_output_tensor, optional_intermediate_tensor});
-    };
-
 private:
     static void validate(const operation_attributes_t&, const tensor_args_t&);
 };
@@ -158,7 +146,12 @@ device_operation::CachedProgram<PointToPointOp::SendReceive::shared_variables_t>
 }  // namespace operations::point_to_point
 
 namespace prim {
-constexpr auto point_to_point =
-    ttnn::register_operation<"ttnn::prim::point_to_point", ttnn::operations::point_to_point::PointToPointOp>();
+ttnn::operations::point_to_point::PointToPointOp::tensor_return_value_t point_to_point(
+    const Tensor& input_tensor,
+    const ::ttnn::ccl::Topology& topology,
+    const MeshCoordinate& receiver_coord,
+    const MeshCoordinate& sender_coord,
+    const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
+    const std::optional<ttnn::Tensor>& optional_intermediate_tensor = std::nullopt);
 }  // namespace prim
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "rand_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include <memory>
 
 namespace ttnn::operations::rand {
@@ -56,18 +57,21 @@ tt::stl::hash::hash_t RandDeviceOperation::compute_program_hash(
     return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
-std::tuple<RandDeviceOperation::operation_attributes_t, RandDeviceOperation::tensor_args_t> RandDeviceOperation::invoke(
+}  // namespace ttnn::operations::rand
+
+namespace ttnn::prim {
+ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
     const ttnn::Shape& shape,
-    const DataType dtype,
-    const Layout layout,
+    DataType dtype,
+    Layout layout,
     const MemoryConfig& memory_config,
     MeshDevice& device,
-    const float from,
-    const float to,
-    const uint32_t seed) {
-    return {
-        operation_attributes_t{shape, dtype, layout, memory_config, std::addressof(device), from, to, seed},
-        tensor_args_t{}};
+    float from,
+    float to,
+    uint32_t seed) {
+    using OperationType = ttnn::operations::rand::RandDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{shape, dtype, layout, memory_config, std::addressof(device), from, to, seed},
+        OperationType::tensor_args_t{});
 }
-
-}  // namespace ttnn::operations::rand
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -55,20 +55,18 @@ struct RandDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Shape& shape,
-        DataType dtype,
-        Layout layout,
-        const MemoryConfig& memory_config,
-        MeshDevice& device,
-        float from,
-        float to,
-        uint32_t seed);
 };
 
 }  // namespace ttnn::operations::rand
 
 namespace ttnn::prim {
-constexpr auto uniform = ttnn::register_operation<"ttnn::prim::rand", ttnn::operations::rand::RandDeviceOperation>();
+ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
+    const ttnn::Shape& shape,
+    DataType dtype,
+    Layout layout,
+    const MemoryConfig& memory_config,
+    MeshDevice& device,
+    float from,
+    float to,
+    uint32_t seed);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include <array>
 
 namespace ttnn::operations::sliding_window::halo {
@@ -116,15 +117,20 @@ HaloDeviceOperation::tensor_return_value_t HaloDeviceOperation::create_output_te
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> HaloDeviceOperation::invoke(
+}  // namespace ttnn::operations::sliding_window::halo
+
+namespace ttnn::prim {
+ttnn::operations::sliding_window::halo::HaloDeviceOperation::tensor_return_value_t halo(
     const Tensor& input_tensor,
-    const SlidingWindowConfig& config,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& config,
     uint32_t pad_val,
     bool remote_read,
     bool transpose_mcast,
     const MemoryConfig& output_memory_config,
     bool is_out_tiled,
     bool config_tensors_in_dram) {
+    using OperationType = ttnn::operations::sliding_window::halo::HaloDeviceOperation;
+
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Halo expects sharded input tensor");
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||
@@ -135,23 +141,22 @@ std::tuple<operation_attributes_t, tensor_args_t> HaloDeviceOperation::invoke(
     //       for BLOCK_SHARDED, ncores_nhw is just the ncores along height dim (last tensor dim is split along
     //       width)
     auto sliding_window_hash = config.get_hash();
-    if (!HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.contains(sliding_window_hash)) {
-        auto op_trace_metadata = sliding_window::generate_op_trace_metadata(config);
-        auto shard_boundaries = sliding_window::generate_shard_boundaries(config);
-        HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.emplace(
-            sliding_window_hash, sliding_window::generate_max_out_nsticks_per_core(shard_boundaries));
+    if (!OperationType::sliding_window_max_out_nsticks_per_core.contains(sliding_window_hash)) {
+        auto op_trace_metadata = ttnn::operations::sliding_window::generate_op_trace_metadata(config);
+        auto shard_boundaries = ttnn::operations::sliding_window::generate_shard_boundaries(config);
+        OperationType::sliding_window_max_out_nsticks_per_core.emplace(
+            sliding_window_hash, ttnn::operations::sliding_window::generate_max_out_nsticks_per_core(shard_boundaries));
     }
 
-    uint32_t max_out_nsticks_per_core =
-        HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
+    uint32_t max_out_nsticks_per_core = OperationType::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
     uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec()->shape[0];
-    ParallelConfig p_config;
+    ttnn::operations::sliding_window::ParallelConfig p_config;
     p_config.grid = input_tensor.shard_spec().value().grid;
     p_config.shard_scheme = input_tensor.memory_config().memory_layout();
     p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
 
-    return {
-        operation_attributes_t{
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .config = config,
             .parallel_config = p_config,
             .pad_val = pad_val,
@@ -162,8 +167,8 @@ std::tuple<operation_attributes_t, tensor_args_t> HaloDeviceOperation::invoke(
             .output_memory_config = output_memory_config,
             .is_out_tiled = is_out_tiled,
             .config_tensors_in_dram = config_tensors_in_dram},
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .input_tensor = input_tensor,
-        }};
+        });
 }
-}  // namespace ttnn::operations::sliding_window::halo
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -32,21 +32,18 @@ struct HaloDeviceOperation {
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const SlidingWindowConfig& config,
-        uint32_t pad_val,
-        bool remote_read,
-        bool transpose_mcast,
-        const MemoryConfig& output_memory_config,
-        bool is_out_tiled,
-        bool config_tensors_in_dram);
 };
 
 }  // namespace ttnn::operations::sliding_window::halo
 
 namespace ttnn::prim {
-constexpr auto halo =
-    ttnn::register_operation<"ttnn::prim::halo", ttnn::operations::sliding_window::halo::HaloDeviceOperation>();
+ttnn::operations::sliding_window::halo::HaloDeviceOperation::tensor_return_value_t halo(
+    const Tensor& input_tensor,
+    const ttnn::operations::sliding_window::SlidingWindowConfig& config,
+    uint32_t pad_val,
+    bool remote_read,
+    bool transpose_mcast,
+    const MemoryConfig& output_memory_config,
+    bool is_out_tiled,
+    bool config_tensors_in_dram);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -180,8 +181,12 @@ tensor_return_value_t JointSDPADeviceOperation::create_output_tensors(
         .joint_output = create_device_tensor(output_specs.joint_output, tensor_args.joint_q.device())};
 }
 
-std::tuple<JointSDPADeviceOperation::operation_attributes_t, JointSDPADeviceOperation::tensor_args_t>
-JointSDPADeviceOperation::invoke(
+}  // namespace ttnn::operations::transformer::sdpa::joint_sdpa
+
+namespace ttnn::prim {
+
+ttnn::operations::transformer::sdpa::joint_sdpa::JointSDPADeviceOperation::tensor_return_value_t
+joint_scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -189,28 +194,28 @@ JointSDPADeviceOperation::invoke(
     const ttnn::Tensor& joint_tensor_k,
     const ttnn::Tensor& joint_tensor_v,
     const std::string& joint_strategy,
-    const std::optional<SDPAProgramConfig>& program_config,
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
     const std::optional<float> scale,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    using OperationType = ttnn::operations::transformer::sdpa::joint_sdpa::JointSDPADeviceOperation;
+
     auto kernel_config_val = init_device_compute_kernel_config(
         input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
     auto scale_val = scale.value_or(1.0f / std::sqrt(static_cast<float>(input_tensor_q.logical_shape()[-1])));
 
-    return {
-        operation_attributes_t{
-            joint_strategy,
-            scale_val,
-            tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            program_config,
-            kernel_config_val},
-        tensor_args_t{
-            .input_q = input_tensor_q,
-            .input_k = input_tensor_k,
-            .input_v = input_tensor_v,
-            .joint_q = joint_tensor_q,
-            .joint_k = joint_tensor_k,
-            .joint_v = joint_tensor_v}};
+    auto operation_attributes = OperationType::operation_attributes_t{
+        joint_strategy, scale_val, tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG, program_config, kernel_config_val};
+
+    auto tensor_args = OperationType::tensor_args_t{
+        .input_q = input_tensor_q,
+        .input_k = input_tensor_k,
+        .input_v = input_tensor_v,
+        .joint_q = joint_tensor_q,
+        .joint_k = joint_tensor_k,
+        .joint_v = joint_tensor_v};
+
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
 
-}  // namespace ttnn::operations::transformer::sdpa::joint_sdpa
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.hpp
@@ -27,26 +27,23 @@ struct JointSDPADeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor_q,
-        const ttnn::Tensor& input_tensor_k,
-        const ttnn::Tensor& input_tensor_v,
-        const ttnn::Tensor& joint_tensor_q,
-        const ttnn::Tensor& joint_tensor_k,
-        const ttnn::Tensor& joint_tensor_v,
-        const std::string& joint_strategy,
-        const std::optional<SDPAProgramConfig>& program_config = std::nullopt,
-        std::optional<float> scale = std::nullopt,
-        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa::joint_sdpa
 
 namespace ttnn::prim {
 
-constexpr auto joint_scaled_dot_product_attention = ttnn::register_operation<
-    "ttnn::prim::joint_scaled_dot_product_attention",
-    ttnn::operations::transformer::sdpa::joint_sdpa::JointSDPADeviceOperation>();
+ttnn::operations::transformer::sdpa::joint_sdpa::JointSDPADeviceOperation::tensor_return_value_t
+joint_scaled_dot_product_attention(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const ttnn::Tensor& input_tensor_v,
+    const ttnn::Tensor& joint_tensor_q,
+    const ttnn::Tensor& joint_tensor_k,
+    const ttnn::Tensor& joint_tensor_v,
+    const std::string& joint_strategy,
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config = std::nullopt,
+    std::optional<float> scale = std::nullopt,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ring_distributed_sdpa_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include "ring_distributed_sdpa_program_factory.hpp"
 
@@ -194,7 +195,12 @@ RingDistributedSdpaDeviceOperation::tensor_return_value_t RingDistributedSdpaDev
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> RingDistributedSdpaDeviceOperation::invoke(
+}  // namespace ttnn::operations::transformer::ring_distributed_sdpa
+
+namespace ttnn::prim {
+
+ttnn::operations::transformer::ring_distributed_sdpa::RingDistributedSdpaDeviceOperation::tensor_return_value_t
+ring_distributed_sdpa(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
@@ -202,12 +208,15 @@ std::tuple<operation_attributes_t, tensor_args_t> RingDistributedSdpaDeviceOpera
     std::optional<uint32_t> ring_id,
     std::optional<float> scale,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    const std::optional<SDPAProgramConfig>& program_config,
-    DeviceComputeKernelConfig compute_kernel_config) {
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using OperationType =
+        ttnn::operations::transformer::ring_distributed_sdpa::RingDistributedSdpaDeviceOperation;
+
     if (not scale.has_value()) {
         scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.logical_shape()[-1]));
     }
-    operation_attributes_t attrs{
+    auto operation_attributes = OperationType::operation_attributes_t{
         .ring_size = ring_size,
         .ring_id = ring_id,
         .scale = scale,
@@ -216,13 +225,13 @@ std::tuple<operation_attributes_t, tensor_args_t> RingDistributedSdpaDeviceOpera
         .compute_kernel_config = compute_kernel_config,
     };
 
-    tensor_args_t tensors{
+    auto tensor_args = OperationType::tensor_args_t{
         .q = input_tensor_q,
         .k = input_tensor_k,
         .v = input_tensor_v,
     };
 
-    return {attrs, tensors};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
 
-}  // namespace ttnn::operations::transformer::ring_distributed_sdpa
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
@@ -37,25 +37,22 @@ struct RingDistributedSdpaDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor_q,
-        const ttnn::Tensor& input_tensor_k,
-        const ttnn::Tensor& input_tensor_v,
-        uint32_t ring_size,
-        std::optional<uint32_t> ring_id,
-        std::optional<float> scale,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const std::optional<SDPAProgramConfig>& program_config,
-        DeviceComputeKernelConfig compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::transformer::ring_distributed_sdpa
 
 namespace ttnn::prim {
 
-constexpr auto ring_distributed_sdpa = ttnn::register_operation<
-    "ttnn::prim::ring_distributed_sdpa",
-    ttnn::operations::transformer::ring_distributed_sdpa::RingDistributedSdpaDeviceOperation>();
+ttnn::operations::transformer::ring_distributed_sdpa::RingDistributedSdpaDeviceOperation::tensor_return_value_t
+ring_distributed_sdpa(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const ttnn::Tensor& input_tensor_v,
+    uint32_t ring_size,
+    std::optional<uint32_t> ring_id,
+    std::optional<float> scale,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -28,37 +28,34 @@ struct RingJointSDPADeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor_q,
-        const ttnn::Tensor& input_tensor_k,
-        const ttnn::Tensor& input_tensor_v,
-        const ttnn::Tensor& joint_tensor_q,
-        const ttnn::Tensor& joint_tensor_k,
-        const ttnn::Tensor& joint_tensor_v,
-        ttnn::Tensor& persistent_output_buffer_k,
-        ttnn::Tensor& persistent_output_buffer_v,
-        const std::string& joint_strategy,
-        std::size_t logical_n,
-        SDPAProgramConfig program_config,
-        int32_t dim,
-        const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
-        uint32_t num_links,
-        uint32_t cluster_axis,
-        const MeshDevice& mesh_device,
-        ttnn::ccl::Topology topology,
-        CoreCoord ccl_core_grid_offset,
-        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
-        std::optional<float> scale = std::nullopt,
-        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa::ring_joint_sdpa
 
 namespace ttnn::prim {
 
-constexpr auto ring_joint_scaled_dot_product_attention = ttnn::register_operation<
-    "ttnn::prim::ring_joint_scaled_dot_product_attention",
-    ttnn::operations::transformer::sdpa::ring_joint_sdpa::RingJointSDPADeviceOperation>();
+ttnn::operations::transformer::sdpa::ring_joint_sdpa::RingJointSDPADeviceOperation::tensor_return_value_t
+ring_joint_scaled_dot_product_attention(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_k,
+    const ttnn::Tensor& input_tensor_v,
+    const ttnn::Tensor& joint_tensor_q,
+    const ttnn::Tensor& joint_tensor_k,
+    const ttnn::Tensor& joint_tensor_v,
+    ttnn::Tensor& persistent_output_buffer_k,
+    ttnn::Tensor& persistent_output_buffer_v,
+    const std::string& joint_strategy,
+    std::size_t logical_n,
+    SDPAProgramConfig program_config,
+    int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    uint32_t num_links,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    ttnn::ccl::Topology topology,
+    CoreCoord ccl_core_grid_offset,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+    std::optional<float> scale = std::nullopt,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_program_factory.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -457,7 +458,10 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> SDPAOp
     return result;
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> SDPAOperation::invoke(
+}  // namespace ttnn::operations::transformer::sdpa
+
+namespace ttnn::prim {
+ttnn::operations::transformer::sdpa::SDPAOperation::tensor_return_value_t sdpa(
     const Tensor& input_tensor_q,
     const Tensor& input_tensor_k,
     const std::optional<Tensor>& input_tensor_v,
@@ -471,10 +475,11 @@ std::tuple<operation_attributes_t, tensor_args_t> SDPAOperation::invoke(
     bool use_mla,
     std::optional<uint32_t> head_dim_v,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    std::optional<SDPAProgramConfig> program_config,
-    DeviceComputeKernelConfig compute_kernel_config) {
-    return {
-        operation_attributes_t{
+    std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using OperationType = ttnn::operations::transformer::sdpa::SDPAOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .scale = scale,
             .output_mem_config = output_mem_config,
             .program_config = std::move(program_config),
@@ -485,14 +490,13 @@ std::tuple<operation_attributes_t, tensor_args_t> SDPAOperation::invoke(
             .head_dim_v = head_dim_v,
             .sliding_window_size = sliding_window_size,
         },
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .q = input_tensor_q,
             .k = input_tensor_k,
             .v = input_tensor_v,
             .attn_mask = attn_mask,
             .page_table = page_table_tensor,
             .attention_sink = attention_sink,
-        }};
+        });
 }
-
-}  // namespace ttnn::operations::transformer::sdpa
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
@@ -34,28 +34,25 @@ struct SDPAOperation {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_q,
-        const Tensor& input_tensor_k,
-        const std::optional<Tensor>& input_tensor_v,
-        const std::optional<Tensor>& attn_mask,
-        const std::optional<Tensor>& page_table_tensor,
-        const std::optional<Tensor>& attention_sink,
-        bool is_causal,
-        std::optional<float> scale,
-        std::optional<uint32_t> sliding_window_size,
-        std::optional<int64_t> chunk_start_idx,
-        bool use_mla,
-        std::optional<uint32_t> head_dim_v,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        std::optional<SDPAProgramConfig> program_config,
-        DeviceComputeKernelConfig compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa
 
 namespace ttnn::prim {
-constexpr auto sdpa =
-    ttnn::register_operation<"ttnn::prim::sdpa", ttnn::operations::transformer::sdpa::SDPAOperation>();
+ttnn::operations::transformer::sdpa::SDPAOperation::tensor_return_value_t sdpa(
+    const Tensor& input_tensor_q,
+    const Tensor& input_tensor_k,
+    const std::optional<Tensor>& input_tensor_v,
+    const std::optional<Tensor>& attn_mask,
+    const std::optional<Tensor>& page_table_tensor,
+    const std::optional<Tensor>& attention_sink,
+    bool is_causal,
+    std::optional<float> scale,
+    std::optional<uint32_t> sliding_window_size,
+    std::optional<int64_t> chunk_start_idx,
+    bool use_mla,
+    std::optional<uint32_t> head_dim_v,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sdpa_decode_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 
 #include <cmath>
 
@@ -382,7 +383,11 @@ tt::stl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
         tensor_args.attention_sink);
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> SdpaDecodeDeviceOperation::invoke(
+}  // namespace ttnn::operations::transformer::sdpa_decode
+
+namespace ttnn::prim {
+
+ttnn::operations::transformer::sdpa_decode::SdpaDecodeDeviceOperation::tensor_return_value_t sdpa_decode(
     const Tensor& input_tensor_q,
     const Tensor& input_tensor_k,
     const std::optional<const Tensor>& input_tensor_v,
@@ -396,13 +401,14 @@ std::tuple<operation_attributes_t, tensor_args_t> SdpaDecodeDeviceOperation::inv
     std::optional<float> scale,
     std::optional<uint32_t> sliding_window_size,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    const std::optional<SDPAProgramConfig>& program_config,
-    DeviceComputeKernelConfig compute_kernel_config,
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
     uint32_t k_chunk_size,
     std::optional<bool> share_cache,
     std::optional<bool> use_mla,
     std::optional<uint32_t> head_dim_v) {
-    operation_attributes_t attrs{
+    using OperationType = ttnn::operations::transformer::sdpa_decode::SdpaDecodeDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
         .is_causal = is_causal,
         .paged_attention = paged_attention,
         .cur_pos = cur_pos,
@@ -417,7 +423,7 @@ std::tuple<operation_attributes_t, tensor_args_t> SdpaDecodeDeviceOperation::inv
         .head_dim_v = head_dim_v,
     };
 
-    tensor_args_t tensors{
+    auto tensor_args = OperationType::tensor_args_t{
         .q = input_tensor_q,
         .k = input_tensor_k,
         .v = input_tensor_v,
@@ -427,7 +433,7 @@ std::tuple<operation_attributes_t, tensor_args_t> SdpaDecodeDeviceOperation::inv
         .attention_sink = attention_sink,
     };
 
-    return {attrs, tensors};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
 
-}  // namespace ttnn::operations::transformer::sdpa_decode
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -41,36 +41,31 @@ struct SdpaDecodeDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_q,
-        const Tensor& input_tensor_k,
-        const std::optional<const Tensor>& input_tensor_v,
-        const std::optional<const Tensor>& cur_pos_tensor,
-        const std::optional<const Tensor>& page_table_tensor,
-        const std::optional<const Tensor>& attn_mask,
-        const std::optional<const Tensor>& attention_sink,
-        bool is_causal,
-        bool paged_attention,
-        const std::vector<uint32_t>& cur_pos,
-        std::optional<float> scale,
-        std::optional<uint32_t> sliding_window_size,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        const std::optional<SDPAProgramConfig>& program_config,
-        DeviceComputeKernelConfig compute_kernel_config,
-        uint32_t k_chunk_size,
-        std::optional<bool> share_cache,
-        std::optional<bool> use_mla,
-        std::optional<uint32_t> head_dim_v);
-
 };
 
 }  // namespace ttnn::operations::transformer::sdpa_decode
 
 namespace ttnn::prim {
 
-constexpr auto sdpa_decode = ttnn::register_operation<
-    "ttnn::prim::sdpa_decode",
-    ttnn::operations::transformer::sdpa_decode::SdpaDecodeDeviceOperation>();
+ttnn::operations::transformer::sdpa_decode::SdpaDecodeDeviceOperation::tensor_return_value_t sdpa_decode(
+    const Tensor& input_tensor_q,
+    const Tensor& input_tensor_k,
+    const std::optional<const Tensor>& input_tensor_v,
+    const std::optional<const Tensor>& cur_pos_tensor,
+    const std::optional<const Tensor>& page_table_tensor,
+    const std::optional<const Tensor>& attn_mask,
+    const std::optional<const Tensor>& attention_sink,
+    bool is_causal,
+    bool paged_attention,
+    const std::vector<uint32_t>& cur_pos,
+    std::optional<float> scale,
+    std::optional<uint32_t> sliding_window_size,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    uint32_t k_chunk_size,
+    std::optional<bool> share_cache,
+    std::optional<bool> use_mla,
+    std::optional<uint32_t> head_dim_v);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp"
+#include "ttnn/api/ttnn/device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_program_factory.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -197,28 +198,33 @@ WindowedScaledDotProductAttentionDeviceOperation::create_op_performance_model(
         input_tensors, output_tensor, ideal_dev_clock_cycles);
 }
 
-std::tuple<operation_attributes_t, tensor_args_t> WindowedScaledDotProductAttentionDeviceOperation::invoke(
+}  // namespace ttnn::operations::transformer::sdpa_windowed
+
+namespace ttnn::prim {
+ttnn::operations::transformer::sdpa_windowed::WindowedScaledDotProductAttentionDeviceOperation::tensor_return_value_t
+windowed_scaled_dot_product_attention(
     const Tensor& input_tensor_q,
     const Tensor& input_tensor_k,
     const Tensor& input_tensor_v,
     const Tensor& cu_window_seqlens,
     std::optional<float> scale,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    std::optional<SDPAProgramConfig> program_config,
-    DeviceComputeKernelConfig compute_kernel_config) {
-    return {
-        operation_attributes_t{
+    std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using OperationType =
+        ttnn::operations::transformer::sdpa_windowed::WindowedScaledDotProductAttentionDeviceOperation;
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+        OperationType::operation_attributes_t{
             .scale = scale,
             .output_mem_config = output_mem_config,
             .program_config = std::move(program_config),
             .compute_kernel_config = compute_kernel_config,
         },
-        tensor_args_t{
+        OperationType::tensor_args_t{
             .q = input_tensor_q,
             .k = input_tensor_k,
             .v = input_tensor_v,
             .cu_window_seqlens = cu_window_seqlens,
-        }};
+        });
 }
-
-}  // namespace ttnn::operations::transformer::sdpa_windowed
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
@@ -42,22 +42,19 @@ struct WindowedScaledDotProductAttentionDeviceOperation {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t& output_tensor);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_q,
-        const Tensor& input_tensor_k,
-        const Tensor& input_tensor_v,
-        const Tensor& cu_window_seqlens,
-        std::optional<float> scale,
-        const tt::tt_metal::MemoryConfig& output_mem_config,
-        std::optional<SDPAProgramConfig> program_config,
-        DeviceComputeKernelConfig compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa_windowed
 
 namespace ttnn::prim {
-constexpr auto windowed_scaled_dot_product_attention = ttnn::register_operation<
-    "ttnn::prim::windowed_scaled_dot_product_attention",
-    ttnn::operations::transformer::sdpa_windowed::WindowedScaledDotProductAttentionDeviceOperation>();
+ttnn::operations::transformer::sdpa_windowed::WindowedScaledDotProductAttentionDeviceOperation::tensor_return_value_t
+windowed_scaled_dot_product_attention(
+    const Tensor& input_tensor_q,
+    const Tensor& input_tensor_k,
+    const Tensor& input_tensor_v,
+    const Tensor& cu_window_seqlens,
+    std::optional<float> scale,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This PR addresses the ongoing refactoring effort to transition `ttnn` device operations from the `ttnn::register_operation` macro to explicit function declarations and implementations, as outlined in `REFACTORING_PROCESS.md`. This change aims to improve code clarity, maintainability, and enable more flexible operation definitions.

### What's changed
This PR refactors 16 device operations, replacing their `ttnn::register_operation` calls with explicit function declarations and implementations in the `ttnn::prim` namespace. This involves:
1.  Removing the `ttnn::register_operation` macro.
2.  Defining the operation's `invoke` logic as a standalone function within `ttnn::prim`.
3.  Updating the operation's header to declare this new function.
4.  Marking the refactored operations in `device_ops_to_process.txt`.

The refactored operations are:
*   `ttnn::prim::reduce_scatter`
*   `ttnn::prim::reduce_to_root`
*   `ttnn::prim::broadcast`
*   `ttnn::prim::all_to_all_dispatch`
*   `ttnn::prim::uniform` (formerly `rand`)
*   `ttnn::prim::halo`
*   `ttnn::prim::typecast`
*   `ttnn::prim::point_to_point`
*   `ttnn::prim::sdpa`
*   `ttnn::prim::ring_distributed_sdpa`
*   `ttnn::prim::joint_scaled_dot_product_attention`
*   `ttnn::prim::ring_joint_scaled_dot_product_attention`
*   `ttnn::prim::windowed_scaled_dot_product_attention`
*   `ttnn::prim::sdpa_decode`
*   `ttnn::prim::moe_expert_token_remap`
*   `ttnn::prim::fold`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ay/agent/device-ops-refactoring-process-d8a4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ay/agent/device-ops-refactoring-process-d8a4)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
<a href="https://cursor.com/background-agent?bcId=bc-288a96e0-09e6-4611-9fd5-f75a24e39899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-288a96e0-09e6-4611-9fd5-f75a24e39899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>