### PR TITLE
Device operations refactoring

### DIFF
--- a/device_ops_to_process.txt
+++ b/device_ops_to_process.txt
@@ -92,30 +92,30 @@
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
 [ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_fold/device/fold_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
-[ ] ./ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
+[x] ./ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
 [x] ./ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.hpp
 [x] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.hpp
 [x] ./ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -109,12 +110,12 @@ MorehAdamOperation::tensor_return_value_t MorehAdamOperation::create_output_tens
     return ret;
 }
 
-std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tensor_args_t> MorehAdamOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_adam::MorehAdamOperation::tensor_return_value_t moreh_adam(
     const Tensor& param_in,
     const Tensor& grad,
     const Tensor& exp_avg_in,
     const Tensor& exp_avg_sq_in,
-
     const std::optional<float> lr,
     const std::optional<float> beta1,
     const std::optional<float> beta2,
@@ -122,7 +123,6 @@ std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tenso
     const std::optional<float> weight_decay,
     const std::optional<uint32_t> step,
     const std::optional<bool> amsgrad,
-
     const std::optional<const Tensor>& max_exp_avg_sq_in,
     const std::optional<const Tensor> param_out,
     const std::optional<const Tensor> exp_avg_out,
@@ -130,26 +130,30 @@ std::tuple<MorehAdamOperation::operation_attributes_t, MorehAdamOperation::tenso
     const std::optional<const Tensor> max_exp_avg_sq_out,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            lr.value_or(0.001f),
-            beta1.value_or(0.9f),
-            beta2.value_or(0.999f),
-            eps.value_or(1e-8f),
-            weight_decay.value_or(0.0f),
-            step.value_or(0),
-            amsgrad.value_or(false),
-            memory_config.value_or(param_in.memory_config()),
-            init_device_compute_kernel_config(param_in.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
-        },
-        tensor_args_t{
-            param_in,
-            grad,
-            exp_avg_in,
-            exp_avg_sq_in,
-            max_exp_avg_sq_in,
-            {param_out, exp_avg_out, exp_avg_sq_out, max_exp_avg_sq_out}}};
+    using OperationType = ttnn::operations::moreh::moreh_adam::MorehAdamOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        lr.value_or(0.001f),
+        beta1.value_or(0.9f),
+        beta2.value_or(0.999f),
+        eps.value_or(1e-8f),
+        weight_decay.value_or(0.0f),
+        step.value_or(0),
+        amsgrad.value_or(false),
+        memory_config.value_or(param_in.memory_config()),
+        init_device_compute_kernel_config(param_in.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        param_in,
+        grad,
+        exp_avg_in,
+        exp_avg_sq_in,
+        max_exp_avg_sq_in,
+        {param_out, exp_avg_out, exp_avg_sq_out, max_exp_avg_sq_out}};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_adam {
 auto MorehAdamOperation::compute_program_hash(
     const MorehAdamOperation::operation_attributes_t& operation_attributes,
     const MorehAdamOperation::tensor_args_t& tensor_args) -> tt::stl::hash::hash_t {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -74,34 +74,32 @@ struct MorehAdamOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& param_in,
-        const Tensor& grad,
-        const Tensor& exp_avg_in,
-        const Tensor& exp_avg_sq_in,
-
-        std::optional<float> lr,
-        std::optional<float> beta1,
-        std::optional<float> beta2,
-        std::optional<float> eps,
-        std::optional<float> weight_decay,
-        std::optional<uint32_t> step,
-        std::optional<bool> amsgrad,
-
-        const std::optional<const Tensor>& max_exp_avg_sq_in,
-        std::optional<const Tensor> param_out,
-        std::optional<const Tensor> exp_avg_out,
-        std::optional<const Tensor> exp_avg_sq_out,
-        std::optional<const Tensor> max_exp_avg_sq_out,
-
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::moreh::moreh_adam
 
 namespace ttnn::prim {
-constexpr auto moreh_adam =
-    ttnn::register_operation<"ttnn::prim::moreh_adam", ttnn::operations::moreh::moreh_adam::MorehAdamOperation>();
+ttnn::operations::moreh::moreh_adam::MorehAdamOperation::tensor_return_value_t moreh_adam(
+    const Tensor& param_in,
+    const Tensor& grad,
+    const Tensor& exp_avg_in,
+    const Tensor& exp_avg_sq_in,
+
+    std::optional<float> lr,
+    std::optional<float> beta1,
+    std::optional<float> beta2,
+    std::optional<float> eps,
+    std::optional<float> weight_decay,
+    std::optional<uint32_t> step,
+    std::optional<bool> amsgrad,
+
+    const std::optional<const Tensor>& max_exp_avg_sq_in,
+    std::optional<const Tensor> param_out,
+    std::optional<const Tensor> exp_avg_out,
+    std::optional<const Tensor> exp_avg_sq_out,
+    std::optional<const Tensor> max_exp_avg_sq_out,
+
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_clip_grad_norm_step1_device_operation.hpp"
-
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -45,20 +45,24 @@ MorehClipGradNormStep1Operation::tensor_return_value_t MorehClipGradNormStep1Ope
     return tensor_args.tmp_pow_sum;
 };
 
-std::tuple<MorehClipGradNormStep1Operation::operation_attributes_t, MorehClipGradNormStep1Operation::tensor_args_t>
-MorehClipGradNormStep1Operation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_clip_grad_norm_step1::MorehClipGradNormStep1Operation::tensor_return_value_t
+moreh_clip_grad_norm_step1(
     const std::vector<Tensor>& inputs,
-    const float norm_type,
-    const uint32_t tile_offset_of_tmp_pow_sum,
+    float norm_type,
+    uint32_t tile_offset_of_tmp_pow_sum,
     const Tensor& tmp_pow_sum,
     const std::optional<MemoryConfig>& memory_config,
-    const DeviceComputeKernelConfig& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            norm_type,
-            tile_offset_of_tmp_pow_sum,
-            memory_config.value_or(inputs.at(0).memory_config()),
-            compute_kernel_config},
-        tensor_args_t{inputs, tmp_pow_sum}};
-};
-}  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step1
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config) {
+    using OperationType = ttnn::operations::moreh::moreh_clip_grad_norm_step1::MorehClipGradNormStep1Operation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        norm_type,
+        tile_offset_of_tmp_pow_sum,
+        memory_config.value_or(inputs.at(0).memory_config()),
+        compute_kernel_config};
+    auto tensor_args = OperationType::tensor_args_t{inputs, tmp_pow_sum};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_clip_grad_norm_step1 {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.hpp
@@ -60,19 +60,17 @@ struct MorehClipGradNormStep1Operation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::vector<Tensor>& inputs,
-        float norm_type,
-        uint32_t tile_offset_of_tmp_pow_sum,
-        const Tensor& tmp_pow_sum,
-        const std::optional<MemoryConfig>& memory_config,
-        const DeviceComputeKernelConfig& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step1
 
 namespace ttnn::prim {
-constexpr auto moreh_clip_grad_norm_step1 = ttnn::register_operation<
-    "ttnn::prim::moreh_clip_grad_norm_step1",
-    ttnn::operations::moreh::moreh_clip_grad_norm_step1::MorehClipGradNormStep1Operation>();
+ttnn::operations::moreh::moreh_clip_grad_norm_step1::MorehClipGradNormStep1Operation::tensor_return_value_t
+moreh_clip_grad_norm_step1(
+    const std::vector<Tensor>& inputs,
+    float norm_type,
+    uint32_t tile_offset_of_tmp_pow_sum,
+    const Tensor& tmp_pow_sum,
+    const std::optional<MemoryConfig>& memory_config,
+    const ttnn::DeviceComputeKernelConfig& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_clip_grad_norm_step2_device_operation.hpp"
-
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -56,15 +56,20 @@ MorehClipGradNormStep2Operation::tensor_return_value_t MorehClipGradNormStep2Ope
         compute_output_specs(operation_attributes, tensor_args), tensor_args.tmp_pow_sum.device());
 };
 
-std::tuple<MorehClipGradNormStep2Operation::operation_attributes_t, MorehClipGradNormStep2Operation::tensor_args_t>
-MorehClipGradNormStep2Operation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_clip_grad_norm_step2::MorehClipGradNormStep2Operation::tensor_return_value_t
+moreh_clip_grad_norm_step2(
     const Tensor& tmp_pow_sum,
-    const float norm_type,
+    float norm_type,
     const std::optional<Tensor>& total_norm,
     const std::optional<MemoryConfig>& memory_config,
-    const DeviceComputeKernelConfig compute_kernel_config) {
-    return {
-        operation_attributes_t{norm_type, memory_config.value_or(tmp_pow_sum.memory_config()), compute_kernel_config},
-        tensor_args_t{tmp_pow_sum, total_norm}};
-};
-}  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step2
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using OperationType = ttnn::operations::moreh::moreh_clip_grad_norm_step2::MorehClipGradNormStep2Operation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        norm_type, memory_config.value_or(tmp_pow_sum.memory_config()), compute_kernel_config};
+    auto tensor_args = OperationType::tensor_args_t{tmp_pow_sum, total_norm};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_clip_grad_norm_step2 {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.hpp
@@ -60,18 +60,16 @@ struct MorehClipGradNormStep2Operation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& tmp_pow_sum,
-        float norm_type,
-        const std::optional<Tensor>& total_norm,
-        const std::optional<MemoryConfig>& memory_config,
-        DeviceComputeKernelConfig compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step2
 
 namespace ttnn::prim {
-constexpr auto moreh_clip_grad_norm_step2 = ttnn::register_operation<
-    "ttnn::prim::moreh_clip_grad_norm_step2",
-    ttnn::operations::moreh::moreh_clip_grad_norm_step2::MorehClipGradNormStep2Operation>();
+ttnn::operations::moreh::moreh_clip_grad_norm_step2::MorehClipGradNormStep2Operation::tensor_return_value_t
+moreh_clip_grad_norm_step2(
+    const Tensor& tmp_pow_sum,
+    float norm_type,
+    const std::optional<Tensor>& total_norm,
+    const std::optional<MemoryConfig>& memory_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_clip_grad_norm_step3_device_operation.hpp"
-
+#include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -52,14 +52,19 @@ MorehClipGradNormStep3Operation::tensor_return_value_t MorehClipGradNormStep3Ope
     return tensor_args.inputs;
 };
 
-std::tuple<MorehClipGradNormStep3Operation::operation_attributes_t, MorehClipGradNormStep3Operation::tensor_args_t>
-MorehClipGradNormStep3Operation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_clip_grad_norm_step3::MorehClipGradNormStep3Operation::tensor_return_value_t
+moreh_clip_grad_norm_step3(
     const std::vector<Tensor>& inputs,
     const Tensor& clip_coef_clamped,
     const std::optional<MemoryConfig>& memory_config,
-    const DeviceComputeKernelConfig compute_kernel_config) {
-    return {
-        operation_attributes_t{memory_config.value_or(inputs.at(0).memory_config()), compute_kernel_config},
-        tensor_args_t{inputs, clip_coef_clamped}};
-};
-}  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step3
+    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using OperationType = ttnn::operations::moreh::moreh_clip_grad_norm_step3::MorehClipGradNormStep3Operation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        memory_config.value_or(inputs.at(0).memory_config()), compute_kernel_config};
+    auto tensor_args = OperationType::tensor_args_t{inputs, clip_coef_clamped};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+}
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_clip_grad_norm_step3 {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.hpp
@@ -59,17 +59,15 @@ struct MorehClipGradNormStep3Operation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const std::vector<Tensor>& inputs,
-        const Tensor& clip_coef_clamped,
-        const std::optional<MemoryConfig>& memory_config,
-        DeviceComputeKernelConfig compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_clip_grad_norm_step3
 
 namespace ttnn::prim {
-constexpr auto moreh_clip_grad_norm_step3 = ttnn::register_operation<
-    "ttnn::prim::moreh_clip_grad_norm_step3",
-    ttnn::operations::moreh::moreh_clip_grad_norm_step3::MorehClipGradNormStep3Operation>();
+ttnn::operations::moreh::moreh_clip_grad_norm_step3::MorehClipGradNormStep3Operation::tensor_return_value_t
+moreh_clip_grad_norm_step3(
+    const std::vector<Tensor>& inputs,
+    const Tensor& clip_coef_clamped,
+    const std::optional<MemoryConfig>& memory_config,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_dot_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -66,19 +67,22 @@ MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensor
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input_a.device());
 }
 
-std::tuple<MorehDotOperation::operation_attributes_t, MorehDotOperation::tensor_args_t> MorehDotOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_return_value_t moreh_dot(
     const Tensor& input_a,
     const Tensor& input_b,
     const std::optional<Tensor>& output,
     const std::optional<DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            dtype.value_or(input_a.dtype()),
-            memory_config.value_or(input_a.memory_config()),
-            init_device_compute_kernel_config(input_a.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{input_a, input_b, output}};
+    using OperationType = ttnn::operations::moreh::moreh_dot::MorehDotOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        dtype.value_or(input_a.dtype()),
+        memory_config.value_or(input_a.memory_config()),
+        init_device_compute_kernel_config(input_a.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{input_a, input_b, output};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_dot
+namespace ttnn::operations::moreh::moreh_dot {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.hpp
@@ -55,18 +55,15 @@ struct MorehDotOperation {
     static void validate(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_a,
-        const Tensor& input_b,
-        const std::optional<Tensor>& output,
-        const std::optional<DataType>& dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_dot
 
 namespace ttnn::prim {
-constexpr auto moreh_dot =
-    ttnn::register_operation<"ttnn::prim::moreh_dot", ttnn::operations::moreh::moreh_dot::MorehDotOperation>();
+ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_return_value_t moreh_dot(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const std::optional<Tensor>& output,
+    const std::optional<DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_dot_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -88,17 +89,19 @@ MorehDotBackwardOperation::tensor_return_value_t MorehDotBackwardOperation::crea
     return tensor_args.output_tensors;
 }
 
-std::tuple<MorehDotBackwardOperation::operation_attributes_t, MorehDotBackwardOperation::tensor_args_t>
-MorehDotBackwardOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_dot_backward::MorehDotBackwardOperation::tensor_return_value_t moreh_dot_backward(
     const Tensor& output_grad,
     const Tensor& input,
     const Tensor& other,
     std::optional<const Tensor> input_grad,
     std::optional<const Tensor> other_grad,
     const std::optional<MemoryConfig>& memory_config) {
-    return {
-        operation_attributes_t{memory_config.value_or(input.memory_config())},
-        tensor_args_t{output_grad, input, other, {input_grad, other_grad}}};
+    using OperationType = ttnn::operations::moreh::moreh_dot_backward::MorehDotBackwardOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{memory_config.value_or(input.memory_config())};
+    auto tensor_args = OperationType::tensor_args_t{output_grad, input, other, {input_grad, other_grad}};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_dot_backward
+namespace ttnn::operations::moreh::moreh_dot_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.hpp
@@ -57,19 +57,16 @@ struct MorehDotBackwardOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& other,
-        std::optional<const Tensor> input_grad,
-        std::optional<const Tensor> other_grad,
-        const std::optional<MemoryConfig>& memory_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_dot_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_dot_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_dot_backward",
-    ttnn::operations::moreh::moreh_dot_backward::MorehDotBackwardOperation>();
+ttnn::operations::moreh::moreh_dot_backward::MorehDotBackwardOperation::tensor_return_value_t moreh_dot_backward(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& other,
+    std::optional<const Tensor> input_grad,
+    std::optional<const Tensor> other_grad,
+    const std::optional<MemoryConfig>& memory_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_getitem_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include <cstdint>
 
@@ -166,15 +167,18 @@ MorehGetItemOperation::tensor_return_value_t MorehGetItemOperation::create_outpu
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<MorehGetItemOperation::operation_attributes_t, MorehGetItemOperation::tensor_args_t>
-MorehGetItemOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation::tensor_return_value_t moreh_getitem(
     const Tensor& input,
     const std::vector<Tensor>& index_tensors,
     const ttnn::SmallVector<uint32_t>& index_dims,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config) {
-    operation_attributes_t operation_attributes = {index_dims, memory_config.value_or(input.memory_config())};
-    tensor_args_t tensor_args = {input, index_tensors, output};
-    return {operation_attributes, tensor_args};
+    using OperationType = ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{index_dims, memory_config.value_or(input.memory_config())};
+    auto tensor_args = OperationType::tensor_args_t{input, index_tensors, output};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_getitem
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_getitem {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.hpp
@@ -86,17 +86,15 @@ struct MorehGetItemOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const std::vector<Tensor>& index_tensors,
-        const ttnn::SmallVector<uint32_t>& index_dims,
-        const std::optional<Tensor>& output,
-        // const CoreRange core_range,
-        const std::optional<MemoryConfig>& memory_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_getitem
 
 namespace ttnn::prim {
-constexpr auto moreh_getitem = ttnn::
-    register_operation<"ttnn::prim::moreh_getitem", ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation>();
+ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation::tensor_return_value_t moreh_getitem(
+    const Tensor& input,
+    const std::vector<Tensor>& index_tensors,
+    const ttnn::SmallVector<uint32_t>& index_dims,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& memory_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_group_norm_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -153,8 +154,8 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     return result;
 }
 
-std::tuple<MorehGroupNormOperation::operation_attributes_t, MorehGroupNormOperation::tensor_args_t>
-MorehGroupNormOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_group_norm::MorehGroupNormOperation::tensor_return_value_t moreh_group_norm(
     const Tensor& input,
     const uint32_t num_groups,
     const float eps,
@@ -168,7 +169,8 @@ MorehGroupNormOperation::invoke(
     const std::optional<MemoryConfig>& mean_memory_config,
     const std::optional<MemoryConfig>& rstd_memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    operation_attributes_t operation_attributes{
+    using OperationType = ttnn::operations::moreh::moreh_group_norm::MorehGroupNormOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
         num_groups,
         eps,
         are_required_outputs,
@@ -176,7 +178,9 @@ MorehGroupNormOperation::invoke(
         mean_memory_config.value_or(input.memory_config()),
         rstd_memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
-    tensor_args_t tensor_args{input, gamma, beta, output, mean, rstd};
-    return {operation_attributes, tensor_args};
+    auto tensor_args = OperationType::tensor_args_t{input, gamma, beta, output, mean, rstd};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_group_norm
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_group_norm {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
@@ -62,25 +62,23 @@ struct MorehGroupNormOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        uint32_t num_groups,
-        float eps,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& beta,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<const Tensor>& output,
-        const std::optional<const Tensor>& mean,
-        const std::optional<const Tensor>& rstd,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<MemoryConfig>& mean_memory_config,
-        const std::optional<MemoryConfig>& rstd_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_group_norm
 
 namespace ttnn::prim {
-constexpr auto moreh_group_norm = ttnn::register_operation<
-    "ttnn::prim::moreh_group_norm",
-    ttnn::operations::moreh::moreh_group_norm::MorehGroupNormOperation>();
+ttnn::operations::moreh::moreh_group_norm::MorehGroupNormOperation::tensor_return_value_t moreh_group_norm(
+    const Tensor& input,
+    uint32_t num_groups,
+    float eps,
+    const std::optional<const Tensor>& gamma,
+    const std::optional<const Tensor>& beta,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<const Tensor>& output,
+    const std::optional<const Tensor>& mean,
+    const std::optional<const Tensor>& rstd,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<MemoryConfig>& mean_memory_config,
+    const std::optional<MemoryConfig>& rstd_memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_layer_norm_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -125,8 +126,8 @@ MorehLayerNormOperation::tensor_return_value_t MorehLayerNormOperation::create_o
     return result;
 }
 
-std::tuple<MorehLayerNormOperation::operation_attributes_t, MorehLayerNormOperation::tensor_args_t>
-MorehLayerNormOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_layer_norm::MorehLayerNormOperation::tensor_return_value_t moreh_layer_norm(
     const Tensor& input,
     uint32_t normalized_dims,
     float eps,
@@ -137,13 +138,15 @@ MorehLayerNormOperation::invoke(
     const std::optional<const Tensor>& rstd,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            normalized_dims,
-            eps,
-            memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
-        },
-        tensor_args_t{input, gamma, beta, output, mean, rstd}};
+    using OperationType = ttnn::operations::moreh::moreh_layer_norm::MorehLayerNormOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        normalized_dims,
+        eps,
+        memory_config.value_or(input.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{input, gamma, beta, output, mean, rstd};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_layer_norm
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_layer_norm {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.hpp
@@ -62,21 +62,20 @@ struct MorehLayerNormOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        uint32_t normalized_dims,
-        float eps,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& beta,
-        const std::optional<const Tensor>& output,
-        const std::optional<const Tensor>& mean,
-        const std::optional<const Tensor>& rstd,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_layer_norm
 
 namespace ttnn::prim {
-constexpr auto moreh_layer_norm = ttnn::
-    register_operation<"ttnn::prim::moreh_layer_norm", operations::moreh::moreh_layer_norm::MorehLayerNormOperation>();
+ttnn::operations::moreh::moreh_layer_norm::MorehLayerNormOperation::tensor_return_value_t moreh_layer_norm(
+    const Tensor& input,
+    uint32_t normalized_dims,
+    float eps,
+    const std::optional<const Tensor>& gamma,
+    const std::optional<const Tensor>& beta,
+    const std::optional<const Tensor>& output,
+    const std::optional<const Tensor>& mean,
+    const std::optional<const Tensor>& rstd,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp"
-
+#include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
@@ -54,24 +54,28 @@ MorehLayerNormBackwardGammaBetaGradOperation::create_output_tensors(
     return result;
 }
 
-std::tuple<
-    MorehLayerNormBackwardGammaBetaGradOperation::operation_attributes_t,
-    MorehLayerNormBackwardGammaBetaGradOperation::tensor_args_t>
-MorehLayerNormBackwardGammaBetaGradOperation::invoke(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& mean,
-    const Tensor& rstd,
-    uint32_t normalized_dims,
-    const std::optional<const Tensor>& gamma_grad,
-    const std::optional<const Tensor>& beta_grad,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            normalized_dims,
-            memory_config.value_or(output_grad.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{output_grad, input, mean, rstd, gamma_grad, beta_grad}};
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad::MorehLayerNormBackwardGammaBetaGradOperation::
+    tensor_return_value_t
+    moreh_layer_norm_backward_gamma_beta_grad(
+        const Tensor& output_grad,
+        const Tensor& input,
+        const Tensor& mean,
+        const Tensor& rstd,
+        uint32_t normalized_dims,
+        const std::optional<const Tensor>& gamma_grad,
+        const std::optional<const Tensor>& beta_grad,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    using OperationType =
+        ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad::MorehLayerNormBackwardGammaBetaGradOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        normalized_dims,
+        memory_config.value_or(output_grad.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{output_grad, input, mean, rstd, gamma_grad, beta_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp
@@ -60,7 +60,13 @@ struct MorehLayerNormBackwardGammaBetaGradOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+};
+}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad::MorehLayerNormBackwardGammaBetaGradOperation::
+    tensor_return_value_t
+    moreh_layer_norm_backward_gamma_beta_grad(
         const Tensor& output_grad,
         const Tensor& input,
         const Tensor& mean,
@@ -70,11 +76,4 @@ struct MorehLayerNormBackwardGammaBetaGradOperation {
         const std::optional<const Tensor>& beta_grad,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-};
-}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad
-
-namespace ttnn::prim {
-constexpr auto moreh_layer_norm_backward_gamma_beta_grad = ttnn::register_operation<
-    "ttnn::prim::moreh_layer_norm_backward_gamma_beta_grad",
-    operations::moreh::moreh_layer_norm_backward_gamma_beta_grad::MorehLayerNormBackwardGammaBetaGradOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_layer_norm_backward_input_grad_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -48,24 +49,28 @@ MorehLayerNormBackwardInputGradOperation::create_output_tensors(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.output_grad.device());
 }
 
-std::tuple<
-    MorehLayerNormBackwardInputGradOperation::operation_attributes_t,
-    MorehLayerNormBackwardInputGradOperation::tensor_args_t>
-MorehLayerNormBackwardInputGradOperation::invoke(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& mean,
-    const Tensor& rstd,
-    uint32_t normalized_dims,
-    const std::optional<const Tensor>& input_grad,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        MorehLayerNormBackwardInputGradOperation::operation_attributes_t{
-            normalized_dims,
-            memory_config.value_or(output_grad.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        MorehLayerNormBackwardInputGradOperation::tensor_args_t{output_grad, input, mean, rstd, input_grad, gamma}};
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBackwardInputGradOperation::
+    tensor_return_value_t
+    moreh_layer_norm_backward_input_grad(
+        const Tensor& output_grad,
+        const Tensor& input,
+        const Tensor& mean,
+        const Tensor& rstd,
+        uint32_t normalized_dims,
+        const std::optional<const Tensor>& input_grad,
+        const std::optional<const Tensor>& gamma,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    using OperationType =
+        ttnn::operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBackwardInputGradOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        normalized_dims,
+        memory_config.value_or(output_grad.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{output_grad, input, mean, rstd, input_grad, gamma};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
@@ -59,7 +59,13 @@ struct MorehLayerNormBackwardInputGradOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+};
+}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBackwardInputGradOperation::
+    tensor_return_value_t
+    moreh_layer_norm_backward_input_grad(
         const Tensor& output_grad,
         const Tensor& input,
         const Tensor& mean,
@@ -69,11 +75,4 @@ struct MorehLayerNormBackwardInputGradOperation {
         const std::optional<const Tensor>& gamma,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-};
-}  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad
-
-namespace ttnn::prim {
-constexpr auto moreh_layer_norm_backward_input_grad = ttnn::register_operation<
-    "ttnn::prim::moreh_layer_norm_backward_input_grad",
-    operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBackwardInputGradOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_matmul_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -169,8 +170,8 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
             output_shape));
 }
 
-std::tuple<MorehMatmulOperation::operation_attributes_t, MorehMatmulOperation::tensor_args_t>
-MorehMatmulOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_matmul::MorehMatmulOperation::tensor_return_value_t moreh_matmul(
     const Tensor& input,
     const Tensor& other,
     bool transpose_input,
@@ -179,12 +180,15 @@ MorehMatmulOperation::invoke(
     const std::optional<const Tensor>& bias,
     const std::optional<MemoryConfig>& output_memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        MorehMatmulOperation::operation_attributes_t{
-            transpose_input,
-            transpose_other,
-            output_memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config)},
-        MorehMatmulOperation::tensor_args_t{input, other, output, bias}};
+    using OperationType = ttnn::operations::moreh::moreh_matmul::MorehMatmulOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        transpose_input,
+        transpose_other,
+        output_memory_config.value_or(input.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config)};
+    auto tensor_args = OperationType::tensor_args_t{input, other, output, bias};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_matmul
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_matmul {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -63,15 +63,6 @@ struct MorehMatmulOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const Tensor& other,
-        bool transpose_input,
-        bool transpose_other,
-        const std::optional<Tensor>& output,
-        const std::optional<const Tensor>& bias,
-        const std::optional<MemoryConfig>& output_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 void get_tensor_dim(ttnn::SmallVector<uint32_t>& dim, const ttnn::Shape& shape);
@@ -81,6 +72,13 @@ bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b);
 }  // namespace ttnn::operations::moreh::moreh_matmul
 
 namespace ttnn::prim {
-constexpr auto moreh_matmul =
-    ttnn::register_operation<"ttnn::prim::moreh_matmul", ttnn::operations::moreh::moreh_matmul::MorehMatmulOperation>();
+ttnn::operations::moreh::moreh_matmul::MorehMatmulOperation::tensor_return_value_t moreh_matmul(
+    const Tensor& input,
+    const Tensor& other,
+    bool transpose_input,
+    bool transpose_other,
+    const std::optional<Tensor>& output,
+    const std::optional<const Tensor>& bias,
+    const std::optional<MemoryConfig>& output_memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_mean_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -103,20 +104,25 @@ MorehMeanOperation::tensor_return_value_t MorehMeanOperation::create_output_tens
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<MorehMeanOperation::operation_attributes_t, MorehMeanOperation::tensor_args_t> MorehMeanOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_mean::MorehMeanOperation::tensor_return_value_t moreh_mean(
     const Tensor& input,
-    const int64_t dim,
-    const bool keepdim,
+    int64_t dim,
+    bool keepdim,
     const std::optional<uint32_t>& divisor,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        {dim,
-         keepdim,
-         divisor,
-         memory_config.value_or(input.memory_config()),
-         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        {input, output}};
+    using OperationType = ttnn::operations::moreh::moreh_mean::MorehMeanOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        dim,
+        keepdim,
+        divisor,
+        memory_config.value_or(input.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{input, output};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_mean
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_mean {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.hpp
@@ -105,19 +105,17 @@ struct MorehMeanOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        int64_t dim,
-        bool keepdim,
-        const std::optional<uint32_t>& divisor,
-        const std::optional<Tensor>& output,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_mean
 
 namespace ttnn::prim {
-constexpr auto moreh_mean =
-    ttnn::register_operation<"ttnn::prim::moreh_mean", ttnn::operations::moreh::moreh_mean::MorehMeanOperation>();
+ttnn::operations::moreh::moreh_mean::MorehMeanOperation::tensor_return_value_t moreh_mean(
+    const Tensor& input,
+    int64_t dim,
+    bool keepdim,
+    const std::optional<uint32_t>& divisor,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_mean_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -57,24 +58,25 @@ MorehMeanBackwardOperation::tensor_return_value_t MorehMeanBackwardOperation::cr
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), output_grad.device());
 }
 
-std::tuple<MorehMeanBackwardOperation::operation_attributes_t, MorehMeanBackwardOperation::tensor_args_t>
-MorehMeanBackwardOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation::tensor_return_value_t moreh_mean_backward(
     const Tensor& output_grad,
     const ttnn::SmallVector<int64_t>& dims,
-    const bool keepdim,
+    bool keepdim,
     const std::optional<ttnn::Shape>& input_grad_shape,
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        {dims,
-         keepdim,
-         input_grad_shape,
-         memory_config.value_or(output_grad.memory_config()),
-         init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        {
-            output_grad,
-            input_grad,
-        }};
+    using OperationType = ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        dims,
+        keepdim,
+        input_grad_shape,
+        memory_config.value_or(output_grad.memory_config()),
+        init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{output_grad, input_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_mean_backward
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_mean_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.hpp
@@ -61,20 +61,17 @@ struct MorehMeanBackwardOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_grad,
-        const ttnn::SmallVector<int64_t>& dims,
-        bool keepdim,
-        const std::optional<ttnn::Shape>& input_grad_shape,
-        const std::optional<Tensor>& input_grad,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_mean_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_mean_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_mean_backward",
-    ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation>();
+ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation::tensor_return_value_t moreh_mean_backward(
+    const Tensor& output_grad,
+    const ttnn::SmallVector<int64_t>& dims,
+    bool keepdim,
+    const std::optional<ttnn::Shape>& input_grad_shape,
+    const std::optional<Tensor>& input_grad,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_nll_loss_step1_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::moreh::moreh_nll_loss_step1 {
 
@@ -55,25 +56,28 @@ MorehNllLossStep1DeviceOperation::tensor_return_value_t MorehNllLossStep1DeviceO
         compute_output_specs(operation_attributes, tensor_args), tensor_args.target_tensor.device());
 }
 
-std::tuple<MorehNllLossStep1DeviceOperation::operation_attributes_t, MorehNllLossStep1DeviceOperation::tensor_args_t>
-MorehNllLossStep1DeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_nll_loss_step1::MorehNllLossStep1DeviceOperation::tensor_return_value_t
+moreh_nll_loss_step1(
     const Tensor& target_tensor,
     const std::optional<Tensor>& weight_tensor,
-    const int32_t ignore_index,
+    int32_t ignore_index,
     const std::string& reduction,
-    const DataType dtype,
-    const uint32_t channel_size,
+    DataType dtype,
+    uint32_t channel_size,
     const std::optional<MemoryConfig>& memory_config,
     const DeviceComputeKernelConfig& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            reduction,
-            ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : ignore_index,
-            dtype,
-            channel_size,
-            memory_config.value_or(target_tensor.memory_config()),
-            compute_kernel_config},
-        tensor_args_t{target_tensor, weight_tensor}};
+    using OperationType = ttnn::operations::moreh::moreh_nll_loss_step1::MorehNllLossStep1DeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        reduction,
+        ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : static_cast<uint32_t>(ignore_index),
+        dtype,
+        channel_size,
+        memory_config.value_or(target_tensor.memory_config()),
+        compute_kernel_config};
+    auto tensor_args = OperationType::tensor_args_t{target_tensor, weight_tensor};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_nll_loss_step1
+namespace ttnn::operations::moreh::moreh_nll_loss_step1 {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.hpp
@@ -64,22 +64,19 @@ struct MorehNllLossStep1DeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& target_tensor,
-        const std::optional<Tensor>& weight_tensor,
-        int32_t ignore_index,
-        const std::string& reduction,
-        DataType dtype,
-        uint32_t channel_size,
-        const std::optional<MemoryConfig>& memory_config,
-        const DeviceComputeKernelConfig& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_step1
 
 namespace ttnn::prim {
-constexpr auto moreh_nll_loss_step1 = ttnn::register_operation<
-    "ttnn::prim::moreh_nll_loss_step1",
-    ttnn::operations::moreh::moreh_nll_loss_step1::MorehNllLossStep1DeviceOperation>();
+ttnn::operations::moreh::moreh_nll_loss_step1::MorehNllLossStep1DeviceOperation::tensor_return_value_t
+moreh_nll_loss_step1(
+    const Tensor& target_tensor,
+    const std::optional<Tensor>& weight_tensor,
+    int32_t ignore_index,
+    const std::string& reduction,
+    DataType dtype,
+    uint32_t channel_size,
+    const std::optional<MemoryConfig>& memory_config,
+    const DeviceComputeKernelConfig& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_nll_loss_step2_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 using namespace tt::tt_metal;
 
@@ -109,24 +110,27 @@ MorehNllLossStep2DeviceOperation::tensor_return_value_t MorehNllLossStep2DeviceO
     return create_device_tensor(output_spec, tensor_args.input_tensor.device());
 }
 
-std::tuple<MorehNllLossStep2DeviceOperation::operation_attributes_t, MorehNllLossStep2DeviceOperation::tensor_args_t>
-MorehNllLossStep2DeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_nll_loss_step2::MorehNllLossStep2DeviceOperation::tensor_return_value_t
+moreh_nll_loss_step2(
     const Tensor& input_tensor,
     const Tensor& target_tensor,
     const std::string& reduction,
     const std::optional<Tensor>& weight_tensor,
     const std::optional<Tensor>& divisor_tensor,
     const std::optional<Tensor>& output_tensor,
-    const int32_t ignore_index,
+    int32_t ignore_index,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const DeviceComputeKernelConfig& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            reduction,
-            ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : ignore_index,
-            memory_config.value_or(input_tensor.memory_config()),
-            compute_kernel_config},
-        tensor_args_t{input_tensor, target_tensor, weight_tensor, divisor_tensor, output_tensor}};
+    using OperationType = ttnn::operations::moreh::moreh_nll_loss_step2::MorehNllLossStep2DeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        reduction,
+        ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : static_cast<uint32_t>(ignore_index),
+        memory_config.value_or(input_tensor.memory_config()),
+        compute_kernel_config};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor, target_tensor, weight_tensor, divisor_tensor, output_tensor};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_nll_loss_step2
+namespace ttnn::operations::moreh::moreh_nll_loss_step2 {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.hpp
@@ -65,23 +65,20 @@ struct MorehNllLossStep2DeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const Tensor& target_tensor,
-        const std::string& reduction,
-        const std::optional<Tensor>& weight_tensor,
-        const std::optional<Tensor>& divisor_tensor,
-        const std::optional<Tensor>& output_tensor,
-        int32_t ignore_index,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        const DeviceComputeKernelConfig& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_step2
 
 namespace ttnn::prim {
-constexpr auto moreh_nll_loss_step2 = ttnn::register_operation<
-    "ttnn::prim::moreh_nll_loss_step2",
-    ttnn::operations::moreh::moreh_nll_loss_step2::MorehNllLossStep2DeviceOperation>();
+ttnn::operations::moreh::moreh_nll_loss_step2::MorehNllLossStep2DeviceOperation::tensor_return_value_t
+moreh_nll_loss_step2(
+    const Tensor& input_tensor,
+    const Tensor& target_tensor,
+    const std::string& reduction,
+    const std::optional<Tensor>& weight_tensor,
+    const std::optional<Tensor>& divisor_tensor,
+    const std::optional<Tensor>& output_tensor,
+    int32_t ignore_index,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const DeviceComputeKernelConfig& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_nll_loss_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::moreh::moreh_nll_loss_backward {
 
@@ -105,27 +106,28 @@ MorehNllLossBackwardDeviceOperation::tensor_return_value_t MorehNllLossBackwardD
         compute_output_specs(operation_attributes, tensor_args), tensor_args.target_tensor.device());
 }
 
-std::tuple<
-    MorehNllLossBackwardDeviceOperation::operation_attributes_t,
-    MorehNllLossBackwardDeviceOperation::tensor_args_t>
-MorehNllLossBackwardDeviceOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_nll_loss_backward::MorehNllLossBackwardDeviceOperation::tensor_return_value_t
+moreh_nll_loss_backward(
     const Tensor& target_tensor,
     const Tensor& output_grad_tensor,
-    const bool reduction_mean,
+    bool reduction_mean,
     const std::optional<Tensor>& weight_tensor,
     const std::optional<Tensor>& input_grad_tensor,
     const std::optional<Tensor>& divisor_tensor,
-    const int32_t ignore_index,
+    int32_t ignore_index,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            reduction_mean,
-            ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : ignore_index,
-            memory_config.value_or(target_tensor.memory_config()),
-            init_device_compute_kernel_config(
-                target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{target_tensor, output_grad_tensor, weight_tensor, divisor_tensor, input_grad_tensor}};
+    using OperationType = ttnn::operations::moreh::moreh_nll_loss_backward::MorehNllLossBackwardDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        reduction_mean,
+        ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : static_cast<uint32_t>(ignore_index),
+        memory_config.value_or(target_tensor.memory_config()),
+        init_device_compute_kernel_config(target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args =
+        OperationType::tensor_args_t{target_tensor, output_grad_tensor, weight_tensor, divisor_tensor, input_grad_tensor};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_nll_loss_backward
+namespace ttnn::operations::moreh::moreh_nll_loss_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.hpp
@@ -69,23 +69,20 @@ struct MorehNllLossBackwardDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& target_tensor,
-        const Tensor& output_grad_tensor,
-        bool reduction_mean,
-        const std::optional<Tensor>& weight_tensor,
-        const std::optional<Tensor>& input_grad_tensor,
-        const std::optional<Tensor>& divisor_tensor,
-        int32_t ignore_index,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_nll_loss_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_nll_loss_backward",
-    ttnn::operations::moreh::moreh_nll_loss_backward::MorehNllLossBackwardDeviceOperation>();
+ttnn::operations::moreh::moreh_nll_loss_backward::MorehNllLossBackwardDeviceOperation::tensor_return_value_t
+moreh_nll_loss_backward(
+    const Tensor& target_tensor,
+    const Tensor& output_grad_tensor,
+    bool reduction_mean,
+    const std::optional<Tensor>& weight_tensor,
+    const std::optional<Tensor>& input_grad_tensor,
+    const std::optional<Tensor>& divisor_tensor,
+    int32_t ignore_index,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_nll_loss_unreduced_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward {
 
@@ -104,28 +105,26 @@ MorehNllLossUnreducedBackwardDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.target_tensor.device());
 }
 
-std::tuple<
-    MorehNllLossUnreducedBackwardDeviceOperation::operation_attributes_t,
-    MorehNllLossUnreducedBackwardDeviceOperation::tensor_args_t>
-MorehNllLossUnreducedBackwardDeviceOperation::invoke(
-    const Tensor& target_tensor,
-    const Tensor& output_grad_tensor,
-    const std::optional<Tensor>& weight_tensor,
-    const std::optional<Tensor>& input_grad_tensor,
-    const int32_t ignore_index,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : ignore_index,
-            memory_config.value_or(target_tensor.memory_config()),
-            init_device_compute_kernel_config(
-                target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{
-            target_tensor,
-            output_grad_tensor,
-            weight_tensor,
-            input_grad_tensor}};  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreducedBackwardDeviceOperation::
+    tensor_return_value_t
+    moreh_nll_loss_unreduced_backward(
+        const Tensor& target_tensor,
+        const Tensor& output_grad_tensor,
+        const std::optional<Tensor>& weight_tensor,
+        const std::optional<Tensor>& input_grad_tensor,
+        int32_t ignore_index,
+        const std::optional<ttnn::MemoryConfig>& memory_config,
+        std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+    using OperationType =
+        ttnn::operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreducedBackwardDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        ignore_index < 0 ? std::numeric_limits<uint32_t>::max() : static_cast<uint32_t>(ignore_index),
+        memory_config.value_or(target_tensor.memory_config()),
+        init_device_compute_kernel_config(target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{target_tensor, output_grad_tensor, weight_tensor, input_grad_tensor};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
+}  // namespace ttnn::prim
 
-}  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward
+namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.hpp
@@ -66,8 +66,14 @@ struct MorehNllLossUnreducedBackwardDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
 
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+}  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward
+
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreducedBackwardDeviceOperation::
+    tensor_return_value_t
+    moreh_nll_loss_unreduced_backward(
         const Tensor& target_tensor,
         const Tensor& output_grad_tensor,
         const std::optional<Tensor>& weight_tensor,
@@ -75,12 +81,4 @@ struct MorehNllLossUnreducedBackwardDeviceOperation {
         int32_t ignore_index,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config);
-};
-
-}  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward
-
-namespace ttnn::prim {
-constexpr auto moreh_nll_loss_unreduced_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_nll_loss_unreduced_backward",
-    ttnn::operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreducedBackwardDeviceOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_norm_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -51,8 +52,8 @@ MorehNormBackwardOperation::tensor_return_value_t MorehNormBackwardOperation::cr
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<MorehNormBackwardOperation::operation_attributes_t, MorehNormBackwardOperation::tensor_args_t>
-MorehNormBackwardOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation::tensor_return_value_t moreh_norm_backward(
     const Tensor& input,
     const Tensor& output,
     const Tensor& output_grad,
@@ -62,22 +63,19 @@ MorehNormBackwardOperation::invoke(
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = get_dim(dim, input.padded_shape().rank());
+    using OperationType = ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation;
+    ttnn::SmallVector<int64_t> dims = ttnn::operations::moreh::get_dim(dim, input.padded_shape().rank());
     std::sort(dims.begin(), dims.end());
-    return {
-        operation_attributes_t{
-            p,
-            dims,
-            keepdim,
-            memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
-        },
-        tensor_args_t{
-            input,
-            output,
-            output_grad,
-            input_grad,
-        },
+    auto operation_attributes = OperationType::operation_attributes_t{
+        p,
+        dims,
+        keepdim,
+        memory_config.value_or(input.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
     };
+    auto tensor_args = OperationType::tensor_args_t{input, output, output_grad, input_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_norm_backward
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_norm_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.hpp
@@ -63,23 +63,19 @@ struct MorehNormBackwardOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        const Tensor& output,
-        const Tensor& output_grad,
-        float p,
-        const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
-        bool keepdim,
-        const std::optional<Tensor>& input_grad,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_norm_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_norm_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_norm_backward",
-    ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation>();
+ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation::tensor_return_value_t moreh_norm_backward(
+    const Tensor& input,
+    const Tensor& output,
+    const Tensor& output_grad,
+    float p,
+    const std::optional<std::variant<int64_t, ttnn::SmallVector<int64_t>>>& dim,
+    bool keepdim,
+    const std::optional<Tensor>& input_grad,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.hpp
@@ -65,25 +65,24 @@ struct MorehSgdOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& param_in,
-        const Tensor& grad,
-        const std::optional<Tensor>& momentum_buffer_in,
-        const std::optional<Tensor>& param_out,
-        const std::optional<Tensor>& momentum_buffer_out,
-        float lr,
-        float momentum,
-        float dampening,
-        float weight_decay,
-        bool nesterov,
-        bool momentum_initialized,
-        const std::optional<MemoryConfig>& param_out_memory_config,
-        const std::optional<MemoryConfig>& momentum_buffer_out_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_sgd
 
 namespace ttnn::prim {
-constexpr auto moreh_sgd =
-    ttnn::register_operation<"ttnn::prim::moreh_sgd", ttnn::operations::moreh::moreh_sgd::MorehSgdOperation>();
+ttnn::operations::moreh::moreh_sgd::MorehSgdOperation::tensor_return_value_t moreh_sgd(
+    const Tensor& param_in,
+    const Tensor& grad,
+    const std::optional<Tensor>& momentum_buffer_in,
+    const std::optional<Tensor>& param_out,
+    const std::optional<Tensor>& momentum_buffer_out,
+    float lr,
+    float momentum,
+    float dampening,
+    float weight_decay,
+    bool nesterov,
+    bool momentum_initialized,
+    const std::optional<MemoryConfig>& param_out_memory_config,
+    const std::optional<MemoryConfig>& momentum_buffer_out_memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp
@@ -88,20 +88,17 @@ struct MorehSoftmaxOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static MorehSoftmaxOpParallelizationStrategy get_parallelization_strategy(
         const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        uint32_t dim,
-        const std::optional<Tensor>& output_tensor,
-        MorehSoftmaxOp op,
-        MorehSoftmaxOpParallelizationStrategy strategy,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_softmax
 
 namespace ttnn::prim {
-constexpr auto moreh_softmax = ttnn::
-    register_operation<"ttnn::prim::moreh_softmax", ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOperation>();
+ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOperation::tensor_return_value_t moreh_softmax(
+    const Tensor& input_tensor,
+    uint32_t dim,
+    const std::optional<Tensor>& output_tensor,
+    ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOp op,
+    ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOpParallelizationStrategy strategy,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.hpp
@@ -89,22 +89,19 @@ struct MorehSoftmaxBackwardOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static MorehSoftmaxBackwardOpParallelizationStrategy get_parallelization_strategy(
         const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_tensor,
-        const Tensor& output_grad_tensor,
-        uint32_t dim,
-        const std::optional<Tensor>& input_grad_tensor,
-        MorehSoftmaxBackwardOp op,
-        MorehSoftmaxBackwardOpParallelizationStrategy strategy,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_softmax_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_softmax_backward",
-    ttnn::operations::moreh::moreh_softmax_backward::MorehSoftmaxBackwardOperation>();
+ttnn::operations::moreh::moreh_softmax_backward::MorehSoftmaxBackwardOperation::tensor_return_value_t
+moreh_softmax_backward(
+    const Tensor& output_tensor,
+    const Tensor& output_grad_tensor,
+    uint32_t dim,
+    const std::optional<Tensor>& input_grad_tensor,
+    ttnn::operations::moreh::moreh_softmax_backward::MorehSoftmaxBackwardOp op,
+    ttnn::operations::moreh::moreh_softmax_backward::MorehSoftmaxBackwardOpParallelizationStrategy strategy,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_sum_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include <cstdint>
 
@@ -122,20 +123,23 @@ MorehSumOperation::tensor_return_value_t MorehSumOperation::create_output_tensor
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-std::tuple<MorehSumOperation::operation_attributes_t, MorehSumOperation::tensor_args_t> MorehSumOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_sum::MorehSumOperation::tensor_return_value_t moreh_sum(
     const Tensor& input,
-    const int64_t dim,
-    const bool keepdim,
+    int64_t dim,
+    bool keepdim,
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        {
-            dim,
-            keepdim,
-            memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
-        },
-        {input, output}};
+    using OperationType = ttnn::operations::moreh::moreh_sum::MorehSumOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        dim,
+        keepdim,
+        memory_config.value_or(input.memory_config()),
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{input, output};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_sum
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_sum {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
@@ -71,18 +71,16 @@ struct MorehSumOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input,
-        int64_t dim,
-        bool keepdim,
-        const std::optional<Tensor>& output,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_sum
 
 namespace ttnn::prim {
-constexpr auto moreh_sum =
-    ttnn::register_operation<"ttnn::prim::moreh_sum", ttnn::operations::moreh::moreh_sum::MorehSumOperation>();
+ttnn::operations::moreh::moreh_sum::MorehSumOperation::tensor_return_value_t moreh_sum(
+    const Tensor& input,
+    int64_t dim,
+    bool keepdim,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "moreh_sum_backward_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -128,8 +129,8 @@ MorehSumBackwardOperation::tensor_return_value_t MorehSumBackwardOperation::crea
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input->device());
 }
 
-std::tuple<MorehSumBackwardOperation::operation_attributes_t, MorehSumBackwardOperation::tensor_args_t>
-MorehSumBackwardOperation::invoke(
+namespace ttnn::prim {
+ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_return_value_t moreh_sum_backward(
     const Tensor& output_grad,
     const std::optional<Tensor>& input,
     tt::stl::Span<const int64_t> dims,
@@ -137,13 +138,15 @@ MorehSumBackwardOperation::invoke(
     const std::optional<Tensor>& input_grad,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        operation_attributes_t{
-            ttnn::SmallVector<int64_t>(dims.begin(), dims.end()),
-            keepdim,
-            memory_config.value_or(output_grad.memory_config()),
-            init_device_compute_kernel_config(
-                output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)},
-        tensor_args_t{output_grad, input, input_grad}};
+    using OperationType = ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{
+        ttnn::SmallVector<int64_t>(dims.begin(), dims.end()),
+        keepdim,
+        memory_config.value_or(output_grad.memory_config()),
+        init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+    auto tensor_args = OperationType::tensor_args_t{output_grad, input, input_grad};
+    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
 }
-}  // namespace ttnn::operations::moreh::moreh_sum_backward
+}  // namespace ttnn::prim
+
+namespace ttnn::operations::moreh::moreh_sum_backward {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.hpp
@@ -56,19 +56,17 @@ struct MorehSumBackwardOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& output_grad,
-        const std::optional<Tensor>& input,
-        tt::stl::Span<const int64_t> dims,
-        bool keepdim,
-        const std::optional<Tensor>& input_grad,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
+
 }  // namespace ttnn::operations::moreh::moreh_sum_backward
 
 namespace ttnn::prim {
-constexpr auto moreh_sum_backward = ttnn::register_operation<
-    "ttnn::prim::moreh_sum_backward",
-    ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation>();
+ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_return_value_t moreh_sum_backward(
+    const Tensor& output_grad,
+    const std::optional<Tensor>& input,
+    tt::stl::Span<const int64_t> dims,
+    bool keepdim,
+    const std::optional<Tensor>& input_grad,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This PR is part of an ongoing refactoring effort to standardize how device operations are registered and dispatched within `ttnn`. The previous `ttnn::register_operation` macro and static `invoke` member functions are being replaced with explicit function declarations in the `ttnn::prim` namespace that utilize the `ttnn::device_operation::detail::launch_on_device` dispatch mechanism. This change aims to improve code clarity, consistency, and maintainability.

### What's changed
This PR refactors the following Moreh device operations:
1.  `moreh_adam`
2.  `moreh_softmax`
3.  `moreh_mean`
4.  `moreh_dot`
5.  `moreh_softmax_backward`
6.  `moreh_norm_backward`
7.  `moreh_nll_loss_unreduced_backward`
8.  `moreh_mean_backward`
9.  `moreh_matmul`
10. `moreh_nll_loss_backward`
11. `moreh_layer_norm_backward_input_grad`
12. `moreh_layer_norm_backward_gamma_beta_grad`
13. `moreh_nll_loss_step2`
14. `moreh_nll_loss_step1`
15. `moreh_clip_grad_norm_step2`
16. `moreh_clip_grad_norm_step3`
17. `moreh_clip_grad_norm_step1`
18. `moreh_getitem`
19. `moreh_sgd`
20. `moreh_sum_backward`
21. `moreh_layer_norm`
22. `moreh_group_norm`
23. `moreh_sum`
24. `moreh_dot_backward`

For each of these operations:
-   The `ttnn::register_operation` macro has been removed from the header files (`.hpp`).
-   The static `invoke` member function has been replaced with an explicit function declaration in the `ttnn::prim` namespace in the header.
-   The implementation in the `.cpp` file now uses `ttnn::device_operation::detail::launch_on_device` to dispatch the operation, passing `operation_attributes_t` and `tensor_args_t`.
-   The `device_ops_to_process.txt` tracking file has been updated to mark these operations as completed.

This change standardizes the device operation interface, making it more explicit and easier to trace the flow from the public API to the device-specific implementation.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ay/agent/device-operations-refactoring-efb6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ay/agent/device-operations-refactoring-efb6)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
<a href="https://cursor.com/background-agent?bcId=bc-c7d5a489-79fc-4bd1-ad86-ec00dff94d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7d5a489-79fc-4bd1-ad86-ec00dff94d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>