### PR TITLE
[DM] Update data movement tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -31,7 +31,6 @@ void kernel_main() {
         loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_multicast<mcast_mode>(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -31,6 +31,7 @@ void kernel_main() {
         loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_multicast<mcast_mode>(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -31,7 +31,6 @@ void kernel_main() {
         loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_multicast<mcast_mode>(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_read_2_0.cpp
@@ -22,6 +22,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
+#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -22,6 +22,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/stateful_write_2_0.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write_with_state(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_read_2_0.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
+#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_read(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 256
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -19,7 +19,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/unicast_write_2_0.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
+#pragma GCC unroll 128
         for (uint32_t i = 0; i < num_transactions; i++) {
             noc.async_write(
                 unicast_endpoint,

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -15,7 +15,7 @@ import numpy as np
 from collections import defaultdict
 
 
-from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
+from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG, clear_profiler_runtime_artifacts
 
 from tests.tt_metal.tt_metal.data_movement.python.config import DataMovementConfig
 from tests.tt_metal.tt_metal.data_movement.python.test_metadata import TestMetadataLoader
@@ -81,6 +81,9 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 def profile_dm_tests(verbose=False, gtest_filter=None):
     if verbose:
         logger.info(f"Profiling Kernels...")
+
+    clear_profiler_runtime_artifacts()
+
     cmd = f"TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT=1333 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/unit_tests_data_movement"
 
     if gtest_filter:

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -554,7 +554,7 @@ tests:
     comment: |
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 2x2 multicast grid.
-      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Important: Since the multicast is transferring a lot of data, the NoC gets congested quickly.
       Because of this, for larger number of transactions, the noc api latency is increasing.
 
   705:
@@ -562,7 +562,7 @@ tests:
     comment: |
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 5x5 multicast grid.
-      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Important: Since the multicast is transferring a lot of data, the NoC gets congested quickly.
       Because of this, for larger number of transactions, the noc api latency is increasing.
 
   706:
@@ -571,5 +571,5 @@ tests:
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a multicast grid
       covering all compute cores in the device.
-      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Important: Since the multicast is transferring a lot of data, the NoC gets congested quickly.
       Because of this, for larger number of transactions, the noc api latency is increasing.

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -520,12 +520,16 @@ tests:
     comment: |
       Measures the latency (in cycles) of NOC unicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+      Important: The increasing latency for larger transactions is due to the congestion on the NoC.
+      The transaction size has very little impact on the api latency.
 
   701:
     name: "NOC API Latency - Unicast Read"
     comment: |
       Measures the latency (in cycles) of NOC unicast read API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
+      Important: The increasing latency for larger transactions is due to the congestion on the NoC.
+      The transaction size has very little impact on the api latency.
 
   702:
     name: "NOC API Latency - Stateful Write"
@@ -533,6 +537,8 @@ tests:
       Measures the latency (in cycles) of NOC stateful write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
       The state setup is done outside the measurement window.
+      Important: The increasing latency for larger transactions is due to the congestion on the NoC.
+      The transaction size has very little impact on the api latency.
 
   703:
     name: "NOC API Latency - Stateful Read"
@@ -540,18 +546,24 @@ tests:
       Measures the latency (in cycles) of NOC stateful read API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256).
       The state setup is done outside the measurement window.
+      Important: The increasing latency for larger transactions is due to the congestion on the NoC.
+      The transaction size has very little impact on the api latency.
 
   704:
     name: "NOC API Latency - Multicast Write 2x2"
     comment: |
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 2x2 multicast grid.
+      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Because of this, for larger number of transactions, the noc api latency is increasing.
 
   705:
     name: "NOC API Latency - Multicast Write 5x5"
     comment: |
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a 5x5 multicast grid.
+      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Because of this, for larger number of transactions, the noc api latency is increasing.
 
   706:
     name: "NOC API Latency - Multicast Write All Cores"
@@ -559,3 +571,5 @@ tests:
       Measures the latency (in cycles) of NOC multicast write API calls using experimental dataflow 2.0 API.
       Tests sweep over transaction sizes (32B-4KB) and number of transactions (1-256) with a multicast grid
       covering all compute cores in the device.
+      Important: Since the multicast is transfering a lot of data, the NoC gets congested quickly.
+      Because of this, for larger number of transactions, the noc api latency is increasing.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?filterQuery=status%3ADone&pane=issue&itemId=116830943&issue=tenstorrent%7Ctt-metal%7C24075)

### Problem description
In the previous [PR](https://github.com/tenstorrent/tt-metal/pull/34523), we introduced a new set of DM tests. These tests are doing loop unrolling to provide more accurate benchmarks.
However, in WH, because of this, the generated kernel size in some cases is too large.

### What's changed

1. Removed the loop unrolling from the kernels in noc_api_latency tests. The loop unrolling could have been kept in BH, but the difference in cycles is negligible. In some cases, loop unrolling actually results in higher cycle counts. To maintain consistency, I removed it from all architectures.

2. Updated the test information to clarify the plot numbers in certain data movement scenarios.

3. This PR also addresses an issue where running the same test twice would cause the second run to use the data from the first run, rather than generating new data.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nstamatovic/update_dm_test_information)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nstamatovic/update_dm_test_information)
- [x] [(TM-DM) Data Movement Test Suite](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-data-movement-wrapper.yaml)