### PR TITLE
[skip ci] ci: allow specifying architecture for L2 tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -139,12 +139,12 @@ jobs:
           # at least one of run_wormhole or run_blackhole is true (exits with error otherwise).
           # Architecture-specific matrices (wormhole-only, blackhole-only) may be empty if that arch is not selected.
 
-          # Helper function to add an entry to a JSON array
+          # Helper function to add an entry to a JSON array (using -c for compact single-line output)
           add_entry() {
             local json="$1"
             local arch="$2"
             local label="$3"
-            echo "$json" | jq --arg arch "$arch" --arg label "$label" '. += [{"arch": $arch, "runner-label": $label}]'
+            echo "$json" | jq -c --arg arch "$arch" --arg label "$label" '. += [{"arch": $arch, "runner-label": $label}]'
           }
 
           # Matrix for tt-metal-l2-tests and didt-tests (N150, N300, P100, P150b)

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       architecture:
-        description: 'Architectures to run tests on. Valid inputs: ["blackhole", "wormhole_b0"] (both), ["blackhole"] (blackhole only), ["wormhole_b0"] (wormhole only)'
+        description: 'Architectures to test: ["blackhole"], ["wormhole_b0"], or both (default)'
         required: false
         type: string
         default: '["blackhole", "wormhole_b0"]'

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -85,9 +85,6 @@ jobs:
   generate-arch-matrix:
     runs-on: ubuntu-latest
     outputs:
-      # Boolean flags for simple checks
-      run-wormhole: ${{ steps.parse.outputs.run-wormhole }}
-      run-blackhole: ${{ steps.parse.outputs.run-blackhole }}
       # Dynamic matrices for each job type
       matrix-l2-tests: ${{ steps.parse.outputs.matrix-l2-tests }}
       matrix-cpp-tests: ${{ steps.parse.outputs.matrix-cpp-tests }}
@@ -105,84 +102,112 @@ jobs:
             arch='["blackhole", "wormhole_b0"]'
           fi
 
-          # Check for each architecture
-          run_wormhole=false
-          run_blackhole=false
-          if [[ "$arch" == *"wormhole_b0"* ]]; then
-            run_wormhole=true
-          fi
-          if [[ "$arch" == *"blackhole"* ]]; then
-            run_blackhole=true
+          # Validate JSON format
+          if ! echo "$arch" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "❌ Error: Invalid JSON format. Input must be a JSON array."
+            echo "   Received input: $arch"
+            echo "   Valid format: [\"blackhole\", \"wormhole_b0\"]"
+            exit 1
           fi
 
-          echo "run-wormhole=$run_wormhole" >> $GITHUB_OUTPUT
-          echo "run-blackhole=$run_blackhole" >> $GITHUB_OUTPUT
+          # Validate each architecture name using jq for exact matching
+          valid_archs='["blackhole", "wormhole_b0"]'
+          invalid_archs=$(echo "$arch" | jq -r --argjson valid "$valid_archs" '.[] | select(. as $a | $valid | index($a) | not)')
+          if [[ -n "$invalid_archs" ]]; then
+            echo "❌ Error: Invalid architecture(s) found:"
+            echo "$invalid_archs" | while read -r invalid; do
+              echo "   - '$invalid'"
+            done
+            echo "   Valid values are: blackhole, wormhole_b0"
+            echo "   Received input: $arch"
+            exit 1
+          fi
 
-          # Build dynamic matrices based on architecture selection
+          # Check for each architecture using jq for exact matching
+          run_wormhole=$(echo "$arch" | jq -r 'if index("wormhole_b0") then "true" else "false" end')
+          run_blackhole=$(echo "$arch" | jq -r 'if index("blackhole") then "true" else "false" end')
+
+          # Ensure at least one valid architecture was specified
+          if [[ "$run_wormhole" == "false" && "$run_blackhole" == "false" ]]; then
+            echo "❌ Error: No valid architectures found in input: $arch"
+            echo "   Valid values are: blackhole, wormhole_b0"
+            exit 1
+          fi
+
+          # Build dynamic matrices based on architecture selection using jq for proper JSON construction
+          # Note: Empty matrices are not possible for the main matrices because validation above ensures
+          # at least one of run_wormhole or run_blackhole is true (exits with error otherwise).
+          # Architecture-specific matrices (wormhole-only, blackhole-only) may be empty if that arch is not selected.
+
+          # Helper function to add an entry to a JSON array
+          add_entry() {
+            local json="$1"
+            local arch="$2"
+            local label="$3"
+            echo "$json" | jq --arg arch "$arch" --arg label "$label" '. += [{"arch": $arch, "runner-label": $label}]'
+          }
+
           # Matrix for tt-metal-l2-tests and didt-tests (N150, N300, P100, P150b)
-          matrix_l2=()
+          matrix_l2='[]'
           if [[ "$run_wormhole" == "true" ]]; then
-            matrix_l2+=('{"arch":"wormhole_b0","runner-label":"N150"}')
-            matrix_l2+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+            matrix_l2=$(add_entry "$matrix_l2" "wormhole_b0" "N150")
+            matrix_l2=$(add_entry "$matrix_l2" "wormhole_b0" "N300")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            matrix_l2+=('{"arch":"blackhole","runner-label":"P100"}')
-            matrix_l2+=('{"arch":"blackhole","runner-label":"P150b"}')
+            matrix_l2=$(add_entry "$matrix_l2" "blackhole" "P100")
+            matrix_l2=$(add_entry "$matrix_l2" "blackhole" "P150b")
           fi
-          echo "matrix-l2-tests=[$(IFS=,; echo "${matrix_l2[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-l2-tests=$matrix_l2" >> $GITHUB_OUTPUT
 
           # Matrix for cpp-unit-tests (N150, N300, P150b, P100a)
-          matrix_cpp=()
+          matrix_cpp='[]'
           if [[ "$run_wormhole" == "true" ]]; then
-            matrix_cpp+=('{"arch":"wormhole_b0","runner-label":"N150"}')
-            matrix_cpp+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+            matrix_cpp=$(add_entry "$matrix_cpp" "wormhole_b0" "N150")
+            matrix_cpp=$(add_entry "$matrix_cpp" "wormhole_b0" "N300")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            matrix_cpp+=('{"arch":"blackhole","runner-label":"P150b"}')
-            matrix_cpp+=('{"arch":"blackhole","runner-label":"P100a"}')
+            matrix_cpp=$(add_entry "$matrix_cpp" "blackhole" "P150b")
+            matrix_cpp=$(add_entry "$matrix_cpp" "blackhole" "P100a")
           fi
-          echo "matrix-cpp-tests=[$(IFS=,; echo "${matrix_cpp[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-cpp-tests=$matrix_cpp" >> $GITHUB_OUTPUT
 
           # Matrix for sd-unit-tests and fast-dispatch-unit-tests (N150, N300, P150, P100)
-          matrix_sd_fd=()
+          matrix_sd_fd='[]'
           if [[ "$run_wormhole" == "true" ]]; then
-            matrix_sd_fd+=('{"arch":"wormhole_b0","runner-label":"N150"}')
-            matrix_sd_fd+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+            matrix_sd_fd=$(add_entry "$matrix_sd_fd" "wormhole_b0" "N150")
+            matrix_sd_fd=$(add_entry "$matrix_sd_fd" "wormhole_b0" "N300")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            matrix_sd_fd+=('{"arch":"blackhole","runner-label":"P150"}')
-            matrix_sd_fd+=('{"arch":"blackhole","runner-label":"P100"}')
+            matrix_sd_fd=$(add_entry "$matrix_sd_fd" "blackhole" "P150")
+            matrix_sd_fd=$(add_entry "$matrix_sd_fd" "blackhole" "P100")
           fi
-          echo "matrix-sd-fd-tests=[$(IFS=,; echo "${matrix_sd_fd[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-sd-fd-tests=$matrix_sd_fd" >> $GITHUB_OUTPUT
 
           # Matrix for test-ttnn-tutorials (N150, P150b, P100)
-          matrix_tutorials=()
+          matrix_tutorials='[]'
           if [[ "$run_wormhole" == "true" ]]; then
-            matrix_tutorials+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+            matrix_tutorials=$(add_entry "$matrix_tutorials" "wormhole_b0" "N150")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            matrix_tutorials+=('{"arch":"blackhole","runner-label":"P150b"}')
-            matrix_tutorials+=('{"arch":"blackhole","runner-label":"P100"}')
+            matrix_tutorials=$(add_entry "$matrix_tutorials" "blackhole" "P150b")
+            matrix_tutorials=$(add_entry "$matrix_tutorials" "blackhole" "P100")
           fi
-          echo "matrix-tutorials=[$(IFS=,; echo "${matrix_tutorials[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-tutorials=$matrix_tutorials" >> $GITHUB_OUTPUT
 
           # Matrix for wormhole-only jobs (N150)
-          matrix_wh=()
+          matrix_wh='[]'
           if [[ "$run_wormhole" == "true" ]]; then
-            matrix_wh+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+            matrix_wh=$(add_entry "$matrix_wh" "wormhole_b0" "N150")
           fi
-          echo "matrix-wormhole-only=[$(IFS=,; echo "${matrix_wh[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-wormhole-only=$matrix_wh" >> $GITHUB_OUTPUT
 
           # Matrix for blackhole-only jobs (P150b)
-          matrix_bh=()
+          matrix_bh='[]'
           if [[ "$run_blackhole" == "true" ]]; then
-            matrix_bh+=('{"arch":"blackhole","runner-label":"P150b"}')
+            matrix_bh=$(add_entry "$matrix_bh" "blackhole" "P150b")
           fi
-          echo "matrix-blackhole-only=[$(IFS=,; echo "${matrix_bh[*]}")]" >> $GITHUB_OUTPUT
+          echo "matrix-blackhole-only=$matrix_bh" >> $GITHUB_OUTPUT
 
-          echo "Architecture input: $arch"
-          echo "Run wormhole: $run_wormhole"
-          echo "Run blackhole: $run_blackhole"
   tt-metal-l2-tests:
     needs: [build-artifact, generate-arch-matrix]
     if: ${{ needs.generate-arch-matrix.outputs.matrix-l2-tests != '[]' }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -5,6 +5,11 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
+      architecture:
+        description: 'Architectures to run tests on. Valid inputs: ["blackhole", "wormhole_b0"] (both), ["blackhole"] (blackhole only), ["wormhole_b0"] (wormhole only)'
+        required: false
+        type: string
+        default: '["blackhole", "wormhole_b0"]'
       run_didt_tests:
         description: 'Run DIDT tests'
         required: false
@@ -77,19 +82,116 @@ jobs:
       tracy: true
       skip-tt-train: false
       version: 22.04
+  generate-arch-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      # Boolean flags for simple checks
+      run-wormhole: ${{ steps.parse.outputs.run-wormhole }}
+      run-blackhole: ${{ steps.parse.outputs.run-blackhole }}
+      # Dynamic matrices for each job type
+      matrix-l2-tests: ${{ steps.parse.outputs.matrix-l2-tests }}
+      matrix-cpp-tests: ${{ steps.parse.outputs.matrix-cpp-tests }}
+      matrix-sd-fd-tests: ${{ steps.parse.outputs.matrix-sd-fd-tests }}
+      matrix-tutorials: ${{ steps.parse.outputs.matrix-tutorials }}
+      matrix-wormhole-only: ${{ steps.parse.outputs.matrix-wormhole-only }}
+      matrix-blackhole-only: ${{ steps.parse.outputs.matrix-blackhole-only }}
+    steps:
+      - id: parse
+        run: |
+          arch='${{ inputs.architecture }}'
+
+          # Default to running all if empty or not provided (scheduled runs)
+          if [[ -z "$arch" || "$arch" == "" ]]; then
+            arch='["blackhole", "wormhole_b0"]'
+          fi
+
+          # Check for each architecture
+          run_wormhole=false
+          run_blackhole=false
+          if [[ "$arch" == *"wormhole_b0"* ]]; then
+            run_wormhole=true
+          fi
+          if [[ "$arch" == *"blackhole"* ]]; then
+            run_blackhole=true
+          fi
+
+          echo "run-wormhole=$run_wormhole" >> $GITHUB_OUTPUT
+          echo "run-blackhole=$run_blackhole" >> $GITHUB_OUTPUT
+
+          # Build dynamic matrices based on architecture selection
+          # Matrix for tt-metal-l2-tests and didt-tests (N150, N300, P100, P150b)
+          matrix_l2=()
+          if [[ "$run_wormhole" == "true" ]]; then
+            matrix_l2+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+            matrix_l2+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+          fi
+          if [[ "$run_blackhole" == "true" ]]; then
+            matrix_l2+=('{"arch":"blackhole","runner-label":"P100"}')
+            matrix_l2+=('{"arch":"blackhole","runner-label":"P150b"}')
+          fi
+          echo "matrix-l2-tests=[$(IFS=,; echo "${matrix_l2[*]}")]" >> $GITHUB_OUTPUT
+
+          # Matrix for cpp-unit-tests (N150, N300, P150b, P100a)
+          matrix_cpp=()
+          if [[ "$run_wormhole" == "true" ]]; then
+            matrix_cpp+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+            matrix_cpp+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+          fi
+          if [[ "$run_blackhole" == "true" ]]; then
+            matrix_cpp+=('{"arch":"blackhole","runner-label":"P150b"}')
+            matrix_cpp+=('{"arch":"blackhole","runner-label":"P100a"}')
+          fi
+          echo "matrix-cpp-tests=[$(IFS=,; echo "${matrix_cpp[*]}")]" >> $GITHUB_OUTPUT
+
+          # Matrix for sd-unit-tests and fast-dispatch-unit-tests (N150, N300, P150, P100)
+          matrix_sd_fd=()
+          if [[ "$run_wormhole" == "true" ]]; then
+            matrix_sd_fd+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+            matrix_sd_fd+=('{"arch":"wormhole_b0","runner-label":"N300"}')
+          fi
+          if [[ "$run_blackhole" == "true" ]]; then
+            matrix_sd_fd+=('{"arch":"blackhole","runner-label":"P150"}')
+            matrix_sd_fd+=('{"arch":"blackhole","runner-label":"P100"}')
+          fi
+          echo "matrix-sd-fd-tests=[$(IFS=,; echo "${matrix_sd_fd[*]}")]" >> $GITHUB_OUTPUT
+
+          # Matrix for test-ttnn-tutorials (N150, P150b, P100)
+          matrix_tutorials=()
+          if [[ "$run_wormhole" == "true" ]]; then
+            matrix_tutorials+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+          fi
+          if [[ "$run_blackhole" == "true" ]]; then
+            matrix_tutorials+=('{"arch":"blackhole","runner-label":"P150b"}')
+            matrix_tutorials+=('{"arch":"blackhole","runner-label":"P100"}')
+          fi
+          echo "matrix-tutorials=[$(IFS=,; echo "${matrix_tutorials[*]}")]" >> $GITHUB_OUTPUT
+
+          # Matrix for wormhole-only jobs (N150)
+          matrix_wh=()
+          if [[ "$run_wormhole" == "true" ]]; then
+            matrix_wh+=('{"arch":"wormhole_b0","runner-label":"N150"}')
+          fi
+          echo "matrix-wormhole-only=[$(IFS=,; echo "${matrix_wh[*]}")]" >> $GITHUB_OUTPUT
+
+          # Matrix for blackhole-only jobs (P150b)
+          matrix_bh=()
+          if [[ "$run_blackhole" == "true" ]]; then
+            matrix_bh+=('{"arch":"blackhole","runner-label":"P150b"}')
+          fi
+          echo "matrix-blackhole-only=[$(IFS=,; echo "${matrix_bh[*]}")]" >> $GITHUB_OUTPUT
+
+          echo "Architecture input: $arch"
+          echo "Run wormhole: $run_wormhole"
+          echo "Run blackhole: $run_blackhole"
   tt-metal-l2-tests:
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: ${{ needs.generate-arch-matrix.outputs.matrix-l2-tests != '[]' }}
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P100 },
-          { arch: blackhole, runner-label: P150b },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-l2-tests) }}
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
@@ -114,16 +216,16 @@ jobs:
       run_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',fused,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
   ttnn-ops-docs-check:
-    if: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',ops_docs_check,') }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',ops_docs_check,')) &&
+      needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]'
     secrets: inherit
     uses: ./.github/workflows/ttnn-ops-docs-check.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 }
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
@@ -132,19 +234,16 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   didt-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_didt_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_didt_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-l2-tests != '[]'
     secrets: inherit
     uses: ./.github/workflows/didt-tests.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P100 },
-          { arch: blackhole, runner-label: P150b },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-l2-tests) }}
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
@@ -154,18 +253,15 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
   cpp-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_cpp_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_cpp_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-cpp-tests != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P150b },
-          { arch: blackhole, runner-label: P100a },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-cpp-tests) }}
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -176,15 +272,15 @@ jobs:
       nightly-run: true
   # Metal IOMMU Unit Tests
   metal-iommu-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_metal_iommu_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_metal_iommu_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-blackhole-only != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: blackhole, runner-label: P150b },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-blackhole-only) }}
     uses: ./.github/workflows/metal-iommu-unit-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -194,18 +290,15 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Slow Dispatch Unit Tests
   sd-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_sd_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_sd_unit_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-sd-fd-tests != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P150 },  # Use P150 instead of P150b to stay on CIv1 for capacity reasons
-          { arch: blackhole, runner-label: P100 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-sd-fd-tests) }}
     uses: ./.github/workflows/build-and-unit-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -215,18 +308,15 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Fast Dispatch Unit Tests
   fast-dispatch-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_fd_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_fd_unit_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-sd-fd-tests != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: wormhole_b0, runner-label: N300 },
-          { arch: blackhole, runner-label: P150 },  # Use P150 instead of P150b to stay on CIv1 for capacity reasons
-          { arch: blackhole, runner-label: P100 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-sd-fd-tests) }}
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -235,18 +325,16 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN Tutorials
   test-ttnn-tutorials:
-    if: ${{ github.event_name == 'schedule' || inputs.run_tutorials_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_tutorials_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-tutorials != '[]'
     secrets: inherit
     uses: ./.github/workflows/ttnn-tutorials-post-commit.yaml
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-          { arch: blackhole, runner-label: P150b },
-          { arch: blackhole, runner-label: P100 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-tutorials) }}
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
@@ -254,15 +342,15 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   run-profiler-regression:
-    if: ${{ github.event_name == 'schedule' || inputs.run_profiler_regression }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_profiler_regression) &&
+      needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     uses: ./.github/workflows/run-profiler-regression.yaml
     with:
       arch: ${{ matrix.test-group.arch}}
@@ -271,15 +359,15 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   tt-train-cpp-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_tt_train_cpp_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_tt_train_cpp_unit_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     uses: ./.github/workflows/tt-train-post-commit.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -289,15 +377,15 @@ jobs:
       gtest_filter: "*"
   # FD Model Tests
   models-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_models_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_models_unit_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     uses: ./.github/workflows/models-post-commit.yaml
     with:
       arch: ${{ matrix.test-group.arch }}
@@ -306,15 +394,15 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TT-CNN Unit tests
   tt-cnn-unit-tests:
-    if: ${{ github.event_name == 'schedule' || inputs.run_tt_cnn_unit_tests }}
-    needs: build-artifact
+    needs: [build-artifact, generate-arch-matrix]
+    if: |
+      (github.event_name == 'schedule' || inputs.run_tt_cnn_unit_tests) &&
+      needs.generate-arch-matrix.outputs.matrix-wormhole-only != '[]'
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N150 },
-        ]
+        test-group: ${{ fromJson(needs.generate-arch-matrix.outputs.matrix-wormhole-only) }}
     uses: ./.github/workflows/tt-cnn-post-commit.yaml
     with:
       arch: ${{ matrix.test-group.arch }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31902

### Problem description
When running the L2 nightly workflow manually to validate changes, all tests run on both Wormhole and Blackhole architectures regardless of which architecture was actually modified. This leads to:
- Wasted CI resources: Running Blackhole tests when only Wormhole code was changed (and vice versa)
- Longer validation cycles: Waiting for irrelevant tests to complete before getting feedback
- Unnecessary runner usage: Occupying runners for tests that won't provide value for the specific change being validated

### What's changed

Added an `architecture` input parameter to the L2 nightly workflow that allows filtering which architecture(s) to run tests on.

**New Input Parameter:**
```yaml
architecture:
  description: 'Architectures to test: ["blackhole"], ["wormhole_b0"], or both (default)'
  type: string
  default: '["blackhole", "wormhole_b0"]'
```
**Implementation Details:**
- Added a `generate-arch-matrix` job that parses the JSON array input and outputs boolean flags (`run-wormhole`, `run-blackhole`)
- Updated all 12 architecture-dependent jobs to filter based on these flags
- Jobs that don't match the selected architecture are skipped (instant completion, no runner usage)

**Behavior:**

| Input | Wormhole Tests | Blackhole Tests |
|-------|----------------|-----------------|
| `["blackhole", "wormhole_b0"]` (default) | ✅ Run | ✅ Run |
| `["blackhole"]` | ⏭️ Skip | ✅ Run |
| `["wormhole_b0"]` | ✅ Run | ⏭️ Skip |
| Empty (scheduled runs) | ✅ Run | ✅ Run |

**Backwards Compatibility:**

- Scheduled nightly runs are unaffected (all architectures run by default)
- Manual runs without specifying architecture behave the same as before (all architectures run)
- The input format follows the JSON array pattern used in other workflows (e.g., `blackhole-post-commit.yaml`)


### Examples of run:
- Running only sd-unit-tests on both architectures: https://github.com/tenstorrent/tt-metal/actions/runs/20487479324/job/58872758006
- Running only fd-unit-tests on wormhole_b0: https://github.com/tenstorrent/tt-metal/actions/runs/20487639711
- Running only cpp-unit-tests on blackhole: https://github.com/tenstorrent/tt-metal/actions/runs/20487646585


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=filip/split-l2-runs-per-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:filip/split-l2-runs-per-arch)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/split-l2-runs-per-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/split-l2-runs-per-arch)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/split-l2-runs-per-arch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/split-l2-runs-per-arch)
- [ ] New/Existing tests provide coverage for changes