### PR TITLE
[CONV] Fix null check and memory validation in ConvTranspose2d DRAM path 

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -550,7 +550,7 @@ Result conv_transpose2d_DRAM(
     ttnn::operations::op_slicing::run_sliced_op(
         input_tensor_on_device, dram_output_tensor, &slice_attr, dram_slice_config_);
 
-    if (conv_config.deallocate_activation) {
+    if (conv_config.deallocate_activation && !input_tensor_on_device.memory_config().is_dram()) {
         input_tensor_on_device.deallocate(true);
     }
     const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -240,7 +240,7 @@ ttnn::Tensor prepare_conv_transpose2d_weights(
             tt::tt_metal::TensorSpec(
                 ttnn::Shape({in_channels, out_channels / groups, kernel_size[0], kernel_size[1]}),
                 tt::tt_metal::TensorLayout(
-                    conv_config.weights_dtype.value(),
+                    weight_dtype,
                     tt::tt_metal::PageConfig(Layout::ROW_MAJOR),
                     MemoryConfig{
                         TensorMemoryLayout::INTERLEAVED,
@@ -253,7 +253,7 @@ ttnn::Tensor prepare_conv_transpose2d_weights(
                 tt::tt_metal::TensorSpec(
                     ttnn::Shape({1, 1, 1, out_channels}),
                     tt::tt_metal::TensorLayout(
-                        conv_config.weights_dtype.value(),
+                        weight_dtype,
                         tt::tt_metal::PageConfig(Layout::ROW_MAJOR),
                         MemoryConfig{
                             TensorMemoryLayout::INTERLEAVED,


### PR DESCRIPTION
Fix two bugs in the ConvTranspose2d DRAM sliced codepath:

1. Missing null check for weights_dtype in prepare_conv_transpose2d_weights.cpp
   - conv_config.weights_dtype.value() was called without checking if the optional had a value, causing "bad optional access" runtime error
   - Fixed by using weight_dtype which is safely computed with fallback: conv_config.weights_dtype.value_or(weight_tensor.dtype())

2. Missing memory layout validation before deallocation in conv_transpose2d.cpp
   - Added check to only deallocate non-DRAM (L1) tensors, matching the pattern used in conv_transpose2d_L1: !input_tensor.memory_config().is_dram()

Added regression tests to cover both fixes.

### Ticket
[Issue 35028](https://github.com/tenstorrent/tt-metal/issues/35028)

### Checklist
  - [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20494452043)
  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20494453618)
  - [ ] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20494454840)
  - [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20494454840)
  - [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/20494458046)
  - [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20488391520)