### PR TITLE
[skip ci] ci: parametrize device perf tests with architecture parameter

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -361,21 +361,20 @@ jobs:
           TRIGGER_TIME=$(date +%s)
           echo "Trigger timestamp: $TRIGGER_TIME"
 
+          # Build architecture parameter based on which architectures have changes
+          if [ "${{ needs.update-submodule.outputs.should-run-wormhole }}" = "true" ] && [ "${{ needs.update-submodule.outputs.should-run-blackhole }}" = "true" ]; then
+            ARCH_PARAM='["wormhole_b0", "blackhole"]'
+          elif [ "${{ needs.update-submodule.outputs.should-run-wormhole }}" = "true" ]; then
+            ARCH_PARAM='["wormhole_b0"]'
+          else
+            ARCH_PARAM='["blackhole"]'
+          fi
+
           # Trigger workflow with appropriate inputs
           echo "Triggering $WORKFLOW..."
-          # Special handling for tt-metal-l2-nightly.yaml to pass C++ and unit test configuration flags
           if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
-            # Build architecture parameter based on which architectures have changes
-            if [ "${{ needs.update-submodule.outputs.should-run-wormhole }}" = "true" ] && [ "${{ needs.update-submodule.outputs.should-run-blackhole }}" = "true" ]; then
-              arch_param='["wormhole_b0", "blackhole"]'
-            elif [ "${{ needs.update-submodule.outputs.should-run-wormhole }}" = "true" ]; then
-              arch_param='["wormhole_b0"]'
-            else
-              arch_param='["blackhole"]'
-            fi
-
             gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" \
-            -f architecture="$arch_param" \
+            -f architecture="$ARCH_PARAM" \
             -f run_cpp_tests=true \
             -f run_metal_iommu_tests=true \
             -f run_sd_unit_tests=true \
@@ -384,6 +383,9 @@ jobs:
             -f run_tt_train_cpp_unit_tests=true \
             -f run_models_unit_tests=true \
             -f run_tt_cnn_unit_tests=true
+          elif [ "$WORKFLOW" = "perf-device-models.yaml" ]; then
+            gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}" \
+            -f architecture="$ARCH_PARAM"
           else
             gh workflow run "$WORKFLOW" --ref "${{ env.BRANCH_NAME }}" --repo "${{ github.repository }}"
           fi

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -155,7 +155,7 @@ jobs:
             )
           ]')
 
-          echo "[info] Matrix after model filtering:"
+          echo "[info] Filtered matrix:"
           echo "$filtered_matrix" | jq .
 
           # Filter matrix based on selected architectures

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -107,7 +107,7 @@ jobs:
 
           # Parse and validate architecture input
           arch='${{ inputs.architecture }}'
-          if [[ -z "$arch" || "$arch" == "" ]]; then
+          if [[ -z "$arch" ]]; then
             arch='["blackhole", "wormhole_b0"]'
           fi
           echo "[info] Architecture input: $arch"

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: "in-service"
+      architecture:
+        description: 'Architectures to test: ["blackhole"], ["wormhole_b0"], or both (default)'
+        required: false
+        type: string
+        default: '["blackhole", "wormhole_b0"]'
       requested-models:
         default: "all"
         type: string
@@ -100,6 +105,33 @@ jobs:
           models_json='${{ needs.define-models.outputs.models-to-run }}'
           echo "[info] Models to run: $models_json"
 
+          # Parse and validate architecture input
+          arch='${{ inputs.architecture }}'
+          if [[ -z "$arch" || "$arch" == "" ]]; then
+            arch='["blackhole", "wormhole_b0"]'
+          fi
+          echo "[info] Architecture input: $arch"
+
+          # Validate JSON format
+          if ! echo "$arch" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "❌ Error: Invalid JSON format for 'architecture' input. Expected a JSON array."
+            echo "   Received input: $arch"
+            echo "   Valid format: [\"blackhole\", \"wormhole_b0\"]"
+            exit 1
+          fi
+
+          # Validate each architecture name using jq for exact matching
+          valid_archs='["blackhole", "wormhole_b0"]'
+          invalid_archs=$(echo "$arch" | jq -r --argjson valid "$valid_archs" '.[] | select(. as $a | $valid | index($a) | not)')
+          if [[ -n "$invalid_archs" ]]; then
+            echo "❌ Error: Invalid architecture(s) found:"
+            echo "$invalid_archs" | while read -r invalid; do
+              echo "   - '$invalid'"
+            done
+            echo "   Valid values are: blackhole, wormhole_b0"
+            exit 1
+          fi
+
           # Define which models belong to each matrix group
           group_models='{
             "N300 WH B0 not yet ported": ["non-civ2"],
@@ -123,12 +155,20 @@ jobs:
             )
           ]')
 
-          echo "[info] Filtered matrix:"
+          echo "[info] Matrix after model filtering:"
+          echo "$filtered_matrix" | jq .
+
+          # Filter matrix based on selected architectures
+          filtered_matrix=$(echo "$filtered_matrix" | jq -c --argjson archs "$arch" '[
+            .[] | select(.arch as $a | $archs | index($a))
+          ]')
+
+          echo "[info] Matrix after architecture filtering:"
           echo "$filtered_matrix" | jq .
 
           # Check if matrix is empty
           matrix_length=$(echo "$filtered_matrix" | jq 'length')
-          echo "[info] Matrix length: $matrix_length"
+          echo "[info] Final matrix length: $matrix_length"
 
           if [ "$matrix_length" -eq 0 ]; then
             echo "[warning] No matrix entries selected - using empty matrix"

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -168,7 +168,7 @@ jobs:
 
           # Check if matrix is empty
           matrix_length=$(echo "$filtered_matrix" | jq 'length')
-          echo "[info] Final matrix length: $matrix_length"
+          echo "[info] Matrix length: $matrix_length"
 
           if [ "$matrix_length" -eq 0 ]; then
             echo "[warning] No matrix entries selected - using empty matrix"

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -3,6 +3,11 @@ name: "(Single-card) Device perf regressions"
 on:
   workflow_dispatch:
     inputs:
+      architecture:
+        description: 'Architectures to test: ["blackhole"], ["wormhole_b0"], or both (default)'
+        required: false
+        type: string
+        default: '["blackhole", "wormhole_b0"]'
       requested-models:
         description: "List of requested models as JSON array, for example: [\"resnet50\", \"vit\"]. Default is 'all'"
         default: "all"
@@ -30,4 +35,5 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      architecture: ${{ inputs.architecture || '["blackhole", "wormhole_b0"]' }}
       requested-models: ${{ inputs.requested-models || 'all' }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -188,24 +188,23 @@ jobs:
 
           declare -A run_ids
 
+          # Build architecture parameter based on which post-commit tests are enabled
+          if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
+            ARCH_PARAM='["wormhole_b0", "blackhole"]'
+          elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
+            ARCH_PARAM='["wormhole_b0"]'
+          else
+            ARCH_PARAM='["blackhole"]'
+          fi
+
           # Function to trigger workflow and get run ID and URL
           trigger_and_get_id() {
             local workflow_file="$1"
             local display_name="$2"
 
-            # Special handling for tt-metal-l2-nightly.yaml to pass C++ and other test configuration flags
             if [ "$workflow_file" = "tt-metal-l2-nightly.yaml" ]; then
-              # Build architecture parameter based on which post-commit tests are enabled
-              if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
-                arch_param='["wormhole_b0", "blackhole"]'
-              elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
-                arch_param='["wormhole_b0"]'
-              else
-                arch_param='["blackhole"]'
-              fi
-
               gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
-              -f architecture="$arch_param" \
+              -f architecture="$ARCH_PARAM" \
               -f run_cpp_tests=true \
               -f run_metal_iommu_tests=true \
               -f run_sd_unit_tests=true \
@@ -214,6 +213,9 @@ jobs:
               -f run_tt_train_cpp_unit_tests=true \
               -f run_models_unit_tests=true \
               -f run_tt_cnn_unit_tests=true
+            elif [ "$workflow_file" = "perf-device-models.yaml" ]; then
+              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
+              -f architecture="$ARCH_PARAM"
             else
               gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
             fi


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/31902

### Problem description
When validating LLK changes, the `perf-device-models.yaml` workflow always runs device performance tests on **all architectures** (Wormhole and Blackhole), regardless of which architecture was actually affected by the changes.

This leads to:
- **Wasted CI resources**: Running Blackhole tests when only Wormhole code changed (and vice versa)
- **Longer feedback cycles**: Developers wait for irrelevant tests to complete
- **Unnecessary machine usage**: Occupying hardware that could be used for other jobs


### What's changed
### 1. Architecture Filtering for Device Performance Tests

Added an `architecture` input to `perf-device-models.yaml` that accepts a JSON array of architectures to test:
- `["blackhole"]` - Run only Blackhole tests
- `["wormhole_b0"]` - Run only Wormhole tests  
- `["blackhole", "wormhole_b0"]` - Run both (default, preserves existing behavior)

The `perf-device-models-impl.yaml` workflow now:
- Validates the architecture input (JSON format, valid architecture names)
- Filters the test matrix to only include selected architectures
- Applies architecture filtering **after** the existing model filtering

### 2. Architecture-Aware Workflow Triggering

Updated `test-llk-metal-integration.yaml` and `llk-auto-uplift-trigger.yaml` to pass the architecture parameter when triggering `perf-device-models.yaml`:

- **Wormhole changes** (`run_all_post_commit` / `should-run-wormhole`) → `["wormhole_b0"]`
- **Blackhole changes** (`run_blackhole_post_commit` / `should-run-blackhole`) → `["blackhole"]`
- **Both** → `["wormhole_b0", "blackhole"]`

The architecture parameter is computed once and reused for both `tt-metal-l2-nightly.yaml` and `perf-device-models.yaml` triggers.

### Files Modified

| File | Changes |
|------|---------|
| `perf-device-models.yaml` | Added `architecture` input, pass to impl |
| `perf-device-models-impl.yaml` | Added `architecture` input, validation, and matrix filtering |
| `test-llk-metal-integration.yaml` | Compute `ARCH_PARAM` once, pass to `perf-device-models.yaml` |
| `llk-auto-uplift-trigger.yaml` | Compute `ARCH_PARAM` once, pass to `perf-device-models.yaml` |

### Backward Compatibility

- Default behavior unchanged: scheduled runs and manual triggers without parameters run all architectures
- Existing callers continue to work without modification

### Examples of perf regression runs:
- WH only: https://github.com/tenstorrent/tt-metal/actions/runs/20488433811
- BH only: https://github.com/tenstorrent/tt-metal/actions/runs/20488579297
- both architectures: https://github.com/tenstorrent/tt-metal/actions/runs/20488678458