### PR TITLE
SDXL CI fix: perf

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -133,7 +133,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'",
-            13_506_772,
+            13_112_562,
             "sdxl_clip_encoder_1",
             "sdxl_clip_encoder_1",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -103,7 +103,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_refiner_unet",
-            602_265_531 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            610_108_504 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_refiner_unet",
             "sdxl_refiner_unet",
             1,
@@ -113,7 +113,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
-            680_239_540,
+            691_874_774,
             "sdxl_vae",
             "sdxl_vae_decode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -123,7 +123,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'",
-            343_068_075,
+            348_815_743,
             "sdxl_vae",
             "sdxl_vae_encode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -133,7 +133,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'",
-            13_265_699,
+            13_506_772,
             "sdxl_clip_encoder_1",
             "sdxl_clip_encoder_1",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -143,7 +143,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
-            62_900_000,
+            63_696_601,
             "sdxl_clip_encoder_2",
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
### Problem description
#34862 improved silu accuracy, but lowered SDXL perf on refiner and VAE.

### What's changed
As the change brings accuracy improvement and perf impact is insignificant we're lowering perf targets.

### Checklist

- [x] [(Single-card) Device perf regressions](http://github.com/tenstorrent/tt-metal/actions/runs/20489481144)