### PR TITLE
Fix GPT-OSS tests

### DIFF
--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
             { "name": "Galaxy Whisper demo tests", "arch": "wormhole_b0", "model": "whisper", "timeout": 30, "owner_id": "U08HL8X1ECD" },
             { "name": "Galaxy Stable Diffusion 3.5 Large demo tests", "arch": "wormhole_b0", "model": "sd35", "timeout": 30, "owner_id": "U03FJB5TM5Y" },
             { "name": "Galaxy Flux.1-dev demo tests", "arch": "wormhole_b0", "model": "flux1", "timeout": 30, "owner_id": "U08TED0JM9D" },
-            { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 30, "owner_id": "U08TJ70UFRT" },
+            { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 20, "owner_id": "U08TJ70UFRT" },
             { "name": "Galaxy Motif-Image-6B-Preview demo tests", "arch": "wormhole_b0", "model": "motif", "timeout": 20, "owner_id": "U08TED0JM9D" },
             { "name": "Galaxy Wan2.2 demo tests", "arch": "wormhole_b0", "model": "wan22", "timeout": 25, "owner_id": "U03FJB5TM5Y" },
             { "name": "Galaxy Mochi demo tests", "arch": "wormhole_b0", "model": "mochi", "timeout": 30, "owner_id": "U09ELB03XRU" },

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -146,12 +146,12 @@ jobs:
 
           # Test GPT-OSS 20B model
           HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ \
-            pytest models/demos/gpt_oss/demo/text_demo.py \
+            pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8"\
             --timeout 1000
 
           # Test GPT-OSS 120B model
           HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ \
-            pytest models/demos/gpt_oss/demo/text_demo.py \
+            pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8"\
             --timeout 1000
       - name: Run Llama3 demo tests (direct pytest)
         if: ${{ matrix.test-group.model == 'llama3' }}

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -229,10 +229,10 @@ jobs:
           pip install -r models/demos/gpt_oss/requirements.txt
 
           HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-20b/ \
-            pytest -n auto models/demos/gpt_oss/tests/unit --timeout 900
+            pytest -n auto models/demos/gpt_oss/tests/unit -k "4x8" --timeout 900
 
           HF_MODEL=/mnt/MLPerf/tt_dnn-models/openai/gpt-oss-120b/ \
-            pytest -n auto models/demos/gpt_oss/tests/unit --timeout 900
+            pytest -n auto models/demos/gpt_oss/tests/unit -k "4x8" --timeout 900
 
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -104,7 +104,7 @@ jobs:
             { "name": "Galaxy Multi-Process tests", "arch": "wormhole_b0", "model": "multiprocess", "timeout": 5, "owner_id": "U03NG0A5ND7" },
             # { "name": "Galaxy Llama3-70b unit tests", "arch": "wormhole_b0", "model": "llama3-70b", "timeout": 30, "owner_id": "U053W15B6JF", "mlperf": true },
             # { "name": "Galaxy DRAM Prefetcher unit tests", "arch": "wormhole_b0", "model": "prefetcher", "timeout": 25, "owner_id": "U044T8U8DEF" },
-            # { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 25, "owner_id": "U08TJ70UFRT", "mlperf": true },
+            { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 25, "owner_id": "U08TJ70UFRT", "mlperf": true },
             { "name": "Galaxy distributed ops tests", "arch": "wormhole_b0", "model": "distributed-ops", "timeout": 10, "owner_id": "U044T8U8DEF" }
           ]')
 

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -104,7 +104,7 @@ jobs:
             { "name": "Galaxy Multi-Process tests", "arch": "wormhole_b0", "model": "multiprocess", "timeout": 5, "owner_id": "U03NG0A5ND7" },
             # { "name": "Galaxy Llama3-70b unit tests", "arch": "wormhole_b0", "model": "llama3-70b", "timeout": 30, "owner_id": "U053W15B6JF", "mlperf": true },
             # { "name": "Galaxy DRAM Prefetcher unit tests", "arch": "wormhole_b0", "model": "prefetcher", "timeout": 25, "owner_id": "U044T8U8DEF" },
-            { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 25, "owner_id": "U08TJ70UFRT", "mlperf": true },
+            { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 10, "owner_id": "U08TJ70UFRT", "mlperf": true },
             { "name": "Galaxy distributed ops tests", "arch": "wormhole_b0", "model": "distributed-ops", "timeout": 10, "owner_id": "U044T8U8DEF" }
           ]')
 

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -201,7 +201,7 @@ jobs:
               "model": "gpt-oss",
               "arch": "wormhole_b0",
               "cmd": "run_t3000_gpt_oss_tests",
-              "timeout": 30,
+              "timeout": 20,
               "owner_id": "U08TJ70UFRT" # Harry Andrews
             }
           ]')
@@ -240,7 +240,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':rw' || ':rw' }}
+        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -195,6 +195,14 @@ jobs:
               "cmd": "run_t3000_mochi_tests",
               "timeout": 60,
               "owner_id": "U09ELB03XRU" # Stephen Osborne
+            },
+            {
+              "name": "t3k_gpt_oss_tests",
+              "model": "gpt_oss",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_gpt_oss_tests",
+              "timeout": 30,
+              "owner_id": "U08TJ70UFRT" # Harry Andrews
             }
           ]')
 

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -198,7 +198,7 @@ jobs:
             },
             {
               "name": "t3k_gpt_oss_tests",
-              "model": "gpt_oss",
+              "model": "gpt-oss",
               "arch": "wormhole_b0",
               "cmd": "run_t3000_gpt_oss_tests",
               "timeout": 30,

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -240,7 +240,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':rw' || ':rw' }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -30,7 +30,7 @@ on:
           - gemma3
           - wan22
           - mochi
-          - gpt_oss
+          - gpt-oss
       extra-tag:
         required: true
         type: string

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -30,6 +30,7 @@ on:
           - gemma3
           - wan22
           - mochi
+          - gpt_oss
       extra-tag:
         required: true
         type: string

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -235,7 +235,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -185,6 +185,14 @@ jobs:
               "cmd": "run_t3000_tt_dit_tests",
               "timeout": 20,
               "owner_id": "U08TED0JM9D" # Samuel Adesoye
+            },
+            {
+              "name": "t3k gpt-oss unit tests",
+              "model": "gpt-oss",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_gpt_oss_unit_tests",
+              "timeout": 30,
+              "owner_id": "U08TJ70UFRT" # Harry Andrews
             }
           ]')
 

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -191,7 +191,7 @@ jobs:
               "model": "gpt-oss",
               "arch": "wormhole_b0",
               "cmd": "run_t3000_gpt_oss_unit_tests",
-              "timeout": 30,
+              "timeout": 10,
               "owner_id": "U08TJ70UFRT" # Harry Andrews
             }
           ]')
@@ -235,7 +235,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -26,6 +26,7 @@ on:
           - qwen25_vl
           - gemma3-small
           - dits
+          - gpt-oss
   schedule:
     - cron: "0 */2 * * *" # This cron schedule runs the workflow every 2 hours
 

--- a/models/demos/gpt_oss/config.py
+++ b/models/demos/gpt_oss/config.py
@@ -138,7 +138,7 @@ class MeshConfig:
             tensor,
             dim=3,
             multi_device_global_semaphore=ccl_manager.get_rs_ping_pong_semaphore(),
-            num_links=4,
+            num_links=ccl_manager.num_links,
             memory_config=memory_config,
             topology=ccl_manager.topology,
             cluster_axis=axis,
@@ -153,7 +153,7 @@ class MeshConfig:
             mesh_device=ccl_manager.mesh_device,
             topology=ccl_manager.topology,
             multi_device_global_semaphore=ccl_manager.get_ag_ping_pong_semaphore(),
-            num_links=4,
+            num_links=ccl_manager.num_links,
             memory_config=memory_config,
             barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         )
@@ -180,7 +180,7 @@ class MeshConfig:
             mesh_device=ccl_manager.mesh_device,
             topology=ttnn.Topology.Linear if linear else ccl_manager.topology,
             multi_device_global_semaphore=ccl_manager.get_ag_ping_pong_semaphore(),
-            num_links=4,
+            num_links=ccl_manager.num_links,
             memory_config=memory_config,
             barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         )

--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from models.demos.gpt_oss.tt.model_config import ModelArgs
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def state_dict():
     model_path = os.getenv("HF_MODEL", None)
     if model_path is None:

--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from models.demos.gpt_oss.tt.model_config import ModelArgs
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def state_dict():
     model_path = os.getenv("HF_MODEL", None)
     if model_path is None:

--- a/models/demos/gpt_oss/tests/test_factory.py
+++ b/models/demos/gpt_oss/tests/test_factory.py
@@ -41,7 +41,7 @@ class TestFactory:
         mesh_config = MeshConfig(mesh_shape, decode=ModeConfig(tp=mesh_shape[1], ep=mesh_shape[0]))
 
         # Setup CCL
-        ccl_manager = CCLManager(mesh_device)
+        ccl_manager = CCLManager(mesh_device, num_links=4 if mesh_shape[0] > 1 else 1)
 
         config = AutoConfig.from_pretrained(model_args.model_path, trust_remote_code=True)
         # state_dict = TestFactory._generate_dummy_state_dict(config)

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -56,7 +56,7 @@ def run_attention_component(
         hidden_states=hidden_states,
         position_embeddings=position_embeddings,
         attention_mask=mask,
-        use_cache=False,
+        use_cache=True,
     )
 
     # TTNN attention forward (no mask needed, causal masking handled internally)

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -234,7 +234,7 @@ def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, te
         pytest test_modules.py --test-modules=attention,mlp
     """
     if mesh_shape[0] == 1 and seq_len > 128 and os.environ.get("CI"):
-        pytest.skip("Skip test for mesh_shape[0] == 1 and seq_len > 128 in CI due to known issue.")
+        pytest.skip("Skip test for mesh_shape[0] == 1 and seq_len > 128 in CI due to known issue (see #35313).")
 
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
 

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -202,6 +202,10 @@ def run_full_mlp_pipeline(mesh_device, hidden_shape, reference_layer, decoder_la
         (1, 8),
         (4, 8),
     ],
+    ids=[
+        "mesh_1x8",
+        "mesh_4x8",
+    ],
 )
 def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, test_modules, reset_seeds):
     """

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -231,8 +233,9 @@ def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, te
         pytest test_modules.py --test-modules=attention
         pytest test_modules.py --test-modules=attention,mlp
     """
-    if mesh_shape[0] == 1 and seq_len > 128:
-        pytest.skip("Skip test for mesh_shape[0] == 1 and seq_len > 128")
+    if mesh_shape[0] == 1 and seq_len > 128 and os.environ.get("CI"):
+        pytest.skip("Skip test for mesh_shape[0] == 1 and seq_len > 128 in CI due to known issue.")
+
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
 
     setup = TestFactory.setup_test(mesh_device, use_real_weights=False)

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -65,6 +65,7 @@ def run_attention_component(
 
     # Compare outputs
     passing, output = run_component_comparison(tt_out, reference_out, mesh_device, pcc_threshold=0.95)
+    logger.info(f"Attention test: {'passed' if passing else 'failed'} with output: {output}")
     assert passing, f"Attention test failed. Output: {output}"
 
 
@@ -90,6 +91,7 @@ def run_rms_norm_component(mesh_device, hidden_shape, reference_layer, decoder_l
 
     # Compare outputs
     passing, output = run_component_comparison(tt_output, ref_output, mesh_device, pcc_threshold=0.99)
+    logger.info(f"RMS norm test: {'passed' if passing else 'failed'} with output: {output}")
     assert passing, f"RMS norm test failed. Output: {output}"
 
 
@@ -113,6 +115,7 @@ def run_topk_router_component(mesh_device, hidden_shape, reference_layer, decode
     # Compare outputs
     for tt_output, reference_output in zip(tt_router_scores, router_scores):
         passing, output = run_component_comparison(tt_output, reference_output, mesh_device, pcc_threshold=0.945)
+        logger.info(f"TopK router test: {'passed' if passing else 'failed'} with output: {output}")
         assert passing, f"TopK router test failed. Output: {output}"
 
 
@@ -163,6 +166,7 @@ def run_experts_component(mesh_device, hidden_shape, config, reference_layer, de
     tt_output = tt_experts(tt_hidden_states, tt_routing_weights)
     # Compare outputs
     passing, output = run_component_comparison(tt_output, reference_output, mesh_device, pcc_threshold=0.93)
+    logger.info(f"Experts test: {'passed' if passing else 'failed'} with output: {output}")
     assert passing, f"Experts test failed. Output: {output}"
 
 
@@ -185,6 +189,7 @@ def run_full_mlp_pipeline(mesh_device, hidden_shape, reference_layer, decoder_la
     # Compare outputs
     passing, output = run_component_comparison(tt_output, reference_output, mesh_device, pcc_threshold=0.88)
 
+    logger.info(f"MLP test: {'passed' if passing else 'failed'} with output: {output}")
     assert passing, f"MLP test failed. Output: {output}"
 
 
@@ -401,7 +406,7 @@ def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, te
         passing, output = run_component_comparison(
             tt_output, reference_output, setup["mesh_device"], pcc_threshold=pcc_threshold
         )
-        logger.info(f"Decoder layer test: {passing} with output: {output}")
+        logger.info(f"Decoder layer test: {'passed' if passing else 'failed'} with output: {output}")
         assert passing, f"Decoder layer test failed. Output: {output}"
 
     tested_modules = [m for m in modules_to_test if m != "router" or seq_len == 1]

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -56,7 +56,7 @@ def run_attention_component(
         hidden_states=hidden_states,
         position_embeddings=position_embeddings,
         attention_mask=mask,
-        use_cache=True,
+        use_cache=False,
     )
 
     # TTNN attention forward (no mask needed, causal masking handled internally)
@@ -230,9 +230,6 @@ def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, te
 
     setup = TestFactory.setup_test(mesh_device, use_real_weights=False)
     model_name = getattr(setup["model_args"], "model_name", None)
-
-    if seq_len >= 4096 and model_name == "gpt-oss-20b":
-        pytest.skip("prefill seq_len=4096 currently unsupported for gpt-oss-20b")
 
     config = setup["config"]
 

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -231,6 +231,8 @@ def test_decoder(mesh_device, device_params, batch_size, seq_len, mesh_shape, te
         pytest test_modules.py --test-modules=attention
         pytest test_modules.py --test-modules=attention,mlp
     """
+    if mesh_shape[0] == 1 and seq_len > 128:
+        pytest.skip("Skip test for mesh_shape[0] == 1 and seq_len > 128")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
 
     setup = TestFactory.setup_test(mesh_device, use_real_weights=False)

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -149,7 +149,8 @@ class Model:
         # Create a dummy CCL manager for GPT-OSS
         from models.demos.gpt_oss.tt.ccl import CCLManager
 
-        ccl_manager = CCLManager(mesh_device)
+        breakpoint()
+        ccl_manager = CCLManager(mesh_device, num_links=4 if mesh_device.shape[0] > 1 else 1)
 
         # Create instance using direct initialization
         instance = cls.__new__(cls)

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -149,7 +149,6 @@ class Model:
         # Create a dummy CCL manager for GPT-OSS
         from models.demos.gpt_oss.tt.ccl import CCLManager
 
-        breakpoint()
         ccl_manager = CCLManager(mesh_device, num_links=4 if mesh_device.shape[0] > 1 else 1)
 
         # Create instance using direct initialization

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -415,11 +415,11 @@ run_t3000_gpt_oss_tests() {
   pip install -r models/demos/gpt_oss/requirements.txt
 
   # Test GPT-OSS 20B model
-  HF_MODEL=openai/gpt-oss-20b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  HF_MODEL=openai/gpt-oss-20b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8"
   echo "LOG_METAL: GPT-OSS 20B tests completed"
 
   # Test GPT-OSS 120B model
-  HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-120b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-120b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8"
   echo "LOG_METAL: GPT-OSS 120B tests completed"
 
   # Record the end time

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -409,6 +409,7 @@ run_t3000_mochi_tests() {
 
 run_t3000_gpt_oss_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   # Install gpt-oss requirements
@@ -426,6 +427,9 @@ run_t3000_gpt_oss_tests() {
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_gpt_oss_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_tests() {

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -407,6 +407,24 @@ run_t3000_mochi_tests() {
   fi
 }
 
+run_t3000_gpt_oss_tests() {
+  # Record the start time
+  start_time=$(date +%s)
+  gpt_oss_20b=openai/gpt-oss-20b
+  gpt_oss_120b=openai/gpt-oss-120b
+
+  HF_MODEL=$gpt_oss_20b TT_CACHE_PATH=$TT_CACHE_HOME/$gpt_oss_20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  echo "LOG_METAL: GPT-OSS 20B tests completed"
+
+  HF_MODEL=$gpt_oss_120b TT_CACHE_PATH=$TT_CACHE_HOME/$gpt_oss_120b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  echo "LOG_METAL: GPT-OSS 120B tests completed"
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_gpt_oss_tests $duration seconds to complete"
+}
+
 run_t3000_tests() {
   # Run llama3 smaller tests (1B, 3B, 8B, 11B)
   run_t3000_llama3_tests
@@ -464,6 +482,9 @@ run_t3000_tests() {
 
   # Run mochi tests
   run_t3000_mochi_tests
+
+  # Run gpt-oss tests
+  run_t3000_gpt_oss_tests
 }
 
 fail=0

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -410,16 +410,16 @@ run_t3000_mochi_tests() {
 run_t3000_gpt_oss_tests() {
   # Record the start time
   start_time=$(date +%s)
-  gpt_oss_20b=openai/gpt-oss-20b
-  gpt_oss_120b=openai/gpt-oss-120b
 
-  # install gpt-oss requirements
+  # Install gpt-oss requirements
   pip install -r models/demos/gpt_oss/requirements.txt
 
-  HF_MODEL=$gpt_oss_20b TT_CACHE_PATH=$TT_CACHE_HOME/$gpt_oss_20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  # Test GPT-OSS 20B model
+  HF_MODEL=openai/gpt-oss-20b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
   echo "LOG_METAL: GPT-OSS 20B tests completed"
 
-  HF_MODEL=$gpt_oss_120b TT_CACHE_PATH=$TT_CACHE_HOME/$gpt_oss_120b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
+  # Test GPT-OSS 120B model
+  HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-120b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
   echo "LOG_METAL: GPT-OSS 120B tests completed"
 
   # Record the end time

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -413,6 +413,9 @@ run_t3000_gpt_oss_tests() {
   gpt_oss_20b=openai/gpt-oss-20b
   gpt_oss_120b=openai/gpt-oss-120b
 
+  # install gpt-oss requirements
+  pip install -r models/demos/gpt_oss/requirements.txt
+
   HF_MODEL=$gpt_oss_20b TT_CACHE_PATH=$TT_CACHE_HOME/$gpt_oss_20b pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8 and prefill_128"
   echo "LOG_METAL: GPT-OSS 20B tests completed"
 

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -621,6 +621,31 @@ run_t3000_tt_dit_tests() {
 
 }
 
+run_t3000_gpt_oss_unit_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_gpt_oss_unit_tests"
+
+  # GPT-OSS weights
+  gpt_oss_20b=openai/gpt-oss-20b
+  gpt_oss_120b=openai/gpt-oss-120b
+  tt_cache_gpt_oss_20b=$TT_CACHE_HOME/$gpt_oss_20b
+  tt_cache_gpt_oss_120b=$TT_CACHE_HOME/$gpt_oss_120b
+
+  HF_MODEL=$gpt_oss_20b TT_CACHE_PATH=$tt_cache_gpt_oss_20b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
+  HF_MODEL=$gpt_oss_120b TT_CACHE_PATH=$tt_cache_gpt_oss_120b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_gpt_oss_unit_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_tests() {
   # Run ttmetal tests
   run_t3000_ttmetal_tests
@@ -672,6 +697,9 @@ run_t3000_tests() {
 
   # Run tt_dit tests
   run_t3000_tt_dit_tests
+
+  # Run gpt-oss unit tests
+  run_t3000_gpt_oss_unit_tests
 }
 
 fail=0

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -628,14 +628,14 @@ run_t3000_gpt_oss_unit_tests() {
 
   echo "LOG_METAL: Running run_t3000_gpt_oss_unit_tests"
 
-  # GPT-OSS weights
-  gpt_oss_20b=openai/gpt-oss-20b
-  gpt_oss_120b=openai/gpt-oss-120b
-  tt_cache_gpt_oss_20b=$TT_CACHE_HOME/$gpt_oss_20b
-  tt_cache_gpt_oss_120b=$TT_CACHE_HOME/$gpt_oss_120b
+  # Install gpt-oss requirements
+  pip install -r models/demos/gpt_oss/requirements.txt
 
-  HF_MODEL=$gpt_oss_20b TT_CACHE_PATH=$tt_cache_gpt_oss_20b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
-  HF_MODEL=$gpt_oss_120b TT_CACHE_PATH=$tt_cache_gpt_oss_120b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
+  # Test GPT-OSS 20B model
+  HF_MODEL=openai/gpt-oss-20b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-20b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
+
+  # Test GPT-OSS 120B model
+  HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=$TT_CACHE_HOME/openai--gpt-oss-120b pytest -n auto models/demos/gpt_oss/tests/unit/test_modules.py -k "1x8"; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/reader_moe_routing_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/reader_moe_routing_remap.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "dprint_pages.h"
 #include "api/numeric/bfloat16.h"
 
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "dprint_pages.h"
 
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"


### PR DESCRIPTION
### Problem description
GPT-OSS CI tests are failing on main due to bad includes in moe_routing_remap op. 

### What's changed
Removes the bad include. Also makes changes to enable running 1x8 mesh configuration on a T3K by parameterising the `num_links` argument in ccls.

Moves 1x8 unit and demo tests from galaxy runners to T3K runners and reduces some CI timeouts.

### Checklist

APC: https://github.com/tenstorrent/tt-metal/actions/runs/20723608152
Galaxy demo: https://github.com/tenstorrent/tt-metal/actions/runs/20723636671
Galaxy unit: https://github.com/tenstorrent/tt-metal/actions/runs/20747719051
T3K demo: https://github.com/tenstorrent/tt-metal/actions/runs/20750172442
T3K unit: https://github.com/tenstorrent/tt-metal/actions/runs/20750101058

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:handrews/gpt-oss-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/gpt-oss-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/gpt-oss-tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/gpt-oss-tests)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/gpt-oss-tests)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/gpt-oss-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/gpt-oss-tests)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs