### PR TITLE
Fix silu initialization mismatch causing PCC errors in Stable Diffusion

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -27,8 +27,13 @@ inline void calculate_silu() {
     }
 }
 
+template <bool APPROXIMATION_MODE>
 inline void silu_init() {
-    _init_reciprocal_<false, false>();
+    if constexpr (!APPROXIMATION_MODE) {
+        _init_sfpu_reciprocal_<false>();
+    } else {
+        _init_sfpu_reciprocal_<true>();
+    }
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -27,8 +27,13 @@ inline void calculate_silu() {
     }
 }
 
+template <bool APPROXIMATION_MODE>
 inline void silu_init() {
-    _init_reciprocal_<false, false>();
+    if constexpr (!APPROXIMATION_MODE) {
+        _init_sfpu_reciprocal_<false>();
+    } else {
+        _init_sfpu_reciprocal_<true>();
+    }
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, bool is_fp32_dest_acc_en>


### PR DESCRIPTION
### Problem

Commit d86d87c90eb561f4689e98cea16ddfeee3c7393a introduced a regression that caused PCC accuracy errors in the Stable Diffusion model, specifically failing the test:
  pytest models/demos/blackhole/stable_diffusion/tests/test_perf.py::test_stable_diffusion_device_perf[20.0]

### Root Cause

The new silu implementation had a critical initialization bug where the init function was hardcoded and did not match the compute function's mode:

1. `silu_init()` was a non-templated function that always called `_init_reciprocal_<false, false>()`, hardcoding both APPROXIMATION_MODE and is_fp32_dest_acc_en to false.

2. However, `calculate_silu<is_fp32_dest_acc_en, ITERATIONS>()` is templated and uses runtime-determined `is_fp32_dest_acc_en` values.

3. This mismatch meant that when silu ran with FP32 accumulation enabled, the reciprocal operation was initialized for bfloat16 mode, causing incorrect sigmoid calculations within silu and resulting in PCC failures.

### The Fix

Changed silu initialization to follow the same pattern as sigmoid:

1. Made `silu_init()` a template function accepting APPROXIMATION_MODE
2. Changed from `_init_reciprocal_<false, false>()` to `_init_sfpu_reciprocal_<APPROXIMATION_MODE>()`, which properly handles both FP32 and bfloat16 accumulation modes
3. Updated llk layer to pass template parameter: `sfpu::silu_init<APPROXIMATE>` instead of `sfpu::silu_init`

This ensures the initialization mode matches the compute mode, fixing the accuracy errors.

  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20490376420)
  - [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20490380168)