### PR TITLE
SDXL CI encoder perf

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -143,7 +143,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
-            63_696_601,
+            63_023_709,  # Note: this is an average value of 5 test runs due to high variability
             "sdxl_clip_encoder_2",
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
### Problem description
`encoder_2` device perf test has been flaky on main

### What's changed
Last 5 runs of device perf for the mentioned test fall within 3% range which corresponds to expected fluctuation of device kernel time. Seems like targets have been set at the start/end of the covered range and with 1.5% margin the test sometimes fails.

Setting perf target to average of last 5 runs. If it fails again on main we can consider larger margin or running several iterations of the test

### Checklist

- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20503410477/job/58914434178)