### PR TITLE
feat: compare CI runs of workflows with main when performing llk uplift

### DIFF
--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -325,10 +325,15 @@ jobs:
 
             # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
             # This avoids false negatives from floating-point drift in error outputs
-            local branch_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId')" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            # Use headSha to query check runs for the commit
+            local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
+            local branch_annotations="[]"
+            if [ -n "$branch_head_sha" ]; then
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')"
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
 
             # Find the latest completed run of the same workflow on main
             local main_run_id=$(gh run list \
@@ -362,10 +367,14 @@ jobs:
             echo "Main failure details: $main_failure_details"
 
             # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
-            local main_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId')" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
+            local main_annotations="[]"
+            if [ -n "$main_head_sha" ]; then
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')"
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"
 
             # Compare job+step failures
             local all_failures_in_main=true
@@ -640,10 +649,15 @@ jobs:
 
             # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
             # This avoids false negatives from floating-point drift in error outputs
-            local branch_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId')" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            # Use headSha to query check runs for the commit
+            local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
+            local branch_annotations="[]"
+            if [ -n "$branch_head_sha" ]; then
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')" >&2
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2
 
             # Find the latest completed run of the same workflow on main
             local main_run_id=$(gh run list \
@@ -677,10 +691,14 @@ jobs:
             echo "Main failure details: $main_failure_details" >&2
 
             # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
-            local main_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId')" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
+            local main_annotations="[]"
+            if [ -n "$main_head_sha" ]; then
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')" >&2
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2
 
             # Compare job+step failures
             local all_failures_in_main=true

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -329,8 +329,9 @@ jobs:
             local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
-              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -370,8 +371,9 @@ jobs:
             local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
-              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -653,8 +655,9 @@ jobs:
             local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
-              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2
@@ -694,8 +697,9 @@ jobs:
             local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ github.repository }}" 2>/dev/null)
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
-              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -301,6 +301,154 @@ jobs:
           DISPLAY_NAME="${{ matrix.name }}"
           TIMEOUT_MINUTES="${{ inputs.workflow_timeout || env.WORKFLOW_TIMEOUT }}"
 
+          # Helper function to check if failures exist in main branch
+          check_failure_exists_in_main() {
+            local run_id=$1
+            local workflow=$2
+
+            echo "🔍 Checking if failures exist in main branch for workflow: $workflow"
+
+            # Get detailed failure info from branch run: job name + failed step names
+            local branch_failure_details=$(gh run view "$run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$branch_failure_details" ] || [ "$branch_failure_details" = "[]" ]; then
+              echo "No failed jobs found in current run"
+              return 1
+            fi
+
+            echo "Branch failure details: $branch_failure_details"
+
+            # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
+            # This avoids false negatives from floating-point drift in error outputs
+            local branch_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId')" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')"
+
+            # Find the latest completed run of the same workflow on main
+            local main_run_id=$(gh run list \
+              --workflow "$workflow" \
+              --branch "main" \
+              --limit 5 \
+              --json databaseId,status,conclusion \
+              --jq '[.[] | select(.status == "completed")] | .[0].databaseId // empty' \
+              --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$main_run_id" ]; then
+              echo "No completed runs found on main for $workflow"
+              return 1
+            fi
+
+            echo "Found main run ID: $main_run_id"
+
+            # Get detailed failure info from main run
+            local main_failure_details=$(gh run view "$main_run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$main_failure_details" ] || [ "$main_failure_details" = "[]" ]; then
+              echo "No failed jobs found in main run - main is passing"
+              return 1
+            fi
+
+            echo "Main failure details: $main_failure_details"
+
+            # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
+            local main_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId')" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')"
+
+            # Compare job+step failures
+            local all_failures_in_main=true
+
+            # Iterate through each branch failure
+            local branch_jobs=$(echo "$branch_failure_details" | jq -r '.[].job')
+
+            while IFS= read -r job_name; do
+              [ -z "$job_name" ] && continue
+
+              # Get failed steps for this job in branch
+              local branch_steps=$(echo "$branch_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if this job exists in main failures
+              local main_job_exists=$(echo "$main_failure_details" | jq -e --arg job "$job_name" '.[] | select(.job == $job)' > /dev/null 2>&1 && echo "true" || echo "false")
+
+              if [ "$main_job_exists" = "false" ]; then
+                echo "✗ Job '$job_name' does NOT fail in main - this is a new failure"
+                all_failures_in_main=false
+                break
+              fi
+
+              # Get failed steps for this job in main
+              local main_steps=$(echo "$main_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if all branch steps exist in main steps
+              while IFS= read -r step_name; do
+                [ -z "$step_name" ] && continue
+
+                if echo "$main_steps" | grep -qxF "$step_name"; then
+                  echo "✓ Job '$job_name' / Step '$step_name' also fails in main"
+                else
+                  echo "✗ Job '$job_name' / Step '$step_name' does NOT fail in main - this is a new failure"
+                  all_failures_in_main=false
+                  break 2
+                fi
+              done <<< "$branch_steps"
+
+            done <<< "$branch_jobs"
+
+            # If job+step comparison passed, also check annotations (test-level failures)
+            if [ "$all_failures_in_main" = "true" ]; then
+              local branch_anno_count=$(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo "0")
+              local main_anno_count=$(echo "$main_annotations" | jq 'length' 2>/dev/null || echo "0")
+
+              # Handle cases where annotations might not exist
+              if [ "$branch_anno_count" -eq 0 ] && [ "$main_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations found in either run - job+step match is sufficient"
+              elif [ "$branch_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations in branch run - job+step match is sufficient"
+              elif [ "$branch_anno_count" -gt 0 ]; then
+                echo "Comparing $branch_anno_count branch annotations against $main_anno_count main annotations..."
+
+                if [ "$main_anno_count" -eq 0 ]; then
+                  echo "⚠️ Branch has $branch_anno_count test annotations but main has none - cannot compare tests"
+                  echo "ℹ️ Falling back to job+step match (sufficient for pre-existing failure detection)"
+                else
+                  # Check if all branch annotations exist in main
+                  local new_annotations=$(echo "$branch_annotations" | jq --argjson main "$main_annotations" '[.[] | select(. as $a | $main | index($a) | not)]')
+                  local new_anno_count=$(echo "$new_annotations" | jq 'length')
+
+                  if [ "$new_anno_count" -gt 0 ]; then
+                    echo "✗ Found $new_anno_count new test failures not in main:"
+                    echo "$new_annotations" | jq -r '.[:5][]' | while read -r anno; do
+                      echo "  - ${anno:0:100}..."
+                    done
+                    all_failures_in_main=false
+                  else
+                    echo "✓ All test failure annotations also exist in main"
+                  fi
+                fi
+              fi
+            fi
+
+            if [ "$all_failures_in_main" = "true" ]; then
+              echo "✅ All failures (jobs, steps, and tests) exist in main branch - treating as pre-existing issues"
+              return 0
+            else
+              echo "❌ New failures detected that don't exist in main"
+              return 1
+            fi
+          }
+
           # Helper function for workflow monitoring
           monitor_workflow() {
             local run_id=$1
@@ -323,6 +471,13 @@ jobs:
                     gh pr comment "$PR_NUMBER" --body "✅ **$DISPLAY_NAME** passed: [View run]($run_url)" --repo "${{ github.repository }}"
                     return 0
                   else
+                    # Check if failures also exist in main branch
+                    if check_failure_exists_in_main "$run_id" "$WORKFLOW"; then
+                      local main_run_url=$(gh run list --workflow "$WORKFLOW" --branch "main" --limit 1 --json url --jq '.[0].url // empty' --repo "${{ github.repository }}")
+                      gh pr comment "$PR_NUMBER" --body "⚠️ **$DISPLAY_NAME** failed, but same failures exist in main - treating as pre-existing issue: [View run]($run_url) | [Main run]($main_run_url)" --repo "${{ github.repository }}"
+                      return 0
+                    fi
+
                     gh pr comment "$PR_NUMBER" --body "❌ **$DISPLAY_NAME** failed (attempt $((retries + 1))): [View run]($run_url/attempts/$((retries + 1)))" --repo "${{ github.repository }}"
                     break
                   fi
@@ -461,6 +616,154 @@ jobs:
           SHOULD_RUN_WH=$(echo "$DECISIONS" | grep -o "should-run-wormhole=[^, ]*" | cut -d= -f2)
           SHOULD_RUN_BH=$(echo "$DECISIONS" | grep -o "should-run-blackhole=[^, ]*" | cut -d= -f2)
 
+          # Helper function to check if failures exist in main branch (for recheck)
+          check_failure_exists_in_main() {
+            local run_id=$1
+            local workflow=$2
+
+            echo "🔍 Checking if failures exist in main branch for workflow: $workflow" >&2
+
+            # Get detailed failure info from branch run: job name + failed step names
+            local branch_failure_details=$(gh run view "$run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$branch_failure_details" ] || [ "$branch_failure_details" = "[]" ]; then
+              echo "No failed jobs found in current run" >&2
+              return 1
+            fi
+
+            echo "Branch failure details: $branch_failure_details" >&2
+
+            # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
+            # This avoids false negatives from floating-point drift in error outputs
+            local branch_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId')" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')" >&2
+
+            # Find the latest completed run of the same workflow on main
+            local main_run_id=$(gh run list \
+              --workflow "$workflow" \
+              --branch "main" \
+              --limit 5 \
+              --json databaseId,status,conclusion \
+              --jq '[.[] | select(.status == "completed")] | .[0].databaseId // empty' \
+              --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$main_run_id" ]; then
+              echo "No completed runs found on main for $workflow" >&2
+              return 1
+            fi
+
+            echo "Found main run ID: $main_run_id" >&2
+
+            # Get detailed failure info from main run
+            local main_failure_details=$(gh run view "$main_run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ github.repository }}" 2>/dev/null)
+
+            if [ -z "$main_failure_details" ] || [ "$main_failure_details" = "[]" ]; then
+              echo "No failed jobs found in main run - main is passing" >&2
+              return 1
+            fi
+
+            echo "Main failure details: $main_failure_details" >&2
+
+            # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
+            local main_annotations=$(gh api "/repos/${{ github.repository }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId')" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')" >&2
+
+            # Compare job+step failures
+            local all_failures_in_main=true
+
+            # Iterate through each branch failure
+            local branch_jobs=$(echo "$branch_failure_details" | jq -r '.[].job')
+
+            while IFS= read -r job_name; do
+              [ -z "$job_name" ] && continue
+
+              # Get failed steps for this job in branch
+              local branch_steps=$(echo "$branch_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if this job exists in main failures
+              local main_job_exists=$(echo "$main_failure_details" | jq -e --arg job "$job_name" '.[] | select(.job == $job)' > /dev/null 2>&1 && echo "true" || echo "false")
+
+              if [ "$main_job_exists" = "false" ]; then
+                echo "✗ Job '$job_name' does NOT fail in main - this is a new failure" >&2
+                all_failures_in_main=false
+                break
+              fi
+
+              # Get failed steps for this job in main
+              local main_steps=$(echo "$main_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if all branch steps exist in main steps
+              while IFS= read -r step_name; do
+                [ -z "$step_name" ] && continue
+
+                if echo "$main_steps" | grep -qxF "$step_name"; then
+                  echo "✓ Job '$job_name' / Step '$step_name' also fails in main" >&2
+                else
+                  echo "✗ Job '$job_name' / Step '$step_name' does NOT fail in main - this is a new failure" >&2
+                  all_failures_in_main=false
+                  break 2
+                fi
+              done <<< "$branch_steps"
+
+            done <<< "$branch_jobs"
+
+            # If job+step comparison passed, also check annotations (test-level failures)
+            if [ "$all_failures_in_main" = "true" ]; then
+              local branch_anno_count=$(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo "0")
+              local main_anno_count=$(echo "$main_annotations" | jq 'length' 2>/dev/null || echo "0")
+
+              # Handle cases where annotations might not exist
+              if [ "$branch_anno_count" -eq 0 ] && [ "$main_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations found in either run - job+step match is sufficient" >&2
+              elif [ "$branch_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations in branch run - job+step match is sufficient" >&2
+              elif [ "$branch_anno_count" -gt 0 ]; then
+                echo "Comparing $branch_anno_count branch annotations against $main_anno_count main annotations..." >&2
+
+                if [ "$main_anno_count" -eq 0 ]; then
+                  echo "⚠️ Branch has $branch_anno_count test annotations but main has none - cannot compare tests" >&2
+                  echo "ℹ️ Falling back to job+step match (sufficient for pre-existing failure detection)" >&2
+                else
+                  # Check if all branch annotations exist in main
+                  local new_annotations=$(echo "$branch_annotations" | jq --argjson main "$main_annotations" '[.[] | select(. as $a | $main | index($a) | not)]')
+                  local new_anno_count=$(echo "$new_annotations" | jq 'length')
+
+                  if [ "$new_anno_count" -gt 0 ]; then
+                    echo "✗ Found $new_anno_count new test failures not in main:" >&2
+                    echo "$new_annotations" | jq -r '.[:5][]' | while read -r anno; do
+                      echo "  - ${anno:0:100}..." >&2
+                    done
+                    all_failures_in_main=false
+                  else
+                    echo "✓ All test failure annotations also exist in main" >&2
+                  fi
+                fi
+              fi
+            fi
+
+            if [ "$all_failures_in_main" = "true" ]; then
+              echo "✅ All failures (jobs, steps, and tests) exist in main branch - treating as pre-existing issues" >&2
+              return 0
+            else
+              echo "❌ New failures detected that don't exist in main" >&2
+              return 1
+            fi
+          }
+
           # Check workflow results
           check_workflow() {
             local workflow=$1
@@ -472,7 +775,7 @@ jobs:
                 --workflow "$workflow" \
                 --branch "${{ env.BRANCH_NAME }}" \
                 --limit 5 \
-                --json conclusion,url,status,attempt \
+                --json conclusion,url,status,attempt,databaseId \
                 --jq 'map(select(.status == "completed")) | .[0] | select(. != null)'
               )
 
@@ -485,11 +788,19 @@ jobs:
             local conclusion=$(echo "$runs" | jq -r '.conclusion // "unknown"')
             local url=$(echo "$runs" | jq -r '.url // ""')
             local attempt=$(echo "$runs" | jq -r '.attempt // 1')
+            local run_id=$(echo "$runs" | jq -r '.databaseId // ""')
 
             if [ "$conclusion" = "success" ]; then
               echo "✅ $name passed: [View run]($url)"
               return 0
             else
+              # Check if failures also exist in main branch
+              if check_failure_exists_in_main "$run_id" "$workflow"; then
+                local main_run_url=$(gh run list --workflow "$workflow" --branch "main" --limit 1 --json url --jq '.[0].url // empty' --repo "${{ github.repository }}")
+                echo "⚠️ $name failed, but same failures exist in main - treating as pre-existing: [View run]($url) | [Main run]($main_run_url)"
+                return 0
+              fi
+
               echo "❌ $name failed (conclusion: $conclusion): [View run]($url/attempts/$attempt)"
               return 1
             fi

--- a/.github/workflows/llk-auto-uplift-trigger.yaml
+++ b/.github/workflows/llk-auto-uplift-trigger.yaml
@@ -330,8 +330,9 @@ jobs:
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -372,8 +373,9 @@ jobs:
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -656,8 +658,9 @@ jobs:
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              branch_annotations=$(gh api "/repos/${{ github.repository }}/commits/$branch_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2
@@ -698,8 +701,9 @@ jobs:
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              main_annotations=$(gh api "/repos/${{ github.repository }}/commits/$main_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)" >&2

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -293,6 +293,154 @@ jobs:
           TT_METAL_L2_NIGHTLY_RUN_ID: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
           PERF_DEVICE_MODELS_RUN_ID: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
         run: |
+          # Helper function to check if failures exist in main branch
+          check_failure_exists_in_main() {
+            local run_id=$1
+            local workflow=$2
+
+            echo "🔍 Checking if failures exist in main branch for workflow: $workflow"
+
+            # Get detailed failure info from branch run: job name + failed step names
+            local branch_failure_details=$(gh run view "$run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
+
+            if [ -z "$branch_failure_details" ] || [ "$branch_failure_details" = "[]" ]; then
+              echo "No failed jobs found in current run"
+              return 1
+            fi
+
+            echo "Branch failure details: $branch_failure_details"
+
+            # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
+            # This avoids false negatives from floating-point drift in error outputs
+            local branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId' --repo "${{ env.METAL_REPO }}")" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')"
+
+            # Find the latest completed run of the same workflow on main
+            local main_run_id=$(gh run list \
+              --workflow "$workflow" \
+              --branch "main" \
+              --limit 5 \
+              --json databaseId,status,conclusion \
+              --jq '[.[] | select(.status == "completed")] | .[0].databaseId // empty' \
+              --repo "${{ env.METAL_REPO }}" 2>/dev/null)
+
+            if [ -z "$main_run_id" ]; then
+              echo "No completed runs found on main for $workflow"
+              return 1
+            fi
+
+            echo "Found main run ID: $main_run_id"
+
+            # Get detailed failure info from main run
+            local main_failure_details=$(gh run view "$main_run_id" --json jobs --jq '
+              [.jobs[] | select(.conclusion == "failure") | {
+                job: .name,
+                failed_steps: [.steps[] | select(.conclusion == "failure") | .name] | sort
+              }] | sort_by(.job)
+            ' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
+
+            if [ -z "$main_failure_details" ] || [ "$main_failure_details" = "[]" ]; then
+              echo "No failed jobs found in main run - main is passing"
+              return 1
+            fi
+
+            echo "Main failure details: $main_failure_details"
+
+            # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
+            local main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId' --repo "${{ env.METAL_REPO }}")" \
+              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')"
+
+            # Compare job+step failures
+            local all_failures_in_main=true
+
+            # Iterate through each branch failure
+            local branch_jobs=$(echo "$branch_failure_details" | jq -r '.[].job')
+
+            while IFS= read -r job_name; do
+              [ -z "$job_name" ] && continue
+
+              # Get failed steps for this job in branch
+              local branch_steps=$(echo "$branch_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if this job exists in main failures
+              local main_job_exists=$(echo "$main_failure_details" | jq -e --arg job "$job_name" '.[] | select(.job == $job)' > /dev/null 2>&1 && echo "true" || echo "false")
+
+              if [ "$main_job_exists" = "false" ]; then
+                echo "✗ Job '$job_name' does NOT fail in main - this is a new failure"
+                all_failures_in_main=false
+                break
+              fi
+
+              # Get failed steps for this job in main
+              local main_steps=$(echo "$main_failure_details" | jq -r --arg job "$job_name" '.[] | select(.job == $job) | .failed_steps | .[]' 2>/dev/null)
+
+              # Check if all branch steps exist in main steps
+              while IFS= read -r step_name; do
+                [ -z "$step_name" ] && continue
+
+                if echo "$main_steps" | grep -qxF "$step_name"; then
+                  echo "✓ Job '$job_name' / Step '$step_name' also fails in main"
+                else
+                  echo "✗ Job '$job_name' / Step '$step_name' does NOT fail in main - this is a new failure"
+                  all_failures_in_main=false
+                  break 2
+                fi
+              done <<< "$branch_steps"
+
+            done <<< "$branch_jobs"
+
+            # If job+step comparison passed, also check annotations (test-level failures)
+            if [ "$all_failures_in_main" = "true" ]; then
+              local branch_anno_count=$(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo "0")
+              local main_anno_count=$(echo "$main_annotations" | jq 'length' 2>/dev/null || echo "0")
+
+              # Handle cases where annotations might not exist
+              if [ "$branch_anno_count" -eq 0 ] && [ "$main_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations found in either run - job+step match is sufficient"
+              elif [ "$branch_anno_count" -eq 0 ]; then
+                echo "ℹ️ No test annotations in branch run - job+step match is sufficient"
+              elif [ "$branch_anno_count" -gt 0 ]; then
+                echo "Comparing $branch_anno_count branch annotations against $main_anno_count main annotations..."
+
+                if [ "$main_anno_count" -eq 0 ]; then
+                  echo "⚠️ Branch has $branch_anno_count test annotations but main has none - cannot compare tests"
+                  echo "ℹ️ Falling back to job+step match (sufficient for pre-existing failure detection)"
+                else
+                  # Check if all branch annotations exist in main
+                  local new_annotations=$(echo "$branch_annotations" | jq --argjson main "$main_annotations" '[.[] | select(. as $a | $main | index($a) | not)]')
+                  local new_anno_count=$(echo "$new_annotations" | jq 'length')
+
+                  if [ "$new_anno_count" -gt 0 ]; then
+                    echo "✗ Found $new_anno_count new test failures not in main:"
+                    echo "$new_annotations" | jq -r '.[:5][]' | while read -r anno; do
+                      echo "  - ${anno:0:100}..."
+                    done
+                    all_failures_in_main=false
+                  else
+                    echo "✓ All test failure annotations also exist in main"
+                  fi
+                fi
+              fi
+            fi
+
+            if [ "$all_failures_in_main" = "true" ]; then
+              echo "✅ All failures (jobs, steps, and tests) exist in main branch - treating as pre-existing issues"
+              return 0
+            else
+              echo "❌ New failures detected that don't exist in main"
+              return 1
+            fi
+          }
+
           # Helper function for workflow monitoring
           monitor_workflow() {
             local run_id="$1"
@@ -321,6 +469,14 @@ jobs:
                     echo "$output_var=success:$run_url" >> $GITHUB_OUTPUT
                     return 0
                   else
+                    # Check if failures also exist in main branch
+                    if check_failure_exists_in_main "$run_id" "$workflow_name"; then
+                      local main_run_url=$(gh run list --workflow "$workflow_name" --branch "main" --limit 1 --json url --jq '.[0].url // empty' --repo "${{ env.METAL_REPO }}")
+                      echo "⚠️ $workflow_name failed, but same failures exist in main - treating as pre-existing issue: [View run]($run_url) | [Main run]($main_run_url)"
+                      echo "$output_var=success:$run_url" >> $GITHUB_OUTPUT
+                      return 0
+                    fi
+
                     echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url/attempts/$(($retries + 1))"
                     if [ $retries -ge $((MAX_RETRIES - 1)) ]; then
                       echo "$output_var=failure:$run_url" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -180,11 +180,12 @@ jobs:
           PARENT_BRANCH_NAME: ${{ env.PARENT_BRANCH_NAME }}
         run: |
           # Define workflows to trigger
+          # TEMPORARILY DISABLED FOR TESTING - uncomment when done
           declare -A workflows
           workflows["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
-          workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
-          workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
-          workflows["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
+          # workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
+          # workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
+          # workflows["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
 
           declare -A run_ids
 
@@ -526,11 +527,12 @@ jobs:
           }
 
           # Monitor workflows using data-driven approach
+          # TEMPORARILY DISABLED FOR TESTING - uncomment when done
           declare -A workflow_configs
           workflow_configs["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}:$ALL_POST_COMMIT_RUN_ID:all-post-commit-result"
-          workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
-          workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
-          workflow_configs["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$PERF_DEVICE_MODELS_RUN_ID:perf-device-models-result"
+          # workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
+          # workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
+          # workflow_configs["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$PERF_DEVICE_MODELS_RUN_ID:perf-device-models-result"
           exit_code=0
           for workflow_file in "${!workflow_configs[@]}"; do
             IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -321,8 +321,9 @@ jobs:
             local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
-              branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$branch_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$branch_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -362,8 +363,9 @@ jobs:
             local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
-              main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$main_head_sha/check-runs" \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Include both "error" and "failure" annotation levels (pytest uses "error")
+              main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$main_head_sha/check-runs" --paginate \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -317,10 +317,15 @@ jobs:
 
             # Get annotations (test failures) from branch run - extract test identifiers only (path + title), NOT error messages
             # This avoids false negatives from floating-point drift in error outputs
-            local branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/check-runs?check_suite_id=$(gh run view "$run_id" --json checkSuiteId --jq '.checkSuiteId' --repo "${{ env.METAL_REPO }}")" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            # Use headSha to query check runs for the commit
+            local branch_head_sha=$(gh run view "$run_id" --json headSha --jq '.headSha' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
+            local branch_annotations="[]"
+            if [ -n "$branch_head_sha" ]; then
+              branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$branch_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length')"
+            echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
 
             # Find the latest completed run of the same workflow on main
             local main_run_id=$(gh run list \
@@ -354,10 +359,14 @@ jobs:
             echo "Main failure details: $main_failure_details"
 
             # Get annotations from main run - extract test identifiers only (path + title), NOT error messages
-            local main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/check-runs?check_suite_id=$(gh run view "$main_run_id" --json checkSuiteId --jq '.checkSuiteId' --repo "${{ env.METAL_REPO }}")" \
-              --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            local main_head_sha=$(gh run view "$main_run_id" --json headSha --jq '.headSha' --repo "${{ env.METAL_REPO }}" 2>/dev/null)
+            local main_annotations="[]"
+            if [ -n "$main_head_sha" ]; then
+              main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$main_head_sha/check-runs" \
+                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+            fi
 
-            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length')"
+            echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"
 
             # Compare job+step failures
             local all_failures_in_main=true

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -322,8 +322,9 @@ jobs:
             local branch_annotations="[]"
             if [ -n "$branch_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$branch_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              branch_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$branch_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Branch failed tests count: $(echo "$branch_annotations" | jq 'length' 2>/dev/null || echo 0)"
@@ -364,8 +365,9 @@ jobs:
             local main_annotations="[]"
             if [ -n "$main_head_sha" ]; then
               # Include both "error" and "failure" annotation levels (pytest uses "error")
-              main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$main_head_sha/check-runs" --paginate \
-                --jq '[.check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
+              # Use paginate with slurp to combine all pages, then process
+              main_annotations=$(gh api "/repos/${{ env.METAL_REPO }}/commits/$main_head_sha/check-runs" --paginate 2>/dev/null | \
+                jq -s '[.[].check_runs[] | select(.conclusion == "failure") | .output.annotations // [] | .[] | select(.annotation_level == "failure" or .annotation_level == "error") | "\(.path // ""):\(.title // "")"] | sort | unique' 2>/dev/null || echo "[]")
             fi
 
             echo "Main failed tests count: $(echo "$main_annotations" | jq 'length' 2>/dev/null || echo 0)"


### PR DESCRIPTION
### Ticket
None

### Problem description
Previously, if someone introduced a failing test in `main` (unrelated to the LLK uplift), the entire uplift process would fail. This caused unnecessary delays and required manual intervention to determine whether failures were caused by the uplift or were pre-existing issues in `main`.

### What's changed
Added a `check_failure_exists_in_main()` function that performs a **3-level comparison**:

#### Level 1: Failed Jobs
Compares which jobs failed between the branch run and the latest main run.

#### Level 2: Failed Steps
For each matching failed job, compares which specific steps failed.

#### Level 3: Failed Tests (with graceful fallback)
Compares test identifiers extracted from GitHub Actions annotations:
- Uses `path:title` format (e.g., `tests/test_matmul.py:test_fp16`)
- **Excludes error messages** to avoid false negatives from floating-point drift
- **Graceful fallback**: If annotations don't exist, job+step match is considered sufficient

#### Behavior

| Branch Failure | Main Failure | Result |
|----------------|--------------|--------|
| Job A / Step X / Test 1 fails | Same failure exists in main | ✅ Treated as pre-existing |
| Job A / Step X / Test 1,2 fail | Only Test 1 fails in main | ❌ Test 2 is new - retry/fail |
| Job A / Step X fails | Main is passing | ❌ New failure - retry/fail |

#### PR Comments

When failures are detected as pre-existing, the PR gets a comment:

```
⚠️ **Workflow Name** failed, but same failures exist in main - treating as pre-existing issue: 
[View run](url) | [Main run](url)
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:filip/compare-with-failures-on-main)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/compare-with-failures-on-main)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/compare-with-failures-on-main)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/compare-with-failures-on-main)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/compare-with-failures-on-main)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/compare-with-failures-on-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/compare-with-failures-on-main)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs