### PR TITLE
Move PDL to 110 cores BH P150

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -136,13 +136,13 @@ jobs:
             { # This test shall be executed on the BH with 20 cores
               name: "panoptic_deeplab demo - 20 cores",
               arch: blackhole,
-              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline',
               owner_id: U09LK84G4TF # Nikola Milicevic
             },
             { # This test shall be executed on the BH P150 on 110 cores
               name: "panoptic_deeplab demo - 110 cores",
               arch: blackhole,
-              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10, 9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10, 9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline',
               owner_id: U09LK84G4TF # Nikola Milicevic
             },
           ]

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -139,10 +139,10 @@ jobs:
               cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
               owner_id: U09LK84G4TF # Nikola Milicevic
             },
-            { # This test shall be executed on the BH P150 on 130 cores
-              name: "panoptic_deeplab demo - 130 cores",
+            { # This test shall be executed on the BH P150 on 110 cores
+              name: "panoptic_deeplab demo - 110 cores",
               arch: blackhole,
-              cmd: 'pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10, 9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo',
               owner_id: U09LK84G4TF # Nikola Milicevic
             },
           ]

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -96,7 +96,7 @@ jobs:
         test-group: [
             { model: panoptic-deeplab, owner_id: U09LK84G4TF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
           ]
-    name: Nightly P150 130 cores ${{ matrix.test-group.model }}
+    name: Nightly P150 110 cores ${{ matrix.test-group.model }}
     # CIv2 to get weights
     runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner-label) }}
     container:
@@ -106,6 +106,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ inputs.arch_name }}
         LOGURU_LEVEL: INFO
+        TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "10,9"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -432,12 +432,14 @@ jobs:
             pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_20_cores -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
 
-      - name: panoptic_deeplab tests (130 cores)
+      - name: panoptic_deeplab tests (110 cores)
+        env:
+          TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "10,9"
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          device_perf_model_name: "panoptic_deeplab_130_cores"
+          device_perf_model_name: "panoptic_deeplab_110_cores"
           commands: |
-            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_130_cores -m models_device_performance_bare_metal --timeout=600
+            pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_110_cores -m models_device_performance_bare_metal --timeout=600
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && matrix.test-info.job-blackhole-set1 && fromJSON(needs.define-models.outputs.models-to-run)['panoptic-deeplab'] }}
 
       - name: Merge test reports

--- a/models/experimental/panoptic_deeplab/README.md
+++ b/models/experimental/panoptic_deeplab/README.md
@@ -1,7 +1,7 @@
 # Panoptic DeepLab
 
 ## Platforms:
-    Made for BOS chips, tested on Blackhole with both 20-core (5x4 grid) and P150 all-core (13x10 grid - 130 cores) configurations.
+    Made for BOS chips, tested on Blackhole with both 20-core (5x4 grid) and P150 all-core (11x10 grid - 110 cores) configurations.
 
 ## Introduction
 Panoptic DeepLab is a unified model for panoptic segmentation that combines semantic segmentation and instance segmentation into a single framework. The model uses a shared ResNet backbone with separate heads for semantic segmentation and instance embedding prediction, enabling comprehensive scene understanding by simultaneously identifying both "stuff" (background regions like road, sky) and "things" (countable objects like cars, people).
@@ -21,9 +21,11 @@ Place the downloaded `model_final_bd324a.pkl` file in `models/experimental/panop
 
 ## How to Run
 
-The model supports both optimized 20-core (5x4 grid) and all-core (13x10 grid) configurations:
+The model supports both optimized 20-core (5x4 grid) and all-core (11x10 grid) configurations:
 - **20 cores (optimized)**: Set `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3"`
-- **130 cores**: Omit/Unset `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE` for P150 device to use all cores (13x10 grid)
+- **110 cores P150**: Set `TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9"`
+
+**Note**: December 2025 - P150 currently has core grid 13x10 but the plan is to have 2 rows harvested (11x10) so in order to prepare for that change, we are setting this env var.
 
 
 ### Run the Full Model Test
@@ -31,10 +33,10 @@ The model supports both optimized 20-core (5x4 grid) and all-core (13x10 grid) c
 # 20-core optimized configuration
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
 
-# 130-core grid configuration (13x10 on Blackhole P150)
-pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+# 110-core grid configuration (11x10 on Blackhole P150)
+TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
 ```
-**Note**: All following tests can be run with or without TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE
+**Note**: All following tests can be run with TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE being "4,3" or "10,9"
 
 ### Run Component Tests
 ```bash
@@ -55,8 +57,8 @@ TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panopti
 ```bash
 # Test full model performance on 20 cores
 TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4,3" pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_20_cores
-# Test full model performance on all cores
-pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_all_cores
+# Test full model performance on all 110 cores
+TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py::test_device_perf_pdl_110_cores
 ```
 
 ### Run the Demo

--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -474,7 +474,7 @@ def run_panoptic_deeplab_demo(
 
 @pytest.mark.parametrize(
     "device_params",
-    [{"l1_small_size": PDL_L1_SMALL_SIZE, "trace_region_size": 2000000}],
+    [{"l1_small_size": PDL_L1_SMALL_SIZE, "trace_region_size": 4000000}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -26,7 +26,7 @@ from models.experimental.panoptic_deeplab.demo.demo_utils import (
     preprocess_image,
     save_predictions,
     preprocess_input_params,
-    skip_if_not_blackhole_20_or_130_cores,
+    skip_if_not_blackhole_20_or_110_cores,
 )
 from models.tt_cnn.tt.pipeline import PipelineConfig
 from models.experimental.panoptic_deeplab.tt.tt_custom_pipeline import (
@@ -487,7 +487,7 @@ def run_panoptic_deeplab_demo(
 @pytest.mark.parametrize("use_trace", [False, True], ids=["ModelExecutor", "CustomTracedModelExecutor"])
 def test_panoptic_deeplab_demo_pipeline(device, output_dir, model_category, use_trace, model_location_generator):
     """Test pipeline execution with both executor types for both model categories."""
-    skip_if_not_blackhole_20_or_130_cores(device)
+    skip_if_not_blackhole_20_or_110_cores(device)
     images, weights_path, output_dir = preprocess_input_params(
         output_dir, model_category, current_dir=__file__, model_location_generator=model_location_generator
     )

--- a/models/experimental/panoptic_deeplab/demo/demo_utils.py
+++ b/models/experimental/panoptic_deeplab/demo/demo_utils.py
@@ -461,14 +461,14 @@ def create_panoptic_visualization(
     return blended, {"segments": segments_info, "panoptic_seg": panoptic_seg, "pure_vis": vis_image}
 
 
-def skip_if_not_blackhole_20_or_130_cores(device):
+def skip_if_not_blackhole_20_or_110_cores(device):
     """
     This function is meant to be run only inside pytest tests.
     """
     if not is_blackhole():
-        pytest.skip("This test is intended to run only on Blackhole devices with 20 or 130 cores.")
+        pytest.skip("This test is intended to run only on Blackhole devices with 20 or 110 cores.")
     compute_grid = device.compute_with_storage_grid_size()
-    if not ((compute_grid.x == 5 and compute_grid.y == 4) or (compute_grid.x == 13 and compute_grid.y == 10)):
+    if not ((compute_grid.x == 5 and compute_grid.y == 4) or (compute_grid.x == 11 and compute_grid.y == 10)):
         pytest.skip(
-            f"This test is intended to run only on Blackhole devices with 20 or 130 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [5, 4] or [13, 10]."
+            f"This test is intended to run only on Blackhole devices with 20 or 110 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [5, 4] or [11, 10]."
         )

--- a/models/experimental/panoptic_deeplab/tests/pcc/common.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/common.py
@@ -76,14 +76,14 @@ def skip_if_not_blackhole_20_cores(device):
         )
 
 
-def skip_if_not_blackhole_130_cores(device):
+def skip_if_not_blackhole_110_cores(device):
     """
     This function is meant to be run only inside pytest tests.
     """
     if not is_blackhole():
-        pytest.skip("This test is intended to run only on Blackhole P150 devices with 130 cores.")
+        pytest.skip("This test is intended to run only on Blackhole P150 devices with 110 cores.")
     compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x != 13 or compute_grid.y != 10:
+    if compute_grid.x != 11 or compute_grid.y != 10:
         pytest.skip(
-            f"This test is intended to run only on Blackhole P150 devices with 130 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [13, 10]."
+            f"This test is intended to run only on Blackhole P150 devices with 110 cores. Core grid [{compute_grid.x},{compute_grid.y}] must be [11, 10]."
         )

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -20,7 +20,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import (
     check_ttnn_output,
-    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_110_cores,
     skip_if_not_blackhole_20_cores,
 )
 
@@ -34,10 +34,10 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         ),
         (
             {"pcc": 0.998, "abs_err": 0.04, "rel_err": 0.5},
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 def test_ttnn_aspp(device, pcc_values, skip_check, model_location_generator):

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -21,7 +21,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import (
     check_ttnn_output,
-    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_110_cores,
     skip_if_not_blackhole_20_cores,
 )
 
@@ -41,10 +41,10 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
                 "center": {"pcc": 0.887, "abs_err": 0.09, "rel_err": 27.5},
                 "offset": {"pcc": 0.741, "abs_err": 6.8, "rel_err": 5.0},
             },
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 def test_ttnn_insemb(device, pcc_values, skip_check, model_location_generator):

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -234,10 +234,10 @@ def test_resnet_layer_pcc(
         ),
         (
             {
-                "res2": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.3},
-                "res3": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.6},
-                "res4": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.3},
-                "res5": {"pcc": 0.992, "abs_err": 0.5, "rel_err": 0.7},
+                "res2": {"pcc": 0.999, "abs_err": 0.1, "rel_err": 0.3},
+                "res3": {"pcc": 0.999, "abs_err": 0.04, "rel_err": 0.6},
+                "res4": {"pcc": 0.999, "abs_err": 0.02, "rel_err": 0.3},
+                "res5": {"pcc": 0.993, "abs_err": 0.02, "rel_err": 0.7},
             },
             skip_if_not_blackhole_110_cores,
         ),

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -26,7 +26,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import (
     check_ttnn_output,
-    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_110_cores,
     skip_if_not_blackhole_20_cores,
 )
 
@@ -239,10 +239,10 @@ def test_resnet_layer_pcc(
                 "res4": {"pcc": 0.999, "abs_err": 0.5, "rel_err": 0.3},
                 "res5": {"pcc": 0.992, "abs_err": 0.5, "rel_err": 0.7},
             },
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("batch_size", [1])

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -21,7 +21,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import (
     check_ttnn_output,
-    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_110_cores,
     skip_if_not_blackhole_20_cores,
 )
 
@@ -35,10 +35,10 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         ),
         (
             {"pcc": 0.972, "abs_err": 1.9, "rel_err": 0.4},
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 def test_ttnn_semseg(device, pcc_values, skip_check, model_location_generator):

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -39,9 +39,9 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             PANOPTIC_DEEPLAB,
             {
-                "semantic": {"pcc": 0.982, "abs_err": 1.4, "rel_err": 0.5},
-                "center": {"pcc": 0.811, "abs_err": 0.1, "rel_err": 2.4},
-                "offset": {"pcc": 0.984, "abs_err": 12.2, "rel_err": 0.7},
+                "semantic": {"pcc": 0.983, "abs_err": 1.4, "rel_err": 0.4},
+                "center": {"pcc": 0.8, "abs_err": 0.1, "rel_err": 2.2},
+                "offset": {"pcc": 0.987, "abs_err": 11.7, "rel_err": 0.7},
             },
             skip_if_not_blackhole_110_cores,
         ),
@@ -55,7 +55,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             DEEPLAB_V3_PLUS,
             {
-                "semantic": {"pcc": 0.982, "abs_err": 1.4, "rel_err": 0.5},
+                "semantic": {"pcc": 0.983, "abs_err": 1.4, "rel_err": 0.4},
             },
             skip_if_not_blackhole_110_cores,
         ),

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -19,7 +19,7 @@ from models.experimental.panoptic_deeplab.tt.common import (
     create_ttnn_model,
 )
 from models.experimental.panoptic_deeplab.tests.pcc.common import (
-    skip_if_not_blackhole_130_cores,
+    skip_if_not_blackhole_110_cores,
     skip_if_not_blackhole_20_cores,
 )
 
@@ -43,7 +43,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
                 "center": {"pcc": 0.811, "abs_err": 0.1, "rel_err": 2.4},
                 "offset": {"pcc": 0.984, "abs_err": 12.2, "rel_err": 0.7},
             },
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
         (
             DEEPLAB_V3_PLUS,
@@ -57,14 +57,14 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
             {
                 "semantic": {"pcc": 0.982, "abs_err": 1.4, "rel_err": 0.5},
             },
-            skip_if_not_blackhole_130_cores,
+            skip_if_not_blackhole_110_cores,
         ),
     ],
     ids=[
         "panoptic_deeplab_20_cores",
-        "panoptic_deeplab_130_cores",
+        "panoptic_deeplab_110_cores",
         "deeplab_v3_plus_20_cores",
-        "deeplab_v3_plus_130_cores",
+        "deeplab_v3_plus_110_cores",
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_upsample.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_upsample.py
@@ -9,7 +9,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from ...tt.tt_upsample import BilinearUpsampleMatmulTTNN
 from ...tt.tt_upsample import BilinearUpsampleTorch
 from ...tt.common import PDL_L1_SMALL_SIZE
-from ...tests.pcc.common import skip_if_not_blackhole_130_cores, skip_if_not_blackhole_20_cores
+from ...tests.pcc.common import skip_if_not_blackhole_110_cores, skip_if_not_blackhole_20_cores
 
 
 @pytest.mark.parametrize(
@@ -69,9 +69,9 @@ def test_bilinear_upsample_matmul_vs_torch(b, h, w, c, scale, input_channels_fir
     "pcc_threshold, skip_check",
     [
         (0.99, skip_if_not_blackhole_20_cores),
-        (0.99, skip_if_not_blackhole_130_cores),
+        (0.99, skip_if_not_blackhole_110_cores),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize(
     "b, h, w, c, scale, input_channels_first, output_channels_first, memory_config",
@@ -168,9 +168,9 @@ def test_bilinear_upsample_ttnn_matmul_vs_ttnn_upsample(
     "pcc_threshold, skip_check",
     [
         (0.99, skip_if_not_blackhole_20_cores),
-        (0.99, skip_if_not_blackhole_130_cores),
+        (0.99, skip_if_not_blackhole_110_cores),
     ],
-    ids=["20_cores", "130_cores"],
+    ids=["20_cores", "110_cores"],
 )
 @pytest.mark.parametrize(
     "b, h, w, c, scale, input_channels_first, output_channels_first, memory_config, output_dtype",

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -53,7 +53,7 @@ def test_device_perf_pdl_20_cores(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_130_cores",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_110_cores",
             12_445_978,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
@@ -63,7 +63,7 @@ def test_device_perf_pdl_20_cores(
             "",
         ),
         (
-            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_130_cores",
+            "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
             8_521_002,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
@@ -73,10 +73,10 @@ def test_device_perf_pdl_20_cores(
             "",
         ),
     ],
-    ids=["test_panoptic_deeplab_130_cores", "test_deeplab_v3_plus_130_cores"],
+    ids=["test_panoptic_deeplab_110_cores", "test_deeplab_v3_plus_110_cores"],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_device_perf_pdl_130_cores(
+def test_device_perf_pdl_110_cores(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
     run_model_device_perf_test(

--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            8_521_002,
+            8_471_069,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35016)

### Problem description
BH P150 will have 2 rows harvested in the future, instead of 13x10 there will be 11x10 core grid. To account for that change, tests and CI is modified since right now it is enabled to run on 13x10.

### What's changed
`TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9"` env var is used to simulate the new P150, checks in tests are adapted for new grid size 11x10 and CI is updated with the env var.

All tests checks inside `models/experimental/panoptic_deeplab/tests/pcc` are updated, some pcc values as well. 

Updated following CI with env var and test names:
```
.github/workflows/blackhole-demo-tests-impl.yaml
.github/workflows/blackhole-nightly-tests-impl.yaml
.github/workflows/perf-device-models-impl.yaml
```
Updated `trace_region_size` in `demo.py `since it was too small for 110 cores.

### Checklist
- [x] New/Existing tests provide coverage for changes


#### Model tests
- [x] [Blackhole nightly test](https://github.com/tenstorrent/tt-metal/actions/runs/20503257717/job/58914046356)
- [x] [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20503247022/job/58914042989) - 20 cores perf time needs to be updated, it got lower. 
- [x] [Blackhole Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20505375513)