### PR TITLE
docs: update dprint.h include path in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,7 +329,7 @@ Breakpoint 1, tt::tt_metal::Device::Device (this=0x3c, device_id=21845, num_hw_c
   - Once the design has been "proven", disable watcher for performance testing.
 - To print within a kernel, use the [Debug Print API](docs/source/tt-metalium/tools/kernel_print.rst):
   - Define the environment variable to specify which cores to print from, `export TT_METAL_DPRINT_CORES=(0,0)-(4,4)` to print from a 5x5 grid of cores.
-  - In the kernel, `#include "debug/dprint.h"`, and to print a variable `x`, `DPRINT << x << ENDL();`
+  - In the kernel, `#include "api/debug/dprint.h"`, and to print a variable `x`, `DPRINT << x << ENDL();`
   - For more information on kernel printing, see the [Kernel Debug Print documentation](docs/source/tt-metalium/tools/kernel_print.rst).
 
 ### Debugging device hangs

--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -29,12 +29,12 @@ Note that the core coordinates are logical coordinates, so worker cores and ethe
     export TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC=0   # optional, enabled by default. Prepends prints with <device id>:(<core x>, <core y>):<RISC>:.
     export TT_METAL_DPRINT_ONE_FILE_PER_RISC=1          # optional, splits DPRINT data on a per-RISC basis into files under $TT_METAL_HOME/generated/dprint/. Overrides TT_METAL_DPRINT_FILE and disables TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC.
 
-To generate kernel debug prints on the device, include the ``debug/dprint.h`` header and use the APIs defined there.
+To generate kernel debug prints on the device, include the ``api/debug/dprint.h`` header and use the APIs defined there.
 An example with the different features available is shown below:
 
 .. code-block:: c++
 
-    #include "debug/dprint.h"  // required in all kernels using DPRINT
+    #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 
     void kernel_main() {
         // Direct printing is supported for const char*/char/uint32_t/float
@@ -93,7 +93,7 @@ formats for printing from CBs are ``DataFormat::Float32``, ``DataFormat::Float16
 
 .. code-block:: c++
 
-    #include "debug/dprint.h"  // required in all kernels using DPRINT
+    #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 
     void kernel_main() {
         // Assuming the tile we want to print from CBIndex::c_25 is from the front the CB, print must happen after

--- a/tech_reports/Debugging/Kernel_Debugging_Tips.md
+++ b/tech_reports/Debugging/Kernel_Debugging_Tips.md
@@ -13,7 +13,7 @@ https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tools/kernel_print.html
 
 * useful for deterministic hang debug and pcc issues
 * simple example:
-    * include `debug/dprint.h` header in your kernel
+    * include `api/debug/dprint.h` header in your kernel
     * print variable from a kernel: `DPRINT << “my variable is ” << my_variable << ENDL();`
     * add `TT_METAL_DPRINT_CORES="(0,0)"`  to your pytest command to output dprints from the first core
 


### PR DESCRIPTION
Update all documentation references to use the new include path `api/debug/dprint.h` instead of the deprecated `debug/dprint.h` path.

This updates:
- CONTRIBUTING.md: Debug printing instructions
- docs/source/tt-metalium/tools/kernel_print.rst: Kernel print API guide
- tech_reports/Debugging/Kernel_Debugging_Tips.md: Debugging tips

#90c25836a6 which reorganized the device-side header directory structure (#34119).

https://github.com/tenstorrent/tt-metal/actions/runs/20506383314