### PR TITLE
[tt-triage] Additional script info

### DIFF
--- a/tools/triage/callstack_provider.py
+++ b/tools/triage/callstack_provider.py
@@ -14,6 +14,9 @@ Options:
 
 Description:
     Provides callstack extraction functionality for RISC cores on devices.
+
+Owner:
+    adjordjevic-TT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/check_arc.py
+++ b/tools/triage/check_arc.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Checking that ARC heartbeat is running. Estimating ARC uptime.
+
+Owner:
+    ihamer-tt
 """
 
 from dataclasses import dataclass

--- a/tools/triage/check_binary_integrity.py
+++ b/tools/triage/check_binary_integrity.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Checking that code binaries are the way they were uploaded to the device (both firmware and kernel).
+
+Owner:
+    tt-vjovanovic
 """
 
 from dispatcher_data import run as get_dispatcher_data, DispatcherData

--- a/tools/triage/check_cb_inactive.py
+++ b/tools/triage/check_cb_inactive.py
@@ -11,6 +11,9 @@ Description:
     Checks that no command buffers (CB0..CB3) are currently active by reading
     NOC_CMD_CTRL_CB0..3 on both NoCs for tensix and eth blocks. If any is nonzero,
     it prints an error with the device, location, NoC, and CB index.
+
+Owner:
+    jbaumanTT
 """
 
 from ttexalens.coordinate import OnChipCoordinate

--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -12,6 +12,9 @@ Description:
     the expected firmware type for that location. If there's a mismatch, it
     attempts to read the mailbox using other firmware types to identify what
     firmware is actually present.
+
+Owner:
+    jbaumanTT
 """
 
 from ttexalens.context import Context

--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Check status on the ethernet cores
+
+Owner:
+    nhuang-tt
 """
 
 from abc import ABC, abstractmethod

--- a/tools/triage/check_noc_locations.py
+++ b/tools/triage/check_noc_locations.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Checking that we can reach all NOC endpoints through NOC0 and NOC1.
+
+Owner:
+    tt-vjovanovic
 """
 
 from ttexalens.coordinate import OnChipCoordinate

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -10,6 +10,9 @@ Usage:
 Description:
     This script checks if there are any mismatches between values of number of NOC transactions
     stored in global variables from risc firmware and NOC status registers.
+
+Owner:
+    jbaumanTT
 """
 
 from ttexalens.context import Context

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -10,6 +10,9 @@ Usage:
 Description:
     Provides dispatcher data noc locations on devices.
     Data include firmware path, kernel path, kernel offset, etc.
+
+Owner:
+    jbaumanTT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -17,6 +17,9 @@ Description:
 
     Color output is automatically enabled when stdout is a TTY (terminal) and can be overridden
     with TT_TRIAGE_COLOR environment variable (0=disable, 1=enable).
+
+Owner:
+    tt-vjovanovic
 """
 
 from triage import ScriptConfig, log_check_risc, run_script

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -11,6 +11,9 @@ Options:
 
 Description:
     Read important variables from fast dispatch kernels.
+
+Owner:
+    jbaumanTT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Dumps information about lightweight asserts that have occurred on the device.
+
+Owner:
+    tt-vjovanovic
 """
 
 

--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -11,6 +11,9 @@ Description:
     Goes through all tensix and idle_eth blocks and tries to halt every core inside them.
     If halt is successful, does nothing. If it throws an exception, prints all debug bus
     signals related to that core (e.g., for brisc, prints all signals matching brisc*).
+
+Owner:
+    adjorjevic-TT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -13,7 +13,7 @@ Description:
     signals related to that core (e.g., for brisc, prints all signals matching brisc*).
 
 Owner:
-    adjorjevic-TT
+    adjordjevic-TT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/dump_running_operations.py
+++ b/tools/triage/dump_running_operations.py
@@ -16,6 +16,9 @@ Description:
     previously observed operations, device/core coverage, and the full list of cores executing
     each operation.
     By default, filters out cores with DONE status. Use --include-done to see all cores.
+
+Owner:
+    miacim
 """
 
 from dataclasses import dataclass

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     Dump watcher ring buffer contents for all cores, skipping cores with empty buffers.
+
+Owner:
+    jbaumanTT
 """
 
 from dataclasses import dataclass

--- a/tools/triage/elfs_cache.py
+++ b/tools/triage/elfs_cache.py
@@ -10,6 +10,9 @@ Usage:
 Description:
     Thread-safe data provider for caching ParsedElfFile objects.
     Provides an API for grabbing or caching ParsedElfFile objects by given elf path.
+
+Owner:
+    adjorjevic-TT
 """
 
 import os

--- a/tools/triage/elfs_cache.py
+++ b/tools/triage/elfs_cache.py
@@ -12,7 +12,7 @@ Description:
     Provides an API for grabbing or caching ParsedElfFile objects by given elf path.
 
 Owner:
-    adjorjevic-TT
+    adjordjevic-TT
 """
 
 import os

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -17,6 +17,9 @@ Description:
     This script will try to connect to Inspector RPC.
     If RPC is not available, it will try to load serialized RPC data from the log directory.
     If RPC data is not available, it will try to parse inspector logs.
+
+Owner:
+    tt-vjovanovic
 """
 
 from triage import triage_singleton, ScriptConfig, run_script

--- a/tools/triage/metal_device_id_mapping.py
+++ b/tools/triage/metal_device_id_mapping.py
@@ -14,6 +14,9 @@ Description:
     restricts devices, Inspector RPC uses remapped metal device IDs (starting from 0), while
     tt-exalens uses the original device IDs from the full device set. This causes a
     mismatch between Metal device IDs and Exalens device IDs.
+
+Owner:
+    adjorjevic-TT
 """
 
 from inspector_data import run as get_inspector_data, InspectorData

--- a/tools/triage/metal_device_id_mapping.py
+++ b/tools/triage/metal_device_id_mapping.py
@@ -16,7 +16,7 @@ Description:
     mismatch between Metal device IDs and Exalens device IDs.
 
 Owner:
-    adjorjevic-TT
+    adjordjevic-TT
 """
 
 from inspector_data import run as get_inspector_data, InspectorData

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -22,7 +22,7 @@ Description:
     block locations and RISC cores without needing to depend on multiple separate scripts.
 
 Owner:
-    adjorjevic-TT
+    adjordjevic-TT
 """
 
 from collections.abc import Callable

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -20,6 +20,9 @@ Description:
 
     This enables other scripts to easily run comprehensive checks across all devices and their
     block locations and RISC cores without needing to depend on multiple separate scripts.
+
+Owner:
+    adjorjevic-TT
 """
 
 from collections.abc import Callable

--- a/tools/triage/test_output.py
+++ b/tools/triage/test_output.py
@@ -9,6 +9,9 @@ Usage:
 
 Description:
     This script does nothing. It is used to test the triage output testing framework.
+
+Owner:
+    tt-vjovanovic
 """
 
 from triage import ScriptConfig, run_script

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -396,13 +396,60 @@ def process_arguments(args: ScriptArguments) -> None:
 
 
 def parse_triage_arguments() -> None:
-    """Parse early triage-only arguments to set verbosity and init console before script loading."""
-    from docopt import docopt
+    """Parse early triage-only arguments to set verbosity and init the main script. Arguments for other scripts are parsed later."""
+    from docopt import (
+        parse_defaults,
+        parse_pattern,
+        formal_usage,
+        printable_usage,
+        parse_argv,
+        TokenStream,
+        DocoptExit,
+    )
 
     # Parse only triage's __doc__, ignoring script args
-    assert __doc__ is not None, "Script docstring must be provided."
+    assert __doc__ is not None, "triage.py docstring must be set."
+    triage_options = parse_defaults(__doc__)
 
-    args = docopt(__doc__, argv=sys.argv[1:], help=False, options_first=True)
+    # Build set of triage's recognized option names
+    recognized_options = set(["-h", "--help", "/?"])  # Always include help options
+    for opt in triage_options:
+        recognized_options.add(opt.short) if opt.short else None
+        recognized_options.add(opt.long) if opt.long else None
+
+    # Filter sys.argv to only include triage's recognized options
+    argv = sys.argv[1:]
+    filtered_argv = []
+    skip_next = False
+
+    for i, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+
+        # Handle --option=value format
+        if "=" in arg:
+            option_name = arg.split("=")[0]
+            if option_name in recognized_options:
+                filtered_argv.append(arg)
+        # Handle standalone option
+        elif arg in recognized_options:
+            filtered_argv.append(arg)
+            # Check if option takes a value (next arg doesn't start with -)
+            if i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                filtered_argv.append(argv[i + 1])
+                skip_next = True
+
+    try:
+        usage = printable_usage(__doc__)
+        pattern = parse_pattern(formal_usage(usage), triage_options)
+        parsed_argv = parse_argv(TokenStream(filtered_argv, DocoptExit), list(triage_options), options_first=False)
+        _, _, collected = pattern.fix().match(parsed_argv)
+        args = dict((a.name, a.value) for a in (pattern.flat() + collected))
+    except Exception:
+        # If parsing fails, use defaults - full validation happens later
+        args = dict((opt.name, opt.value) for opt in triage_options)
+
     triage_args = ScriptArguments(args)
     process_arguments(triage_args)
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -395,12 +395,8 @@ def process_arguments(args: ScriptArguments) -> None:
     init_console_and_verbosity(args)
 
 
-def parse_triage_arguments() -> None:
-    parse_arguments({}, only_triage_script_args=True)
-
-
 def parse_arguments(
-    scripts: dict[str, TriageScript],
+    scripts: dict[str, TriageScript] = {},
     script_path: str | None = None,
     argv: list[str] | None = None,
     only_triage_script_args=False,
@@ -728,7 +724,8 @@ class TTTriageError(Exception):
 def main():
     triage_start = time()
 
-    parse_triage_arguments()
+    # Parse only tt-triage script arguments first to initialize logging and console
+    parse_arguments(only_triage_script_args=True)
 
     # Enumerate all scripts in application directory
     application_path = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR:

- Adds an owner field in the docstring with the script's corresponding owner
- Enforces scripts to have this field filled, otherwise the script will fail to load
a) If you call `tt-triage.py`, the script will not be shown in the list, if called with `--verbosity=5` the debug info will show that the script does not have an owner set (**all dependent scripts as well**)
b) If you call the script directly it will fail with an error saying the script does not have an owner
<img width="997" height="134" alt="image" src="https://github.com/user-attachments/assets/2395e29e-80bb-4cf2-b9cf-3de3726c1a59" />
<img width="1025" height="185" alt="image" src="https://github.com/user-attachments/assets/ee7df86a-7045-4bf0-85f7-f8310e25b049" />

- If a script fails, after the failure messages (log checks), the docstring script is printed out as well with the idea of that docstring being the one proper place used for figuring out what the script does and what does it mean when it fails (a + if troubleshooting steps) which can then later be used for generating readme files - **as a follow up to this PR the owners will be assigned tasks to enrich the docstrings for their scripts**
<img width="638" height="280" alt="image" src="https://github.com/user-attachments/assets/77151163-0257-4412-94bb-512fa0964739" />