### PR TITLE
Add LLK and Compute API for pack_rows operation

### DIFF
--- a/tests/tt_metal/tt_metal/llk/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/llk/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UNIT_TESTS_LLK_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cumsum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dropout_sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_golden_impls.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_pack_rows.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reconfig.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reduce.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sfpu_compute.cpp

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -268,4 +268,17 @@ std::vector<uint32_t> gold_standard_tilize_w_elwadd(
     return tt::test_utils::pack_vector<uint32_t, bfloat16>(result_vec);
 }
 
+std::vector<uint32_t> gold_standard_pack_rows(const std::vector<uint32_t>& src_vec, const PackRowsConfig& config) {
+    vector<uint32_t> dst_vec;
+
+    // Each row = 16 datums = 8 uint32_t (bfloat16 pairs)
+    int num_uint32_to_extract = config.num_rows * 8;
+
+    for (int i = 0; i < num_uint32_to_extract && i < static_cast<int>(src_vec.size()); i++) {
+        dst_vec.push_back(src_vec[i]);
+    }
+
+    return dst_vec;
+}
+
 }  // namespace unit_tests::compute

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -269,15 +269,11 @@ std::vector<uint32_t> gold_standard_tilize_w_elwadd(
 }
 
 std::vector<uint32_t> gold_standard_pack_rows(const std::vector<uint32_t>& src_vec, const PackRowsConfig& config) {
-    vector<uint32_t> dst_vec;
-
     // Each row = 16 datums = 8 uint32_t (bfloat16 pairs)
-    int num_uint32_to_extract = config.num_rows * 8;
-
-    for (int i = 0; i < num_uint32_to_extract && i < static_cast<int>(src_vec.size()); i++) {
-        dst_vec.push_back(src_vec[i]);
-    }
-
+    size_t num_uint32_to_extract = config.num_rows * 8;
+    size_t actual_count = std::min(num_uint32_to_extract, src_vec.size());
+    vector<uint32_t> dst_vec(actual_count);
+    std::copy_n(src_vec.begin(), actual_count, dst_vec.begin());
     return dst_vec;
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
@@ -71,4 +71,11 @@ std::vector<uint16_t> gold_reduce_hw(
 std::vector<uint32_t> gold_standard_tilize_w_elwadd(
     const std::vector<uint32_t>& src0_vec, const std::vector<uint32_t>& src1_vec, const GoldenConfig& config);
 
+// Used if golden function needs pack_rows details
+struct PackRowsConfig {
+    int num_rows{};
+};
+
+std::vector<uint32_t> gold_standard_pack_rows(const std::vector<uint32_t>& src_vec, const PackRowsConfig& config);
+
 }  // namespace unit_tests::compute

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -87,10 +87,10 @@ void run_single_core_pack_rows_program(
             .set_page_size(src0_cb_index, input_single_tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
 
-    uint32_t ouput_cb_index = tt::CBIndex::c_16;
+    uint32_t output_cb_index = tt::CBIndex::c_16;
     tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(output_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(ouput_cb_index, output_size);
+        tt_metal::CircularBufferConfig(output_size, {{output_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(output_cb_index, output_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
 
     auto reader_kernel = tt_metal::CreateKernel(
@@ -124,7 +124,7 @@ void run_single_core_pack_rows_program(
     std::vector<uint32_t> src0_vec;
     for (uint32_t i = 0; i < input_single_tile_size / sizeof(uint32_t); i++) {
         bfloat16 val1(static_cast<float>(i * 2));
-        bfloat16 val2(static_cast<float>(i * 2 + 1));
+        bfloat16 val2(static_cast<float>((i * 2) + 1));
         src0_vec.push_back(pack_two_bfloat16_into_uint32({val1, val2}));
     }
     tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include "device_fixture.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include "test_golden_impls.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/packing.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include <umd/device/types/arch.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal {
+
+using std::vector;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::compute::pack_rows {
+
+struct TestConfig {
+    // Whether or not to sync full/half DST between MATH and PACK:
+    bool dst_full_sync_en = false;
+    // Number of rows to pack from DEST (1-64):
+    uint32_t num_rows;
+};
+
+void run_single_core_pack_rows_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = tt::tt_metal::CreateProgram();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto* device = mesh_device->get_devices()[0];
+
+    CoreCoord core = {0, 0};
+
+    // Input: 1 tile (32x32 = 1024 bfloat16 = 2048 bytes)
+    uint32_t input_single_tile_size = 2 * 1024;
+    // Output: num_rows * 16 datums * 2 bytes each
+    uint32_t output_size = test_config.num_rows * 16 * 2;
+
+    tt_metal::InterleavedBufferConfig input_dram_config{
+        .device = device,
+        .size = input_single_tile_size,
+        .page_size = input_single_tile_size,
+        .buffer_type = tt_metal::BufferType::DRAM};
+
+    tt_metal::InterleavedBufferConfig output_dram_config{
+        .device = device, .size = output_size, .page_size = output_size, .buffer_type = tt_metal::BufferType::DRAM};
+
+    std::shared_ptr<tt_metal::Buffer> src0_dram_buffer = CreateBuffer(input_dram_config);
+    uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
+
+    std::shared_ptr<tt_metal::Buffer> dst_dram_buffer = CreateBuffer(output_dram_config);
+    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(input_single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(src0_cb_index, input_single_tile_size);
+    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+
+    uint32_t ouput_cb_index = tt::CBIndex::c_16;
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(output_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(ouput_cb_index, output_size);
+    tt_metal::CreateCircularBuffer(program_, core, cb_output_config);
+
+    auto reader_kernel = tt_metal::CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+    auto unary_writer_kernel = tt_metal::CreateKernel(
+        program_,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    vector<uint32_t> compute_kernel_args = {
+        uint(test_config.num_rows),
+    };
+
+    tt_metal::CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_rows.cpp",
+        core,
+        tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = false,
+            .dst_full_sync_en = test_config.dst_full_sync_en,
+            .compile_args = compute_kernel_args});
+
+    // Generate tilized input data with sequential values
+    std::vector<uint32_t> src0_vec;
+    for (uint32_t i = 0; i < input_single_tile_size / sizeof(uint32_t); i++) {
+        bfloat16 val1(static_cast<float>(i * 2));
+        bfloat16 val2(static_cast<float>(i * 2 + 1));
+        src0_vec.push_back(pack_two_bfloat16_into_uint32({val1, val2}));
+    }
+    tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+
+    tt_metal::SetRuntimeArgs(
+        program_,
+        reader_kernel,
+        core,
+        {dram_buffer_src0_addr,
+         (uint32_t)0,  // dram bank id
+         (uint32_t)1,  // num_tiles
+         src0_cb_index,
+         (uint32_t)1,  // block_size
+         false});
+
+    tt_metal::SetRuntimeArgs(program_, unary_writer_kernel, core, {dram_buffer_dst_addr, (uint32_t)0, (uint32_t)1});
+
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> result_vec;
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+
+    ::unit_tests::compute::PackRowsConfig golden_config = {
+        .num_rows = static_cast<int>(test_config.num_rows),
+    };
+    vector<uint32_t> golden = ::unit_tests::compute::gold_standard_pack_rows(src0_vec, golden_config);
+
+    bool pass = true;
+    pass &= (golden.size() == result_vec.size());
+    pass &= (golden == result_vec);
+
+    if (not pass) {
+        std::cout << "GOLDEN " << std::endl;
+        print_vector(unpack_vector<bfloat16, uint32_t>(golden));
+        std::cout << "RESULTS " << std::endl;
+        print_vector(unpack_vector<bfloat16, uint32_t>(result_vec));
+    }
+
+    log_info(
+        tt::LogTest,
+        "Done running test with: num_rows = {}, DstSyncFull = {}, pass = {}",
+        test_config.num_rows,
+        test_config.dst_full_sync_en,
+        pass);
+    ASSERT_TRUE(pass);
+}
+
+}  // namespace unit_tests::compute::pack_rows
+
+/**************************************
+Following tests are for pack_rows
+***************************************/
+
+TEST_F(MeshDeviceFixture, TensixComputePackRows) {
+    vector<uint32_t> num_rows_values = {1, 8, 16, 32, 48, 64};
+    for (auto num_rows : num_rows_values) {
+        for (bool dst_full_sync_en : {true, false}) {
+            unit_tests::compute::pack_rows::TestConfig test_config = {
+                .dst_full_sync_en = dst_full_sync_en,
+                .num_rows = num_rows,
+            };
+            unit_tests::compute::pack_rows::run_single_core_pack_rows_program(this->devices_.at(0), test_config);
+        }
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+
+namespace NAMESPACE {
+
+void MAIN {
+    constexpr uint32_t num_rows = get_compile_time_arg_val(0);
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+
+    copy_tile_init(tt::CBIndex::c_0);
+    pack_rows_init(num_rows);
+
+    cb_wait_front(tt::CBIndex::c_0, 1);
+    cb_reserve_back(tt::CBIndex::c_16, 1);
+
+    tile_regs_acquire();
+    copy_tile(tt::CBIndex::c_0, 0, 0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_rows(0, tt::CBIndex::c_16, 0);
+    tile_regs_release();
+
+    pack_rows_uninit();
+
+    cb_pop_front(tt::CBIndex::c_0, 1);
+    cb_push_back(tt::CBIndex::c_16, 1);
+}
+}  // namespace NAMESPACE

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -236,15 +236,15 @@ inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_in
 /**
  * @brief Pack rows from a destination register to L1 memory.
  *
- * @param output The output circular buffer identifier
  * @param dst_index Index in the destination register to read from
+ * @param output The output circular buffer identifier
  * @param output_index The index in the output CB to write to
  *
  * This function packs the specified number of rows (configured via llk_pack_rows_init)
  * from the destination register to the output circular buffer.
  */
 inline void llk_pack_rows(
-    const std::uint32_t output, const std::uint32_t dst_index, const std::uint32_t output_index = 0) {
+    const std::uint32_t dst_index, const std::uint32_t output, const std::uint32_t output_index = 0) {
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
     _llk_pack_rows_(dst_index, pack_addr);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -15,6 +15,7 @@
 #include "llk_outputs.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
+#include "llk_pack_rows.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
 
@@ -216,6 +217,46 @@ inline void llk_pack_untilize(
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }
 }
+
+/*************************************************************************
+ * LLK PACK ROWS
+ *************************************************************************/
+
+/**
+ * @brief Initialize the pack rows operation.
+ *
+ * @param num_rows Total number of rows to pack from the destination register to L1.
+ *                 Each row contains 16 datums.
+ *
+ * This function prepares the packer hardware to pack a specified number of rows
+ * from the destination register to L1 memory in row-major format.
+ */
+inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_init_(num_rows); }
+
+/**
+ * @brief Pack rows from a destination register to L1 memory.
+ *
+ * @param output The output circular buffer identifier
+ * @param dst_index Index in the destination register to read from
+ * @param output_index The index in the output CB to write to
+ *
+ * This function packs the specified number of rows (configured via llk_pack_rows_init)
+ * from the destination register to the output circular buffer.
+ */
+inline void llk_pack_rows(
+    const std::uint32_t output, const std::uint32_t dst_index, const std::uint32_t output_index = 0) {
+    const std::uint8_t output_id = get_output_id(output);
+    const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
+    _llk_pack_rows_(dst_index, pack_addr);
+}
+
+/**
+ * @brief Uninitialize the pack rows operation.
+ *
+ * Restores packer addrmods and counters to a safe default state.
+ * Should be called after the pack rows operation is complete.
+ */
+inline void llk_pack_rows_uninit() { _llk_pack_rows_uninit_(); }
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, bool untilize = false>
 inline void llk_matmul_pack(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -220,13 +220,16 @@ inline void llk_pack_untilize(
 
 /*************************************************************************
  * LLK PACK ROWS
+ *
+ * This is a non-standard packing operation that requires explicit initialization
+ * and uninitialization, similar to pack_untilize.
  *************************************************************************/
 
 /**
  * @brief Initialize the pack rows operation.
  *
  * @param num_rows Total number of rows to pack from the destination register to L1.
- *                 Each row contains 16 datums.
+ *                 Each row contains 16 datums. Valid range: 1 to 64.
  *
  * This function prepares the packer hardware to pack a specified number of rows
  * from the destination register to L1 memory in row-major format.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -240,13 +240,16 @@ inline void llk_matmul_pack(
 
 /*************************************************************************
  * LLK PACK ROWS
+ *
+ * This is a non-standard packing operation that requires explicit initialization
+ * and uninitialization, similar to pack_untilize.
  *************************************************************************/
 
 /**
  * @brief Initialize the pack rows operation.
  *
  * @param num_rows Total number of rows to pack from the destination register to L1.
- *                 Each row contains 16 datums.
+ *                 Each row contains 16 datums. Valid range: 1 to 64.
  *
  * This function prepares the packer hardware to pack a specified number of rows
  * from the destination register to L1 memory in row-major format.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -256,15 +256,15 @@ inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_in
 /**
  * @brief Pack rows from a destination register to L1 memory.
  *
- * @param output The output circular buffer identifier
  * @param dst_index Index in the destination register to read from
+ * @param output The output circular buffer identifier
  * @param output_index The index in the output CB to write to
  *
  * This function packs the specified number of rows (configured via llk_pack_rows_init)
  * from the destination register to the output circular buffer.
  */
 inline void llk_pack_rows(
-    const std::uint32_t output, const std::uint32_t dst_index, const std::uint32_t output_index = 0) {
+    const std::uint32_t dst_index, const std::uint32_t output, const std::uint32_t output_index = 0) {
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
     _llk_pack_rows_(dst_index, pack_addr);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -17,6 +17,7 @@
 #include "llk_param_structs.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
+#include "llk_pack_rows.h"
 #include "llk_pack_untilize.h"
 
 /*************************************************************************
@@ -236,6 +237,46 @@ inline void llk_matmul_pack(
         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
     }
 }
+
+/*************************************************************************
+ * LLK PACK ROWS
+ *************************************************************************/
+
+/**
+ * @brief Initialize the pack rows operation.
+ *
+ * @param num_rows Total number of rows to pack from the destination register to L1.
+ *                 Each row contains 16 datums.
+ *
+ * This function prepares the packer hardware to pack a specified number of rows
+ * from the destination register to L1 memory in row-major format.
+ */
+inline void llk_pack_rows_init(const std::uint32_t num_rows) { _llk_pack_rows_init_(num_rows); }
+
+/**
+ * @brief Pack rows from a destination register to L1 memory.
+ *
+ * @param output The output circular buffer identifier
+ * @param dst_index Index in the destination register to read from
+ * @param output_index The index in the output CB to write to
+ *
+ * This function packs the specified number of rows (configured via llk_pack_rows_init)
+ * from the destination register to the output circular buffer.
+ */
+inline void llk_pack_rows(
+    const std::uint32_t output, const std::uint32_t dst_index, const std::uint32_t output_index = 0) {
+    const std::uint8_t output_id = get_output_id(output);
+    const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
+    _llk_pack_rows_(dst_index, pack_addr);
+}
+
+/**
+ * @brief Uninitialize the pack rows operation.
+ *
+ * Restores packer addrmods and counters to a safe default state.
+ * Should be called after the pack rows operation is complete.
+ */
+inline void llk_pack_rows_uninit() { _llk_pack_rows_uninit_(); }
 
 /*************************************************************************
  * LLK PACK FAST TILIZE

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -216,7 +216,7 @@ ALWI void pack_rows_init(uint32_t num_rows) { PACK((llk_pack_rows_init(num_rows)
  */
 // clang-format on
 ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
-    PACK((llk_pack_rows(ocb, idst, output_index)));
+    PACK((llk_pack_rows(idst, ocb, output_index)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -166,4 +166,70 @@ ALWI void pack_reconfig_data_format(const uint32_t old_cb_id, const uint32_t new
 // clang-format on
 ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconfig_l1_acc(l1_acc_en))); }
 
+// clang-format off
+/**
+ * Initializes the pack rows operation. This function prepares the packer hardware to pack
+ * a specified number of rows from the destination register to L1 memory in row-major order.
+ * Each row contains 16 datums by default.
+ *
+ * The pack rows operation is useful when you need to pack data from the destination register
+ * to L1 memory in a row-major layout, as opposed to the tile-based layout used by standard
+ * pack operations.
+ *
+ * This initialization function should be called before using `pack_rows` to perform the
+ * actual packing.
+ *
+ * NOTE: Before calling this function, ensure that the packer hardware has been configured
+ * for the output circular buffer (e.g., via an earlier initialization function that sets
+ * up the destination format).
+ *
+ * Return value: None
+ *
+ * | Param Type | Name     | Description                                                    | Type     | Valid Range | Required |
+ * |------------|----------|----------------------------------------------------------------|----------|-------------|----------|
+ * | Function   | num_rows | Number of rows to pack from dest to L1 (each row = 16 datums)  | uint32_t | 1 to 64     | True     |
+ */
+// clang-format on
+ALWI void pack_rows_init(uint32_t num_rows) { PACK((llk_pack_rows_init(num_rows))); }
+
+// clang-format off
+/**
+ * Packs rows from a destination register to the output circular buffer in row-major order.
+ * Before calling this function:
+ * 1. Initialize the pack rows operation with `pack_rows_init`
+ * 2. Ensure cb_reserve_back has been called on the output CB
+ * 3. Data must be present in the destination register (from unpack/math operations)
+ *
+ * Each call to `pack_rows` will pack the configured number of rows (set via `pack_rows_init`)
+ * from the data in the destination register to the output circular buffer.
+ *
+ * After pack_rows operation is complete, call `pack_rows_uninit` to restore the packer
+ * to its default state.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name         | Description                                       | Type     | Valid Range                                          | Required |
+ * |------------|--------------|---------------------------------------------------|----------|------------------------------------------------------|----------|
+ * | Function   | idst         | The index in the DEST register                    | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Function   | ocb          | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
+ * | Function   | output_index | The index in the output CB to write to            | uint32_t | Must be less than the size of the CB                 | False    |
+ */
+// clang-format on
+ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
+    PACK((llk_pack_rows(ocb, idst, output_index)));
+}
+
+// clang-format off
+/**
+ * Uninitializes the pack rows operation and restores the packer to its default state.
+ * This function should be called after the pack_rows operation is complete.
+ *
+ * The function restores packer address modifiers and counters to default values,
+ * allowing other packing operations to function correctly.
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void pack_rows_uninit() { PACK((llk_pack_rows_uninit())); }
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -168,20 +168,12 @@ ALWI void pack_reconfig_l1_acc(const uint32_t l1_acc_en) { PACK((llk_pack_reconf
 
 // clang-format off
 /**
- * Initializes the pack rows operation. This function prepares the packer hardware to pack
+ * Initializes the pack rows operation. This function configures the packer to pack
  * a specified number of rows from the destination register to L1 memory in row-major order.
- * Each row contains 16 datums by default.
+ * Each row contains 16 datums.
  *
- * The pack rows operation is useful when you need to pack data from the destination register
- * to L1 memory in a row-major layout, as opposed to the tile-based layout used by standard
- * pack operations.
- *
- * This initialization function should be called before using `pack_rows` to perform the
- * actual packing.
- *
- * NOTE: Before calling this function, ensure that the packer hardware has been configured
- * for the output circular buffer (e.g., via an earlier initialization function that sets
- * up the destination format).
+ * Call this function before using `pack_rows`. After the pack_rows operation is complete,
+ * call `pack_rows_uninit` to restore the packer state.
  *
  * Return value: None
  *
@@ -225,7 +217,9 @@ ALWI void pack_rows(uint32_t idst, uint32_t ocb, uint32_t output_index = 0) {
  * This function should be called after the pack_rows operation is complete.
  *
  * The function restores packer address modifiers and counters to default values,
- * allowing other packing operations to function correctly.
+ * allowing subsequent standard packing operations (e.g., pack_tile) to function correctly.
+ * This is necessary because pack_rows uses a specialized packer configuration that differs
+ * from the default tile packing setup.
  *
  * Return value: None
  */


### PR DESCRIPTION
### Ticket
#35066

### Problem description
A new LLK for packing row major data from Destination register to L1 was introduced and tested via LLK test infra.
In order to use it in tt-metal, both LLK APIs and compute APIs had to be added. 

### What's changed

- Added LLK APIs for WH & BH;
- Introduced new Compute APIs for pack_rows;
- Wrote a testing kernel and adequate tests. 

The tests are passing on both WH and BH. 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/pack_rows_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/pack_rows_api)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/pack_rows_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/pack_rows_api)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/pack_rows_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/pack_rows_api)
- [ ] New/Existing tests provide coverage for changes