### PR TITLE
Add SDXL op unit tests to APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -192,6 +192,24 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
+  ops-unit-tests:
+    needs: [build-artifact, find-changed-files]
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    if: ${{ needs.find-changed-files.outputs.test-everything == 'true' }}
+    uses: ./.github/workflows/ops-post-commit.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Enable ops-sanity workflow after issue:30675 resolved
   # ops-sanity:
   #   needs: build-artifact

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -1,0 +1,174 @@
+name: "[internal] ops unit tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 40
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      enable-watcher:
+        required: false
+        type: boolean
+        default: false
+      enable-lightweight-kernel-asserts:
+        description: 'Enable lightweight kernel asserts'
+        required: false
+        type: boolean
+        default: false
+      enable-llk-asserts:
+        description: 'Enable LLK asserts'
+        required: false
+        type: boolean
+        default: false
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
+
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - wormhole_b0
+          - blackhole
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 40
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  define-ops-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      ops-tests: ${{ steps.compute-tests.outputs.ops-tests }}
+    strategy:
+      matrix:
+        default-ops-tests:
+          [[
+            { name: "sdxl op tests", cmd: "pytest -n auto --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false },
+          ]]
+    steps:
+      - name: Compute tests
+        shell: bash
+        id: compute-tests
+        run: |
+          set -euo pipefail
+          echo "[info] Outputing default values"
+          default_ops_tests='${{ toJSON(matrix.default-ops-tests) }}'
+          echo $default_ops_tests
+          echo $default_ops_tests | jq
+          requested_ops_tests=$default_ops_tests
+
+          requested_ops_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$requested_ops_tests")
+          echo "[info] after filtering for requested workflow tests: $requested_ops_tests"
+
+          # Check that we have a valid test list that's not empty
+          echo "$requested_ops_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          echo "ops-tests=$(echo $requested_ops_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          echo "[info] Showing GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+  ops:
+    needs: define-ops-tests
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJSON(needs.define-ops-tests.outputs.ops-tests) }}
+    name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        (inputs.runner-label == 'P100') && fromJSON(format('["in-service", "cloud-virtual-machine", "{0}"]', inputs.runner-label))
+        || ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
+      }}
+    container:
+      image: ${{ ((inputs.runner-label != 'P100') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher || false }}
+          enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+          auto-triage: ${{ !inputs.enable-watcher }}
+          slow-dispatch-timeout: 10.0
+
+      - name: ${{ matrix.test-group.name }} tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: |
+          ${{ matrix.test-group.cmd }}
+
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: U08VC9954CE # David Popov
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+from models.perf.device_perf_utils import run_device_perf_detailed
+
+MARGIN = 0.015
+USE_PERF_TEST_MODE = True
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+def test_dram_group_norm_welford_reciprocal_vae(device):
+    from tests.ttnn.unit_tests.operations.fused.test_group_norm_DRAM import test_group_norm_DRAM
+
+    test_group_norm_DRAM(device, 1, 256, 256, 256, 32, 4, 8, 8, "welford_reciprocal", perf_test_mode=USE_PERF_TEST_MODE)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+def test_block_sharded_group_norm_sdxl(device):
+    from tests.ttnn.unit_tests.operations.fused.test_group_norm import test_sdxl_base_group_norm
+
+    test_sdxl_base_group_norm(device, (1, 1920, 32, 32), use_welford=False, perf_test_mode=USE_PERF_TEST_MODE)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 47000}], indirect=True)
+def test_block_sharded_group_norm_negative_mask_sdxl(device):
+    from tests.ttnn.unit_tests.operations.fused.test_group_norm import test_sdxl_base_group_norm_negative_mask
+
+    test_sdxl_base_group_norm_negative_mask(device, (1, 640, 128, 128), perf_test_mode=USE_PERF_TEST_MODE)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+def test_ff_matmul_with_gelu_sdxl(device):
+    from tests.ttnn.nightly.unit_tests.operations.matmul.test_matmul import test_sdxl_matmul
+
+    test_sdxl_matmul(
+        device,
+        core_grid=ttnn.CoreGrid(y=8, x=5),
+        M=1024,
+        K=1280,
+        N=5120,
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        per_core_M=4,
+        per_core_N=32,
+        has_gelu=True,
+        perf_test_mode=USE_PERF_TEST_MODE,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 2 * 16384}], indirect=True)
+def test_conv2d_block_sharded_sdxl(device):
+    from tests.ttnn.nightly.unit_tests.operations.conv.test_conv2d import test_conv2d_sdxl
+
+    test_conv2d_sdxl(
+        device,
+        torch_tensor_map={},
+        batch=1,
+        input_channels=2560,
+        output_channels=1280,
+        input_height=32,
+        input_width=32,
+        weights_dtype=ttnn.bfloat8_b,
+        output_dtype=ttnn.bfloat16,
+        groups=1,
+        kernel=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        dilation=(1, 1),
+        shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        act_block_h_override=64,
+        act_block_w_div=1,
+        deallocate_activation=True,
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        fp32_accum=False,
+        packer_l1_acc=True,
+        act_db=True,
+        w_db=True,
+        perf_test_mode=USE_PERF_TEST_MODE,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 27 * 1024}], indirect=True)
+def test_conv2d_auto_sliced_vae(device):
+    from tests.ttnn.nightly.unit_tests.operations.conv.test_conv2d import test_conv2d_vae_sdxl
+
+    test_conv2d_vae_sdxl(
+        device,
+        torch_tensor_map={},
+        batch=1,
+        input_channels=512,
+        output_channels=512,
+        input_height=256,
+        input_width=256,
+        weights_dtype=ttnn.bfloat8_b,
+        output_dtype=ttnn.bfloat16,
+        groups=1,
+        kernel=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        dilation=(1, 1),
+        shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        deallocate_activation=False,
+        slice_type=ttnn.Conv2dDRAMSliceWidth,
+        num_slices=2,
+        act_block_h_override=256,
+        throttle=0,
+        auto_slice=True,
+        perf_test_mode=USE_PERF_TEST_MODE,
+    )
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_dram_group_norm_vae_welford_reciprocal_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_dram_group_norm_welford_reciprocal_vae" -v'
+    subdir = f"dram_group_norm_vae_welford_reciprocal_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "GroupNormDeviceOperation"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 1516464  # Measured: 1.52ms for GroupNorm VAE welford_reciprocal
+
+    # Log the performance result
+    print(
+        f"DRAM GroupNorm VAE welford_reciprocal Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_block_sharded_group_norm_sdxl_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_block_sharded_group_norm_sdxl" -v'
+    subdir = f"block_sharded_group_norm_sdxl_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "GroupNormDeviceOperation"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 83180  # Measured: ~83μs for GroupNorm SDXL block sharded
+
+    # Log the performance result
+    print(
+        f"Block Sharded GroupNorm SDXL Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_block_sharded_group_norm_negative_mask_sdxl_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_block_sharded_group_norm_negative_mask_sdxl" -v'
+    subdir = f"block_sharded_group_norm_negative_mask_sdxl_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "GroupNormDeviceOperation"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 600338  # Measured: ~600μs for GroupNorm SDXL negative mask
+
+    # Log the performance result
+    print(
+        f"Block Sharded GroupNorm Negative Mask SDXL Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_ff_matmul_with_gelu_sdxl_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_ff_matmul_with_gelu_sdxl" -v'
+    subdir = f"ff_matmul_with_gelu_sdxl_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "Matmul"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 238419  # Measured: 238μs for FF Matmul SDXL with GELU
+
+    # Log the performance result
+    print(
+        f"FF Matmul SDXL (with GELU) Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_conv2d_block_sharded_sdxl_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_conv2d_block_sharded_sdxl" -v'
+    subdir = f"conv2d_block_sharded_sdxl_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "Conv2dDeviceOperation"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 1115831  # Measured: 1.12ms for Conv2D SDXL block sharded
+
+    # Log the performance result
+    print(
+        f"Conv2D Block Sharded SDXL Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"
+
+
+@pytest.mark.models_device_performance_bare_metal
+def test_conv2d_auto_sliced_vae_performance():
+    # Create a command that runs the specific test
+    command = f'pytest "models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py::test_conv2d_auto_sliced_vae" -v'
+    subdir = f"conv2d_auto_sliced_vae_perf"
+    cols = ["DEVICE KERNEL"]
+    op_name = "Conv2dDeviceOperation"
+
+    # Run the performance test and get detailed results
+    results = run_device_perf_detailed(
+        command=command,
+        subdir=subdir,
+        cols=cols,
+        op_name=op_name,
+    )
+
+    # Extract the device kernel duration result
+    device_kernel_duration = results["DEVICE KERNEL"]["AVG"]
+
+    expected_duration_ns = 3185244  # Measured: 3.19ms for Conv2D VAE auto sliced
+
+    # Log the performance result
+    print(
+        f"Conv2D Auto Sliced VAE Device Kernel Duration: {device_kernel_duration:.2f} ns (expected: {expected_duration_ns} ns)"
+    )
+
+    # Performance validation with 1.5% margin
+    lower_bound = expected_duration_ns * (1 - MARGIN)
+    upper_bound = expected_duration_ns * (1 + MARGIN)
+
+    # Performance validation - assert if outside expected range
+    assert (
+        lower_bound <= device_kernel_duration <= upper_bound
+    ), f"Performance outside expected range. Got {device_kernel_duration:.2f} ns, expected {expected_duration_ns} ± {MARGIN * 100}% ({lower_bound:.2f}-{upper_bound:.2f} ns)"


### PR DESCRIPTION
### Ticket
Link to Github Issue
-

### Problem description
Op perf tests should exist in APC so op regressions can be easily caught.


### What's changed
Add some SDXL op tests in APC.
Matmul with gelu, Groupnorm (sharded, dram and negative mask), and conv (block sharded and dram sliced).
They last about ~5min on CI, locally about 1 min 😢 
Tests in question are modified to have perf_mode, which removes ref op calculation and pcc check (without this, duration is ~6 min on CI).
Had to add matmul unit tests as they didn't exist before in standalone variants.
Example of APC run https://github.com/tenstorrent/tt-metal/actions/runs/20520522235/job/58955420026

### Checklist

- [x] [![All post-commit tests] (https://github.com/tenstorrent/tt-metal/actions/runs/20570169858)

