### PR TITLE
Skipping SGD cpp test with segmentation fault until it gets resolved

### DIFF
--- a/tt-train/tests/autograd/module_base_parameters_test.cpp
+++ b/tt-train/tests/autograd/module_base_parameters_test.cpp
@@ -85,6 +85,7 @@ TEST_F(ModuleBaseParametersTest, AllParametersIncluded) {
 };
 
 TEST_F(ModuleBaseParametersTest, NIGHTLY_UnusedParametersInModuleSGD) {
+    GTEST_SKIP() << "Skipping due to segmentation fault - see GitHub issue 35082";
     auto* device = &ttml::autograd::ctx().get_device();
 
     ModelUnusedLayer model;


### PR DESCRIPTION
### Ticket
[35082](https://github.com/tenstorrent/tt-metal/issues/35082)

### Problem description
[L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20517129360/job/58946841939) is deterministically failing on main due to segmentation fault happening in `ModuleBaseParametersTest.NIGHTLY_UnusedParametersInModuleSGD`. This issue was communicated but due to ongoing holiday's period takes longer to resolve. Therefore this PR is skipping the test until the issue can be revisited once holiday season is over. 

### What's changed
Test is skipped with link to an issue describing why it needed skipping.

### Checklist

- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20523573480)