### PR TITLE
Skipping bad pcc test_split.py breaking L2 Nightly until it gets resolved

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py
@@ -20,6 +20,7 @@ chunksize_list = [1, 2, 4, 5]
 dims = [0, 1, 2, 3, 4]
 
 
+@pytest.mark.skip(reason="Skipping due to test failure - github issue ##35085")
 @pytest.mark.parametrize("layout", layouts)
 @pytest.mark.parametrize("dtype", dtypes)
 @pytest.mark.parametrize("shape", shapes)


### PR DESCRIPTION
### Ticket
[35085](https://github.com/tenstorrent/tt-metal/issues/35085)

### Problem description
[L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20517129360/job/58946841940) is deterministically failing on main due to badd pcc happening in `tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py::test_split`. This issue was communicated but due to ongoing holiday's period takes longer to resolve. Therefore this PR is skipping the test until the issue can be revisited once holiday season is over.

### What's changed
Test is skipped with link to an issue describing why it needed skipping.

### Checklist

- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20524067558)