### PR TITLE
[Bug fix] Altering ALU config from TRISC0

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -75,7 +75,7 @@ void math_main() {
     constexpr bool spill = num_blocks > 1U;
     bool enable_reload = false;
 
-    llk_math_hw_configure(0, 1);
+    llk_math_hw_configure<DST_ACCUM_MODE>(0, 1);
 
     for (uint32_t block = 0U; block < num_blocks; block++) {
         bool last_out = block == num_blocks - 1U;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -15,7 +15,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure(0, 1);
+    llk_math_hw_configure<DST_ACCUM_MODE>(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -19,7 +19,7 @@ void math_main() {
     int __outer_loop_iter;
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0)));
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure(0, 0);
+    llk_math_hw_configure<DST_ACCUM_MODE>(0, 0);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -25,7 +25,7 @@ void math_main() {
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
     llk_math_pack_sync_init<DST_ACCUM_MODE>();
-    llk_math_hw_configure(0, 1);
+    llk_math_hw_configure<DST_ACCUM_MODE>(0, 1);
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {
         for (uint32_t r = 0; r < per_core_block_r_tiles; r++) {
             // Untilize

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -166,7 +166,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
     expected_peak_size += compute_tensor_size(mul_result) + 10240;
     expected_peak_size += compute_tensor_size(matmul_result) + 18432;
     expected_peak_size +=
-        compute_tensor_size(sdpa_result->get_value()) + 1828864;  // All the intermediate tensors / activations
+        compute_tensor_size(sdpa_result->get_value()) + 1830912;  // All the intermediate tensors / activations
 
     expected_size = expected_peak_size - 983040;  // Some intermediates are deallocated
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,10 +21,12 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(
+        unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,10 +21,12 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+template <bool is_fp32_dest_acc_en>
 inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
     std::uint32_t srcb_operand_id = get_operand_id(srcb_operand);
-    _llk_math_hw_configure_(unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(
+        unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
 inline void llk_math_wait_for_dest_available() {

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -47,7 +47,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
         MATH((llk_math_eltwise_unary_datacopy_init<B2D, DST_ACCUM_MODE, bcast_type>(icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb, icb)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 #endif
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
@@ -115,7 +115,7 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
     }
 
     if (unpacker_dst_format_change) {
-        MATH((llk_math_hw_configure(new_icb, new_icb)));
+        MATH((llk_math_hw_configure<DST_ACCUM_MODE>(new_icb, new_icb)));
     }
 
     if (unpacker_dst_format_change || bcast_type_change) {
@@ -249,7 +249,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb0, icb1)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 }
 
 /*

--- a/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
+++ b/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h
@@ -41,7 +41,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb0, icb1)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_hw_configure_disaggregated<

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -32,7 +32,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb0, icb1)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -25,7 +25,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
 
     MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb, icb)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 }
 
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -96,7 +96,7 @@ ALWI void mm_init(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t out_cb_id, co
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
@@ -217,7 +217,7 @@ ALWI void mm_block_init(
 
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id)));
 #ifdef ARCH_BLACKHOLE
     // Dynamic throttling is only available on Blackhole architecture
     MATH((throttled_mop_status = 0));

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -77,7 +77,7 @@ ALWI void tilizeA_B_reduce_init(
 
     MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb0, icb1_scaler)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -44,7 +44,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb) {
         MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure(icb, icb)));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 #endif
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35079
LLK PR: https://github.com/tenstorrent/tt-llk/pull/1016

### Problem description
This is a follow up on [this PR change](https://github.com/tenstorrent/tt-llk/pull/1016), checkout for more detailed problem explanation. 

### What's changed
In this change I only added newly created template parameters that follows change mentioned above

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=njokovic/35079-altering-ALU-config-from-TRISC0)](https://github.com/tenstorrent/tt-metal/actions/runs/21030952716)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/35079-altering-ALU-config-from-TRISC0)](https://github.com/tenstorrent/tt-metal/actions/runs/20952476843)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/35079-altering-ALU-config-from-TRISC0)](https://github.com/tenstorrent/tt-metal/actions/runs/20952545281)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/35079-altering-ALU-config-from-TRISC0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/35079-altering-ALU-config-from-TRISC0)
  - [x] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20952619400/job/60238281589) with matching [main branch run](https://github.com/tenstorrent/tt-metal/actions/runs/20952750593) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20952651522) with matching [main branch run](https://github.com/tenstorrent/tt-metal/actions/runs/20945497760))
  - [x] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/20953687660)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/20953201364)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs