### PR TITLE
[UNET] Bumping the average kernel samples per second threshold

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -129,7 +129,7 @@ def run_multi_iteration_perf_test(test_func, num_runs, *args, **kwargs) -> Perfo
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1633.0) if is_wormhole_b0() else (1, 4, 2875.5),),
+    ((1, 4, 1640.0) if is_wormhole_b0() else (1, 4, 2875.5),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"


### PR DESCRIPTION
### Problem description
[Single Card Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/20523771174/job/58963616787) pipeline failed due to average kernel samples per second being higher than the given range. 
Last 6 runs of this pipeline gave following average kernel samples per second values 

1642.4868
1639.01075
1640.2738
1639.959079
1639.006059
1641.123267

which results in an average of 1640.309959 and the previous average was 1633

### What's changed
This pr bumps the threshold having average values of last six runs in mind

### Checklist

- [x] [Single card Device Perf Regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20571028678)