### PR TITLE
[skip ci] cleanup cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,6 @@
         "cacheVariables": {
           "TT_METAL_BUILD_TESTS": {"value": "TRUE"},
           "TTNN_BUILD_TESTS": {"value": "TRUE"},
-          "EXPERIMENTAL_NANOBIND_BINDINGS": {"value": "TRUE"},
           "TT_UMD_BUILD_TESTS": {"value": "FALSE"},
           "BUILD_PROGRAMMING_EXAMPLES": {"value": "TRUE"},
           "BUILD_TT_TRAIN": {"value": "TRUE"},


### PR DESCRIPTION
### Ticket
N/A

### Problem description
CMakePresets still had a vestigial flag for nanobind.

### What's changed
Removed unused flag