### PR TITLE
[TT-Transformers]  Enable fused rotary and paged cache update ops in attention module

### DIFF
--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -89,6 +89,7 @@ class ModelArgs(TTModelArgs):
         self.tile_size = 32
         self.is_70b = False
         self.is_90b = False
+        self.use_qk_fused = False  # For Gemini 3, we do not use qk fused ops (rotary embedding + paged cache update)
         self.prefill_len_cutoff = 512 if is_blackhole() else 1024
         self.dummy_weights = dummy_weights
         self.cache_hf_flag = cache_hf  # Whether to cache HF model to avoid multiple loads (uses extra memory)

--- a/models/demos/gemma3/tt/model_config.py
+++ b/models/demos/gemma3/tt/model_config.py
@@ -89,7 +89,7 @@ class ModelArgs(TTModelArgs):
         self.tile_size = 32
         self.is_70b = False
         self.is_90b = False
-        self.use_qk_fused = False  # For Gemini 3, we do not use qk fused ops (rotary embedding + paged cache update)
+        self.use_qk_fused = False  # For Gemma 3, we do not use qk fused ops (rotary embedding + paged cache update)
         self.prefill_len_cutoff = 512 if is_blackhole() else 1024
         self.dummy_weights = dummy_weights
         self.cache_hf_flag = cache_hf  # Whether to cache HF model to avoid multiple loads (uses extra memory)

--- a/models/demos/qwen25_vl/tt/rope.py
+++ b/models/demos/qwen25_vl/tt/rope.py
@@ -26,6 +26,7 @@ class RotarySetup(LightweightModule):
         max_seq_len: int,
         rope_theta: float,
         rope_scaling: Optional[RopeScaling],
+        use_qk_fused: bool = False,  # For Qwen2.5 VL, we do not use qk fused ops (rotary embedding + paged cache update)
         datatype=ttnn.bfloat16,
     ):
         super().__init__()

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -9,8 +9,9 @@ import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
+from models.common.utility_functions import nearest_32
 from models.tt_transformers.tt.ccl import tt_all_gather, tt_all_reduce
-from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+from models.tt_transformers.tt.model_config import OpGroup, TensorGroup, num_to_corerange
 
 
 class Attention(LightweightModule):
@@ -18,6 +19,7 @@ class Attention(LightweightModule):
         self,
         mesh_device,
         tt_ccl,
+        args,
         state_dict,
         weight_cache_path,
         layer_num,
@@ -28,7 +30,7 @@ class Attention(LightweightModule):
         use_paged_kv_cache=False,
     ):
         super().__init__()
-
+        self.args = args
         self.mesh_device = mesh_device
         self.tt_ccl = tt_ccl
         self.num_devices = configuration.num_devices
@@ -382,6 +384,65 @@ class Attention(LightweightModule):
             for k_or_v in [cache_k, cache_v]
         ]
 
+    def to_qk_fused_memory_config(self, q_tensor: ttnn.Tensor, k_tensor: ttnn.Tensor):
+        """
+        Convert Q and K tensors to height-sharded memory layouts suitable for
+        fused QK ops such as rotary_embedding_llama_fused_qk and  computation.
+
+        This function:
+        - Infers the number of Q heads and KV heads from the input tensors
+        - Shards Q and K along the batch dimension using HEIGHT sharding
+        - Places Q and K on disjoint core regions to avoid overlap:
+            * Q cores start at (0, 0)
+            * K cores start at (0, 4)
+        - Uses row-major shard orientation with explicit shard shapes
+
+        The resulting memory layouts are compatible with fused attention
+        kernels that expect Q and K to be distributed across separate
+        core ranges while preserving per-head contiguity.
+
+        Args:
+            q_tensor (ttnn.Tensor):
+                Query tensor with shape [..., batch, num_q_heads, head_dim].
+
+            k_tensor (ttnn.Tensor):
+                Key tensor with shape [..., batch, num_kv_heads, head_dim].
+
+        Returns:
+            Tuple[ttnn.Tensor, ttnn.Tensor]:
+                (q_tensor, k_tensor) converted to sharded memory configurations.
+        """
+        n_q_heads = q_tensor.shape[2]
+        n_kv_heads = k_tensor.shape[2]
+        q_batch = q_tensor.shape[1]
+        k_batch = k_tensor.shape[1]
+        assert q_batch == k_batch
+        if q_batch == 32:
+            k_start_core = ttnn.CoreCoord(0, 4)
+        else:
+            k_start_core = ttnn.CoreCoord(1, 0)
+
+        q_core_grid = ttnn.CoreRangeSet({num_to_corerange(q_batch)})
+        k_core_grid = ttnn.CoreRangeSet({num_to_corerange(k_batch, start_core=k_start_core)})
+
+        q_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(n_q_heads), self.head_dim),
+            core_grid=q_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        k_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(n_kv_heads), self.head_dim),
+            core_grid=k_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        q_tensor = ttnn.to_memory_config(q_tensor, q_mem_config)
+        k_tensor = ttnn.to_memory_config(k_tensor, k_mem_config)
+        return q_tensor, k_tensor
+
     def forward_decode(self, x: ttnn.Tensor, current_pos, rot_mats=None, page_table=None, kv_cache=None) -> ttnn.Tensor:
         """
         x: (seq_len, 1, batch, dim)
@@ -462,16 +523,25 @@ class Attention(LightweightModule):
 
         ttnn.deallocate(xqkv_fused)
 
-        # Q Rotary Embeddings
-        q_heads_1BQD = ttnn.experimental.rotary_embedding_llama(
-            q_heads_pre_rot_1BQD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
-        )
+        # Q, K Rotary Embeddings
+        if self.args.use_qk_fused:
+            q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD = self.to_qk_fused_memory_config(
+                q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD
+            )
 
-        # K Rotary Embeddings
-        k_heads_1BKD = ttnn.experimental.rotary_embedding_llama(
-            k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
-        )
+            q_heads_1BQD, k_heads_1BKD = ttnn.experimental.rotary_embedding_llama_fused_qk(
+                q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"]
+            )
+        else:
+            # Q Rotary Embeddings
+            q_heads_1BQD = ttnn.experimental.rotary_embedding_llama(
+                q_heads_pre_rot_1BQD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+            )
 
+            # K Rotary Embeddings
+            k_heads_1BKD = ttnn.experimental.rotary_embedding_llama(
+                k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+            )
         ttnn.deallocate(q_heads_pre_rot_1BQD)
         ttnn.deallocate(k_heads_pre_rot_1BKD)
 
@@ -487,11 +557,18 @@ class Attention(LightweightModule):
         # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
         # v_heads [seqlen, n_kv_heads, bsz, head_dim]
         # keys, [max_batch_size, n_kv_heads // configuration.num_devices, max_seq_len, head_dim]
-        ttnn.experimental.paged_update_cache(keys, k_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table)
-        ttnn.experimental.paged_update_cache(
-            values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
-        )
 
+        if self.args.use_qk_fused:
+            ttnn.experimental.paged_fused_update_cache(
+                keys, k_heads_1BKD, values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
+        else:
+            ttnn.experimental.paged_update_cache(
+                keys, k_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
+            ttnn.experimental.paged_update_cache(
+                values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
         ttnn.deallocate(k_heads_1BKD)
         ttnn.deallocate(v_heads_1BKD)
 

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -387,7 +387,8 @@ class Attention(LightweightModule):
     def to_qk_fused_memory_config(self, q_tensor: ttnn.Tensor, k_tensor: ttnn.Tensor):
         """
         Convert Q and K tensors to height-sharded memory layouts suitable for
-        fused QK ops such as rotary_embedding_llama_fused_qk and  computation.
+        fused QK ops such as rotary_embedding_llama_fused_qk and the subsequent
+        QK matmul/attention score computation.
 
         This function:
         - Infers the number of Q heads and KV heads from the input tensors

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -52,6 +52,7 @@ class TransformerBlock(LightweightModule):
         self.attention = ActualAttentionClass(
             mesh_device=mesh_device,
             tt_ccl=self.tt_ccl,
+            args=args,
             state_dict=state_dict,
             weight_cache_path=weight_cache_path,
             layer_num=layer_num,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -78,6 +78,7 @@ class Transformer(LightweightModule):
                 args.head_dim,
                 args.max_seq_len,
                 args.rope_theta_local,
+                use_qk_fused=args.use_qk_fused,
             )
 
         self.trans_mats_dict = self.rope_setup.get_both_trans_mats()

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -68,6 +68,7 @@ class Transformer(LightweightModule):
             max_seq_len=args.max_seq_len,
             rope_theta=args.rope_theta,
             rope_scaling=args.rope_scaling,
+            use_qk_fused=args.use_qk_fused,
         )
 
         if args.rope_theta_local:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -3272,75 +3272,46 @@ class DecodersPrecision:
 def num_to_corerange(
     x: int,
     start_core: ttnn.CoreCoord = ttnn.CoreCoord(0, 0),
+    grid_x: int = 8,
+    grid_y: int = 8,
 ) -> ttnn.CoreRange:
     """
     Construct a rectangular CoreRange of exactly ``x`` cores starting at
-    ``start_core`` on an 8×8 core grid.
+    ``start_core`` on a ``grid_x × grid_y`` core grid.
 
     The CoreRange is allocated in row-major order semantics but must form
     a single contiguous rectangle representable by ``ttnn.CoreRange``.
-    The function validates that:
-      - ``start_core`` lies within the 8×8 grid
-      - At least ``x`` cores exist from ``start_core`` onward in row-major
-        traversal
-      - ``x`` can be expressed as a rectangular region starting at
-        ``start_core`` without exceeding grid bounds
 
-    Constraints:
-      - ``x`` must be positive
-      - ``x < 8`` or ``x`` must be a multiple of 8
-      - Rectangular allocation may fail even when linear availability
-        exists (e.g., when ``start_core.x != 0``)
-
-    This helper is intended for configuring sharded tensor layouts where
-    a rectangular core region is required (e.g., ``CoreRangeSet`` inputs).
-
-    Args:
-        x (int):
-            Number of cores to include in the CoreRange.
-
-        start_core (ttnn.CoreCoord, optional):
-            Lower-left corner of the CoreRange. Defaults to ``(0, 0)``.
-
-    Returns:
-        ttnn.CoreRange:
-            A rectangular CoreRange covering exactly ``x`` cores starting
-            at ``start_core``.
-
-    Raises:
-        AssertionError:
-            If the requested CoreRange cannot be formed within the grid
-            or violates shape or availability constraints.
+    Defaults to an 8×8 grid for backward compatibility.
     """
-    GRID_X = 8
-    GRID_Y = 8
 
     # --- basic sanity ---
     assert x > 0, "x must be positive"
-    assert 0 <= start_core.x < GRID_X
-    assert 0 <= start_core.y < GRID_Y
+    assert grid_x > 0 and grid_y > 0
+    assert 0 <= start_core.x < grid_x
+    assert 0 <= start_core.y < grid_y
 
     sx, sy = start_core.x, start_core.y
 
     # --- linear availability (row-major correctness) ---
-    remaining_linear_cores = (GRID_X - sx) + (GRID_Y - sy - 1) * GRID_X  # remainder of start row  # full rows below
+    remaining_linear_cores = (grid_x - sx) + (grid_y - sy - 1) * grid_x  # remainder of start row  # full rows below
     assert remaining_linear_cores >= x, (
         f"Not enough cores from start_core {start_core} "
         f"to allocate {x} cores (only {remaining_linear_cores} available)"
     )
 
     # --- rectangular availability ---
-    remaining_x = GRID_X - sx
-    remaining_y = GRID_Y - sy
+    remaining_x = grid_x - sx
+    remaining_y = grid_y - sy
 
-    # --- shape rule (same as original) ---
-    assert x < GRID_X or x % GRID_X == 0, "x must be < 8 or a multiple of 8"
+    # --- shape rule ---
+    assert x < grid_x or x % grid_x == 0, f"x must be < grid_x ({grid_x}) or a multiple of grid_x"
 
     # --- choose rectangle dimensions ---
     num_x = min(x, remaining_x)
     num_y = x // num_x
 
-    assert num_x * num_y == x, f"x={x} cannot form a rectangular CoreRange " f"starting at {start_core}"
+    assert num_x * num_y == x, f"x={x} cannot form a rectangular CoreRange starting at {start_core}"
 
     # --- bounds check ---
     assert num_y <= remaining_y, f"CoreRange height {num_y} exceeds available rows {remaining_y}"

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -480,9 +480,10 @@ class ModelArgs:
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
         self.tile_size = 32
+
         # Flag to indicate whether we use fused version of QK ops (rotary embedding + page cached update)
-        # We can only enable it for batch 32 since the fused ops have certain batch size assumptions and batch 1 has not been extensively tested.
-        self.use_qk_fused = True if max_batch_size == 32 else False
+        self.use_qk_fused = True
+
         self.is_70b = False
         self.is_90b = False
         self.fuse_qkv = False

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -635,8 +635,8 @@ class ModelArgs:
         self.processor = None if dummy_weights else self.create_processor()
 
         # Flag to indicate whether we use fused version of QK ops (rotary embedding + page cached update)
-        # We currently disable this fusion of ops for vision-capable models
-        self.use_qk_fused = not self.is_vision()
+        # We currently disable this fusion of ops for vision-capable or multimodal models
+        self.use_qk_fused = not self.is_multimodal
 
         if device is not None:  # Avoid issue with test_torch.py not having a device
             self.n_local_heads = self.n_heads // self.cluster_shape[1]

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -480,11 +480,6 @@ class ModelArgs:
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
         self.tile_size = 32
-
-        # Flag to indicate whether we use fused version of QK ops (rotary embedding + page cached update)
-        # We currently disable this fusion of ops for vision-capable models
-        self.use_qk_fused = not self.is_vision()
-
         self.is_70b = False
         self.is_90b = False
         self.fuse_qkv = False
@@ -638,6 +633,10 @@ class ModelArgs:
 
         self.tokenizer = None if dummy_weights else self.create_tokenizer()
         self.processor = None if dummy_weights else self.create_processor()
+
+        # Flag to indicate whether we use fused version of QK ops (rotary embedding + page cached update)
+        # We currently disable this fusion of ops for vision-capable models
+        self.use_qk_fused = not self.is_vision()
 
         if device is not None:  # Avoid issue with test_torch.py not having a device
             self.n_local_heads = self.n_heads // self.cluster_shape[1]

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -482,7 +482,8 @@ class ModelArgs:
         self.tile_size = 32
 
         # Flag to indicate whether we use fused version of QK ops (rotary embedding + page cached update)
-        self.use_qk_fused = True
+        # We currently disable this fusion of ops for vision-capable models
+        self.use_qk_fused = not self.is_vision()
 
         self.is_70b = False
         self.is_90b = False

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -465,11 +465,13 @@ class RotarySetup(LightweightModule):
         return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}
 
     def get_rot_idxs(self, position_idxs: torch.Tensor, on_host: bool = False) -> ttnn.Tensor:
-        if self.use_qk_fused:
-            position_idxs = position_idxs.repeat(2)
-
         assert isinstance(position_idxs, torch.Tensor), "Position ids must be a torch tensor"
         assert len(position_idxs.shape) == 1, "position idxs must be a [batch] tensor"
+
+        if self.use_qk_fused:
+            # NOTE: For fused QK ops (rotary embedding + paged cache update), we intentionally double the batch dimension so that
+            # the rotary indices can be used for Q and K tensors each.
+            position_idxs = position_idxs.repeat(2)
 
         batch = position_idxs.shape[0]
         position_idxs = position_idxs.reshape(1, batch)  # [1, 1, 1, batch]

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -471,10 +471,10 @@ class RotarySetup(LightweightModule):
         if self.use_qk_fused:
             # NOTE: For fused QK ops (rotary embedding + paged cache update), we intentionally double the batch dimension so that
             # the rotary indices can be used for Q and K tensors each.
+            position_idxs = position_idxs.repeat(2)
             assert (
                 position_idxs.shape[0] == self.batch_size_per_device_group
             ), "Position idxs must be the same as the batch size per device group"
-            position_idxs = position_idxs.repeat(2)
 
         batch = position_idxs.shape[0]
         position_idxs = position_idxs.reshape(1, batch)  # [1, 1, 1, batch]

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -471,12 +471,15 @@ class RotarySetup(LightweightModule):
         if self.use_qk_fused:
             # NOTE: For fused QK ops (rotary embedding + paged cache update), we intentionally double the batch dimension so that
             # the rotary indices can be used for Q and K tensors each.
+            assert (
+                position_idxs.shape[0] == self.batch_size_per_device_group
+            ), "Position idxs must be the same as the batch size per device group"
             position_idxs = position_idxs.repeat(2)
 
         batch = position_idxs.shape[0]
         position_idxs = position_idxs.reshape(1, batch)  # [1, 1, 1, batch]
-        assert position_idxs.shape == (1, batch), "position idxs must be a [1, batch] tensor"
-        assert torch.min(position_idxs) >= 0, "position idxs must be non-negative"
+        assert position_idxs.shape == (1, batch), "Position idxs must be a [1, batch] tensor"
+        assert torch.min(position_idxs) >= 0, "Position idxs must be non-negative"
 
         # Add padding if needed
         pad_size = nearest_32(batch) - batch

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -416,7 +416,7 @@ class RotarySetup(LightweightModule):
         trans_mat = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(
             1,
             1,
-            batch_size,
+            self.batch_size,
             1,
             # 1, 1, num_cores, 1
         )  # Repeat across all cores on device


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33977

### Problem description
The Llama team brought up fused rotary embedding fused ops and paged cache update fused in llama glx codebase we can port them to TT Transformers to boost decode performance for all T3k and BH models.

### What's changed
- Added a helper function to convert q and k to be on separate shard grids since that is the requirements for those ops (Q and K must not have overlapping shard grids)
- Repeating transformation matrix by batch dim since we want a copy for each Q and K on each core
- Allowed enabling of using fused ops via the `use_qk_fused` flag, they can be disabled and we can use the non fused version if needed. Both batch 32 and 1 can use this optimization.

Perf change for batch 32 Llama 8b TP=4 (kernel times in nanoseconds):
```
Before:
'RotaryEmbeddingLlamaDeviceOperation_0': 3032.8888888888887
'RotaryEmbeddingLlamaDeviceOperation_1': 3010.4444444444443
'PagedUpdateCacheDeviceOperation_0': 5090.0
'PagedUpdateCacheDeviceOperation_1': 5113.444444444444,
Rotary: 3032.89 + 3010.44 = 6043.33
PagedUpdate: 5090.00 + 5113.44 = 10203.44
Total Before = 16246.78

After:
'RotaryEmbeddingLlamaFusedQKDeviceOperation_0': 2913.6666666666665,
'PagedFusedUpdateCacheDeviceOperation_0': 5860.222222222223
Total After = 8773.89

Improvement
Speedup factor: 1.85× (≈ 46% reduction in total time)
```

To reproduce: run `pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-131072-2-10-1-32-False"` and toggle the flag `use_qk_fused ` in `model_config.py` for TTT
`

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/20758564684)
- [x] [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/20758507389) (runs single card demo)
- [x] [BH multi card demo](https://github.com/tenstorrent/tt-metal/actions/runs/20705248407)
- [x] [T3K demo ](https://github.com/tenstorrent/tt-metal/actions/runs/20939800300) 
All relevant pipelines passing, failures are irrelevant to this PR for T3k demo