### PR TITLE
readability-avoid-nested-conditional-operator

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -114,7 +114,6 @@ Checks: >
   -performance-no-int-to-ptr,
   -portability-simd-intrinsics,
   -portability-template-virtual-member-function,
-  -readability-avoid-nested-conditional-operator,
   -readability-avoid-unconditional-preprocessor-if,
   -readability-container-contains,
   -readability-convert-member-functions-to-static,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -116,9 +116,14 @@ inline void verify_kernel_coordinates(
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
-    CoreType core_type = hal_core_type == HalProgrammableCoreType::TENSIX     ? CoreType::WORKER
-                         : hal_core_type == HalProgrammableCoreType::IDLE_ETH ? CoreType::IDLE_ETH
-                                                                              : CoreType::ETH;
+    CoreType core_type;
+    if (hal_core_type == HalProgrammableCoreType::TENSIX) {
+        core_type = CoreType::WORKER;
+    } else if (hal_core_type == HalProgrammableCoreType::IDLE_ETH) {
+        core_type = CoreType::IDLE_ETH;
+    } else {
+        core_type = CoreType::ETH;
+    }
 
     const auto& sub_device_origin = mesh_device->worker_cores(hal_core_type, sub_device_id).bounding_box().start_coord;
     for (const auto& cr : cr_set.ranges()) {

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -88,8 +88,16 @@ bfloat16 sfpu_function(const std::string& op_name, const bfloat16& input) {
     } else if (op_name == "tanh") {
         return bfloat16(std::tanh(static_cast<float>(input)));
     } else if (op_name == "sign") {
-        return bfloat16(
-            (0.0f < static_cast<float>(input)) ? 1.0f : ((static_cast<float>(input) < 0.0f) ? -1.0f : 0.0f));
+        float val = static_cast<float>(input);
+        float result;
+        if (0.0f < val) {
+            result = 1.0f;
+        } else if (val < 0.0f) {
+            result = -1.0f;
+        } else {
+            result = 0.0f;
+        }
+        return bfloat16(result);
     } else {
         TT_THROW("Unsupported op_name in test");
         return bfloat16(0.0f);

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -89,14 +89,7 @@ bfloat16 sfpu_function(const std::string& op_name, const bfloat16& input) {
         return bfloat16(std::tanh(static_cast<float>(input)));
     } else if (op_name == "sign") {
         float val = static_cast<float>(input);
-        float result;
-        if (0.0f < val) {
-            result = 1.0f;
-        } else if (val < 0.0f) {
-            result = -1.0f;
-        } else {
-            result = 0.0f;
-        }
+        float result = static_cast<float>((val > 0.0f) - (val < 0.0f));
         return bfloat16(result);
     } else {
         TT_THROW("Unsupported op_name in test");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -292,7 +292,14 @@ int main(int argc, char** argv) {
         uint32_t* start_ptr = (uint32_t*)align(src_vec.data(), addr_align);
         std::vector<uint32_t> result_vec;
 
-        const std::string copy_mode_str = copy_mode == 0 ? "memcpy" : copy_mode == 1 ? "4 byte writes" : "nt_memcpy";
+        std::string copy_mode_str;
+        if (copy_mode == 0) {
+            copy_mode_str = "memcpy";
+        } else if (copy_mode == 1) {
+            copy_mode_str = "4 byte writes";
+        } else {
+            copy_mode_str = "nt_memcpy";
+        }
 
         log_info(
             LogTest,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -155,9 +155,14 @@ void generate_receiver_worker_kernels(
 
     // Just want a dummy DF
     uint32_t src0_cb_index = CBIndex::c_0;
-    tt::DataFormat df = page_size == 1024   ? tt::DataFormat::Bfp8
-                        : page_size == 2048 ? tt::DataFormat::Float16
-                                            : tt::DataFormat::Float32;
+    tt::DataFormat df;
+    if (page_size == 1024) {
+        df = tt::DataFormat::Bfp8;
+    } else if (page_size == 2048) {
+        df = tt::DataFormat::Float16;
+    } else {
+        df = tt::DataFormat::Float32;
+    }
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(2 * num_pages_per_edm_buffer * page_size, {{src0_cb_index, df}})
             .set_page_size(src0_cb_index, page_size);
@@ -275,9 +280,14 @@ void generate_sender_worker_kernels(
         log_info(tt::LogTest, "\t\t{}", arg);
     }
     // Just want a dummy DF
-    tt::DataFormat df = page_size == 1024   ? tt::DataFormat::Bfp8
-                        : page_size == 2048 ? tt::DataFormat::Float16
-                                            : tt::DataFormat::Float32;
+    tt::DataFormat df;
+    if (page_size == 1024) {
+        df = tt::DataFormat::Bfp8;
+    } else if (page_size == 2048) {
+        df = tt::DataFormat::Float16;
+    } else {
+        df = tt::DataFormat::Float32;
+    }
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(2 * num_pages_per_edm_buffer * page_size, {{src0_cb_index, df}})
             .set_page_size(src0_cb_index, page_size);

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -189,9 +189,14 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
         "Only Wormhole and Blackhole are supported to get optimal worker placement for interfacing with DRAM");
     for (int i = 0; i < num_dram_banks; ++i) {
         auto dram_core = dram_phy_coords[i];
-        uint32_t dram_core_y = (arch == ARCH::BLACKHOLE)                ? std::max((uint32_t)dram_core.y, (uint32_t)2)
-                               : (dram_core.y == 0 || dram_core.y == 6) ? dram_core.y + 1
-                                                                        : dram_core.y;
+        uint32_t dram_core_y;
+        if (arch == ARCH::BLACKHOLE) {
+            dram_core_y = std::max((uint32_t)dram_core.y, (uint32_t)2);
+        } else if (dram_core.y == 0 || dram_core.y == 6) {
+            dram_core_y = dram_core.y + 1;
+        } else {
+            dram_core_y = dram_core.y;
+        }
         dram_interface_workers.push_back(CoreCoord(dram_core.x + 1, dram_core_y));
     }
 

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -191,7 +191,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
         auto dram_core = dram_phy_coords[i];
         uint32_t dram_core_y;
         if (arch == ARCH::BLACKHOLE) {
-            dram_core_y = std::max(dram_core.y, 2);
+            dram_core_y = std::max(dram_core.y, 2u);
         } else if (dram_core.y == 0 || dram_core.y == 6) {
             dram_core_y = dram_core.y + 1;
         } else {

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -191,7 +191,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
         auto dram_core = dram_phy_coords[i];
         uint32_t dram_core_y;
         if (arch == ARCH::BLACKHOLE) {
-            dram_core_y = std::max((uint32_t)dram_core.y, (uint32_t)2);
+            dram_core_y = std::max(dram_core.y, 2);
         } else if (dram_core.y == 0 || dram_core.y == 6) {
             dram_core_y = dram_core.y + 1;
         } else {

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -191,7 +191,7 @@ std::vector<CoreCoord> get_optimal_dram_to_physical_worker_assignment(
         auto dram_core = dram_phy_coords[i];
         uint32_t dram_core_y;
         if (arch == ARCH::BLACKHOLE) {
-            dram_core_y = std::max(dram_core.y, 2u);
+            dram_core_y = std::max(static_cast<uint32_t>(dram_core.y), 2u);
         } else if (dram_core.y == 0 || dram_core.y == 6) {
             dram_core_y = dram_core.y + 1;
         } else {

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -154,9 +154,8 @@ struct __attribute__((packed)) intra_mesh_routing_path_t {
 
     static constexpr uint16_t MAX_CHIPS_LOWLAT = (dim == 1) ? MAX_CHIPS_LOWLAT_1D : MAX_CHIPS_LOWLAT_2D;
     static constexpr uint16_t COMPRESSED_ROUTE_SIZE = (dim == 1) ? COMPRESSED_ROUTE_SIZE_1D : COMPRESSED_ROUTE_SIZE_2D;
-    static constexpr uint16_t SINGLE_ROUTE_SIZE =
-        compressed ? ((dim == 1) ? COMPRESSED_ROUTE_SIZE_1D : COMPRESSED_ROUTE_SIZE_2D)
-                   : ((dim == 1) ? SINGLE_ROUTE_SIZE_1D : SINGLE_ROUTE_SIZE_2D);
+    static constexpr uint16_t UNCOMPRESSED_ROUTE_SIZE = (dim == 1) ? SINGLE_ROUTE_SIZE_1D : SINGLE_ROUTE_SIZE_2D;
+    static constexpr uint16_t SINGLE_ROUTE_SIZE = compressed ? COMPRESSED_ROUTE_SIZE : UNCOMPRESSED_ROUTE_SIZE;
 
     typename std::conditional<
         !compressed,

--- a/tt_metal/impl/data_format/bfloat4.cpp
+++ b/tt_metal/impl/data_format/bfloat4.cpp
@@ -94,7 +94,14 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     int data_dwords_per_exp_log2 = log2(data_dwords_per_exp);
 
     // the exponent index will always be 0 when tile_HW == 16, between 0-1 when tile_HW == 32, and between 0-3 otherwise
-    uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
+    uint32_t exp_bit_mask;
+    if (tile_HW == 16) {
+        exp_bit_mask = 0x0;
+    } else if (tile_HW == 32) {
+        exp_bit_mask = 0x1;
+    } else {
+        exp_bit_mask = 0x3;
+    }
 
     uint32_t size_bytes = bfp_tiles.size() * 4;
     uint32_t single_bfp_tile_size =

--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -90,7 +90,14 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     uint32_t num_bfp8_in_tile = num_tile_words + num_exp_words;
 
     // the exponent index will always be 0 when tile_HW == 16, between 0-1 when tile_HW == 32, and between 0-3 otherwise
-    uint32_t exp_bit_mask = (tile_HW == 16) ? 0x0 : (tile_HW == 32) ? 0x1 : 0x3;
+    uint32_t exp_bit_mask;
+    if (tile_HW == 16) {
+        exp_bit_mask = 0x0;
+    } else if (tile_HW == 32) {
+        exp_bit_mask = 0x1;
+    } else {
+        exp_bit_mask = 0x3;
+    }
 
     int num_elements_in_dword = 4;
     uint32_t size_bytes = bfp8_tiles.size() * num_elements_in_dword;  // each uint32_t contains 4 BFP8 values

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -237,7 +237,7 @@ uint8_t convert_u32_to_bfp(uint32_t input, uint32_t shared_exp, bool is_exp_a) {
         BfpFormat == tt::DataFormat::Bfp2_b || BfpFormat == tt::DataFormat::Bfp4_b ||
         BfpFormat == tt::DataFormat::Bfp8_b);
 
-    constexpr uint32_t MANTISSA_BFP_WIDTH = []() constexpr {
+    constexpr uint32_t MANTISSA_BFP_WIDTH = []() {
         if constexpr (BfpFormat == tt::DataFormat::Bfp2 || BfpFormat == tt::DataFormat::Bfp2_b) {
             return 1;
         } else if constexpr (BfpFormat == tt::DataFormat::Bfp4 || BfpFormat == tt::DataFormat::Bfp4_b) {

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -84,7 +84,7 @@ uint32_t create_packed_bfp_packed_as_u32(const std::vector<uint32_t>& u32_vec, u
         BfpFormat == tt::DataFormat::Bfp2 || BfpFormat == tt::DataFormat::Bfp4 || BfpFormat == tt::DataFormat::Bfp8 ||
         BfpFormat == tt::DataFormat::Bfp2_b || BfpFormat == tt::DataFormat::Bfp4_b ||
         BfpFormat == tt::DataFormat::Bfp8_b);
-    constexpr int nums_in_dword = []() constexpr {
+    constexpr int nums_in_dword = []() {
         if constexpr (BfpFormat == tt::DataFormat::Bfp2 || BfpFormat == tt::DataFormat::Bfp2_b) {
             return 16;
         } else if constexpr (BfpFormat == tt::DataFormat::Bfp4 || BfpFormat == tt::DataFormat::Bfp4_b) {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -496,9 +496,14 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
             reader.device_id, logical_coord, core_type);
 
     // Print device id, core coords (logical)
-    string core_type_str = programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH ? "acteth"
-                           : programmable_core_type == HalProgrammableCoreType::IDLE_ETH ? "idleth"
-                                                                                         : "worker";
+    string core_type_str;
+    if (programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) {
+        core_type_str = "acteth";
+    } else if (programmable_core_type == HalProgrammableCoreType::IDLE_ETH) {
+        core_type_str = "idleth";
+    } else {
+        core_type_str = "worker";
+    }
     string core_coord_str = fmt::format(
         "core(x={:2},y={:2}) virtual(x={:2},y={:2})",
         logical_coord.x,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -112,12 +112,17 @@ FDKernel* FDKernel::Generate(
 uint32_t FDKernel::get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core) {
     // TODO(#22895): Too many core types. Consolidate programmable_core_type_index with ProgrammableCoreType and
     // CoreType
-    uint32_t programmable_core_type_index =
-        (dispatch_core_type == CoreType::WORKER)
-            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)
-        : is_active_eth_core
-            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)
-            : MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+    uint32_t programmable_core_type_index;
+    if (dispatch_core_type == CoreType::WORKER) {
+        programmable_core_type_index =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    } else if (is_active_eth_core) {
+        programmable_core_type_index =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    } else {
+        programmable_core_type_index =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+    }
 
     return programmable_core_type_index;
 }

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -220,9 +220,11 @@ DataFormat get_single_pack_src_format(
         pack_src_format = DataFormat::Float16;
     } else if (fp32_dest_acc_en) {
         if (is_bfp_format(data_format)) {
-            pack_src_format = bfp8_pack_precise
-                                  ? DataFormat::Float32
-                                  : (is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8);
+            if (bfp8_pack_precise) {
+                pack_src_format = DataFormat::Float32;
+            } else {
+                pack_src_format = is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
+            }
         } else if (is_exp_b_format(data_format) || (data_format == DataFormat::Float32)) {
             pack_src_format = data_format;
         } else if (data_format == DataFormat::Float16) {
@@ -270,9 +272,11 @@ DataFormat get_single_pack_src_format(
             }
             pack_src_format = unpack_conditional_dst_format;
         } else if (is_bfp_format(data_format)) {
-            pack_src_format = bfp8_pack_precise
-                                  ? (is_exp_b_format(data_format) ? DataFormat::Float16_b : DataFormat::Float16)
-                                  : (is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8);
+            if (bfp8_pack_precise) {
+                pack_src_format = is_exp_b_format(data_format) ? DataFormat::Float16_b : DataFormat::Float16;
+            } else {
+                pack_src_format = is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
+            }
         } else {
             pack_src_format = data_format;
         }
@@ -283,9 +287,11 @@ DataFormat get_single_pack_src_format(
         DataFormat pack_src_format_tmp = data_format;
 
         if (is_bfp_format(data_format)) {
-            pack_src_format_tmp = bfp8_pack_precise
-                                      ? (is_exp_b_format(data_format) ? DataFormat::Float16_b : DataFormat::Float16)
-                                      : (is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8);
+            if (bfp8_pack_precise) {
+                pack_src_format_tmp = is_exp_b_format(data_format) ? DataFormat::Float16_b : DataFormat::Float16;
+            } else {
+                pack_src_format_tmp = is_exp_b_format(data_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
+            }
         }
 
         if (pack_src_format_tmp != DataFormat::Float32) {

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -214,13 +214,13 @@ public:
                 break;
             case HalProgrammableCoreType::ACTIVE_ETH:
                 if (params.processor_id < 2) {
-                    return fmt::format(
-                        "{}/{}_{}aerisc.ld",
-                        path,
-                        fork,
-                        params.processor_id    ? "subordinate_"
-                        : enable_2_erisc_mode_ ? "main_"
-                                               : "");
+                    const char* prefix = "";
+                    if (params.processor_id) {
+                        prefix = "subordinate_";
+                    } else if (enable_2_erisc_mode_) {
+                        prefix = "main_";
+                    }
+                    return fmt::format("{}/{}_{}aerisc.ld", path, fork, prefix);
                 }
                 break;
             case HalProgrammableCoreType::IDLE_ETH:

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -128,9 +128,13 @@ tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const CoreCo
         TT_ASSERT(is_active_eth_core or is_inactive_eth_core);
     }
 
-    return is_active_eth_core     ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH
-           : is_inactive_eth_core ? tt_metal::HalProgrammableCoreType::IDLE_ETH
-                                  : tt_metal::HalProgrammableCoreType::TENSIX;
+    if (is_active_eth_core) {
+        return tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
+    } else if (is_inactive_eth_core) {
+        return tt_metal::HalProgrammableCoreType::IDLE_ETH;
+    } else {
+        return tt_metal::HalProgrammableCoreType::TENSIX;
+    }
 }
 
 void send_reset_go_signal(tt::ChipId chip, const CoreCoord& virtual_core) {

--- a/ttnn/.clang-tidy
+++ b/ttnn/.clang-tidy
@@ -1,2 +1,2 @@
 InheritParentConfig: true
-Checks: -bugprone-suspicious-stringview-data-usage, -misc-use-anonymous-namespace
+Checks: -bugprone-suspicious-stringview-data-usage, -misc-use-anonymous-namespace, -readability-avoid-nested-conditional-operator


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-nested-conditional-operator.html

### What's changed
- Enable check for all code except `ttnn` due to too many copy pasted nested conditional operators.
- Fix violations using Claude Opus 4.5

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs