### PR TITLE
#0: Update clip encoder margin

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -148,7 +148,7 @@ def test_refiner_unet(
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
             1,
-            0.015,
+            0.020,
             "",
         ),
     ],


### PR DESCRIPTION
### Ticket
-

### Problem description
Clip encoder 2  from SDXL pipeline failed on CI https://github.com/tenstorrent/tt-metal/actions/runs/20567161610


### What's changed
We have a problem where device to device oscilations are bigger then the expected margin (margin is 0.015 atm, the device perf failed due to perf being out of scope by 0.01578 relative to expected).
Bump margin to 0.02 at the moment

#### Model tests
[Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20568835139)