### PR TITLE
PDL: Move matmul configs to model_configs.py

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_aspp.py
@@ -101,6 +101,7 @@ def test_ttnn_aspp(device, pcc_values, skip_check, model_location_generator):
 
         # Create centralized configuration
         model_configs = ModelOptimisations(
+            device=device,
             conv_act_dtype=ttnn.bfloat8_b,
             conv_w_dtype=ttnn.bfloat8_b,
         )

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_insemb.py
@@ -111,6 +111,7 @@ def test_ttnn_insemb(device, pcc_values, skip_check, model_location_generator):
 
         # Create centralized configuration
         model_configs = ModelOptimisations(
+            device=device,
             conv_act_dtype=ttnn.bfloat8_b,
             conv_w_dtype=ttnn.bfloat8_b,
         )

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_resnet.py
@@ -75,6 +75,7 @@ def create_panoptic_models(device, weights_path):
 
     # Create centralized configuration
     model_configs = ModelOptimisations(
+        device=device,
         conv_act_dtype=ttnn.bfloat8_b,
         conv_w_dtype=ttnn.bfloat8_b,
     )

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_semseg.py
@@ -105,6 +105,7 @@ def test_ttnn_semseg(device, pcc_values, skip_check, model_location_generator):
 
         # Create centralized configuration
         model_configs = ModelOptimisations(
+            device=device,
             conv_act_dtype=ttnn.bfloat8_b,
             conv_w_dtype=ttnn.bfloat8_b,
         )

--- a/models/experimental/panoptic_deeplab/tests/test_pipeline_e2e.py
+++ b/models/experimental/panoptic_deeplab/tests/test_pipeline_e2e.py
@@ -155,6 +155,7 @@ def test_panoptic_deeplab_pipeline_e2e(
         )
 
         model_configs = ModelOptimisations(
+            device=device,
             conv_act_dtype=ttnn.bfloat8_b,
             conv_w_dtype=ttnn.bfloat8_b,
         )

--- a/models/experimental/panoptic_deeplab/tt/common.py
+++ b/models/experimental/panoptic_deeplab/tt/common.py
@@ -470,6 +470,7 @@ def create_ttnn_model(
     # Create model configurations if not provided
     if model_configs is None:
         model_configs = ModelOptimisations(
+            device=device,
             conv_act_dtype=ttnn.bfloat8_b,
             conv_w_dtype=ttnn.bfloat8_b,
         )

--- a/models/experimental/panoptic_deeplab/tt/model_configs.py
+++ b/models/experimental/panoptic_deeplab/tt/model_configs.py
@@ -36,8 +36,9 @@ class ModelOptimisations:
         Initialize model optimization configurations.
 
         Args:
-            conv_act_dtype: Default data type for convolution activations
-            conv_w_dtype: Default data type for convolution weights
+            device: Target device on which model optimizations will be applied.
+            conv_act_dtype: Default data type for convolution activations.
+            conv_w_dtype: Default data type for convolution weights.
         """
         self.device = device
         self.conv_output_dtype = conv_act_dtype

--- a/models/experimental/panoptic_deeplab/tt/tt_insemb.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_insemb.py
@@ -86,54 +86,12 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
         # perf wise this makes sense because we dont need to permute to channel last after it
         # we dont need to permute to channel last because this is final output that goes to the host
 
-        compute_grid = device.compute_with_storage_grid_size()
-
-        if compute_grid.x == 5 and compute_grid.y == 4:
-            final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(5, 4),
-                in0_block_w=2,
-                out_subblock_h=4,
-                out_subblock_w=2,
-                out_block_h=4,
-                out_block_w=2,
-                per_core_M=4,
-                per_core_N=2,
-                fuse_batch=False,
-                fused_activation=None,
-                mcast_in0=True,
-                gather_in0=False,
-                num_global_cb_receivers=0,
-                untilize_out=False,
-            )
-
-            final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(5, 4),
-                in0_block_w=2,
-                out_subblock_h=4,
-                out_subblock_w=2,
-                out_block_h=16,
-                out_block_w=2,
-                per_core_M=16,
-                per_core_N=2,
-                fuse_batch=False,
-                fused_activation=None,
-                mcast_in0=True,
-                gather_in0=False,
-                num_global_cb_receivers=0,
-                untilize_out=False,
-            )
-        elif compute_grid.x == 13 and compute_grid.y == 10:
-            # TODO Optimized configs for 13x10 grid (130 cores) can be added here
-            final_upsample_mm_config1 = None
-            final_upsample_mm_config2 = None
-        else:
-            # Auto-config for all other grid sizes
-            # TTNN will automatically select optimal configuration based on device capabilities
-            logger.debug(
-                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
-            )
-            final_upsample_mm_config1 = None
-            final_upsample_mm_config2 = None
+        final_upsample_mm_config1 = (
+            self.model_configs.get_matmul_config("final_upsample_mm_config1") if self.model_configs else None
+        )
+        final_upsample_mm_config2 = (
+            self.model_configs.get_matmul_config("final_upsample_mm_config2") if self.model_configs else None
+        )
 
         self.final_upsample = TtBilinearUpsample(
             device,

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -387,54 +387,12 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
         # we dont need to permute to channel last because this is final output that goes to the host
         # todo: remove hardcoded values; they should come from infer_ttnn_params in the preprocessing step
 
-        compute_grid = device.compute_with_storage_grid_size()
-
-        if compute_grid.x == 5 and compute_grid.y == 4:
-            final_upsample_mm_config1 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(5, 4),
-                in0_block_w=2,
-                out_subblock_h=4,
-                out_subblock_w=2,
-                out_block_h=4,
-                out_block_w=2,
-                per_core_M=4,
-                per_core_N=2,
-                fuse_batch=False,
-                fused_activation=None,
-                mcast_in0=True,
-                gather_in0=False,
-                num_global_cb_receivers=0,
-                untilize_out=False,
-            )
-
-            final_upsample_mm_config2 = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(5, 4),
-                in0_block_w=2,
-                out_subblock_h=4,
-                out_subblock_w=2,
-                out_block_h=16,
-                out_block_w=2,
-                per_core_M=16,
-                per_core_N=2,
-                fuse_batch=False,
-                fused_activation=None,
-                mcast_in0=True,
-                gather_in0=False,
-                num_global_cb_receivers=0,
-                untilize_out=False,
-            )
-        elif compute_grid.x == 13 and compute_grid.y == 10:
-            # TODO Optimized configs for 13x10 grid (130 cores) will be added here
-            final_upsample_mm_config1 = None
-            final_upsample_mm_config2 = None
-        else:
-            # Auto-config for all other grid sizes
-            # TTNN will automatically select optimal configuration based on device capabilities
-            logger.debug(
-                f"Using auto-config for {compute_grid.x}x{compute_grid.y} grid ({compute_grid.x * compute_grid.y} cores)"
-            )
-            final_upsample_mm_config1 = None
-            final_upsample_mm_config2 = None
+        final_upsample_mm_config1 = (
+            self.model_configs.get_matmul_config("final_upsample_mm_config1") if self.model_configs else None
+        )
+        final_upsample_mm_config2 = (
+            self.model_configs.get_matmul_config("final_upsample_mm_config2") if self.model_configs else None
+        )
 
         self.final_upsample = TtBilinearUpsample(
             device,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34412)

### Problem description
Matmul configs for bilinear upsampling were set inside instance embedding and semantic segmentation heads implementations rather than in module_configs.py. This duplicates code and makes it harder to maintain. 

### What's changed
Matmul configs for `BilinearUpsampleMatmulTTNN` in `models/experimental/panoptic_deeplab/tt/tt_insemb.py` and `models/experimental/panoptic_deeplab/tt/tt_semseg.py` are moved to `models/experimental/panoptic_deeplab/tt/model_configs.py` and `insemb.py` and `semseg.py` are updated to retrieve the configs. 

#### Model tests
- [x] [Blackhole nightly test](https://github.com/tenstorrent/tt-metal/actions/runs/20573764073) - PDL passes
- [x] [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20571368967)
- [x] [Blackhole Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20571395496)