### PR TITLE
[TT Transformers] Enable using fused rms norm all gather op usage to TTT

### DIFF
--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
 import ttnn
 from models.tt_transformers.tt.model_config import determine_device_name
 
@@ -511,6 +513,7 @@ def tt_sharded_distributed_rmsnorm(
             epsilon=epsilon,
             weight=gamma,
             memory_config=output_mem_config,
+            stats=stats_buffer,  # Pre-allocated stats buffer for intermediate all-gather
             use_noc1_only=False,
         )
     return tt_out

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -470,14 +470,47 @@ def tt_sharded_distributed_rmsnorm(
         num_buffers_per_channel=2,
     )
 
-    # Run distributed rmsnorm part 2
-    tt_out = ttnn.rms_norm_post_all_gather(
-        inp,
-        epsilon=epsilon,
-        weight=gamma,
-        program_config=ln_sharded_progcfg,
-        stats=tt_stats,
-    )
-    tt_stats.deallocate(True)
+        # Run distributed rmsnorm part 1
+        tt_stats = ttnn.rms_norm_pre_all_gather(inp, program_config=ln_sharded_progcfg)
 
+        # All gather stats
+        tt_stats = ttnn.experimental.all_gather_async(
+            tt_stats,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+            num_links=1,
+            cluster_axis=cluster_axis,
+            topology=ttnn.Topology.Linear,
+            memory_config=ln_sharded_stats_memcfg,
+            barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
+        )
+
+        # Run distributed rmsnorm part 2
+        tt_out = ttnn.rms_norm_post_all_gather(
+            inp,
+            epsilon=epsilon,
+            weight=gamma,
+            program_config=ln_sharded_progcfg,
+            stats=tt_stats,
+        )
+        tt_stats.deallocate(True)
+    else:
+        tt_out = ttnn.fused_rms_minimal(
+            inp,
+            ln_sharded_progcfg,
+            cluster_axis,
+            tt_ccl.mesh_device,
+            tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis)[0],
+            topology=ttnn.Topology.Linear,
+            residual_input_tensor=None,
+            num_links=1,
+            epsilon=epsilon,
+            weight=gamma,
+            memory_config=output_mem_config,
+            use_noc1_only=False,
+        )
     return tt_out

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -12,44 +12,55 @@ class DistributedNorm(LightweightModule):
         self.norm = norm
         self.args = args
         self.tt_ccl = tt_ccl
+        self.use_fused_rms_norm = True
 
-        if TG:
-            core_grid_ln = (
-                min(4, args.dim // 4 // 32 // 8),
-                8,
-            )  # dividing by 4 and 8 for num_cols and num_rows of mesh, and 32 for tile size
-            num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
-            hidden_size_per_device_distributed_ln = args.dim // 4
-            self.gather_in_mem_cfg = ttnn.create_sharded_memory_config(
-                shape=(1, 1, 32, hidden_size_per_device_distributed_ln),
-                core_grid=ttnn.CoreGrid(y=core_grid_ln[0], x=core_grid_ln[1]),
-                strategy=ttnn.ShardStrategy.WIDTH,
-            )
-            self.ln_prg_cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
-                compute_with_storage_grid_size=(core_grid_ln[1], core_grid_ln[0]),
-                subblock_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
-                block_h=1,
-                block_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
-                inplace=False,
-            )
-            self.ln_sharded_stats_memcfg = ttnn.create_sharded_memory_config(
-                shape=[1, 1, 32, 32 * 4],
-                core_grid=ttnn.CoreGrid(y=1, x=1),
-                strategy=ttnn.ShardStrategy.WIDTH,
-            )
-            self.ln_cfg = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi2,
-                math_approx_mode=False,
-                fp32_dest_acc_en=False,
-                packer_l1_acc=False,
-            )
+        core_grid_ln = (
+            min(4, args.dim // 4 // 32 // 8),
+            8,
+        )  # dividing by 4 and 8 for num_cols and num_rows of mesh, and 32 for tile size
+        num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
+        hidden_size_per_device_distributed_ln = args.dim // 4
+        self.gather_in_mem_cfg = ttnn.create_sharded_memory_config(
+            shape=(1, 1, 32, hidden_size_per_device_distributed_ln),
+            core_grid=ttnn.CoreGrid(y=core_grid_ln[0], x=core_grid_ln[1]),
+            strategy=ttnn.ShardStrategy.WIDTH,
+        )
+        self.ln_prg_cfg = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=(core_grid_ln[1], core_grid_ln[0]),
+            subblock_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
+            block_h=1,
+            block_w=(hidden_size_per_device_distributed_ln // num_cores_ln) // 32,
+            inplace=False,
+        )
+        self.ln_sharded_stats_memcfg = ttnn.create_sharded_memory_config(
+            shape=[1, 1, 32, 32 * 4],
+            core_grid=ttnn.CoreGrid(y=1, x=1),
+            strategy=ttnn.ShardStrategy.WIDTH,
+        )
+        self.ln_cfg = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
         self.TG = TG
 
     def forward(self, x, mode):
         """Apply a norm, possibly gathering inputs if required."""
-        if self.TG:
-            if mode == "decode":
-                return tt_sharded_distributed_rmsnorm(
+
+        if mode == "prefill" and self.TG:
+            return tt_distributed_rmsnorm(
+                x,
+                epsilon=self.norm.eps,
+                gamma=self.norm.weight_distributed,
+                mesh_device=self.args.mesh_device,
+                tt_ccl=self.tt_ccl,
+                compute_kernel_config=self.ln_cfg,
+            )
+
+        if mode == "decode":
+            if self.use_fused_rms_norm:
+                x = tt_sharded_distributed_rmsnorm(
                     x,
                     epsilon=self.norm.eps,
                     gamma=self.norm.weight_distributed,
@@ -58,21 +69,34 @@ class DistributedNorm(LightweightModule):
                     ln_sharded_input_memcfg=self.gather_in_mem_cfg,
                     ln_sharded_progcfg=self.ln_prg_cfg,
                     ln_sharded_stats_memcfg=self.ln_sharded_stats_memcfg,
+                    output_mem_config=self.gather_in_mem_cfg,
+                    use_fused_rms_norm=self.use_fused_rms_norm,
                 )
-            else:
-                return tt_distributed_rmsnorm(
-                    x,
-                    epsilon=self.norm.eps,
-                    gamma=self.norm.weight_distributed,
-                    mesh_device=self.args.mesh_device,
-                    tt_ccl=self.tt_ccl,
-                    compute_kernel_config=self.ln_cfg,
-                )
-
         input_mem_cfg = self.norm.sharded_output_config if mode == "decode" else ttnn.DRAM_MEMORY_CONFIG
 
         # Distributed norm already performs a gather
-        if self.args.is_multichip and not self.args.is_distributed_norm(mode):
+        if not self.use_fused_rms_norm:
+            if self.args.is_multichip and not self.args.is_distributed_norm(mode):
+                x = ttnn.experimental.all_gather_async(
+                    x,
+                    persistent_output_buffer=None,
+                    dim=3,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                    num_links=1,
+                    topology=self.args.ccl_topology(),
+                    memory_config=input_mem_cfg,
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                    chunks_per_sync=10,
+                    num_workers_per_link=2,
+                    num_buffers_per_channel=2,
+                )
+            else:
+                x = ttnn.to_memory_config(x, input_mem_cfg)
+
+            x = self.norm(x, mode=mode, in_sharded=(mode == "decode"), out_sharded=(mode == "decode"))
+
+        # Distributed norm requires a gather
+        if self.args.is_distributed_norm(mode) or self.use_fused_rms_norm:
             x = ttnn.experimental.all_gather_async(
                 x,
                 persistent_output_buffer=None,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -165,6 +165,12 @@ class Generator:
                     model_id,
                 )
 
+        # Initialize L1 buffers for decode mode after prefill warmup completes
+        # This must happen before decode trace capture
+        for model_instance in self.model:
+            if hasattr(model_instance, "init_decode_buffers"):
+                model_instance.init_decode_buffers()
+
     def _capture_trace_prefill(
         self,
         prefill_ids,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -145,6 +145,12 @@ class Transformer(LightweightModule):
         else:
             self.sampling = None
 
+    def init_decode_buffers(self):
+        """Initialize L1 buffers needed for decode mode.
+        Must be called after prefill warmup but before decode trace capture."""
+        # Initialize shared buffers in TT_CCL (used by all DistributedNorm instances)
+        self.tt_ccl.init_decode_buffers()
+
     def process_logits_after_prefill_trace(self, logits, last_token_idx):
         get_last_token = (last_token_idx // 32) * 32
         logits = ttnn.slice(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -178,52 +178,95 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         shard_spec.shape[1]);
 }
 
-TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
+std::vector<TensorSpec> RMSAllGatherDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    if (args.inplace) {
-        return input_tensor.tensor_spec();
-    }
 
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output->tensor_spec();
-    }
+    // Compute output tensor spec
+    TensorSpec output_spec = [&]() {
+        if (args.inplace) {
+            return input_tensor.tensor_spec();
+        }
 
-    auto output_shape = input_tensor.logical_shape();
-    auto output_padded_shape = input_tensor.padded_shape();
+        if (tensor_args.preallocated_output.has_value()) {
+            return tensor_args.preallocated_output->tensor_spec();
+        }
 
-    auto output_shard_spec = args.output_mem_config.shard_spec().value();
-    auto input_shard_spec = input_tensor.shard_spec().value();
-    if (output_shard_spec != input_shard_spec) {
-        output_padded_shape[3] = output_shard_spec.shape[1] * output_shard_spec.num_cores();
-    }
+        auto output_shape = input_tensor.logical_shape();
+        auto output_padded_shape = input_tensor.padded_shape();
 
-    auto mem_config = args.output_mem_config;
-    if (!mem_config.shard_spec().has_value()) {
-        mem_config = mem_config.with_shard_spec(input_tensor.shard_spec());
-    }
+        auto output_shard_spec = args.output_mem_config.shard_spec().value();
+        auto input_shard_spec = input_tensor.shard_spec().value();
+        if (output_shard_spec != input_shard_spec) {
+            output_padded_shape[3] = output_shard_spec.shape[1] * output_shard_spec.num_cores();
+        }
 
-    return ttnn::TensorSpec(
-        output_shape,
-        TensorLayout::fromPaddedShape(
-            args.dtype.value_or(input_tensor.dtype()),
-            PageConfig(Layout::TILE),
-            mem_config,
+        auto mem_config = args.output_mem_config;
+        if (!mem_config.shard_spec().has_value()) {
+            mem_config = mem_config.with_shard_spec(input_tensor.shard_spec());
+        }
+
+        return ttnn::TensorSpec(
             output_shape,
-            output_padded_shape));
+            TensorLayout::fromPaddedShape(
+                args.dtype.value_or(input_tensor.dtype()),
+                PageConfig(Layout::TILE),
+                mem_config,
+                output_shape,
+                output_padded_shape));
+    }();
+
+    // Compute stats tensor spec (used for all-gather intermediate buffer)
+    TensorSpec stats_spec = [&]() {
+        if (tensor_args.stats.has_value()) {
+            return tensor_args.stats->tensor_spec();
+        }
+
+        // Create stats tensor spec: shape (1, 1, 32, ring_size * TILE_WIDTH)
+        // Stats buffer collects one tile per device in the ring
+        uint32_t stats_width = args.ring_size * TILE_WIDTH;
+        ttnn::SimpleShape stats_shape({1, 1, TILE_HEIGHT, stats_width});
+
+        // Get the first core from input's shard grid for stats placement
+        auto input_shard_spec = input_tensor.shard_spec().value();
+        auto first_core = input_shard_spec.grid.bounding_box().start_coord;
+        CoreRangeSet stats_grid(CoreRange(first_core, first_core));
+
+        ShardSpec stats_shard_spec(stats_grid, {TILE_HEIGHT, stats_width}, ShardOrientation::ROW_MAJOR);
+
+        MemoryConfig stats_mem_config(TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1, stats_shard_spec);
+
+        return ttnn::TensorSpec(
+            stats_shape,
+            TensorLayout::fromPaddedShape(
+                DataType::BFLOAT16, PageConfig(Layout::TILE), stats_mem_config, stats_shape, stats_shape));
+    }();
+
+    return {output_spec, stats_spec};
 }
 
-Tensor RMSAllGatherDeviceOperation::create_output_tensors(
+std::vector<Tensor> RMSAllGatherDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output.value();
-    }
+    auto tensor_specs = compute_output_specs(args, tensor_args);
+    const auto& input_tensor = tensor_args.input;
 
-    if (args.inplace) {
-        return tensor_args.input;
-    }
-    auto output_spec = compute_output_specs(args, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input.device());
+    // Create or use preallocated output tensor
+    ttnn::Tensor output_tensor = [&]() {
+        if (tensor_args.preallocated_output.has_value()) {
+            return tensor_args.preallocated_output.value();
+        }
+        if (args.inplace) {
+            return tensor_args.input;
+        }
+        return create_device_tensor(tensor_specs[0], input_tensor.device());
+    }();
+
+    // Create or use preallocated stats tensor
+    ttnn::Tensor stats_tensor = tensor_args.stats.has_value()
+                                    ? tensor_args.stats.value()
+                                    : create_device_tensor(tensor_specs[1], input_tensor.device());
+
+    return {output_tensor, stats_tensor};
 }
 
 tt::stl::hash::hash_t RMSAllGatherDeviceOperation::compute_program_hash(
@@ -327,7 +370,10 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
         .stats = stats,
         .preallocated_output = persistent_output_tensor};
 
-    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+    // Launch operation - returns [output_tensor, stats_tensor]
+    // Return only the output tensor (index 0) to the caller
+    auto result = ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+    return result.at(0);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -225,7 +225,7 @@ std::vector<TensorSpec> RMSAllGatherDeviceOperation::compute_output_specs(
         // Create stats tensor spec: shape (1, 1, 32, ring_size * TILE_WIDTH)
         // Stats buffer collects one tile per device in the ring
         uint32_t stats_width = args.ring_size * TILE_WIDTH;
-        ttnn::SimpleShape stats_shape({1, 1, TILE_HEIGHT, stats_width});
+        ttnn::Shape stats_shape({1, 1, TILE_HEIGHT, stats_width});
 
         // Get the first core from input's shard grid for stats placement
         auto input_shard_spec = input_tensor.shard_spec().value();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33977

### Problem description
Fused RMS norm was an optimized op that was brought up in Llama glx codebase, we can extend usage to TT transformers since it works for various shapes (1,1,32,N) where N is hidden dim divisible by 32 (tested 4096, 8192).
There was also lack of documentation on how this op works and what configs is supported for this op, this PR adds comprehensive documentation for this op and provides example usage. 

### What's changed
- Added comprehensive documentation to fused rms norm op
- Internalize the creation of the stats buffer tensor so passing a persistent buffer is no longer required
- rename the op from `ttnn.fused_rms_1_1_32_8192` to `ttnn.fused_rms_norm`
- enable usage of the op in `distributed_norm.py` thought the `use_fused_rms` flag

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aling/fused-rms-bh)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aling/fused-rms-bh)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aling/fused-rms-bh)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aling/fused-rms-bh)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aling/fused-rms-bh)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aling/fused-rms-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aling/fused-rms-bh)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs