### PR TITLE
Modernize use starts ends with

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -104,7 +104,6 @@ Checks: >
   -modernize-use-integer-sign-comparison,
   -modernize-use-nodiscard,
   -modernize-use-ranges,
-  -modernize-use-starts-ends-with,
   -modernize-use-std-numbers,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -231,7 +231,7 @@ inline bool DeleteLinesStartingWith(const std::string& file_name, const std::str
     std::string content;
     std::string line;
     while (getline(log_file, line)) {
-        if (line.rfind(prefix, 0) == 0) {
+        if (line.starts_with(prefix)) {
             // Skip lines that begin with prefix
             continue;
         }

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -545,13 +545,11 @@ void CablingGenerator::emit_cabling_guide_csv(const std::string& output_path, bo
         //  all the default connections are enumerated
         const std::string suffix = "_DEFAULT";
         std::string host1_node_type = host1.node_type;
-        if (host1_node_type.size() >= suffix.size() &&
-            host1_node_type.compare(host1_node_type.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        if (host1_node_type.size() >= suffix.size() && host1_node_type.ends_with(suffix)) {
             host1_node_type = host1_node_type.substr(0, host1_node_type.size() - suffix.size());
         }
         std::string host2_node_type = host2.node_type;
-        if (host2_node_type.size() >= suffix.size() &&
-            host2_node_type.compare(host2_node_type.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        if (host2_node_type.size() >= suffix.size() && host2_node_type.ends_with(suffix)) {
             host2_node_type = host2_node_type.substr(0, host2_node_type.size() - suffix.size());
         }
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[]) {
         if (s == "-h" || s == "--help") {
             print_usage(argv[0]);
             return 0;
-        } else if ((s.rfind("-d=", 0) == 0) || (s.rfind("--devices=", 0) == 0)) {
+        } else if ((s.starts_with("-d=")) || (s.starts_with("--devices="))) {
             string list = s.substr(s.find('=') + 1);
             // "all" is acceptable, and the same as the default.
             if (list == "all") {
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
                 }
                 device_ids.push_back(stoi(item));
             }
-        } else if ((s.rfind("-n=", 0) == 0) || (s.rfind("--num-hw-cqs==", 0) == 0)) {
+        } else if ((s.starts_with("-n=")) || (s.starts_with("--num-hw-cqs=="))) {
             string value_str = s.substr(s.find('=') + 1);
             num_hw_cqs = std::stoi(value_str);
         } else if (s == "-w" || s == "--dump-watcher") {

--- a/tt_stl/tt_stl/type_name.hpp
+++ b/tt_stl/tt_stl/type_name.hpp
@@ -43,10 +43,10 @@ constexpr std::string_view long_name() {
     std::string_view struct_name("struct ");
     std::string_view class_name("class ");
 
-    if (raw_name.substr(0, struct_name.size()) == struct_name) {
+    if (raw_name.starts_with(struct_name)) {
         raw_name.remove_prefix(struct_name.size());
     }
-    if (raw_name.substr(0, class_name.size()) == class_name) {
+    if (raw_name.starts_with(class_name)) {
         raw_name.remove_prefix(class_name.size());
     }
 

--- a/ttnn/core/graph/levelized_graph.cpp
+++ b/ttnn/core/graph/levelized_graph.cpp
@@ -335,15 +335,13 @@ void LevelizedGraph::populate_output_info() {
             if (!consumer.arguments.empty()) {
                 const std::string& first_arg = consumer.arguments[0];
                 // Check if it's a Tensor argument (starts with "Tensor(")
-                if (first_arg.starts_witht "Tensor(") {
-                    ")) {
-                        // Add to output_info if not already present (avoid duplicates)
-                        // Note: this is not scalable, but the only viable solution for now since graph capture does not
-                        // store the output info of each vertex.
-                        if (std::ranges::find(vertex.output_info, first_arg) == vertex.output_info.end()) {
+                if (first_arg.starts_with("Tensor(")) {
+                    // Add to output_info if not already present (avoid duplicates)
+                    // Note: this is not scalable, but the only viable solution for now since graph capture does not
+                    // store the output info of each vertex.
+                    if (std::ranges::find(vertex.output_info, first_arg) == vertex.output_info.end()) {
                         vertex.output_info.push_back(first_arg);
                     }
-                }
                     break;  // Found it, no need to check other consumers
                 }
             }

--- a/ttnn/core/graph/levelized_graph.cpp
+++ b/ttnn/core/graph/levelized_graph.cpp
@@ -335,13 +335,15 @@ void LevelizedGraph::populate_output_info() {
             if (!consumer.arguments.empty()) {
                 const std::string& first_arg = consumer.arguments[0];
                 // Check if it's a Tensor argument (starts with "Tensor(")
-                if (first_arg.find("Tensor(") == 0) {
-                    // Add to output_info if not already present (avoid duplicates)
-                    // Note: this is not scalable, but the only viable solution for now since graph capture does not
-                    // store the output info of each vertex.
-                    if (std::ranges::find(vertex.output_info, first_arg) == vertex.output_info.end()) {
+                if (first_arg.starts_witht "Tensor(") {
+                    ")) {
+                        // Add to output_info if not already present (avoid duplicates)
+                        // Note: this is not scalable, but the only viable solution for now since graph capture does not
+                        // store the output info of each vertex.
+                        if (std::ranges::find(vertex.output_info, first_arg) == vertex.output_info.end()) {
                         vertex.output_info.push_back(first_arg);
                     }
+                }
                     break;  // Found it, no need to check other consumers
                 }
             }


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-starts-ends-with.html

C++20 gives us cool new string utilities to make code more concise and readable.

Lets use!

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs