### PR TITLE
Added Uniform DeepCache implementation

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -30,7 +30,7 @@ UNET_LOOP_PCC = {"10": 0.923, "50": 0.911}
 
 
 @torch.no_grad()
-def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, debug_mode):
+def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, debug_mode, deepcache_N=1):
     torch.manual_seed(0)
 
     if isinstance(prompts, str):
@@ -58,6 +58,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, deb
         "unet",
         model_config=tt_model_config,
         debug_mode=debug_mode,
+        deepcache_N=deepcache_N,
     )
     tt_scheduler = TtEulerDiscreteScheduler(
         ttnn_device,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -12,7 +12,7 @@ from models.experimental.stable_diffusion_xl_base.tests.pcc.test_module_tt_unet 
 from models.experimental.stable_diffusion_xl_base.refiner.tests.pcc.test_module_tt_unet import run_refiner_unet_model
 
 VAE_DEVICE_TEST_TOTAL_ITERATIONS = 1
-UNET_DEVICE_TEST_TOTAL_ITERATIONS = 1
+UNET_DEVICE_TEST_TOTAL_ITERATIONS = 2
 CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS = 1
 
 


### PR DESCRIPTION
### Feature description
This is the uniform implementation of DeepCache from the following paper :
https://arxiv.org/abs/2312.00858


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ddjekic/deepcache_sdxl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ddjekic/deepcache_sdxl)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/deepcache_sdxl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/deepcache_sdxl)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/deepcache_sdxl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/deepcache_sdxl)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/deepcache_sdxl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/deepcache_sdxl)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs