### PR TITLE
Removing Code Duplication in Untilize Migration #34981

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -243,6 +243,7 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
         // specs
         return program::UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory{};
     }
+
     uint32_t tensor_width = input_tensor_a.padded_shape()[-1];
     uint32_t tensor_height = input_tensor_a.physical_volume() / tensor_width;
 
@@ -256,32 +257,17 @@ UntilizeDeviceOperation::program_factory_t UntilizeDeviceOperation::select_progr
     auto grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
 
     size_t grid_area = grid_size.x * grid_size.y;
-    const uint32_t nblocks_per_core = grid_area == 0 ? 1 : std::ceil(static_cast<float>(num_tiles_per_col) / grid_area);
-    const uint32_t num_compute_cores =
-        nblocks_per_core == 0 ? num_tiles_per_col : std::ceil(static_cast<float>(num_tiles_per_col) / nblocks_per_core);
+    auto [num_compute_cores, nblocks_per_core] = compute_ncores(grid_area, num_tiles_per_col);
 
     constexpr uint32_t threshold_row_block = 32;
     if (!input_is_sharded and !output_is_sharded) {
-        if (num_tiles_per_row > threshold_row_block) {
-            if (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col) {
-                uint32_t num_blocks_block = (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) /
-                                            (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
-
-                // Compute grid area and initial blocks-per-core using integer math.
-                uint32_t nblocks_per_core_wh = (grid_area == 0) ? 1 : (num_blocks_block + grid_area - 1) / grid_area;
-
-                // Adjust nblocks_per_core_wh and determine the optimal block size.
-                auto [adjusted_nblocks_per_core, single_block_size] =
-                    closest_square_larger_than_b(nblocks_per_core_wh, num_tiles_per_row, num_tiles_per_col, grid_area);
-                nblocks_per_core_wh = adjusted_nblocks_per_core;
-
-                const uint32_t total_blocks_width = tt::div_up(num_tiles_per_row, single_block_size);
-                const uint32_t total_blocks_height = tt::div_up(num_tiles_per_col, single_block_size);
-                const uint32_t total_blocks = total_blocks_width * total_blocks_height;
-                const uint32_t ncores_block = (nblocks_per_core_wh == 0) ? num_blocks_block : total_blocks;
-                if (num_compute_cores < ncores_block) {
-                    return program::UntilizeMultiCoreBlockProgramFactory{};
-                }
+        if (num_tiles_per_row > threshold_row_block and
+            (num_tiles_per_col > threshold_row_block or num_tiles_per_row > num_tiles_per_col)) {
+            uint32_t num_blocks_block = (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) /
+                                        (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+            auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+            if (num_compute_cores < ncores_wh.ncores) {
+                return program::UntilizeMultiCoreBlockProgramFactory{};
             }
         }
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some code logic in `split_blocks_for_tilize` and `split_blocks_for_tilize_wh` was repeated in the migration of the untilize op to the TMP infrastructure [#34981](https://github.com/tenstorrent/tt-metal/pull/34981/files).

### What's changed
Added a helper function API to reduce this code repetition.

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20580735925)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20580757451). Compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/20531637979).
- [ ] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20580771922). Compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/20532478406).
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/20580786570). Compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/20530913571).
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20580799731). Compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/20530897063).
- [x] New/Existing tests provide coverage for changes