### PR TITLE
TT-Train: Invert SIMD_RNG env var logic to disable by default

### DIFF
--- a/tt-train/sources/ttml/core/random.hpp
+++ b/tt-train/sources/ttml/core/random.hpp
@@ -55,10 +55,10 @@ void parallel_generate(
 }  // namespace legacy
 
 static inline bool use_simd_rng() {
-    constexpr auto DISABLE_SIMD_RNG = "TT_TRAIN_DISABLE_SIMD_RNG";
-    static bool simd_disabled = (std::getenv(DISABLE_SIMD_RNG) != nullptr);
+    constexpr auto ENABLE_SIMD_RNG = "TT_TRAIN_ENABLE_SIMD_RNG";
+    static bool simd_enabled = (std::getenv(ENABLE_SIMD_RNG) != nullptr);
 
-    return !simd_disabled;
+    return simd_enabled;
 }
 
 template <typename T, typename DistGenFunc>


### PR DESCRIPTION
### Ticket
[Link to Github Issue 5558](https://github.com/tenstorrent/cloud/issues/5558)

### Problem description
Use of SIMD RNG had some effects that were undesirable, one example is the final loss in the tt-train nanogpt example- it is higher with SIMD than without.
With SIMD:       `Step: 5000, Loss: 1.3046875`
Without SIMD: `Step: 5000, Loss: 1.1640625`

### What's changed
Invert default behavior logic regarding use of SIMD RNG.  It is now disabled by default.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=athompson/disable_simd_rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:athompson/disable_simd_rng)
- [ ] New/Existing tests provide coverage for changes