### PR TITLE
34951: use output mem config for compute_output_specs in generic reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -85,13 +85,13 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
             tt::tt_metal::PageConfig(Layout::TILE),
             MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
 
-    if (input_tensor.nd_shard_spec().has_value()) {
-        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-            const auto& nd_shard_spec = *input_tensor.nd_shard_spec();
+    if (operation_attributes.output_mem_config.nd_shard_spec().has_value()) {
+        if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+            const auto& nd_shard_spec = *operation_attributes.output_mem_config.nd_shard_spec();
             return tensor_spec.width_sharded(nd_shard_spec.grid, nd_shard_spec.orientation);
         }
 
-        auto nd_shard_spec = *input_tensor.nd_shard_spec();
+        auto nd_shard_spec = *operation_attributes.output_mem_config.nd_shard_spec();
         if (operation_attributes.dim == tt::tt_metal::ReduceOpDim::W ||
             operation_attributes.dim == tt::tt_metal::ReduceOpDim::HW) {
             nd_shard_spec.shard_shape[-1] = 1;


### PR DESCRIPTION
### Ticket
Link to Github Issue #34951

### Problem description
compute_output_specs was using input tensor's mem config instead of output mem config in generic reduce

### What's changed
- fix that
- add a unit test, with a skip since extended testing uncovered a corner case where reshape didn't work

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-34951_mem_config) https://github.com/tenstorrent/tt-metal/actions/runs/20581421735
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-34951_mem_config)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-34951_mem_config)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-34951_mem_config)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-34951_mem_config)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-34951_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-34951_mem_config)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs