### PR TITLE
[Deepseek] Use page tables and Kv cache shape provided by vLLM for Dual Galaxy 6U

### DIFF
--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
@@ -12,6 +12,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_base import DecoderBlockBase
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
+from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
@@ -67,10 +68,11 @@ class DecoderBlock2DBase(DecoderBlockBase):
         mesh_device: ttnn.MeshDevice,
         ccl: CCL,
         mla_cache: torch.Tensor | None = None,
+        kv_cache_override: KvCacheConfig | None = None,
     ) -> ModelState:
         return {
             "mla_norm": DistributedRMSNorm.create_state(hf_config, mesh_device, ccl),
-            "mla": cls.create_mla_state(hf_config, paged_config, mesh_device, ccl, mla_cache),
+            "mla": cls.create_mla_state(hf_config, paged_config, mesh_device, ccl, mla_cache, kv_cache_override),
             "mlp_norm": DistributedRMSNorm.create_state(hf_config, mesh_device, ccl),
             "mlp": cls.create_mlp_state(hf_config, mesh_device, ccl),
         }
@@ -178,8 +180,9 @@ class DecoderBlock2DBase(DecoderBlockBase):
         mesh_device: ttnn.MeshDevice,
         ccl: CCL,
         mla_cache: torch.Tensor | None = None,
+        kv_cache_override: KvCacheConfig | None = None,
     ) -> ModelState:
-        return MLA2D.create_state(hf_config, paged_config, mesh_device, ccl, mla_cache)
+        return MLA2D.create_state(hf_config, paged_config, mesh_device, ccl, mla_cache, kv_cache_override)
 
     @classmethod
     @abstractmethod

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -16,7 +16,8 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.tt.rope import RotarySetup
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, get_weight_config
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
@@ -92,6 +93,7 @@ class DeepseekGenerator:
         )
         # self._ensure_max_seq_len(self.hf_config)
         self.hf_config.max_seq_len = 1024  # TODO: Change this when needed?
+        # self.hf_config.num_hidden_layers = 5 # TODO
         # Optional overrides for layer counts before building states
         if override_num_layers is not None:
             try:
@@ -176,23 +178,27 @@ class DeepseekGenerator:
             single_layer=self.single_layer,
         )
 
-    def _prepare_model_states(self) -> None:
+    def _prepare_model_states(self, kv_cache_override: KvCacheConfig | None = None) -> None:
         logger.info("Creating model states...")
         self.model_state = RowBatchedModel.create_state(
-            hf_config=self.hf_config, mesh_device=self.mesh_device, paged_config=self.paged_config, ccl=self.ccl
+            hf_config=self.hf_config,
+            mesh_device=self.mesh_device,
+            paged_config=self.paged_config,
+            ccl=self.ccl,
+            kv_cache_override=kv_cache_override,
         )
         logger.info("Creating model shared states...")
         self.model_shared_state = RowBatchedModel.create_shared_state(
             hf_config=self.hf_config, mesh_device=self.mesh_device
         )
 
-    def _prepare_run_configs(self, mode: str) -> None:
+    def _prepare_run_configs(self, mode: str, kv_cache_override: KvCacheConfig | None = None) -> None:
         if mode == "prefill":
             logger.info("Creating model prefill config...")
             self.model_prefill_cfg = RowBatchedModel.prefill_model_config(
                 hf_config=self.hf_config, mesh_device=self.mesh_device
             )
-            self._prepare_model_states()
+            self._prepare_model_states(kv_cache_override=kv_cache_override)
             self.model_run_config_prefill = create_run_config(
                 self.model_prefill_cfg,
                 self.model_weight_config,
@@ -381,7 +387,12 @@ class DeepseekGenerator:
         return rope_tensors, tt_positions
 
     def _decode_step(
-        self, tokens_step: torch.Tensor, positions: torch.Tensor, batch_size_per_row: int, return_rot_idxs: bool = False
+        self,
+        tokens_step: torch.Tensor,
+        positions: torch.Tensor,
+        batch_size_per_row: int,
+        page_table: list[ttnn.Tensor] | None = None,
+        return_rot_idxs: bool = False,
     ) -> torch.Tensor | Tuple[torch.Tensor, ttnn.Tensor]:
         """Run a single decode step and return logits on host as torch tensor [1, 1, B, V].
 
@@ -410,13 +421,22 @@ class DeepseekGenerator:
             dtype=ttnn.int32,
         )
 
+        if page_table is not None:
+            logger.info(f"page_table is provided in _decode_step")
+            page_tables_to_use = self._convert_vllm_page_table_for_batch(page_table)
+        else:
+            logger.info(f"page_table is not provided in _decode_step, using page_tables_tt")
+            page_tables_to_use = self.page_tables_tt
+
+        logger.info(f"decode_step: page_tables_to_use")
+        self.print_page_table(page_tables_to_use)
         # RowBatchedModel forward
         logits_tt = RowBatchedModel.forward_decode(
             tt_tokens,
             tt_positions,
             self.model_run_config_decode,
             rope_tensors,
-            self.page_tables_tt,
+            page_tables=page_tables_to_use,
         )
         # Gather to host
         logits = ttnn.to_torch(
@@ -651,7 +671,17 @@ class DeepseekGenerator:
             out.append(1)
         return out
 
-    def _prefill(self, tokens: torch.Tensor, user_id: int) -> torch.Tensor:
+    def print_page_table(self, page_table):
+        if isinstance(page_table, list) or isinstance(page_table, tuple):
+            logger.info(f"print_page_table length: {len(page_table)}")
+            for i in range(len(page_table)):
+                logger.info(f"print_page_table: index {i} shape: {page_table[i].shape}")
+        else:
+            logger.info(f"print_page_table: shape: {page_table.shape}")
+
+    def _prefill(
+        self, tokens: torch.Tensor, user_id: int, page_table: list[ttnn.Tensor] | list[torch.Tensor] | None = None
+    ) -> torch.Tensor:
         """Run prefill for the full prompt sequence and return logits for the last position.
 
         Args:
@@ -690,12 +720,22 @@ class DeepseekGenerator:
         }
 
         # RowBatchedModel forward prefill
+
+        if page_table is not None:
+            logger.info(f"page_table is provided in _prefill")
+            page_tables_to_use = self._convert_vllm_page_table_for_user(page_table, user_id)
+        else:
+            logger.info(f"page_table is not provided in _prefill, using  page_tables_tt")
+            page_tables_to_use = self.page_tables_tt
+
+        logger.info(f"_prefill: page_tables_to_use")
+        self.print_page_table(page_tables_to_use)
         logits_tt = RowBatchedModel.forward_prefill(
             x=tt_tokens,
             user_id=user_id,
             cfg=self.model_run_config_prefill,
             rope_tensors=rope_tensors,
-            page_tables=self.page_tables_tt,
+            page_tables=page_tables_to_use,
         )
 
         # Gather to host
@@ -827,6 +867,119 @@ class DeepseekGenerator:
     def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params) -> None:
         logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
         logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
+
+    def get_kv_cache(self):
+        assert self.model_state is not None, "Model state is not initialized"
+
+        kv_cache_list = []
+        for decoder_type in ["mlp_decoder_block", "moe_decoder_block"]:
+            if decoder_type in self.model_run_config_prefill:
+                decoder_blocks = self.model_run_config_prefill[decoder_type]
+                for block_cfg in decoder_blocks:
+                    if "mla" in block_cfg and "mla1d" in block_cfg["mla"] and "kvpe_cache" in block_cfg["mla"]["mla1d"]:
+                        kvpe_cache = block_cfg["mla"]["mla1d"]["kvpe_cache"]
+                        kv_cache_list.append(kvpe_cache)
+                    else:
+                        raise ValueError(f"KVPE cache not found for decoder block {decoder_type}")
+
+        return kv_cache_list
+
+    def set_kv_cache(self, kv_cache_list: list[ttnn.Tensor]) -> None:
+        """
+        Set the kvpe_cache values in block configs from the provided kv_cache_list.
+        This is the inverse operation of get_kv_cache().
+
+        Args:
+            kv_cache_list: List of TTNN tensors to set as kvpe_cache, one per decoder block
+        """
+        assert self.model_run_config_prefill is not None, "Model run config prefill is not initialized"
+        assert len(kv_cache_list) > 0, "kv_cache_list cannot be empty"
+
+        cache_idx = 0
+        for decoder_type in ["mlp_decoder_block", "moe_decoder_block"]:
+            if decoder_type in self.model_run_config_prefill:
+                decoder_blocks = self.model_run_config_prefill[decoder_type]
+                for block_cfg in decoder_blocks:
+                    if "mla" in block_cfg and "mla1d" in block_cfg["mla"] and "kvpe_cache" in block_cfg["mla"]["mla1d"]:
+                        if cache_idx >= len(kv_cache_list):
+                            raise ValueError(
+                                f"Not enough kv_cache entries. Expected at least {cache_idx + 1}, got {len(kv_cache_list)}"
+                            )
+                        cache_idx += 1
+                    else:
+                        raise ValueError(f"MLA structure not found for decoder block {decoder_type}")
+
+        if cache_idx < len(kv_cache_list):
+            logger.warning(
+                f"set_kv_cache: More kv_cache entries provided ({len(kv_cache_list)}) than decoder blocks ({cache_idx})"
+            )
+
+    def _convert_vllm_page_table_for_user(self, page_table: torch.Tensor, user_id: int) -> tuple[ttnn.Tensor, ...]:
+        """
+        Convert vLLM's block_tables (page_table) to TTNN tensor format for a specific user.
+        Creates one page table per layer as expected by the model.
+
+        Args:
+            page_table: torch.Tensor of shape [batch_size, max_num_blocks_per_req] from vLLM
+            user_id: The user index to extract the page table for
+
+        Returns:
+            Tuple of TTNN tensors, one per layer
+        """
+        # Calculate expected shape: [batch_per_shard, blocks_per_user]
+        batch_per_shard = even_int_div(self.batch_size_per_row, self.mesh_device.shape[0])
+        blocks_per_user = even_int_div(self.paged_config.max_num_blocks, batch_per_shard)
+
+        # Extract the user's block table row
+        user_blocks = page_table[
+            user_id, : min(blocks_per_user, page_table.shape[1])
+        ].clone()  # [max_num_blocks_per_req] or less
+
+        # Create a full page table with shape [batch_per_shard, blocks_per_user]
+        max_num_blocks = batch_per_shard * blocks_per_user
+        full_page_table = torch.randperm(max_num_blocks, dtype=torch.int32)
+        full_page_table = full_page_table.reshape(batch_per_shard, blocks_per_user)
+
+        local_user_id = user_id % batch_per_shard
+        num_user_blocks = min(user_blocks.shape[0], blocks_per_user)
+        full_page_table[local_user_id, :num_user_blocks] = user_blocks[:num_user_blocks]
+
+        # Convert to TTNN format using the model's helper
+        page_table_tt = MLA2D.create_page_table(
+            paged_config=self.paged_config,
+            mesh_device=self.mesh_device,
+            page_table=full_page_table,
+            batch_size_per_row=self.batch_size_per_row // self.mesh_device.shape[0],
+        )
+
+        num_layers = self.hf_config.num_hidden_layers
+        return tuple(ttnn.clone(page_table_tt) for _ in range(num_layers))
+
+    def _convert_vllm_page_table_for_batch(self, page_table: torch.Tensor) -> tuple[ttnn.Tensor, ...]:
+        """
+        Convert vLLM's block_tables (page_table) to TTNN tensor format for the entire batch.
+        Creates one page table per layer as expected by the model.
+
+        Args:
+            page_table: torch.Tensor of shape [batch_size, max_num_blocks_per_req] from vLLM
+
+        Returns:
+            Tuple of TTNN tensors, one per layer
+        """
+        # Use vLLM page table directly, but shard it across devices to match the sharded batch size
+        # in paged_update_cache.
+        # page_table shape: [batch_size, max_blocks_per_req]
+
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=self.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        return tuple(page_table_tt for _ in range(self.hf_config.num_hidden_layers))
 
 
 __all__ = ["DeepseekGenerator", "SamplingParams"]

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -935,7 +935,7 @@ class DeepseekGenerator:
             Tuple of TTNN tensors, one per layer
         """
         # Calculate expected shape: [batch_per_shard, blocks_per_user]
-        batch_per_shard = even_int_div(self.batch_size_per_row, self.mesh_device.shape[0])
+        batch_per_shard = even_int_div(self.batch_size_per_row, self.dp_factor)
         blocks_per_user = even_int_div(self.paged_config.max_num_blocks, batch_per_shard)
 
         # Extract the user's block table row

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
+from models.demos.deepseek_v3.utils.config_dataclass import KvCacheConfig
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 
@@ -63,8 +64,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             cache_dir=Path(cache_dir),
             tokenizer=tokenizer,
         )
-        model._prepare_run_configs("prefill")
-        model._prepare_run_configs("decode")
+
         return model
 
     @property
@@ -72,29 +72,65 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return self.cache_dir
 
     def prefill_forward(self, *args, **kwargs):
+        # print args and kwargs
+        logger.info(f"prefill_forward: args: {args}")
+        logger.info(f"prefill_forward: kwargs: {kwargs.keys()}")
+        assert self.model_run_config_prefill is not None, "Model run config prefill is not initialized"
         kwargs.pop("enable_trace", None)
         logger.warning(f"Prefill tracing not supported for DeepseekGenerator")
 
         tokens = kwargs["tokens"]
         lengths = kwargs["prompt_lens"]
+        page_table = kwargs.get("page_table", None)
+        kv_cache = kwargs.get("kv_cache", None)
+        # Set kv_cache if provided and all entries are valid
+        if kv_cache is not None and not any(entry is None for entry in kv_cache):
+            logger.info(f"prefill_forward: Setting kv_cache for {len(kv_cache)}")
+            self.set_kv_cache(kv_cache)
+        else:
+            logger.info(f"prefill_forward: kv_cache not updated")
+
         tokens = _pad_tokens(tokens, self.tokenizer.pad_token_id, block_size=USERS_PER_ROW)
         num_of_users = tokens.shape[0]
         last_logits = []
         for user_id in range(num_of_users):
             if lengths[user_id] == 0:
+                logger.info(f"prefill_forward: User {user_id} has no tokens")
                 last_logits.append(
                     torch.zeros(tokens.shape[1], self.hf_config.vocab_size, device=tokens.device, dtype=tokens.dtype)
                 )
                 continue
-            user_out = self._prefill(tokens[user_id], user_id)
+            logger.info(f"prefill_forward: Running prefill for user {user_id}")
+            user_out = self._prefill(tokens[user_id], user_id, page_table)
             last_logits.append(user_out.squeeze(0).squeeze(0))  # [1, 1, S, V] -> [S, V]
         last_logits = torch.stack(last_logits)  # [num_of_users, S, V]
+
+        logger.info(f"prefill_forward: Last logits shape: {last_logits.shape}")
         return last_logits
 
     def decode_forward(self, *args, **kwargs):
+        # print args and kwargs
+        logger.info(f"decode_forward: args: {args}")
+        logger.info(f"decode_forward: kwargs: {kwargs.keys()}")
+        assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
+
+        page_table = kwargs.get("page_table", None)
+        kv_cache = kwargs.get("kv_cache", None)
+        # Set kv_cache if provided and all entries are valid
+        if kv_cache is not None and not any(entry is None for entry in kv_cache):
+            logger.info(f"decode_forward: Setting kv_cache for {len(kv_cache)} decoder blocks")
+            self.set_kv_cache(kv_cache)
+        else:
+            logger.info(f"decode_forward: kv_cache not updated")
+
         tokens_step = kwargs["tokens"].squeeze(1)
         return_value = (
-            self._decode_step(tokens_step=tokens_step, positions=kwargs["start_pos"], batch_size_per_row=USERS_PER_ROW)
+            self._decode_step(
+                tokens_step=tokens_step,
+                positions=kwargs["start_pos"],
+                batch_size_per_row=USERS_PER_ROW,
+                page_table=page_table,
+            )
             .squeeze(0)
             .squeeze(0)
             .unsqueeze(1)
@@ -102,4 +138,14 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         return return_value
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
-        return [None] * num_layers
+        assert (
+            num_layers == self.hf_config.num_hidden_layers
+        ), f"Number of layers {num_layers} does not match the number of layers in the model {self.hf_config.num_hidden_layers}"
+        logger.info(f"allocate_kv_cache: kv cache shape: {kv_cache_shape}")
+
+        kv_cache_config = KvCacheConfig(kv_cache_shape=kv_cache_shape, dtype=dtype)
+        self._prepare_run_configs("prefill", kv_cache_override=kv_cache_config)
+        self._prepare_run_configs("decode", kv_cache_override=kv_cache_config)
+
+        kv_cache = self.get_kv_cache()
+        return kv_cache

--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Sequence
 
 import torch
-from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
@@ -719,11 +718,14 @@ class MLA1D(AbstractModule):
         if kv_cache_override is None:
             kvpe_dim = hf_config.kv_lora_rank + hf_config.qk_rope_head_dim
             cache_shape = (paged_config.max_num_blocks * mesh_device.shape[1], 1, paged_config.block_size, kvpe_dim)
-            logger.info(f"create_state: cache_shape: {cache_shape}")
         else:
-            logger.info(f"create_state: kv_cache_override: {kv_cache_override.kv_cache_shape}")
-            kvpv_os = kv_cache_override.kv_cache_shape
-            cache_shape = (kvpv_os[0] * mesh_device.shape[1], kvpv_os[1], kvpv_os[2], kvpv_os[3])
+            kv_cache_shape = kv_cache_override.kv_cache_shape
+            cache_shape = (
+                kv_cache_shape[0] * mesh_device.shape[1],
+                kv_cache_shape[1],
+                kv_cache_shape[2],
+                kv_cache_shape[3],
+            )
 
         assert (
             caches is None

--- a/models/demos/deepseek_v3/tt/mla/mla2d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla2d.py
@@ -13,6 +13,7 @@ from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.utils.config_dataclass import (
     AllGatherAsyncConfig,
+    KvCacheConfig,
     MeshDeviceStub,
     ReduceScatterAsyncMinimalConfig,
     SavedWeight,
@@ -126,6 +127,7 @@ class MLA2D(MLA1D):
         mesh_device: ttnn.MeshDevice,
         ccl: CCL,
         cache: torch.Tensor | None = None,
+        kv_cache_override: KvCacheConfig | None = None,
     ) -> ModelState:
         return {
             MESH_DEVICE_STATE_DICT_KEY: mesh_device,
@@ -135,6 +137,7 @@ class MLA2D(MLA1D):
                 mesh_device,
                 ccl,
                 None if cache is None else cache.reshape(mesh_device.shape[0], -1, *cache.shape[1:]),
+                kv_cache_override,
             ),
             "ccl": ccl,
         }

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import torch
-from loguru import logger
 from tqdm.auto import tqdm
 from transformers.configuration_utils import PretrainedConfig
 
@@ -219,11 +218,6 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
     ) -> ttnn.Tensor:
         """Forward pass for decode mode."""
 
-        logger.info(f"forward_decode: User {position_idxs}")
-        logger.info(f"forward_decode: page tables len : {len(page_tables)}")
-        for i in range(len(page_tables)):
-            logger.info(f"forward_decode: Page table {i} shape: {page_tables[i].shape}")
-
         x = Embedding2D.forward_decode(x, cfg["embedding"])
 
         for (block_cfg, BlockClass), page_table in zip(
@@ -255,10 +249,6 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
         page_tables: Sequence[ttnn.Tensor],
     ) -> ttnn.Tensor:
         """Forward pass for prefill mode."""
-
-        logger.info(f"forward_prefill: User {user_id} has {len(page_tables)} page tables")
-        for i in range(len(page_tables)):
-            logger.info(f"forward_prefill: Page table {i} shape: {page_tables[i].shape}")
 
         x = Embedding2D.forward_prefill(x, cfg["embedding"])
 

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -343,3 +343,11 @@ class SparseMatmulConfig(OpConfigBase):
     output_tile: ttnn.Tile | None = None
     sparsity: ttnn.Tensor | None = None
     nnz: int | None = None
+
+
+@dataclass
+class KvCacheConfig(OpConfigBase):
+    """Common parameters for a kv cache"""
+
+    kv_cache_shape: tuple[int, int, int, int]
+    dtype: ttnn.DataType | None = None

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -347,7 +347,11 @@ class SparseMatmulConfig(OpConfigBase):
 
 @dataclass
 class KvCacheConfig(OpConfigBase):
-    """Common parameters for a kv cache"""
+    """Common parameters for a kv cache.
+    Attributes:
+        The expected ordering is:
+        (num_blocks, num_heads = 1, block_size, kvpe_dim)
+    """
 
     kv_cache_shape: tuple[int, int, int, int]
     dtype: ttnn.DataType | None = None


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33425

### Problem description
Use page tables and Kv cache shape provided by vLLM
Tested with online and offline inference, model works and o/p generated text is also good.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pprajapati/vllm_pt_kvpe)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/vllm_pt_kvpe)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/vllm_pt_kvpe)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/vllm_pt_kvpe)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/vllm_pt_kvpe)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/vllm_pt_kvpe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/vllm_pt_kvpe)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs