### PR TITLE
Readability use anyofallof

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -130,7 +130,6 @@ Checks: >
   -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,
-  -readability-use-anyofallof,
   -abseil-*,
   -altera-*,
   -android-*,

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <map>
+#include <ranges>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -235,12 +236,9 @@ void MeshSocketTestContext::execute_socket_test(
 }
 
 bool MeshSocketTestContext::should_participate_in_test(const ParsedTestConfig& test) const {
-    for (const auto& socket_config : test.sockets) {
-        if (socket_config.sender_rank == local_rank_ || socket_config.receiver_rank == local_rank_) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(test.sockets, [this](const auto& socket_config) {
+        return socket_config.sender_rank == local_rank_ || socket_config.receiver_rank == local_rank_;
+    });
 }
 
 /*

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/span.hpp>
 #include <algorithm>
 #include <cstdint>
+#include <ranges>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -86,12 +87,7 @@ bool CoreRange::contains(const CoreRange& other) const {
 }
 
 bool CoreRange::contains(const CoreRangeSet& other) const {
-    for (const auto& cr : other.ranges()) {
-        if (!this->contains(cr)) {
-            return false;
-        }
-    }
-    return true;
+    return std::ranges::all_of(other.ranges(), [this](const auto& cr) { return this->contains(cr); });
 }
 
 // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
@@ -267,21 +263,11 @@ bool CoreRangeSet::intersects(const CoreCoord& other) const {
 }
 
 bool CoreRangeSet::intersects(const CoreRange& other) const {
-    for (const auto& local_cr : this->ranges_) {
-        if (local_cr.intersects(other)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(this->ranges_, [&other](const auto& local_cr) { return local_cr.intersects(other); });
 }
 
 bool CoreRangeSet::intersects(const CoreRangeSet& other) const {
-    for (const auto& cr : other.ranges()) {
-        if (this->intersects(cr)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(other.ranges(), [this](const auto& cr) { return this->intersects(cr); });
 }
 
 CoreRangeSet CoreRangeSet::intersection(const CoreRangeSet& other) const {
@@ -297,12 +283,7 @@ CoreRangeSet CoreRangeSet::intersection(const CoreRangeSet& other) const {
 }
 
 bool CoreRangeSet::contains(const CoreCoord& other) const {
-    for (const auto& cr : this->ranges_) {
-        if (cr.contains(other)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(this->ranges_, [&other](const auto& cr) { return cr.contains(other); });
 }
 
 bool CoreRangeSet::contains(const CoreRange& other) const {

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -322,6 +322,7 @@ bool MeshCoordinateRange::intersects(const MeshCoordinateRange& range) const {
     // Fallback: iterate over the smaller range and test containment to cover wrap semantics.
     const MeshCoordinateRange& smaller = (range.shape().mesh_size() <= this->shape().mesh_size()) ? range : *this;
     const MeshCoordinateRange& larger = (&smaller == this) ? range : *this;
+    // NOLINTNEXTLINE(readability-use-anyofallof)
     for (const auto& c : smaller) {
         if (larger.contains(c)) {
             return true;

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -7,6 +7,7 @@
 #include <tt_stl/assert.hpp>
 #include <algorithm>
 #include <array>
+#include <ranges>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -640,12 +641,8 @@ void FreeListOpt::insert_block_to_alloc_table(DeviceAddr address, size_t block_i
 }
 bool FreeListOpt::is_address_in_alloc_table(DeviceAddr address) const {
     size_t bucket = hash_device_address(address);
-    for (const auto& [addr, block_index] : allocated_block_table_[bucket]) {
-        if (addr == address) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(
+        allocated_block_table_[bucket], [address](const auto& entry) { return entry.first == address; });
 }
 std::optional<size_t> FreeListOpt::get_and_remove_from_alloc_table(DeviceAddr address) {
     size_t bucket = hash_device_address(address);

--- a/tt_metal/impl/allocator/allocator_state.cpp
+++ b/tt_metal/impl/allocator/allocator_state.cpp
@@ -8,6 +8,7 @@
 #include <enchantum/enchantum.hpp>
 
 #include <algorithm>
+#include <ranges>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -134,14 +135,11 @@ bool AllocatorState::BufferTypeState::is_compatible_with(const BufferTypeState& 
         return false;
     }
 
-    for (const auto& [bank_id, offset] : bank_id_to_bank_offset) {
+    return std::ranges::all_of(bank_id_to_bank_offset, [&other](const auto& entry) {
+        const auto& [bank_id, offset] = entry;
         auto it = other.bank_id_to_bank_offset.find(bank_id);
-        if (it == other.bank_id_to_bank_offset.end() || it->second != offset) {
-            return false;
-        }
-    }
-
-    return true;
+        return it != other.bank_id_to_bank_offset.end() && it->second == offset;
+    });
 }
 
 DeviceAddr AllocatorState::BufferTypeState::total_allocated_size() const {

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -11,6 +11,7 @@
 
 #include <sys/types.h>
 #include <cstddef>
+#include <ranges>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt_stl/enum.hpp>
@@ -67,12 +68,7 @@ public:
         return (masks_[static_cast<size_t>(core_type)] & (1u << processor_index)) != 0;
     }
     bool empty() const {
-        for (const auto& mask : masks_) {
-            if (mask != 0) {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::all_of(masks_, [](const auto& mask) { return mask == 0; });
     }
     // Returns the bitmask of processors for the given core type.
     // Bit i set <=> processor index i is in the set.

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <ranges>
 
 #include "impl/context/metal_context.hpp"
 
@@ -22,13 +23,10 @@ namespace tt {
      (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
 
 static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, CoreCoord core) {
-    for (const tt::umd::CoreCoord& core_coord : coords) {
+    return std::ranges::any_of(coords, [core](const tt::umd::CoreCoord& core_coord) {
         CoreCoord item = {core_coord.x, core_coord.y};
-        if (item == core) {
-            return true;
-        }
-    }
-    return false;
+        return item == core;
+    });
 }
 
 static bool coord_found_p(std::unordered_set<CoreCoord> coords, CoreCoord core) {

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <vector>
@@ -548,13 +549,7 @@ void print_help() {
 }
 
 bool has_flag(const std::vector<std::string>& input_args, const std::string& flag) {
-    for (const auto& arg : input_args) {
-        if (arg == flag) {
-            return true;
-        }
-    }
-
-    return false;
+    return std::ranges::any_of(input_args, [&flag](const auto& arg) { return arg == flag; });
 }
 
 std::optional<int> get_device_id_from_args(const std::vector<std::string>& input_args) {

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <optional>
 #include <random>
+#include <ranges>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/indestructible.hpp>
@@ -344,12 +345,9 @@ void launch_operation_with_adapter(
 
 // Returns true if the tensor is fully replicated, false otherwise.
 inline bool is_fully_replicated(const Tensor& tensor) {
-    for (const auto& placement : tensor.tensor_topology().placements()) {
-        if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placement)) {
-            return false;
-        }
-    }
-    return true;
+    return std::ranges::all_of(tensor.tensor_topology().placements(), [](const auto& placement) {
+        return !std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placement);
+    });
 }
 
 // Default TensorTopology for output tensors is determined only by the input tensors with the highest distribution rank

--- a/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pool_utils.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <string>
 #include <tt_stl/assert.hpp>
 
@@ -188,19 +189,8 @@ bool validate_pooling_params_uniformity(
         input_w, output_w, params.kernel_size[1], params.stride[1], params.padding[2], params.padding[3]);
 
     // All strides should be exactly the same (since we're using fixed stride)
-    for (uint32_t stride : h_actual_strides) {
-        if (stride != params.stride[0]) {
-            return false;
-        }
-    }
-
-    for (uint32_t stride : w_actual_strides) {
-        if (stride != params.stride[1]) {
-            return false;
-        }
-    }
-
-    return true;
+    return std::ranges::all_of(h_actual_strides, [&params](uint32_t stride) { return stride == params.stride[0]; }) &&
+           std::ranges::all_of(w_actual_strides, [&params](uint32_t stride) { return stride == params.stride[1]; });
 }
 
 // Validation function to check if adaptive pooling approach is feasible


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/readability/use-anyofallof.html

The argument for this check, is that it makes intent more declarative, instead of reading through the control flow logic.

### What's changed
- Enable check
- Fix violations with AI

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs