### PR TITLE
Combine Conv2d Prepared Weights with Config

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -127,8 +127,6 @@ def prepare_conv_weights_func(
         if has_bias
         else None
     )
-    tt_weight_tensor_formatted = ttnn.to_device(tt_weight_tensor_formatted, device)
-    tt_bias_tensor_formatted = ttnn.to_device(tt_bias_tensor_formatted, device) if has_bias else None
     (k := next(iter(conv_kwargs)), conv_kwargs.pop(k))  ##removing 1st element from dict
     tt_output_tensor_on_device = ttnn.conv2d(
         input_tensor=tt_input_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -5,15 +5,10 @@
 #pragma once
 #include <optional>
 #include <string>
-#include <ttnn/operations/conv/conv2d/conv2d_utils.hpp>
 #include <ttnn/tensor/types.hpp>
 #include <ttnn/types.hpp>
 #include <ttnn/tensor/tensor.hpp>
-
-namespace ttnn::operations::sliding_window {
-struct ParallelConfig;
-}
-
+#include "conv2d_utils.hpp"
 namespace ttnn::operations::conv::conv2d {
 
 // Device validation functions for conv2d tensors (after preparation/on device)
@@ -77,7 +72,7 @@ Tensor convert_conv_weight_tensor_to_grouped_layout_for_conv_transpose2d(
 Tensor convert_conv_weight_tensor_to_depthwise_layout(
     const Tensor& conv_weight_tensor, uint32_t act_block_h_ntiles, DataType output_dtype);
 
-ttnn::Tensor prepare_conv_weights(
+PreparedConv2dWeightBiasTensor prepare_conv_weights(
     const ttnn::Tensor& weight_tensor,
     const ttnn::MemoryConfig& input_memory_config,
     Layout input_layout,
@@ -100,7 +95,7 @@ ttnn::Tensor prepare_conv_weights(
     const std::optional<const DeviceComputeKernelConfig>& compute_config_,
     const std::optional<const Conv2dSliceConfig>& dram_slice_config_);
 
-ttnn::Tensor prepare_conv_bias(
+PreparedConv2dWeightBiasTensor prepare_conv_bias(
     const ttnn::Tensor& bias_tensor,
     const ttnn::MemoryConfig& input_memory_config,
     Layout input_layout,
@@ -121,118 +116,14 @@ ttnn::Tensor prepare_conv_bias(
     const std::optional<const DeviceComputeKernelConfig>& compute_config_,
     const std::optional<const Conv2dSliceConfig>& dram_slice_config_ = std::nullopt);
 
-// Unified parameter struct for conv2d weight and bias preparation
-struct Conv2dWeightsBiasPrepConfig {
-    // Constructor to ensure all required parameters are initialized
-    Conv2dWeightsBiasPrepConfig(
-        uint32_t input_channels_alignment_,
-        std::optional<DataType> weights_bias_dtype_,
-        uint32_t weight_block_h_ntiles_,
-        uint32_t weight_block_w_ntiles_,
-        const std::optional<sliding_window::ParallelConfig>& input_parallel_config_,
-        const std::optional<sliding_window::ParallelConfig>& output_parallel_config_,
-        uint32_t groups_,
-        uint32_t act_block_h_ntiles_,
-        uint32_t input_height_,
-        uint32_t input_width_,
-        bool interleaved_mm_conv,
-        uint32_t out_channels_,
-        bool has_bias_ = false,
-        bool enable_kernel_stride_folding_ = false,
-        bool full_inner_dim_ = false,
-        bool enable_activation_reuse_ = false,
-        std::array<uint32_t, 2> stride_ = {1, 1}) :
-        input_channels_alignment(input_channels_alignment_),
-        weights_bias_dtype(weights_bias_dtype_),
-        weight_block_h_ntiles(weight_block_h_ntiles_),
-        weight_block_w_ntiles(weight_block_w_ntiles_),
-        input_parallel_config(input_parallel_config_),
-        output_parallel_config(output_parallel_config_),
-        groups(groups_),
-        act_block_h_ntiles(act_block_h_ntiles_),
-        input_height(input_height_),
-        input_width(input_width_),
-        has_bias(has_bias_),
-        enable_kernel_stride_folding(enable_kernel_stride_folding_),
-        full_inner_dim(full_inner_dim_),
-        enable_activation_reuse(enable_activation_reuse_),
-        stride(stride_),
-        interleaved_mm_conv(interleaved_mm_conv),
-        out_channels(out_channels_) {}
-
-    // Common parameters
-    const uint32_t input_channels_alignment;
-    const std::optional<DataType> weights_bias_dtype;
-    uint32_t weight_block_h_ntiles;
-    const uint32_t weight_block_w_ntiles;
-
-    // Interleaved MM convs don't need parallel configs
-    const std::optional<sliding_window::ParallelConfig> input_parallel_config;
-    const std::optional<sliding_window::ParallelConfig> output_parallel_config;
-    const uint32_t groups;
-    const uint32_t act_block_h_ntiles;
-    const uint32_t input_height;
-    const uint32_t input_width;
-    const bool has_bias;
-
-    const bool enable_kernel_stride_folding;
-    const bool full_inner_dim;
-    const bool enable_activation_reuse;
-
-    // Kernel stride folding parameter
-    const std::array<uint32_t, 2> stride;
-    // This conv will go through auto shard codepath for matmul based convs
-    const bool interleaved_mm_conv;
-    // Output channels (mandatory)
-    const uint32_t out_channels;
-
-    static constexpr auto attribute_names = std::make_tuple(
-        "input_channels_alignment",
-        "weights_bias_dtype",
-        "weight_block_h_ntiles",
-        "weight_block_w_ntiles",
-        "input_parallel_config",
-        "output_parallel_config",
-        "groups",
-        "act_block_h_ntiles",
-        "input_height",
-        "input_width",
-        "has_bias",
-        "enable_kernel_stride_folding",
-        "full_inner_dim",
-        "enable_activation_reuse",
-        "stride",
-        "interleaved_mm_conv",
-        "out_channels");
-    auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->input_channels_alignment),
-            std::cref(this->weights_bias_dtype),
-            std::cref(this->weight_block_h_ntiles),
-            std::cref(this->weight_block_w_ntiles),
-            std::cref(this->input_parallel_config),
-            std::cref(this->output_parallel_config),
-            std::cref(this->groups),
-            std::cref(this->act_block_h_ntiles),
-            std::cref(this->input_height),
-            std::cref(this->input_width),
-            std::cref(this->has_bias),
-            std::cref(this->enable_kernel_stride_folding),
-            std::cref(this->full_inner_dim),
-            std::cref(this->enable_activation_reuse),
-            std::cref(this->stride),
-            std::cref(this->interleaved_mm_conv),
-            std::cref(this->out_channels));
-    }
-};
-
-std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(
+std::pair<PreparedConv2dWeightBiasTensor, PreparedConv2dWeightBiasTensor>
+prepare_conv_weights_biases_and_move_to_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
     Conv2dWeightsBiasPrepConfig& params,
     MeshDevice* device);
 
-std::optional<ttnn::Tensor> prepare_conv_bias_internal(
+PreparedConv2dWeightBiasTensor prepare_conv_bias_internal(
     const std::optional<const ttnn::Tensor>& bias_tensor,
     uint32_t out_channels,
     const Conv2dWeightsBiasPrepConfig& params,


### PR DESCRIPTION
### Problem description
Conv2d needs weights preprocessed in a particular format. This is dependent on how the op is executed. Using a different execution strategy with prepared weights leads to a PCC error, which is hard to debug.

### What's changed
The prepared weights and execution strategy are paired into a single object. Using this object prevents error due to mismatch of weights & config.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:smanoj/conv_weights_prep_info)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smanoj/conv_weights_prep_info)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smanoj/conv_weights_prep_info)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smanoj/conv_weights_prep_info)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smanoj/conv_weights_prep_info)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smanoj/conv_weights_prep_info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smanoj/conv_weights_prep_info)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs