### PR TITLE
#33778: Add uint16 support for bitwise shift ops

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_shift_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_shift_tile.rst
@@ -7,17 +7,11 @@ Left Shift
 ----------
 
 .. doxygenfunction:: binary_left_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_left_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_left_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 
 Right Shift
 -----------
 
 .. doxygenfunction:: binary_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
-.. doxygenfunction:: binary_right_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 
 Logical Right Shift
 -------------------

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_shift_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/binary_shift_tile.rst
@@ -9,6 +9,7 @@ Left Shift
 .. doxygenfunction:: binary_left_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 .. doxygenfunction:: binary_left_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 .. doxygenfunction:: binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
+.. doxygenfunction:: binary_left_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 
 Right Shift
 -----------
@@ -16,6 +17,7 @@ Right Shift
 .. doxygenfunction:: binary_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 .. doxygenfunction:: binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 .. doxygenfunction:: binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
+.. doxygenfunction:: binary_right_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst)
 
 Logical Right Shift
 -------------------

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -730,3 +730,38 @@ def test_binary_rsub_uint16_edge_cases(device):
     output_tensor = ttnn.to_torch(output_tensor, dtype=torch.int32)
 
     assert torch.equal(output_tensor, torch_output_tensor)
+
+
+def test_binary_bitwise_left_shift(device):
+    x_torch = torch.tensor([0, 1, 2, 3, 15, 31, 255, 127, 63, 31, 15, 1], dtype=torch.int32)
+
+    y_torch = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15], dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_left_shift)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_out = ttnn.bitwise_left_shift(x_tt, y_tt)
+
+    z_tt_out = ttnn.typecast(z_tt_out, dtype=ttnn.uint32)
+    tt_out = ttnn.to_torch(z_tt_out, dtype=torch.int32)
+    assert torch.equal(tt_out, z_torch)
+
+
+def test_binary_bitwise_right_shift(device):
+    # Corner cases: 0, 1, max uint16 (65535), values that shift to 0, shift by 0, shift by 15 (max for uint16), shift by 16+
+    x_torch = torch.tensor(
+        [0, 1, 2, 3, 15, 31, 255, 127, 63, 31, 15, 1, 65535, 32768, 16384, 8192, 1], dtype=torch.int32
+    )
+
+    y_torch = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 0, 1, 1, 13, 20], dtype=torch.int32)
+
+    golden_fn = ttnn.get_golden_function(ttnn.bitwise_right_shift)
+    z_torch = golden_fn(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt_out = ttnn.bitwise_right_shift(x_tt, y_tt)
+
+    z_tt_out = ttnn.typecast(z_tt_out, dtype=ttnn.uint32)
+    tt_out = ttnn.to_torch(z_tt_out, dtype=torch.int32)
+    assert torch.equal(tt_out, z_torch)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint16.py
@@ -749,7 +749,6 @@ def test_binary_bitwise_left_shift(device):
 
 
 def test_binary_bitwise_right_shift(device):
-    # Corner cases: 0, 1, max uint16 (65535), values that shift to 0, shift by 0, shift by 15 (max for uint16), shift by 16+
     x_torch = torch.tensor(
         [0, 1, 2, 3, 15, 31, 255, 127, 63, 31, 15, 1, 65535, 32768, 16384, 8192, 1], dtype=torch.int32
     )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -16,7 +16,7 @@ namespace sfpu {
 template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = 8,
-    InstrModLoadStore INSTRUCTION_MODE = INT32,
+    InstrModLoadStore INSTRUCTION_MODE,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
@@ -26,7 +26,7 @@ inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst
 template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = 8,
-    InstrModLoadStore INSTRUCTION_MODE = INT32,
+    InstrModLoadStore INSTRUCTION_MODE,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void calculate_binary_right_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -15,9 +15,14 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATE, DataFormat data_format, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    static_assert(
+        data_format == DataFormat::Int32 || data_format == DataFormat::UInt32 || data_format == DataFormat::UInt16,
+        "Unsupported data format for left shift");
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (data_format == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
@@ -26,9 +31,14 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
         vector_mode);
 }
 
-template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATE, DataFormat data_format, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    static_assert(
+        data_format == DataFormat::Int32 || data_format == DataFormat::UInt32 || data_format == DataFormat::UInt16,
+        "Unsupported data format for right shift");
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (data_format == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -16,7 +16,7 @@ namespace sfpu {
 template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = 8,
-    InstrModLoadStore INSTRUCTION_MODE = INT32,
+    InstrModLoadStore INSTRUCTION_MODE,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     _calculate_binary_left_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(
@@ -26,7 +26,7 @@ inline void calculate_binary_left_shift(const uint dst_index_in0, const uint dst
 template <
     bool APPROXIMATION_MODE,
     int ITERATIONS = 8,
-    InstrModLoadStore INSTRUCTION_MODE = INT32,
+    InstrModLoadStore INSTRUCTION_MODE,
     bool SIGN_MAGNITUDE_FORMAT = false>
 inline void calculate_binary_right_shift(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     _calculate_binary_right_shift_<APPROXIMATION_MODE, ITERATIONS, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_shift.h
@@ -15,9 +15,14 @@ inline void llk_math_eltwise_binary_sfpu_shift_init() {
     llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
 }
 
-template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATE, DataFormat data_format, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_left_shift(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    static_assert(
+        data_format == DataFormat::Int32 || data_format == DataFormat::UInt32 || data_format == DataFormat::UInt16,
+        "Unsupported data format for left shift");
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (data_format == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_left_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,
@@ -26,9 +31,14 @@ inline void llk_math_eltwise_binary_sfpu_left_shift(
         vector_mode);
 }
 
-template <bool APPROXIMATE, InstrModLoadStore INSTRUCTION_MODE = INT32, bool SIGN_MAGNITUDE_FORMAT = false>
+template <bool APPROXIMATE, DataFormat data_format, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void llk_math_eltwise_binary_sfpu_right_shift(
     uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    static_assert(
+        data_format == DataFormat::Int32 || data_format == DataFormat::UInt32 || data_format == DataFormat::UInt16,
+        "Unsupported data format for right shift");
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (data_format == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
     _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_right_shift<APPROXIMATE, 8, INSTRUCTION_MODE, SIGN_MAGNITUDE_FORMAT>,
         dst_index0,

--- a/tt_metal/include/compute_kernel_api/binary_shift.h
+++ b/tt_metal/include/compute_kernel_api/binary_shift.h
@@ -14,7 +14,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Performs an elementwise shift operation to the left on the input at idst0, by input at idst1: y = x0 << x1
- * Both inputs must be of Int32 data type only. Output overwrites odst in DST.
+ * Both inputs must be of Int32 or UInt32 or UInt16 data type only. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -30,28 +30,15 @@ namespace ckernel {
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+template <DataFormat data_format>
 ALWI void binary_left_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX>(idst0, idst1, odst)));
-}
-
-template <bool sign_magnitude_format = false>
-ALWI void binary_left_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
-        idst0, idst1, odst)));
-}
-
-ALWI void binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
-}
-
-ALWI void binary_left_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::LO16>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, data_format>(idst0, idst1, odst)));
 }
 
 // clang-format off
 /**
  * Performs an elementwise shift operation to the right on the input at idst0, by input at idst1: y = x0 >> x1
- * Both inputs must be of Int32 data type only. Output overwrites odst in DST.
+ * Both inputs must be of Int32 or UInt32 or UInt16 data type only. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.
@@ -67,22 +54,9 @@ ALWI void binary_left_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+template <DataFormat data_format>
 ALWI void binary_right_shift_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX>(idst0, idst1, odst)));
-}
-
-template <bool sign_magnitude_format = false>
-ALWI void binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32, sign_magnitude_format>(
-        idst0, idst1, odst)));
-}
-
-ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
-}
-
-ALWI void binary_right_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
-    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::LO16>(idst0, idst1, odst)));
+    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, data_format>(idst0, idst1, odst)));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/binary_shift.h
+++ b/tt_metal/include/compute_kernel_api/binary_shift.h
@@ -44,6 +44,10 @@ ALWI void binary_left_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t 
     MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
 }
 
+ALWI void binary_left_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_left_shift<APPROX, InstrModLoadStore::LO16>(idst0, idst1, odst)));
+}
+
 // clang-format off
 /**
  * Performs an elementwise shift operation to the right on the input at idst0, by input at idst1: y = x0 >> x1
@@ -75,6 +79,10 @@ ALWI void binary_right_shift_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_
 
 ALWI void binary_right_shift_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::INT32>(idst0, idst1, odst)));
+}
+
+ALWI void binary_right_shift_uint16_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_right_shift<APPROX, InstrModLoadStore::LO16>(idst0, idst1, odst)));
 }
 
 // clang-format off

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -2386,7 +2386,7 @@ void py_module(nb::module_& mod) {
         R"doc(Perform bitwise_left_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32, UINT32)doc");
+        R"doc(INT32, UINT32, UINT16)doc");
 
     detail::bind_bitwise_binary_ops_operation(
         mod,
@@ -2394,7 +2394,7 @@ void py_module(nb::module_& mod) {
         R"doc(Perform bitwise_right_shift operation on :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`. :attr:`input_tensor_b` has shift_bits which are integers within range (0, 31))doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_and|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32, UINT32)doc");
+        R"doc(INT32, UINT32, UINT16)doc");
 
     detail::bind_bitwise_binary_ops_operation(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -38,6 +38,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case GCD: return (a == INT32 && b == INT32);
         case LEFT_SHIFT:
         case RIGHT_SHIFT:
+            return ((a == INT32 || a == UINT32 || a == UINT16) && (b == INT32 || b == UINT32 || b == UINT16));
         case LOGICAL_RIGHT_SHIFT: return ((a == INT32 || a == UINT32) && (b == INT32 || b == UINT32));
         case BITWISE_XOR:
         case BITWISE_OR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -417,6 +417,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
                 return {"binary_shift_tile_init();", "binary_left_shift_uint32_tile"};
             } else if (dtype == DataType::INT32) {
                 return {"binary_shift_tile_init();", "binary_left_shift_int32_tile"};
+            } else if (dtype == DataType::UINT16) {
+                return {"binary_shift_tile_init();", "binary_left_shift_uint16_tile"};
             } else {
                 return {"binary_shift_tile_init();", "binary_left_shift_tile"};
             }
@@ -425,6 +427,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
                 return {"binary_shift_tile_init();", "binary_right_shift_uint32_tile"};
             } else if (dtype == DataType::INT32) {
                 return {"binary_shift_tile_init();", "binary_right_shift_int32_tile"};
+            } else if (dtype == DataType::UINT16) {
+                return {"binary_shift_tile_init();", "binary_right_shift_uint16_tile"};
             } else {
                 return {"binary_shift_tile_init();", "binary_right_shift_tile"};
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -414,23 +414,19 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case LCM: return {"lcm_tile_init();", "lcm_tile"};
         case LEFT_SHIFT:
             if (dtype == DataType::UINT32) {
-                return {"binary_shift_tile_init();", "binary_left_shift_uint32_tile"};
-            } else if (dtype == DataType::INT32) {
-                return {"binary_shift_tile_init();", "binary_left_shift_int32_tile"};
+                return {"binary_shift_tile_init();", "binary_left_shift_tile<DataFormat::UInt32>"};
             } else if (dtype == DataType::UINT16) {
-                return {"binary_shift_tile_init();", "binary_left_shift_uint16_tile"};
+                return {"binary_shift_tile_init();", "binary_left_shift_tile<DataFormat::UInt16>"};
             } else {
-                return {"binary_shift_tile_init();", "binary_left_shift_tile"};
+                return {"binary_shift_tile_init();", "binary_left_shift_tile<DataFormat::Int32>"};
             }
         case RIGHT_SHIFT:
             if (dtype == DataType::UINT32) {
-                return {"binary_shift_tile_init();", "binary_right_shift_uint32_tile"};
-            } else if (dtype == DataType::INT32) {
-                return {"binary_shift_tile_init();", "binary_right_shift_int32_tile"};
+                return {"binary_shift_tile_init();", "binary_right_shift_tile<DataFormat::UInt32>"};
             } else if (dtype == DataType::UINT16) {
-                return {"binary_shift_tile_init();", "binary_right_shift_uint16_tile"};
+                return {"binary_shift_tile_init();", "binary_right_shift_tile<DataFormat::UInt16>"};
             } else {
-                return {"binary_shift_tile_init();", "binary_right_shift_tile"};
+                return {"binary_shift_tile_init();", "binary_right_shift_tile<DataFormat::Int32>"};
             }
         case LOGICAL_RIGHT_SHIFT:
             if (dtype == DataType::UINT32) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #33778


### What's changed
Added uint16 support for binary bitwise shift ops

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20945366143)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20945370301)
- [x] [Nightly L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20945378157)