### PR TITLE
Lower ULP threshold for approximate numeric stable softmax.

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -443,16 +443,20 @@ def test_softmax_dtypes(device, shape, dim, dtype):
 
 
 @pytest.mark.parametrize(
-    "fp32_acc_en, math_approx_mode, expected_ulp",
+    "fp32_acc_en, math_approx_mode, expected_ulp, numeric_stable",
     [
-        (True, False, 3),
-        (False, True, 11),
-        (True, True, 9),
-        (False, False, 7),
+        (True, False, 3, False),
+        (True, False, 3, True),
+        (False, True, 11, False),
+        (False, True, 13, True),
+        (True, True, 9, False),
+        (True, True, 9, True),
+        (False, False, 7, False),
+        (False, False, 7, True),
     ],
 )
 @pytest.mark.parametrize("shape", [(1, 1, 16384, 256)])
-def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected_ulp):
+def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected_ulp, numeric_stable):
     torch.manual_seed(0)
 
     # Reference output
@@ -469,12 +473,6 @@ def test_softmax_accuracy(device, shape, fp32_acc_en, math_approx_mode, expected
     )
 
     ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-
-    numeric_stable = True
-    if math_approx_mode:
-        # TODO: fix accuracy issue when both math_approx_mode and numeric_stable are True
-        # See issue #28500
-        numeric_stable = False
 
     ttnn_output = ttnn.softmax(
         ttnn_tensor, dim=-1, compute_kernel_config=compute_kernel_config, numeric_stable=numeric_stable


### PR DESCRIPTION
### Ticket
#28500

### Problem description
softmax test is failing fast approximate numeric stable case on ULPs.

### What's changed
It seems that without adding additional corrections (with performance impact) this behavior is expected.
Lowered test threshold for the failing case. Also, extended test cases to properly cover all possible parameter combinations (previously numeric stable was on by default except workaround).

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
- [x] New/Existing tests provide coverage for changes


#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/28500_lower_softmax_test_threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/28500_lower_softmax_test_threshold)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs