### PR TITLE
[Hang_device_operation] Undocumented op detect fix

### DIFF
--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -65,7 +65,7 @@ SKIPPED_OPS = [
     "ttnn.padded_slice",  # Experimental operation, but wrongly registered without ttnn.experimental.
     "ttnn.pearson_correlation_coefficient",  # Internal operation only.
     "ttnn.plus_one",  # Experimental operation, but wrongly registered without ttnn.experimental.
-    "ttnn.test_hang_device_operation",  # Internal operation only.
+    "ttnn.hang_device_operation",  # Internal operation only.
     "ttnn.slice_write",  # Experimental operation, but wrongly registered without ttnn.experimental.
     "ttnn.tosa_gather",  # TOSA operation omitted for docs.
     "ttnn.tosa_scatter",  # TOSA operation omitted for docs.


### PR DESCRIPTION
### Problem description
[L2 Nightly ](https://github.com/tenstorrent/tt-metal/actions/runs/20590106969/job/59133886011)is failing due to undocumented ops check script which is neither finding documentation for the hang_device_operation nor it is in the skipped ops section. That is due to the op being skipped as test_hang_device_operation in one of the recent [commits](https://github.com/tenstorrent/tt-metal/commit/476b46f18a5b27212199647cda73a91de8933a9d#diff-5fa255a889283433278e88c2d93aa928ca75da017716b9e8783b369fb7e2be36) when its bind is just hang_device_operation

### What's changed
Registering the op with the correct binding name

### Checklist

- [x] [L2 Nightly doc checks](https://github.com/tenstorrent/tt-metal/actions/runs/20594261844)