### PR TITLE
Fix ResNet50 large model regression in average pooling layer

### DIFF
--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large.py
@@ -477,7 +477,6 @@ class resnet50:
         self.layer4_module2 = self.layer4[1]
         self.layer4_module3 = self.layer4[2]
 
-        self.avgpool = ttnn.global_avg_pool2d
         self.fc = ResnetLinear(
             weight=ttnn.to_device(parameters.fc.weight, device),
             bias=ttnn.to_device(parameters.fc.bias, device),
@@ -747,99 +746,40 @@ class resnet50:
         print(f"=================================== layer: 4, module: 3")
         x, x_height, x_width = self.layer4_module3(x, device, batch_size, x_height, x_width)
 
-        unpadded_shape = x.shape
-        x = ttnn.untilize_with_unpadding(
-            x,
-            output_tensor_end=(
-                unpadded_shape[0] - 1,
-                unpadded_shape[1] - 1,
-                unpadded_shape[2] - 1,
-                unpadded_shape[3] - 1,
-            ),
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+        grid_size = (8, 8)
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
         )
-        x = ttnn.reshape(
-            x,
-            (
-                self.batch_size,
-                x.shape[1],
-                x.shape[2] // self.batch_size,
-                x.shape[3],
-            ),
+        x = ttnn.to_memory_config(x, width_mem_config)
+
+        x = ttnn.avg_pool2d(
+            input_tensor=x,
+            batch_size=self.batch_size,
+            input_h=x_height,
+            input_w=x_width,
+            channels=x.shape[3],
+            kernel_size=[x_height, x_width],
+            stride=[1, 1],
+            padding=[0, 0, 0, 0],
+            output_layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat8_b,
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.CoreRangeSet(
-            {
-                ttnn.CoreRange(
-                    ttnn.CoreCoord(0, 0),
-                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
-                )
-            }
+        width_mem_config = ttnn.create_sharded_memory_config_(
+            [nearest_32(x.shape[2]), x.shape[3] // (grid_size[0] * grid_size[1])],
+            ttnn.CoreGrid(x=grid_size[0], y=grid_size[1]),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
         )
-        shard_shape = [
-            x.volume() // x.padded_shape[-1],
-            x.padded_shape[-1] // (grid_size[0] * grid_size[1]),
-        ]
-        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-        width_sharded_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
-        )
-        x = ttnn.to_memory_config(x, width_sharded_mem_config)
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
-
-        x = self.avgpool(x, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
-
-        unpadded_shape_end = [
-            x.padded_shape[0] - 1,
-            x.padded_shape[1] - 1,
-            1 - 1,
-            x.padded_shape[3] - 1,
-        ]
-        x = ttnn.untilize_with_unpadding(
-            x,
-            output_tensor_end=unpadded_shape_end,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-        )
-
-        x = ttnn.reshape(
-            x,
-            (
-                1,
-                x.padded_shape[1],
-                self.batch_size * x.padded_shape[2],
-                x.padded_shape[3],
-            ),
-        )
-
-        unpadded_shape = x.padded_shape
-        padded_shape = [
-            unpadded_shape[0],
-            unpadded_shape[1],
-            _nearest_32(unpadded_shape[2]),
-            _nearest_32(unpadded_shape[3]),
-        ]
-
-        x = ttnn.tilize_with_val_padding(
-            x,
-            padded_shape,
-            0.0,
-            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-            dtype=self.model_config["ACTIVATIONS_DTYPE"],
-        )
+        x = ttnn.to_memory_config(x, width_mem_config)
 
         x = self.fc(x)
         desired_shape = list(x.shape)


### PR DESCRIPTION
Regression from dd6d1e74329e93f3e5931c7d11cb95d4c6fd0af7
34951: use output mem config for compute_output_specs in generic reduce

Why it regressed:
The manual implementation of average pooling using untilize_with_unpadding, manual reshaping, and custom sharding configuration broke due to recent changes in tensor operation handling. The error "MemoryConfig must have Shard Spec specified for sharded memory layout" occurred during untilize_with_unpadding at ttnn/core/tensor/layout/tensor_layout.cpp:177, indicating the manual sharding specification was no longer compatible with the tensor memory layout system.

How it was fixed:
Replaced the complex 60-line manual average pooling implementation with:
1. Direct call to ttnn.avg_pool2d which properly handles all tensor operations internally
2. Simplified sharding configuration using ttnn.create_sharded_memory_config_ helper instead of manual ShardSpec construction
3. Removed the redundant self.avgpool = ttnn.global_avg_pool2d member
4. Changed grid size from (8,4) to (8,8) for initial pooling operation

 - [x] [(Single-card) Frequent model and ttnn tests] (https://github.com/tenstorrent/tt-metal/actions/runs/20593885715)