### PR TITLE
[skip ci] Remove efficientnetb0 model perf test

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -174,12 +174,12 @@ jobs:
         with:
           commands: pytest -n auto models/demos/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/ufld_v2/tests/perf/ -m models_performance_bare_metal
         if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'ufld_v2') }}
-      - name: Run efficientnetb0 model_perf test
-        timeout-minutes: ${{ matrix.test-info.timeout }}
-        uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
-        with:
-          commands: pytest -n auto models/experimental/efficientnetb0/tests/perf/ -m models_performance_bare_metal
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'other_magic_env' && (inputs.model == 'all' || inputs.model == 'efficientnetb0') }}
+      # - name: Run efficientnetb0 model_perf test
+      #   timeout-minutes: ${{ matrix.test-info.timeout }}
+      #   uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
+      #   with:
+      #     commands: pytest -n auto models/experimental/efficientnetb0/tests/perf/ -m models_performance_bare_metal
+      #   if: ${{ !cancelled() && matrix.test-info.model-group == 'other_magic_env' && (inputs.model == 'all' || inputs.model == 'efficientnetb0') }}
       - name: Merge all the generated reports
         timeout-minutes: 10
         run: |

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -174,6 +174,7 @@ jobs:
         with:
           commands: pytest -n auto models/demos/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/ufld_v2/tests/perf/ -m models_performance_bare_metal
         if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'ufld_v2') }}
+      # Disabled until the test is fixed Issue: #35171
       # - name: Run efficientnetb0 model_perf test
       #   timeout-minutes: ${{ matrix.test-info.timeout }}
       #   uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main


### PR DESCRIPTION
### Problem description
Test is failing on `(Single-card) Model perf tests`

### What's changed
Commented test `efficientnetb0 model_perf test`

Followup issue: https://github.com/tenstorrent/tt-metal/issues/35171