### PR TITLE
Setting the slow-dispatch-timeout to 40 since vLLM nightly tests for Llama fail

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -361,7 +361,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          slow-dispatch-timeout: 15 # Increased above default to account for vLLM's longer-running dispatch operations and avoid false-positive hang detection when auto-triage is enabled.
+          slow-dispatch-timeout: 40 # Increased above default to account for vLLM's longer-running dispatch operations and avoid false-positive hang detection when auto-triage is enabled.
 
       - name: Ensure BH Eth links online
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}


### PR DESCRIPTION
Llama-3.1-8B on DP=16 failed in vLLM nightly because the slow-dispatch-timeout was too short for the 64K prefill warmup to finish


https://github.com/tenstorrent/tt-metal/actions/runs/20593749570/job/59144224663