### PR TITLE
Bring up the function of MoLE (Mixture-of-Linear-Experts) Using TTNN

### DIFF
--- a/models/experimental/functional_mole/tests/common.py
+++ b/models/experimental/functional_mole/tests/common.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from loguru import logger
+import torch
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+MOLE_L1_SMALL_REGION_SIZE = 24576
+MOLE_FULL_MODEL_PCC = 0.9995
+MOLE_RTOL_LIMIT = 5e-2
+MOLE_ATOL_LIMIT = 8e-2
+
+
+def verify_with_pcc(torch_tensor, ttnn_tensor, pcc):
+    _, computed_pcc = assert_with_pcc(torch_tensor, ttnn_tensor, pcc)
+    logger.info(f"PCC check was successful ({computed_pcc:.6f} > {pcc:.6f})")
+    if (computed_pcc - pcc) / pcc > 0.0025:
+        logger.warning(
+            f"Computed PCC ({computed_pcc:.6f}) was higher than the expected PCC ({pcc:.6f}) - consider updating the expected PCC value"
+        )
+
+
+def verify_with_errlimit(output_torch_tensor, output_ttnn_tensor, rtol, atol):
+    try:
+        torch.testing.assert_close(output_torch_tensor, output_ttnn_tensor, rtol=rtol, atol=atol, equal_nan=False)
+    except AssertionError as e:
+        logger.error("Mismatch details:\n", e)
+        assert False
+    logger.info(f"error check was successful with atol_limit {atol}, rtol_limit {rtol}")

--- a/models/experimental/functional_mole/tt/model_preprocessing.py
+++ b/models/experimental/functional_mole/tt/model_preprocessing.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+"""
+def pad_channels_up_to_target(input_tensor, target=16):
+    assert len(input_tensor.shape) == 4, "Expected input tensor to rank 4"
+    N, C, H, W = input_tensor.shape
+    if C < target:
+        return torch.nn.functional.pad(input_tensor, (0, 0, 0, 0, 0, target - C), mode="constant", value=0)
+    else:
+        return input_tensor
+
+"""
+
+
+def create_mole_input_tensors(
+    batch_size: int,
+    seq_len: int,
+    enc_in: int,
+    time_features: int,
+    torch_dtype=torch.float32,
+    ttnn_dtype=ttnn.float32,
+    device=None,
+):
+    torch_input_tensor = torch.randn(batch_size, seq_len, enc_in).to(torch_dtype)
+    torch_input_x_tensor = torch.randn(batch_size, seq_len, time_features).to(torch_dtype)
+
+    ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn_dtype, device=device)
+    ttnn_input_x_tensor = ttnn.from_torch(torch_input_x_tensor, dtype=ttnn_dtype, device=device)
+
+    return torch_input_tensor, torch_input_x_tensor, ttnn_input_tensor, ttnn_input_x_tensor
+
+
+"""
+
+def create_unet_model_parameters(
+    model: unet_shallow_torch.UNet, input_tensor: torch.Tensor, groups: int, device: ttnn.Device
+):
+    parameters = infer_ttnn_module_args(model=model, run_model=lambda model: model(input_tensor), device=None)
+    assert parameters is not None
+    for key in parameters.keys():
+        parameters[key].module = getattr(model, key)
+
+    parameters.c1["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c1["use_activation_double_buffer"] = True
+    parameters.c1["enable_activation_reuse"] = True
+    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
+    parameters.c1_2["use_activation_double_buffer"] = True
+
+    parameters.c2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c2["use_activation_double_buffer"] = True
+    parameters.c2["enable_activation_reuse"] = True
+    parameters.c2_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c2_2["use_activation_double_buffer"] = True
+    parameters.c2_2["enable_activation_reuse"] = True
+
+    parameters.c3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c3["use_activation_double_buffer"] = True
+    parameters.c3_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c3_2["use_activation_double_buffer"] = True
+
+    parameters.c4["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c4["use_activation_double_buffer"] = True
+    parameters.c4_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c4_2["use_activation_double_buffer"] = True
+
+    parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
+    parameters.bnc["use_activation_double_buffer"] = False
+    parameters.bnc_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.bnc_2["use_activation_double_buffer"] = False
+
+    parameters.c5["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5["use_activation_double_buffer"] = False
+    parameters.c5_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5_2["use_activation_double_buffer"] = False
+    parameters.c5_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5_3["use_activation_double_buffer"] = False
+
+    parameters.c6["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6["use_activation_double_buffer"] = True
+    parameters.c6_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6_2["use_activation_double_buffer"] = True
+    parameters.c6_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6_3["use_activation_double_buffer"] = True
+
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 3 * 32}
+    parameters.c7["use_activation_double_buffer"] = True
+    parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c7_2["use_activation_double_buffer"] = True
+    parameters.c7_2["enable_activation_reuse"] = True
+    parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c7_3["use_activation_double_buffer"] = True
+    parameters.c7_3["enable_activation_reuse"] = True
+
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
+    parameters.c8["use_activation_double_buffer"] = True
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
+    parameters.c8_2["use_activation_double_buffer"] = True
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
+
+    parameters.c8_3["use_activation_double_buffer"] = True
+
+    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 42 * 32}
+    parameters.output_layer["use_activation_double_buffer"] = True
+
+    return parameters
+    """

--- a/models/experimental/functional_mole/tt/mole_torch.py
+++ b/models/experimental/functional_mole/tt/mole_torch.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+
+
+class HeadDropout(nn.Module):
+    def __init__(self, p=0.5):
+        super(HeadDropout, self).__init__()
+        if p < 0 or p > 1:
+            raise ValueError("Dropout probability has to be between 0 and 1, but got {}".format(p))
+        self.p = p
+
+    def forward(self, x):
+        # If in evaluation mode, return the input as-is
+        if not self.training:
+            return x
+
+        # Create a binary mask of the same shape as x
+        binary_mask = (torch.rand_like(x) > self.p).float()
+
+        # Set dropped values to negative infinity during training
+        return x * binary_mask + (1 - binary_mask) * -1e20
+
+
+class moving_avg(nn.Module):
+    """
+    Moving average block to highlight the trend of time series
+    """
+
+    def __init__(self, kernel_size, stride):
+        super(moving_avg, self).__init__()
+        self.kernel_size = kernel_size
+        self.avg = nn.AvgPool1d(kernel_size=kernel_size, stride=stride, padding=0)
+
+    def forward(self, x):
+        # padding on the both ends of time series
+        front = x[:, 0:1, :].repeat(1, (self.kernel_size - 1) // 2, 1)
+        end = x[:, -1:, :].repeat(1, (self.kernel_size - 1) // 2, 1)
+        x = torch.cat([front, x, end], dim=1)
+        x = self.avg(x.permute(0, 2, 1))
+        x = x.permute(0, 2, 1)
+        return x
+
+
+class series_decomp(nn.Module):
+    """
+    Series decomposition block
+    """
+
+    def __init__(self, kernel_size, stride):
+        super(series_decomp, self).__init__()
+        self.moving_avg = moving_avg(kernel_size, stride=stride)
+
+    def forward(self, x):
+        moving_mean = self.moving_avg(x)
+        res = x - moving_mean
+        return res, moving_mean
+
+
+class Mole(nn.Module):
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride):
+        super(Mole, self).__init__()
+
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.dropout_p = 0.1
+        self.enc_in = enc_in
+        self.time_features = time_features
+
+        # Decompsition Kernel Size
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.decompsition = series_decomp(self.kernel_size, self.stride)
+
+        self.Linear_Seasonal = nn.Linear(self.seq_len, self.pred_len * self.t_dim)
+        self.Linear_Trend = nn.Linear(self.seq_len, self.pred_len * self.t_dim)
+
+        self.Linear_Temporal = nn.Sequential(
+            nn.Linear(self.time_features, self.t_dim * self.enc_in),
+            nn.ReLU(),
+            nn.Linear(self.t_dim * self.enc_in, self.t_dim * self.enc_in),
+        )
+        self.head_dropout = HeadDropout(self.dropout_p)
+
+    def forward(self, x, x_mark):
+        # x: [batch_size, seq_len, enc_in]
+        ## x_mark: [batch_size, seq_len, time_features]
+        # print("x: {}, x_mark: {}".format(x.shape, x_mark.shape))
+        x_mark_initial = None
+        seasonal_init, trend_init = None, None
+        x_mark_initial = x_mark[:, 0]
+        # print("x_mark_initial: {}".format(x_mark_initial.shape))
+        seasonal_init, trend_init = self.decompsition(x)
+        # print("seasonal_init(res): {}, trend_init(avg): {}".format(seasonal_init.shape, trend_init.shape))
+        seasonal_init, trend_init = seasonal_init.permute(0, 2, 1), trend_init.permute(0, 2, 1)
+        # print("after permutation, seasonal_init(res): {}, trend_init(avg): {}".format(seasonal_init.shape, trend_init.shape))
+        seasonal_output = self.Linear_Seasonal(seasonal_init)
+        # print("seasonal_output: {}".format(seasonal_output.shape))
+        trend_output = self.Linear_Trend(trend_init)
+
+        # print("trend_output: {}".format(trend_output.shape))
+        x = seasonal_output + trend_output
+
+        temporal_out = self.Linear_Temporal(x_mark_initial)
+        temporal_out = temporal_out.reshape(-1, self.t_dim)
+
+        # print("temporal_out: {}".format(temporal_out.shape))
+        temporal_out = self.head_dropout(temporal_out)
+        temporal_out = nn.Softmax(dim=1)(temporal_out)
+
+        x_raw = x.reshape(-1, self.pred_len, self.t_dim)
+        temporal_out = temporal_out.unsqueeze(2)
+
+        x = torch.matmul(x_raw, temporal_out)
+        x = x.squeeze(2).reshape(-1, self.enc_in, self.pred_len)
+        x = x.permute(0, 2, 1)
+
+        return x
+
+    @staticmethod
+    def from_random_weights(seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride):
+        model = Mole(seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride)
+
+        new_state_dict = {}
+        for name, parameter in model.state_dict().items():
+            new_state_dict[name] = parameter
+
+        model.load_state_dict(new_state_dict)
+
+        model.eval()
+        return model
+
+
+class RevIN(nn.Module):
+    def __init__(self, enc_in: int, eps=1e-5, affine=True):
+        """
+        :param enc_in: the number of features or enc_in
+        :param eps: a value added for numerical stability
+        :param affine: if True, RevIN has learnable affine parameters
+        """
+        super(RevIN, self).__init__()
+
+        self.enc_in = enc_in
+        self.eps = eps
+        self.affine = affine
+
+        if self.affine:
+            self._init_params()
+
+    def forward(self, x, mode: str):
+        if mode == "norm":
+            self._get_statistics(x)
+            x = self._normalize(x)
+
+        elif mode == "denorm":
+            x = self._denormalize(x)
+
+        else:
+            raise NotImplementedError
+
+        return x
+
+    def _init_params(self):
+        # initialize RevIN params: (C,)
+        self.affine_weight = nn.Parameter(torch.ones(self.enc_in))
+        self.affine_bias = nn.Parameter(torch.zeros(self.enc_in))
+
+    def _get_statistics(self, x):
+        dim2reduce = tuple(range(1, x.ndim - 1))
+        self.mean = torch.mean(x, dim=dim2reduce, keepdim=True).detach()
+        self.stdev = torch.sqrt(torch.var(x, dim=dim2reduce, keepdim=True, unbiased=False) + self.eps).detach()
+
+    def _normalize(self, x):
+        x = x - self.mean
+        x = x / self.stdev
+        if self.affine:
+            x = x * self.affine_weight
+            x = x + self.affine_bias
+
+        return x
+
+    def _denormalize(self, x):
+        if self.affine:
+            x = x - self.affine_bias
+            x = x / (self.affine_weight + self.eps * self.eps)
+        x = x * self.stdev
+        x = x + self.mean
+
+        return x
+
+
+class Rmlp(nn.Module):
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, time_features):
+        super(Rmlp, self).__init__()
+
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.enc_in = enc_in
+        self.time_features = time_features
+        self.d_model = 512
+        self.dropout_p = 0.1
+        self.eps = 1e-5
+
+        self.Linear = nn.Linear(self.seq_len, self.pred_len * self.t_dim)
+
+        self.temporal = nn.Sequential(
+            nn.Linear(self.seq_len, self.d_model), nn.ReLU(), nn.Linear(self.d_model, self.seq_len)
+        )
+
+        self.rev = RevIN(self.enc_in, self.eps)
+
+        self.Linear_Temporal = nn.Sequential(
+            nn.Linear(self.time_features, self.t_dim * self.enc_in),
+            nn.ReLU(),
+            nn.Linear(self.t_dim * self.enc_in, self.t_dim * self.enc_in),
+        )
+        self.head_dropout = HeadDropout(self.dropout_p)
+
+    def forward(self, x, x_mark):
+        # x: [batch_size, seq_len, enc_in]
+        ## x_mark: [batch_size, seq_len, time_features]
+        x_mark_initial = x_mark[:, 0]
+        x = self.rev(x, "norm")
+        x = x + self.temporal(x.transpose(1, 2)).transpose(1, 2)
+        pred = self.Linear(x.transpose(1, 2)).transpose(1, 2)
+
+        temporal_out = self.Linear_Temporal(x_mark_initial).reshape(-1, self.t_dim, self.enc_in)
+        temporal_out = self.head_dropout(temporal_out)
+        temporal_out = nn.Softmax(dim=1)(temporal_out)
+        pred_raw = pred.permute(0, 2, 1).reshape(-1, self.enc_in, self.pred_len, self.t_dim).permute(0, 3, 1, 2)
+        pred = pred_raw * temporal_out.unsqueeze(-1)
+        pred = pred.sum(dim=1).permute(0, 2, 1)
+
+        pred = self.rev(pred, "denorm")
+
+        return pred
+
+    @staticmethod
+    def from_random_weights(seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride):
+        model = Rmlp(seq_len, pred_len, enc_in, t_dim, time_features)
+
+        new_state_dict = {}
+        for name, parameter in model.state_dict().items():
+            new_state_dict[name] = parameter
+
+        model.load_state_dict(new_state_dict)
+
+        model.eval()
+        return model
+
+
+class Rlinear(nn.Module):
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, time_features):
+        super(Rlinear, self).__init__()
+
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.enc_in = enc_in
+        self.time_features = time_features
+
+        self.time_features = time_features
+        self.d_model = 512
+        self.dropout_p = 0.1
+        self.eps = 1e-5
+
+        self.Linear = nn.Linear(self.seq_len, self.pred_len * self.t_dim)
+
+        self.dropout = nn.Dropout(self.dropout_p)
+        self.rev = RevIN(self.enc_in)
+
+        self.Linear_Temporal = nn.Sequential(
+            nn.Linear(self.time_features, self.t_dim * self.enc_in),
+            nn.ReLU(),
+            nn.Linear(self.t_dim * self.enc_in, self.t_dim * self.enc_in),
+        )
+        self.head_dropout = HeadDropout(self.dropout_p)
+
+    def forward(self, x, x_mark):
+        # x: [B, L, D]
+        x_mark_initial = x_mark[:, 0]
+
+        temporal_out = self.Linear_Temporal(x_mark_initial).reshape(-1, self.t_dim, self.enc_in)
+        temporal_out = self.head_dropout(temporal_out)
+        temporal_out = nn.Softmax(dim=1)(temporal_out)
+
+        x = self.rev(x, "norm")
+        x = self.dropout(x)
+
+        pred = self.Linear(x.transpose(1, 2)).transpose(1, 2)
+
+        pred_raw = pred.permute(0, 2, 1).reshape(-1, self.enc_in, self.pred_len, self.t_dim).permute(0, 3, 1, 2)
+        pred = pred_raw * temporal_out.unsqueeze(-1)
+        pred = pred.sum(dim=1).permute(0, 2, 1)
+
+        pred = self.rev(pred, "denorm")
+
+        return pred
+
+    @staticmethod
+    def from_random_weights(seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride):
+        model = Rlinear(seq_len, pred_len, enc_in, t_dim, time_features)
+
+        new_state_dict = {}
+        for name, parameter in model.state_dict().items():
+            new_state_dict[name] = parameter
+
+        model.load_state_dict(new_state_dict)
+
+        model.eval()
+        return model

--- a/models/experimental/functional_mole/tt/mole_ttnn.py
+++ b/models/experimental/functional_mole/tt/mole_ttnn.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+class Mole:
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, kernel_size, stride, device):
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.enc_in = enc_in
+
+        # Decompsition Kernel Size
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.dtype = ttnn.float32
+        self.device = device
+
+    def set_parameters(self, torch_model):
+        self.linear_season_w = ttnn.from_torch(
+            torch_model.Linear_Seasonal.weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_season_b = ttnn.from_torch(
+            torch_model.Linear_Seasonal.bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_tread_w = ttnn.from_torch(
+            torch_model.Linear_Trend.weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_tread_b = ttnn.from_torch(
+            torch_model.Linear_Trend.bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_0_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_0_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_2_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_2_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+    def __call__(self, x, x_mark):
+        """
+        To conduct the function of mole.
+        Args:
+            x: [batch_size, seq_len, enc_in]
+            x_mark: [batch_size, seq_len, time_features]
+        Returns:
+            y: [batch_size, pred_len, enc_in]
+        """
+
+        "---------------------------- slice --------------------------"
+        x_mark_initial = ttnn.slice(
+            x_mark, slice_start=(0, 0, 0), slice_end=(x_mark.shape[0], 1, x_mark.shape[2]), slice_step=(1, 1, 1)
+        )  ## [batch_size, 1, time_features]
+
+        "---------------------------- mov avg --------------------------"
+        x_low_h = ttnn.slice(x, slice_start=(0, 0, 0), slice_end=(x.shape[0], 1, x.shape[2]), slice_step=(1, 1, 1))
+        x_high_h = ttnn.slice(
+            x, slice_start=(0, x.shape[1] - 1, 0), slice_end=(x.shape[0], x.shape[1], x.shape[2]), slice_step=(1, 1, 1)
+        )
+
+        x_low_h_repeat = ttnn.repeat(x_low_h, (1, (self.kernel_size - 1) // 2, 1))
+        x_high_h_repeat = ttnn.repeat(x_high_h, (1, (self.kernel_size - 1) // 2, 1))
+
+        x_pad = ttnn.concat([x_low_h_repeat, x, x_high_h_repeat], dim=1)
+
+        x_pad = ttnn.to_layout(x_pad, ttnn.TILE_LAYOUT)
+        x_pad = ttnn.typecast(x_pad, ttnn.bfloat16)
+        x_pad = ttnn.unsqueeze(x_pad, 2)  ## [batch_size, seq_len_pad, 1, enc_in]
+        dims_x_pad = x_pad.shape
+        # print("x_pad.shape: ", dims_x_pad)
+
+        avg_x_nch_bf16 = ttnn.avg_pool2d(
+            input_tensor=x_pad,
+            batch_size=dims_x_pad[0],
+            input_h=dims_x_pad[1],
+            input_w=dims_x_pad[2],
+            channels=dims_x_pad[3],
+            kernel_size=[self.kernel_size, 1],
+            stride=[self.stride, 1],
+            padding=[0, 0, 0, 0],
+            output_layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            applied_shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        avg_x_nch = ttnn.typecast(avg_x_nch_bf16, self.dtype)
+        ## must reshape, otherwise dims doesn't match the infered dims
+        trend_init = ttnn.reshape(avg_x_nch, x.shape)  ## [batch_size, seq_len, enc_in]
+
+        # print("trend_init: ",trend_init.shape)
+        seasonal_init = x - trend_init  ## [batch_size, seq_len, enc_in]
+
+        trend_init_nch = ttnn.permute(trend_init, (0, 2, 1))  ## [batch_size, enc_in, seq_len]
+        seasonal_init_nch = ttnn.permute(seasonal_init, (0, 2, 1))  ## [batch_size, enc_in, seq_len]
+
+        "---------------------------- linear season --------------------------"
+        seasonal_init = ttnn.to_layout(seasonal_init_nch, layout=ttnn.TILE_LAYOUT)
+        seasonal_output = ttnn.linear(
+            seasonal_init, self.linear_season_w, bias=self.linear_season_b, transpose_b=True
+        )  ## [batch_size, enc_in, pred_len * t_dim]
+
+        "---------------------------- linear tread --------------------------"
+        trend_init_nch = ttnn.to_layout(trend_init_nch, layout=ttnn.TILE_LAYOUT)
+        trend_output = ttnn.linear(trend_init_nch, self.linear_tread_w, bias=self.linear_tread_b, transpose_b=True)
+        x_raw = seasonal_output + trend_output  ## [batch_size, enc_in, pred_len * t_dim]
+
+        "---------------------------- linear temp --------------------------"
+        x_mark_initial = ttnn.to_layout(x_mark_initial, layout=ttnn.TILE_LAYOUT)
+        output_temp0 = ttnn.linear(
+            x_mark_initial, self.linear_0_w, bias=self.linear_0_b, transpose_b=True
+        )  ##  [batch_size, 1, enc_in * t_dim]
+        output_temp1 = ttnn.relu(output_temp0)
+        output_temp2 = ttnn.linear(
+            output_temp1, self.linear_2_w, bias=self.linear_2_b, transpose_b=True
+        )  ##  [batch_size, 1, enc_in * t_dim]
+        temporal_out = ttnn.reshape(output_temp2, (-1, self.t_dim))  ##  [batch_size* enc_in, t_dim]
+
+        "---------------------------- softmax --------------------------"
+        # print("temporal_out: {}".format(temporal_out.shape))
+        temporal_out = ttnn.softmax(temporal_out, dim=1)  ## softmax brings a lot of precision loss from 1e-4 upto 1e-3
+        temporal_out = ttnn.unsqueeze(temporal_out, dim=2)  ## [batch_size* enc_in, t_dim, 1]
+        x_raw = ttnn.reshape(x_raw, (-1, self.pred_len, self.t_dim))  ## [batch_size*enc_in, pred_len, t_dim]
+
+        "---------------------------- matmul --------------------------"
+        result = ttnn.matmul(x_raw, temporal_out)  ## [batch_size*enc_in, pred_len, 1]
+
+        result = ttnn.squeeze(result, dim=2)  ## [batch_size*enc_in, pred_len]
+        result = ttnn.reshape(result, (-1, self.enc_in, self.pred_len))  ## [batch_size, enc_in, pred_len]
+        result = ttnn.permute(result, (0, 2, 1))  ## [batch_size, pred_len, enc_in]
+
+        return result
+
+
+class Rmlp:
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, kernel_size, stride, device):
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.enc_in = enc_in
+        self.d_model = 512
+        self.dropout_p = 0.1
+        self.eps = 1e-5
+
+        self.dtype = ttnn.float32
+        self.device = device
+
+    def set_parameters(self, torch_model):
+        self.rev_w = ttnn.from_torch(
+            torch_model.rev.affine_weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.rev_b = ttnn.from_torch(
+            torch_model.rev.affine_bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.temporal_0_w = ttnn.from_torch(
+            torch_model.temporal[0].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.temporal_0_b = ttnn.from_torch(
+            torch_model.temporal[0].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.temporal_2_w = ttnn.from_torch(
+            torch_model.temporal[2].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.temporal_2_b = ttnn.from_torch(
+            torch_model.temporal[2].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_season_w = ttnn.from_torch(
+            torch_model.Linear.weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_season_b = ttnn.from_torch(
+            torch_model.Linear.bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_temporal_0_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_temporal_0_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_temporal_2_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_temporal_2_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+    def __call__(self, x, x_mark):
+        """
+        To conduct the function of mole.
+        Args:
+            x: [batch_size, seq_len, enc_in]
+            x_mark: [batch_size, seq_len, time_features]
+        Returns:
+            y: [batch_size, pred_len, enc_in]
+        """
+
+        "---------------------------- slice --------------------------"
+        x_mark_initial = ttnn.slice(
+            x_mark, slice_start=(0, 0, 0), slice_end=(x_mark.shape[0], 1, x_mark.shape[2]), slice_step=(1, 1, 1)
+        )  ## [batch_size, 1, time_features]
+
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+        x_mark_initial = ttnn.to_layout(x_mark_initial, ttnn.TILE_LAYOUT)
+
+        "---------------------------- RevIN norm --------------------------"
+        target_reduce_dim = 1
+        mean = ttnn.mean(x, dim=target_reduce_dim, keepdim=True)  ## [batch_size, 1, enc_in]
+        stdev = ttnn.var(x, dim=target_reduce_dim, keepdim=True)  ## [batch_size, 1, enc_in]
+        stdev = stdev + self.eps
+        stdev = ttnn.sqrt(stdev)
+
+        norm0 = x - mean  ## [batch_size, seq_len, enc_in]
+        norm1 = norm0 / stdev  ## [batch_size, seq_len, enc_in]
+
+        norm = norm1 * self.rev_w + self.rev_b  ## [batch_size, seq_len, enc_in]
+
+        "---------------------------- temporal map --------------------------"
+        norm_trans = ttnn.permute(norm, (0, 2, 1))  ## [batch_size, enc_in, seq_len]
+        ## [batch_size, enc_in, seq_len] ** [seq_len, d_model] --> [batch_size, enc_in, d_model]
+        t_map0 = ttnn.linear(norm_trans, self.temporal_0_w, bias=self.temporal_0_b, transpose_b=True)
+        t_map1 = ttnn.relu(t_map0)  ## [batch_size, enc_in, d_model]
+        ## [batch_size, enc_in, d_model] ** [d_model, seq_len] --> [batch_size, enc_in, seq_len]
+        t_map2 = ttnn.linear(t_map1, self.temporal_2_w, bias=self.temporal_2_b, transpose_b=True)
+        t_map3 = ttnn.permute(t_map2, (0, 2, 1))  ## [batch_size, seq_len, enc_in]
+        t_map = norm + t_map3
+
+        "---------------------------- linear --------------------------"
+        t_map_trans = ttnn.permute(t_map, (0, 2, 1))  ## [batch_size, enc_in, seq_len]
+        ## [batch_size, enc_in, seq_len] ** [seq_len, pred_len * t_dim] --> [batch_size, enc_in, pred_len * t_dim]
+        pred0 = ttnn.linear(t_map_trans, self.linear_season_w, bias=self.linear_season_b, transpose_b=True)
+
+        "---------------------------- temp linear --------------------------"
+        ## [batch_size, 1, time_features] ** [time_features, t_dim * enc_in]  --> [batch_size, 1, t_dim * enc_in]
+        temporal_out0 = ttnn.linear(
+            x_mark_initial, self.linear_temporal_0_w, bias=self.linear_temporal_0_b, transpose_b=True
+        )
+        temporal_out1 = ttnn.relu(temporal_out0)
+        ## [batch_size, 1, t_dim * enc_in] ** [t_dim * enc_in, t_dim * enc_in] --> [batch_size, 1, t_dim * enc_in]
+        temporal_out2 = ttnn.linear(
+            temporal_out1, self.linear_temporal_2_w, bias=self.linear_temporal_2_b, transpose_b=True
+        )
+
+        "---------------------------- softmax --------------------------"
+        temporal_out3 = ttnn.reshape(temporal_out2, (-1, self.t_dim, self.enc_in))  ## [batch_size, t_dim, enc_in]
+        temporal_out = ttnn.softmax(temporal_out3, dim=1)  ## [batch_size, t_dim, enc_in]
+
+        "---------------------------- multiply --------------------------"
+        pred1 = ttnn.reshape(
+            pred0, (-1, self.enc_in, self.pred_len, self.t_dim)
+        )  ## [batch_size, enc_in, pred_len, t_dim]
+        pred2 = ttnn.permute(pred1, (0, 3, 1, 2))  ## [batch_size, t_dim, enc_in, pred_len]
+        pred3 = pred2 * ttnn.unsqueeze(temporal_out, -1)  ## [batch_size, t_dim, enc_in, pred_len]
+
+        "---------------------------- sum --------------------------"
+        pred4 = ttnn.sum(pred3, dim=1, keepdim=False)  ## [batch_size, enc_in, pred_len]
+        pred = ttnn.permute(pred4, (0, 2, 1))  ## [batch_size, pred_len, enc_in]
+
+        "---------------------------- RevIN denorm --------------------------"
+        result0 = pred - self.rev_b  ## [batch_size, pred_len, enc_in]
+        result1 = result0 / (self.rev_w + self.eps * self.eps)
+        result2 = result1 * stdev
+        result = result2 + mean  ## [batch_size, pred_len, enc_in]
+
+        return result
+
+
+class Rlinear:
+    def __init__(self, seq_len, pred_len, enc_in, t_dim, kernel_size, stride, device):
+        self.t_dim = t_dim
+        self.seq_len = seq_len
+        self.pred_len = pred_len
+        self.enc_in = enc_in
+        self.d_model = 512
+        self.dropout_p = 0.1
+        self.eps = 1e-5
+
+        self.dtype = ttnn.float32
+        self.device = device
+
+    def set_parameters(self, torch_model):
+        self.rev_w = ttnn.from_torch(
+            torch_model.rev.affine_weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.rev_b = ttnn.from_torch(
+            torch_model.rev.affine_bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_temporal_0_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_temporal_0_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[0].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_temporal_2_w = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_temporal_2_b = ttnn.from_torch(
+            torch_model.Linear_Temporal[2].bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+        self.linear_season_w = ttnn.from_torch(
+            torch_model.Linear.weight, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+        self.linear_season_b = ttnn.from_torch(
+            torch_model.Linear.bias, layout=ttnn.TILE_LAYOUT, device=self.device, dtype=self.dtype
+        )
+
+    def __call__(self, x, x_mark):
+        """
+        To conduct the function of mole.
+        Args:
+            x: [batch_size, seq_len, enc_in]
+            x_mark: [batch_size, seq_len, time_features]
+        Returns:
+            y: [batch_size, pred_len, enc_in]
+        """
+
+        "---------------------------- slice --------------------------"
+        x_mark_initial = ttnn.slice(
+            x_mark, slice_start=(0, 0, 0), slice_end=(x_mark.shape[0], 1, x_mark.shape[2]), slice_step=(1, 1, 1)
+        )  ## [batch_size, 1, time_features]
+
+        x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+        x_mark_initial = ttnn.to_layout(x_mark_initial, ttnn.TILE_LAYOUT)
+
+        "---------------------------- temp linear --------------------------"
+        ## [batch_size, 1, time_features] ** [time_features, t_dim * enc_in]  --> [batch_size, 1, t_dim * enc_in]
+        temporal_out0 = ttnn.linear(
+            x_mark_initial, self.linear_temporal_0_w, bias=self.linear_temporal_0_b, transpose_b=True
+        )
+        temporal_out1 = ttnn.relu(temporal_out0)
+        ## [batch_size, 1, t_dim * enc_in] ** [t_dim * enc_in, t_dim * enc_in] --> [batch_size, 1, t_dim * enc_in]
+        temporal_out2 = ttnn.linear(
+            temporal_out1, self.linear_temporal_2_w, bias=self.linear_temporal_2_b, transpose_b=True
+        )
+
+        "---------------------------- softmax --------------------------"
+        temporal_out3 = ttnn.reshape(temporal_out2, (-1, self.t_dim, self.enc_in))  ## [batch_size, t_dim, enc_in]
+        temporal_out = ttnn.softmax(temporal_out3, dim=1)  ## [batch_size, t_dim, enc_in]
+
+        "---------------------------- RevIN norm --------------------------"
+        target_reduce_dim = 1
+        mean = ttnn.mean(x, dim=target_reduce_dim, keepdim=True)  ## [batch_size, 1, enc_in]
+        stdev = ttnn.var(x, dim=target_reduce_dim, keepdim=True)  ## [batch_size, 1, enc_in]
+        stdev = stdev + self.eps
+        stdev = ttnn.sqrt(stdev)
+
+        norm0 = x - mean  ## [batch_size, seq_len, enc_in]
+        norm1 = norm0 / stdev  ## [batch_size, seq_len, enc_in]
+
+        norm = norm1 * self.rev_w + self.rev_b  ## [batch_size, seq_len, enc_in]
+
+        "---------------------------- linear --------------------------"
+        norm_trans = ttnn.permute(norm, (0, 2, 1))  ## [batch_size, enc_in, seq_len]
+        ## [batch_size, enc_in, seq_len] ** [seq_len, pred_len * t_dim] --> [batch_size, enc_in, pred_len * t_dim]
+        pred0 = ttnn.linear(norm_trans, self.linear_season_w, bias=self.linear_season_b, transpose_b=True)
+
+        "---------------------------- multiply --------------------------"
+        pred1 = ttnn.reshape(
+            pred0, (-1, self.enc_in, self.pred_len, self.t_dim)
+        )  ## [batch_size, enc_in, pred_len, t_dim]
+        pred2 = ttnn.permute(pred1, (0, 3, 1, 2))  ## [batch_size, t_dim, enc_in, pred_len]
+        pred3 = pred2 * ttnn.unsqueeze(temporal_out, -1)  ## [batch_size, t_dim, enc_in, pred_len]
+
+        "---------------------------- sum --------------------------"
+        pred4 = ttnn.sum(pred3, dim=1, keepdim=False)  ## [batch_size, enc_in, pred_len]
+        pred = ttnn.permute(pred4, (0, 2, 1))  ## [batch_size, pred_len, enc_in]
+
+        "---------------------------- RevIN denorm --------------------------"
+        result0 = pred - self.rev_b  ## [batch_size, pred_len, enc_in]
+        result1 = result0 / (self.rev_w + self.eps * self.eps)
+        result2 = result1 * stdev
+        result = result2 + mean  ## [batch_size, pred_len, enc_in]
+
+        return result

--- a/tests/nightly/single_card/mole/test_mole_model.py
+++ b/tests/nightly/single_card/mole/test_mole_model.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+from loguru import logger
+
+from ttnn.device import is_wormhole_b0
+
+from models.experimental.functional_mole.tt import mole_torch, mole_ttnn
+from models.experimental.functional_mole.tt.model_preprocessing import create_mole_input_tensors
+
+from models.experimental.functional_mole.tests.common import (
+    verify_with_pcc,
+    verify_with_errlimit,
+    MOLE_L1_SMALL_REGION_SIZE,
+    MOLE_FULL_MODEL_PCC,
+    MOLE_RTOL_LIMIT,
+    MOLE_ATOL_LIMIT,
+)
+
+model_torch_dict = {"dlinear": mole_torch.Mole, "rmlp": mole_torch.Rmlp, "rlinear": mole_torch.Rlinear}
+
+model_ttnn_dict = {
+    "dlinear": mole_ttnn.Mole,
+    "rmlp": mole_ttnn.Rmlp,
+    "rlinear": mole_ttnn.Rlinear,
+}
+
+
+def run_mole_model(seq_len, pred_len, t_dim, enc_in, batch_size, model_name, device):
+    logger.info("enter mole_model.")
+    "------------- internal model configs(with fixed value) ---------------"
+    kernel_size = 25
+    stride = 1
+    time_features = 4
+
+    torch_dtype = torch.float32
+    ttnn_dtype = ttnn.float32
+
+    "------------- create input tensors ---------------"
+    torch_input_tensor, torch_input_mark_tensor, ttnn_input_tensor, ttnn_input_mark_tensor = create_mole_input_tensors(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        enc_in=enc_in,
+        time_features=time_features,
+        torch_dtype=torch_dtype,
+        ttnn_dtype=ttnn_dtype,
+        device=device,
+    )
+    # print("ttnn_input_tensor: {}\nttnn_input_mark_tensor: {}".format(ttnn_input_tensor, ttnn_input_mark_tensor))
+
+    "------------- define the mole torch model ---------------"
+    mole_torch_model = model_torch_dict[model_name].from_random_weights(
+        seq_len, pred_len, enc_in, t_dim, time_features, kernel_size, stride
+    )
+    logger.info("mole_torch_model: {}", model_name)
+
+    "------------- run the mole torch model ---------------"
+    output_torch_tensor = None
+    with torch.no_grad():
+        output_torch_tensor = mole_torch_model(torch_input_tensor, torch_input_mark_tensor)
+    # print("output_torch_tensor: ", output_torch_tensor.shape)
+
+    "------------- define the mole ttnn model ---------------"
+    mole_ttnn_model = model_ttnn_dict[model_name](seq_len, pred_len, enc_in, t_dim, kernel_size, stride, device)
+
+    "------------- initialize the weights/bias ---------------"
+    mole_ttnn_model.set_parameters(mole_torch_model)
+
+    "------------- run the mole ttnn model ---------------"
+    output_ttnn_tensor = mole_ttnn_model(ttnn_input_tensor, ttnn_input_mark_tensor)
+    # print("output_ttnn_tensor: ", output_ttnn_tensor.shape)
+    output_ttnn_tensor = ttnn.to_torch(output_ttnn_tensor)
+
+    "------------- verify the results ---------------"
+    verify_with_pcc(output_torch_tensor, output_ttnn_tensor, MOLE_FULL_MODEL_PCC)
+
+    # verify_with_errlimit(output_torch_tensor, output_ttnn_tensor, MOLE_RTOL_LIMIT, MOLE_ATOL_LIMIT)
+
+    logger.info("end of mole_model.")
+    return
+
+
+@pytest.mark.parametrize("seq_len", [336])
+@pytest.mark.parametrize("pred_len", [96, 192, 336, 720])
+@pytest.mark.parametrize("t_dim", [1, 2, 4, 8])
+@pytest.mark.parametrize("enc_in", [321])
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("model_name", ["dlinear", "rmlp", "rlinear"])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": MOLE_L1_SMALL_REGION_SIZE}], indirect=True)
+def test_mole_model(seq_len, pred_len, t_dim, enc_in, batch_size, model_name, device, reset_seeds):
+    if not is_wormhole_b0(device):
+        pytest.skip(f"mole only support wormhole platform!")
+
+    run_mole_model(seq_len, pred_len, t_dim, enc_in, batch_size, model_name, device)


### PR DESCRIPTION
the models supported  in this patch: MoLE_Dlinear, RMLP and RLinear
local test time:~700s

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/32143)

### Problem description
To bring up models using ttnn apis on wormhole platform

### What's changed
add new and independent test cases: tt-metal/tests/nightly/single_card/mole/test_mole_model.py

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212832436210714