### PR TITLE
Modernize use auto

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -95,7 +95,6 @@ Checks: >
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-type-traits,
-  -modernize-use-auto,
   -modernize-use-constraints,
   -modernize-use-designated-initializers,
   -modernize-use-emplace,

--- a/tests/tests_common/sfpu_helper/sfpu_helper.hpp
+++ b/tests/tests_common/sfpu_helper/sfpu_helper.hpp
@@ -61,8 +61,8 @@ inline std::vector<uint32_t> sfpu(const std::vector<uint32_t>& src, const std::f
         float exp_top = sfpu_func(top_);
         float exp_bottom = sfpu_func(bottom_);
 
-        bfloat16 bfp16_top = bfloat16(exp_top);
-        bfloat16 bfp16_bottom = bfloat16(exp_bottom);
+        auto bfp16_top = bfloat16(exp_top);
+        auto bfp16_bottom = bfloat16(exp_bottom);
 
         uint32_t new_val = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfp16_bottom, bfp16_top));
         dst.push_back(new_val);
@@ -89,8 +89,8 @@ inline std::vector<uint32_t> create_random_ones_and_twos_vector_of_bfloat16(uint
         float top_plus_one = 1 + top_;
         float bottom_plus_one = 1 + bottom_;
 
-        bfloat16 bfp16_top = bfloat16(top_plus_one);
-        bfloat16 bfp16_bottom = bfloat16(bottom_plus_one);
+        auto bfp16_top = bfloat16(top_plus_one);
+        auto bfp16_bottom = bfloat16(bottom_plus_one);
 
         uint32_t new_val = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfp16_bottom, bfp16_top));
         dst.push_back(new_val);

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -555,7 +555,7 @@ void test_single_device_socket_with_workers(
 
     EnqueueMeshWorkload(md0->mesh_command_queue(), mesh_workload, false);
 
-    uint8_t* src_ptr = reinterpret_cast<uint8_t*>(src_vec.data());
+    auto* src_ptr = reinterpret_cast<uint8_t*>(src_vec.data());
     uint32_t pages_per_core = data_size / page_size;
     for (const auto& mapping : socket_core_mappings) {
         std::vector<uint32_t> output_data_readback;

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -351,7 +351,7 @@ FabricConfig MeshSocketYamlParser::parse_fabric_config(const YAML::Node& node) {
 
     TT_FATAL(node["topology"].IsDefined(), "FabricConfig missing required 'topology' field");
 
-    std::string topology_str = node["topology"].as<std::string>();
+    auto topology_str = node["topology"].as<std::string>();
 
     auto topology = enchantum::cast<tt::tt_fabric::Topology>(topology_str, ttsl::ascii_caseless_comp);
     if (topology.has_value()) {
@@ -499,8 +499,8 @@ PatternExpansionConfig MeshSocketYamlParser::parse_pattern_expansion(const YAML:
 MeshCoordinate MeshSocketYamlParser::parse_mesh_coordinate(const YAML::Node& node) {
     TT_FATAL(node.IsSequence() && node.size() == 2, "mesh_coord must be a 2-element array [row, col]");
 
-    uint32_t row = node[0].as<uint32_t>();
-    uint32_t col = node[1].as<uint32_t>();
+    auto row = node[0].as<uint32_t>();
+    auto col = node[1].as<uint32_t>();
 
     return MeshCoordinate(row, col);
 }
@@ -508,8 +508,8 @@ MeshCoordinate MeshSocketYamlParser::parse_mesh_coordinate(const YAML::Node& nod
 CoreCoord MeshSocketYamlParser::parse_core_coordinate(const YAML::Node& node) {
     TT_FATAL(node.IsSequence() && node.size() == 2, "core_coord must be a 2-element array [x, y]");
 
-    uint32_t x = node[0].as<uint32_t>();
-    uint32_t y = node[1].as<uint32_t>();
+    auto x = node[0].as<uint32_t>();
+    auto y = node[1].as<uint32_t>();
 
     return CoreCoord(x, y);
 }

--- a/tests/tt_metal/test_utils/packing.hpp
+++ b/tests/tt_metal/test_utils/packing.hpp
@@ -91,7 +91,7 @@ std::vector<ValueType> unpack_vector(const std::vector<PackType>& values) {
     std::for_each(values.begin(), values.end(), [&](const PackType& value) {
         PackType current_value = value;
         for (unsigned j = 0; j < num_values_to_unpack; j++) {
-            bits_type bits_of_value = static_cast<bits_type>(current_value & bitmask);
+            auto bits_of_value = static_cast<bits_type>(current_value & bitmask);
             results.push_back(std::bit_cast<ValueType>(bits_of_value));
             current_value = current_value >> (sizeof(ValueType) * CHAR_BIT);
         }

--- a/tests/tt_metal/test_utils/test_common.hpp
+++ b/tests/tt_metal/test_utils/test_common.hpp
@@ -52,8 +52,7 @@ inline std::string get_command_option(
     const std::vector<std::string>& test_args,
     const std::string& option,
     const std::optional<std::string>& default_value = std::nullopt) {
-    std::vector<std::string>::const_iterator option_pointer =
-        std::find(std::begin(test_args), std::end(test_args), option);
+    auto option_pointer = std::find(std::begin(test_args), std::end(test_args), option);
     if (option_pointer != std::end(test_args) && std::next(option_pointer) != std::end(test_args)) {
         return *std::next(option_pointer);
     }
@@ -103,8 +102,7 @@ inline double get_command_option_double(
 }
 
 inline bool has_command_option(const std::vector<std::string>& test_args, const std::string& option) {
-    std::vector<std::string>::const_iterator option_pointer =
-        std::find(std::begin(test_args), std::end(test_args), option);
+    auto option_pointer = std::find(std::begin(test_args), std::end(test_args), option);
     return option_pointer != std::end(test_args);
 }
 
@@ -113,8 +111,7 @@ inline std::tuple<std::string, std::vector<std::string>> get_command_option_and_
     const std::string& option,
     const std::optional<std::string>& default_value = std::nullopt) {
     std::vector<std::string> remaining_args = test_args;
-    std::vector<std::string>::const_iterator option_pointer =
-        std::find(std::begin(remaining_args), std::end(remaining_args), option);
+    auto option_pointer = std::find(std::begin(remaining_args), std::end(remaining_args), option);
     if (option_pointer != std::end(remaining_args) and (option_pointer + 1) != std::end(remaining_args)) {
         std::string value = *(option_pointer + 1);
         remaining_args.erase(option_pointer, option_pointer + 2);
@@ -190,8 +187,7 @@ inline std::tuple<double, std::vector<std::string>> get_command_option_double_an
 inline std::tuple<bool, std::vector<std::string>> has_command_option_and_remaining_args(
     const std::vector<std::string>& test_args, const std::string& option) {
     std::vector<std::string> remaining_args = test_args;
-    std::vector<std::string>::const_iterator option_pointer =
-        std::find(std::begin(remaining_args), std::end(remaining_args), option);
+    auto option_pointer = std::find(std::begin(remaining_args), std::end(remaining_args), option);
     bool value = option_pointer != std::end(remaining_args);
     if (value) {
         remaining_args.erase(option_pointer);

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/common/perf_helpers.cpp
@@ -36,7 +36,7 @@ double percentile(std::vector<double> v, double p_in_0_100) {
     }
     p_in_0_100 = std::clamp(p_in_0_100, 0.0, 100.0);
     const size_t n = v.size();
-    const size_t k = static_cast<size_t>(std::round((p_in_0_100 / 100.0) * (n - 1)));
+    const auto k = static_cast<size_t>(std::round((p_in_0_100 / 100.0) * (n - 1)));
     std::nth_element(v.begin(), v.begin() + k, v.end());
     return v[k];
 }

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -308,7 +308,7 @@ Notes:
     // Perf point
     const double e2e_sec_total = std::chrono::duration<double>(t1 - t0).count();
     const double e2e_sec = (p.trace_iters > 0) ? (e2e_sec_total / static_cast<double>(p.trace_iters)) : 0.0;
-    const uint64_t bytes = static_cast<uint64_t>(p.tensor_bytes);
+    const auto bytes = static_cast<uint64_t>(p.tensor_bytes);
     const double GB = static_cast<double>(bytes) / 1e9;          // gigabytes
     const double GB_s = (e2e_sec > 0.0) ? (GB / e2e_sec) : 0.0;  // GB per second
     const double ms = e2e_sec * 1000.0;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -2547,7 +2547,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
         GTEST_SKIP() << "Not enough active devices for all-to-all test";
     }
 
-    const uint32_t num_other_devices = static_cast<uint32_t>(num_active_devices - 1);
+    const auto num_other_devices = static_cast<uint32_t>(num_active_devices - 1);
 
     // Calculate number of sender/receiver cores per device (all cores in top/bottom half)
     // Split grid into top half (senders) and bottom half (receivers)
@@ -2627,7 +2627,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocSendType noc_
         const auto& device_ptr = device_ptrs[dev_idx];
 
         // This device's index - used directly as L1 slot index (simple indexing)
-        uint32_t this_device_idx = static_cast<uint32_t>(dev_idx);
+        auto this_device_idx = static_cast<uint32_t>(dev_idx);
 
         // Sender compile time args - includes num_destinations and sender_device_idx
         std::vector<uint32_t> sender_compile_time_args = {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -713,7 +713,7 @@ TEST(MultiHost, TestClosetBox3PodTTSwitchAPIs) {
     EXPECT_EQ(*switch_ids[0], 3) << "Switch ID should be 0";
 
     SwitchId switch_id = switch_ids[0];
-    MeshId switch_mesh_id = MeshId(*switch_id);
+    auto switch_mesh_id = MeshId(*switch_id);
 
     EXPECT_EQ(*switch_id, 3) << "Switch should have a mapped mesh_id";
     // Verify switch mesh_id is unique (not used by regular meshes)

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -1129,7 +1129,7 @@ TEST_F(ControlPlaneFixture, TestSerializeEthCoordinatesToFile) {
 
         // Verify coordinate values match expected mesh coordinates
         for (size_t dim = 0; dim < expected_coord.dims(); ++dim) {
-            uint32_t actual_coord = coord_array[dim].as<uint32_t>();
+            auto actual_coord = coord_array[dim].as<uint32_t>();
             EXPECT_EQ(actual_coord, expected_coord[dim])
                 << "Physical chip " << physical_chip_id << " (logical chip " << logical_chip_id << ") coordinate["
                 << dim << "] should be " << expected_coord[dim] << ", got " << actual_coord;

--- a/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
+++ b/tests/tt_metal/tt_fabric/feature_bringup/fabric_elastic_channels_host_test.cpp
@@ -394,7 +394,7 @@ void run_test(
     std::vector<tt_metal::KernelHandle>& remote_sender_worker_kernels,
     const TestConfig& config) {
     auto rt_args = [&](bool send_channels_at_offset_0, DeviceTestResources& device_resources) -> std::vector<uint32_t> {
-        uint32_t base_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+        auto base_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED));
 
         // Calculate buffer sizes and addresses
@@ -504,7 +504,7 @@ void run_test(
     //
     // Timing Stats Readback
     //
-    uint32_t handshake_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+    auto handshake_addr = static_cast<uint32_t>(tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED));
 
     //

--- a/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
@@ -22,7 +22,7 @@ void roundtrip_test_for_mantissa_rounding_with_bfp8(
     EXPECT_EQ(output_mantissa, expected_mantissa);
 
     uint32_t uint32_output = convert_bfp_to_u32(tt::DataFormat::Bfp8_b, output_mantissa, shared_exp, false);
-    float float_output = std::bit_cast<float>(uint32_output);
+    auto float_output = std::bit_cast<float>(uint32_output);
     EXPECT_EQ(float_output, expected_float_output);
 };
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_multicast_schemes.cpp
@@ -141,7 +141,7 @@ void run_all_tests(
         for (uint32_t sub_grid_dimension_size = starting_sub_grid_dimension_size;
              sub_grid_dimension_size <= sub_grid_dimension_limit;
              sub_grid_dimension_size++) {
-            for (uint32_t multicast_scheme_type = static_cast<uint32_t>(starting_multicast_scheme_type);
+            for (auto multicast_scheme_type = static_cast<uint32_t>(starting_multicast_scheme_type);
                  multicast_scheme_type < static_cast<uint32_t>(MulticastSchemeType::End);
                  multicast_scheme_type++) {
                 test(

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -115,7 +115,7 @@ TEST_F(DPrintMeshFixture, ActiveEthTestPrint) {
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
         for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
             log_info(tt::LogTest, "Test active ethernet DM{}", erisc_idx);
-            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
             this->RunTestOnDevice(
                 [=](DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                     CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, mesh_device, true, dm_processor);
@@ -140,7 +140,7 @@ TEST_F(DPrintMeshFixture, IdleEthTestPrint) {
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH);
         for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
             log_info(tt::LogTest, "Test idle ethernet DM{}", erisc_idx);
-            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
 
             this->RunTestOnDevice(
                 [=](DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
@@ -154,7 +154,7 @@ std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_
                 *reinterpret_cast<float*>(&float_vec[(col * 32) + 24]));
         }
     } else if (data_format == tt::DataFormat::Int8) {
-        int8_t* int8_ptr = reinterpret_cast<int8_t*>(input_tile.data());
+        auto* int8_ptr = reinterpret_cast<int8_t*>(input_tile.data());
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
                 "\n{} {} {} {}",
@@ -164,7 +164,7 @@ std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_
                 int8_ptr[(col * 32) + 24]);
         }
     } else if (data_format == tt::DataFormat::UInt8) {
-        uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(input_tile.data());
+        auto* uint8_ptr = reinterpret_cast<uint8_t*>(input_tile.data());
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
                 "\n{} {} {} {}",
@@ -174,7 +174,7 @@ std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_
                 uint8_ptr[(col * 32) + 24]);
         }
     } else if (data_format == tt::DataFormat::UInt16) {
-        uint16_t* uint16_ptr = reinterpret_cast<uint16_t*>(input_tile.data());
+        auto* uint16_ptr = reinterpret_cast<uint16_t*>(input_tile.data());
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
                 "\n{} {} {} {}",
@@ -184,7 +184,7 @@ std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_
                 uint16_ptr[(col * 32) + 24]);
         }
     } else if (data_format == tt::DataFormat::Int32) {
-        int32_t* int32_ptr = reinterpret_cast<int32_t*>(input_tile.data());
+        auto* int32_ptr = reinterpret_cast<int32_t*>(input_tile.data());
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
                 "\n{} {} {} {}",
@@ -194,7 +194,7 @@ std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_
                 int32_ptr[(col * 32) + 24]);
         }
     } else if (data_format == tt::DataFormat::UInt32) {
-        uint32_t* uint32_ptr = reinterpret_cast<uint32_t*>(input_tile.data());
+        auto* uint32_ptr = reinterpret_cast<uint32_t*>(input_tile.data());
         for (uint32_t col = 0; col < 32; col += 8) {
             data += fmt::format(
                 "\n{} {} {} {}",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -49,9 +49,9 @@ using namespace tt::tt_metal;
 void inc_populate(std::vector<std::uint32_t>& vec, float start_from) {
     float val = start_from;
     for (std::uint32_t i = 0; i < vec.size(); i++) {
-        bfloat16 num_1_bfloat16 = bfloat16(val);
+        auto num_1_bfloat16 = bfloat16(val);
         val = val + 1.0f;
-        bfloat16 num_2_bfloat16 = bfloat16(val);
+        auto num_2_bfloat16 = bfloat16(val);
         val = val + 1.0f;
         vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -530,8 +530,8 @@ TEST_F(MeshDeviceFixture, MeshL1ToPinnedMemoryAt16BAlignedAddress) {
     ASSERT_TRUE(noc_addr.has_value());
     ASSERT_EQ(noc_addr.value().device_id, device->id());
 
-    uint32_t dst_lo = static_cast<uint32_t>(noc_addr.value().addr & 0xFFFFFFFFull);
-    uint32_t dst_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32);
+    auto dst_lo = static_cast<uint32_t>(noc_addr.value().addr & 0xFFFFFFFFull);
+    auto dst_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32);
     uint32_t pcie_xy_enc = noc_addr.value().pcie_xy_enc;
 
     CreateKernel(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
@@ -62,7 +62,7 @@ void test_BufferCorePageMapping_Iterator(const std::vector<uint32_t>& page_mappi
     const auto core_page_mapping = core_page_mapping_from_page_mapping(page_mapping);
 
     auto core_it = BufferCorePageMapping::Iterator(&core_page_mapping, 0, 0);
-    uint32_t last_non_padding_idx = static_cast<uint32_t>(-1);
+    auto last_non_padding_idx = static_cast<uint32_t>(-1);
     for (uint32_t i = 0; i < page_mapping.size(); i++) {
         if (page_mapping[i] != PADDING) {
             last_non_padding_idx = i;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -280,7 +280,7 @@ TEST_P(ShardedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
         GTEST_SKIP();
     }
 
-    uint32_t num_pages = static_cast<uint32_t>(device_tensor_size / page_size);
+    auto num_pages = static_cast<uint32_t>(device_tensor_size / page_size);
     if (uint64_t(num_pages) * page_size != device_tensor_size) {
         TT_THROW(
             "Check test parameters: shard shape:{}, page size:{} are incompatible (shard size:{}, #pages:{})",

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -71,7 +71,7 @@ static void test_sems_across_core_types(
         }
         for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
             log_info(tt::LogTest, "Test {} ethernet DM{}", active_eth ? "active" : "idle", erisc_idx);
-            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
 
             const auto& eth_cores_unordered =
                 active_eth ? device->get_active_ethernet_cores(true) : device->get_inactive_ethernet_cores();
@@ -167,7 +167,7 @@ TEST_F(MeshDispatchFixture, EthTestBlank) {
         for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
             distributed::MeshWorkload workload;
             log_info(tt::LogTest, "Add ethernet DM{}", erisc_idx);
-            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
             Program program = CreateProgram();
 
             CoreCoord eth_core = *eth_cores.begin();
@@ -248,7 +248,7 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH);
     }
     for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
-        DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+        auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
         CoreCoord eth_core = *eth_cores.begin();
         log_info(tt::LogTest, "Adding {} ethernet DM{} {}", this->slow_dispatch_ ? "idle" : "active", erisc_idx, eth_core.str());
         distributed::MeshWorkload workload;
@@ -313,7 +313,7 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
 
         for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; erisc_idx++) {
             log_info(tt::LogTest, "Test active ethernet DM{}", erisc_idx);
-            DataMovementProcessor dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
+            auto dm_processor = static_cast<DataMovementProcessor>(erisc_idx);
             distributed::MeshWorkload workload;
 
             auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -116,8 +116,8 @@ bool chip_to_chip_dram_buffer_transfer(
     uint32_t MAX_BUFFER = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
 
-    uint32_t num_loops = (uint32_t)(byte_size / MAX_BUFFER);
-    uint32_t remaining_bytes = (uint32_t)(byte_size % MAX_BUFFER);
+    auto num_loops = (uint32_t)(byte_size / MAX_BUFFER);
+    auto remaining_bytes = (uint32_t)(byte_size % MAX_BUFFER);
     // Clear expected value at ethernet L1 address
     std::vector<uint32_t> all_zeros(inputs.size(), 0);
 
@@ -267,8 +267,8 @@ bool chip_to_chip_interleaved_buffer_transfer(
 
     const uint32_t max_buffer = round_down(max_transfer_size, cfg.page_size_bytes);
     uint32_t pages_per_loop = max_buffer / cfg.page_size_bytes;
-    uint32_t num_loops = (uint32_t)(cfg.size_bytes / max_buffer);
-    uint32_t remaining_bytes = (uint32_t)(cfg.size_bytes % max_buffer);
+    auto num_loops = (uint32_t)(cfg.size_bytes / max_buffer);
+    auto remaining_bytes = (uint32_t)(cfg.size_bytes % max_buffer);
     uint32_t remaining_pages = remaining_bytes / cfg.page_size_bytes;
 
     std::vector<uint32_t> sender_compile_args = {(uint32_t)input_is_dram};
@@ -587,7 +587,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         receiver_device->id(),
                         sender_eth_core.str(),
                         receiver_eth_core.str());
-                    BankedConfig test_config = BankedConfig{
+                    auto test_config = BankedConfig{
                         .num_pages = num_pages,
                         .size_bytes = num_pages * page_size,
                         .page_size_bytes = page_size,
@@ -753,7 +753,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         sender_eth_core.str(),
                         erisc_idx,
                         receiver_eth_core.str());
-                    BankedConfig test_config = BankedConfig{
+                    auto test_config = BankedConfig{
                         .num_pages = num_pages,
                         .size_bytes = num_pages * page_size,
                         .page_size_bytes = page_size,

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -551,8 +551,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsInterleavedRingGatherAllChips) {
     const size_t src_eth_l1_byte_address = erisc_unreserved_base_addr + 32;
     const size_t dst_eth_l1_byte_address = erisc_unreserved_base_addr + 32;
     const size_t sem_l1_byte_address = erisc_unreserved_base_addr;
-    BankedConfig test_config =
-        BankedConfig{.num_pages = 10, .size_bytes = 10 * 2 * 32 * 32, .page_size_bytes = 2 * 32 * 32};
+    auto test_config = BankedConfig{.num_pages = 10, .size_bytes = 10 * 2 * 32 * 32, .page_size_bytes = 2 * 32 * 32};
     const auto& device_ring = get_device_ring(devices_);
     if (device_ring.empty()) {
         GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/hal_codegen/codegen_test.cpp
+++ b/tests/tt_metal/tt_metal/hal_codegen/codegen_test.cpp
@@ -39,9 +39,9 @@ void verify_equal(const ::PacketInfo& expected, types::PacketInfo::ConstView vie
 
 TEST(CodegenTest, CodegenTest) {
     auto factory = create_factory();
-    types::PacketInfo info = factory.create<types::PacketInfo>();
+    auto info = factory.create<types::PacketInfo>();
     ASSERT_EQ(info.size(), sizeof(::PacketInfo));
-    ::PacketInfo* raw_ptr = reinterpret_cast<::PacketInfo*>(info.data());
+    auto* raw_ptr = reinterpret_cast<::PacketInfo*>(info.data());
 
     std::random_device rd;
     std::mt19937 gen(rd());

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -380,7 +380,7 @@ using namespace unit_tests_common::matmul::test_matmul_X_tile;
 */
 
 TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -411,7 +411,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulMultiTile) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -450,7 +450,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiTile) {
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulBlock) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -487,7 +487,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlock) {
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -524,7 +524,7 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
 }
 
 TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShortWithDt) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -438,7 +438,7 @@ bool matmul_large_block(
 }  // namespace unit_tests_common::matmul::test_matmul_large_block
 
 TEST_F(MeshDispatchFixture, TensixMatmulLargeBlock) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         };

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -70,11 +70,11 @@ void create_and_run_row_pipeline(
     tt_metal::Program program = tt_metal::CreateProgram();
     distributed::MeshWorkload mesh_workload;
 
-    uint32_t num_cores = (uint32_t)test_config.num_cores;
-    uint32_t num_tiles = (uint32_t)test_config.num_tiles;
-    uint32_t block_size_tiles = (uint32_t)test_config.block_size_tiles;
-    uint32_t num_blocks_in_CB = (uint32_t)test_config.num_blocks_in_CB;
-    uint32_t num_repetitions = (uint32_t)test_config.num_repetitions;
+    auto num_cores = (uint32_t)test_config.num_cores;
+    auto num_tiles = (uint32_t)test_config.num_tiles;
+    auto block_size_tiles = (uint32_t)test_config.block_size_tiles;
+    auto num_blocks_in_CB = (uint32_t)test_config.num_blocks_in_CB;
+    auto num_repetitions = (uint32_t)test_config.num_repetitions;
 
     TT_FATAL(num_cores >= 2 && num_cores <= 12, "Error");  // grayskull
     TT_FATAL(num_tiles % block_size_tiles == 0, "Error");

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -392,7 +392,7 @@ class BroadcastParameterizedDeviceFixture
 
 TEST_P(BroadcastParameterizedDeviceFixture, TensixComputeSingleTileBroadcast) {
     unit_tests::compute::broadcast::BroadcastConfig test_config = GetParam();
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -144,7 +144,7 @@ void add_reader_writer_kernels(
 
     switch (test_config.reduce_dim) {
         case ReduceDim::H: {
-            bfloat16 bfloat_scaler_value = bfloat16(scaler);
+            auto bfloat_scaler_value = bfloat16(scaler);
             uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
             std::vector<uint32_t> reader_compile_args = {};
             tt_metal::TensorAccessorArgs(src_dram_buffer).append_to(reader_compile_args);
@@ -481,12 +481,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceH) {
     }
     std::vector<uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     ReduceConfig test_config = {
@@ -514,12 +514,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceH) {
 TEST_F(MeshDeviceFixture, TensixComputeReduceW) {
     std::vector<uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
                     continue;
@@ -550,12 +550,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceW) {
 TEST_F(MeshDeviceFixture, TensixComputeReduceHW) {
     std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 // Currently fp32 dest unsupported with reduce scalar
                 if (fp32_dest_acc_en) {
@@ -590,12 +590,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHMathOnly) {
     }
     std::vector<uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     ReduceConfig test_config = {
@@ -623,12 +623,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHMathOnly) {
 TEST_F(MeshDeviceFixture, TensixComputeReduceWMathOnly) {
     std::vector<uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
                     continue;
@@ -659,12 +659,12 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceWMathOnly) {
 TEST_F(MeshDeviceFixture, TensixComputeReduceHWMathOnly) {
     std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 // Currently fp32 dest unsupported with reduce scalar
                 if (fp32_dest_acc_en) {
@@ -694,15 +694,15 @@ TEST_F(MeshDeviceFixture, TensixComputeReduceHWMathOnly) {
 }
 
 TEST_F(MeshDeviceFixture, TensixComputeReduceWTinyTiles) {
-    tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
+    auto tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
     std::vector<uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
     std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (auto math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (auto reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 if ((fp32_dest_acc_en) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
                     continue;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -326,7 +326,7 @@ bool single_core_binary(
 }  // namespace unit_tests::compute::binary
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -346,7 +346,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -366,7 +366,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -386,7 +386,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -407,7 +407,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -428,7 +428,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -449,7 +449,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -469,7 +469,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -489,7 +489,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -509,7 +509,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -529,7 +529,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -549,7 +549,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
 }
 
 TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -573,7 +573,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
     if (arch == tt::ARCH::GRAYSKULL) {
         GTEST_SKIP();
     }
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -599,7 +599,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
     if (arch == tt::ARCH::GRAYSKULL) {
         GTEST_SKIP();
     }
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -625,7 +625,7 @@ TEST_F(MeshDeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
     if (arch == tt::ARCH::GRAYSKULL) {
         GTEST_SKIP();
     }
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (auto i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }

--- a/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
@@ -45,10 +45,10 @@ struct StochasticRoundingResult {
 
 /// @brief Get the next representable BF16 value away from zero (1 ULP)
 float bf16_next(float value) {
-    bfloat16 bf = bfloat16(value);
-    uint16_t bits = std::bit_cast<uint16_t>(bf);
+    auto bf = bfloat16(value);
+    auto bits = std::bit_cast<uint16_t>(bf);
     bits += 1;
-    bfloat16 result = std::bit_cast<bfloat16>(bits);
+    auto result = std::bit_cast<bfloat16>(bits);
     return static_cast<float>(result);
 }
 
@@ -63,8 +63,8 @@ StochasticRoundingResult run_stochastic_rounding(
     float base_value = test_config.base_value;
     float fraction = test_config.fraction;
 
-    bfloat16 base_bf16 = bfloat16(base_value);
-    float base_bf16_float = static_cast<float>(base_bf16);
+    auto base_bf16 = bfloat16(base_value);
+    auto base_bf16_float = static_cast<float>(base_bf16);
     float upper_bf16 = bf16_next(base_bf16_float);
 
     // Test value: at 'fraction' position between base and upper BF16
@@ -101,7 +101,7 @@ StochasticRoundingResult run_stochastic_rounding(
     uint32_t output_dram_byte_address = output_dram_buffer->address();
 
     std::vector<uint32_t> packed_input(num_elements);
-    uint32_t test_value_bits = std::bit_cast<uint32_t>(test_value);
+    auto test_value_bits = std::bit_cast<uint32_t>(test_value);
     std::fill(packed_input.begin(), packed_input.end(), test_value_bits);
 
     std::vector<uint32_t> compute_kernel_args = {
@@ -189,7 +189,7 @@ StochasticRoundingResult run_stochastic_rounding(
     size_t count_rounded_down = 0;
 
     for (const auto& val : output) {
-        float val_float = static_cast<float>(val);
+        auto val_float = static_cast<float>(val);
         if (val_float == base_bf16_float) {
             count_rounded_down++;
         } else if (val_float == upper_bf16) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -734,7 +734,7 @@ int main(int argc, char** argv) {
         std::vector<std::shared_ptr<tt_metal::distributed::MeshBuffer>> in1_buffers(num_layers);
         std::shared_ptr<tt_metal::distributed::MeshBuffer> in1_l1_buffer;
         std::shared_ptr<tt_metal::distributed::MeshBuffer> output_buffer;
-        SHAPE in0_shape = SHAPE{1, 1, m, k * num_receivers};
+        auto in0_shape = SHAPE{1, 1, m, k * num_receivers};
         tt::deprecated::Tensor<bfloat16> in0_tensor_fp16 = tt::deprecated::initialize_tensor<bfloat16>(
             in0_shape,
             tt::deprecated::Initialize::RANDOM,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -62,7 +62,7 @@ using std::chrono::microseconds;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void* align(void* ptr, std::size_t max_alignment) {
-    const std::uintptr_t uptr = reinterpret_cast<std::uintptr_t>(ptr);
+    const auto uptr = reinterpret_cast<std::uintptr_t>(ptr);
     std::uintptr_t aligned = (uptr - 1u + max_alignment) & -max_alignment;
     // Make max alignment of ptr equal to the actual specified alignment
     // ex. if the current ptr here is 16, but we specified an alignment of 8,
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             total_transfer_size + (2 * addr_align), 1000, std::chrono::system_clock::now().time_since_epoch().count());
 
-        uint32_t* start_ptr = (uint32_t*)align(src_vec.data(), addr_align);
+        auto* start_ptr = (uint32_t*)align(src_vec.data(), addr_align);
         std::vector<uint32_t> result_vec;
 
         const std::string copy_mode_str = copy_mode == 0 ? "memcpy" : copy_mode == 1 ? "4 byte writes" : "nt_memcpy";
@@ -342,7 +342,7 @@ int main(int argc, char** argv) {
                 if (copy_mode == 0) {
                     memcpy(host_mem_ptr, start_ptr + src_data_offset, write_size_bytes);
                 } else if (copy_mode == 1) {
-                    uint32_t* host_mem_ptr4B = (uint32_t*)host_mem_ptr;
+                    auto* host_mem_ptr4B = (uint32_t*)host_mem_ptr;
                     uint32_t write_size_words = write_size_bytes / sizeof(uint32_t);
 
                     for (uint32_t i = 0; i < write_size_words; i++) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
 
         int clock_freq_mhz = get_tt_npu_clock(device->get_devices()[0]);
 
-        uint32_t num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
+        auto num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
         auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
         uint32_t num_cores_x = compute_with_storage_grid_size.x;
         uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -371,8 +371,8 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 
-        bfloat16 num_1_bfloat16 = bfloat16(num_1_float);
-        bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
+        auto num_1_bfloat16 = bfloat16(num_1_float);
+        auto num_2_bfloat16 = bfloat16(num_2_float);
 
         // pack 2 uint16 into uint32
         vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -419,7 +419,7 @@ int main(int argc, char** argv) {
         TT_ASSERT(
             device->arch() == ARCH::WORMHOLE_B0 or device->arch() == ARCH::BLACKHOLE, "device must be wh_b0 or bh");
 
-        uint32_t num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
+        auto num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
         uint32_t num_cores = num_banks;  // number of DRAM banks
         // uint32_t num_banks_all = 12;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -537,7 +537,7 @@ int main(int argc, char** argv) {
         log_debug(tt::LogTest, "device x : {}", num_cores_x);
         log_debug(tt::LogTest, "device y : {}", num_cores_y);
 
-        uint32_t num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
+        auto num_tiles = static_cast<uint32_t>((input_size + single_tile_size - 1) / single_tile_size);
         uint32_t num_cores = num_banks;  // number of DRAM banks
 
         CoreRangeSet all_dram_reader_cores;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -471,7 +471,7 @@ inline bool DeviceData::validate_host(
 
     bool failed = false;
 
-    uint32_t* results = (uint32_t*)this->base_data_addr[static_cast<int>(tt::CoreType::PCIE)];
+    auto* results = (uint32_t*)this->base_data_addr[static_cast<int>(tt::CoreType::PCIE)];
 
     int fail_count = 0;
     for (int data_index = 0; data_index < host_data.data.size(); data_index++) {
@@ -692,7 +692,7 @@ inline HostMemDeviceCommand build_packed_write_command(
     uint32_t l1_alignment,
     uint32_t packed_write_max_unicast_sub_cmds,
     bool no_stride) {
-    const uint32_t num_sub_cmds = static_cast<uint32_t>(sub_cmds.size());
+    const auto num_sub_cmds = static_cast<uint32_t>(sub_cmds.size());
     const uint32_t sub_cmds_bytes = tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
     uint32_t num_data_copies = no_stride ? 1u : static_cast<uint32_t>(num_sub_cmds);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -396,7 +396,7 @@ public:
 
         uint32_t remaining_bytes = get_transfer_size_bytes();
 
-        const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
+        const auto num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
         const uint32_t sub_cmds_bytes =
             tt::align(num_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -332,7 +332,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
         log_info(tt::LogTest, "Device {} index {}", device_helper.devices[i]->get_devices()[0]->id(), i);
     }
 
-    uint32_t measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
+    auto measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
     uint32_t benchmark_type_val = enchantum::to_underlying(params.benchmark_type);
 
     // eth core ct args

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -45,13 +45,13 @@ ParsedYamlConfig YamlConfigParser::parse_file(const std::string& yaml_config_pat
 
 DeviceIdentifier YamlConfigParser::parse_device_identifier(const YAML::Node& node) {
     if (node.IsScalar()) {
-        ChipId chip_id = parse_scalar<ChipId>(node);
+        auto chip_id = parse_scalar<ChipId>(node);
         return chip_id;
     } else if (node.IsSequence() && node.size() == 2) {
         MeshId mesh_id = parse_mesh_id(node[0]);
         if (node[1].IsScalar()) {
             // Format: [mesh_id, chip_id]
-            ChipId chip_id = parse_scalar<ChipId>(node[1]);
+            auto chip_id = parse_scalar<ChipId>(node[1]);
             return std::make_pair(mesh_id, chip_id);
         } else if (node[1].IsSequence()) {
             // Format: [mesh_id, [row, col]]
@@ -76,9 +76,9 @@ ParsedDestinationConfig YamlConfigParser::parse_destination_config(const YAML::N
         TT_FATAL(dest_yaml["hops"].IsMap(), "Expected 'hops' to be a map.");
         std::unordered_map<RoutingDirection, uint32_t> hops_map;
         for (const auto& it : dest_yaml["hops"]) {
-            std::string dir_str = parse_scalar<std::string>(it.first);
+            auto dir_str = parse_scalar<std::string>(it.first);
             RoutingDirection dir = detail::routing_direction_mapper.from_string(dir_str, "RoutingDirection");
-            uint32_t num_hops = parse_scalar<uint32_t>(it.second);
+            auto num_hops = parse_scalar<uint32_t>(it.second);
             hops_map[dir] = num_hops;
         }
         config.hops = hops_map;
@@ -794,7 +794,7 @@ MeshCoordinate YamlConfigParser::parse_mesh_coord(const YAML::Node& node) {
 }
 
 MeshId YamlConfigParser::parse_mesh_id(const YAML::Node& yaml_node) {
-    uint32_t mesh_id = yaml_node.as<uint32_t>();
+    auto mesh_id = yaml_node.as<uint32_t>();
     return MeshId{mesh_id};
 }
 
@@ -804,7 +804,7 @@ ParametrizationOptionsMap YamlConfigParser::parse_parametrization_params(const Y
     TT_FATAL(params_yaml.IsMap(), "Expected 'parametrization_params' to be a map.");
 
     for (const auto& it : params_yaml) {
-        std::string key = parse_scalar<std::string>(it.first);
+        auto key = parse_scalar<std::string>(it.first);
         const auto& node = it.second;
         TT_FATAL(node.IsSequence(), "Parametrization option '{}' must be a sequence of values.", key);
 
@@ -1002,7 +1002,7 @@ std::vector<TestConfig> TestConfigBuilder::expand_high_level_patterns(ParsedTest
             } else if (p.type == "sequential_all_to_all") {
                 // Dynamically calculate iterations for sequential_all_to_all patterns based on all device pairs
                 auto all_pairs = this->route_manager_.get_all_to_all_unicast_pairs();
-                uint32_t num_pairs = static_cast<uint32_t>(all_pairs.size());
+                auto num_pairs = static_cast<uint32_t>(all_pairs.size());
                 max_iterations = std::max(max_iterations, num_pairs);
                 log_info(
                     LogTest,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -230,7 +230,7 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
                 core,
                 static_cast<int>(key.direction),
                 key.link_idx);
-            uint8_t channel_id = static_cast<uint8_t>(channel_it->second);
+            auto channel_id = static_cast<uint8_t>(channel_it->second);
 
             // Get the stored mux core location for this connection
             auto mux_core_it = mux_cores_.find(key);
@@ -802,7 +802,7 @@ void TestDevice::create_sync_kernel() {
     }
 
     // Local sync args
-    uint32_t local_sync_val = static_cast<uint32_t>(senders_.size() + 1);  // Expected sync value
+    auto local_sync_val = static_cast<uint32_t>(senders_.size() + 1);  // Expected sync value
     local_args.push_back(sender_memory_map_->get_local_sync_address());
     local_args.push_back(local_sync_val);
 
@@ -895,7 +895,7 @@ void TestDevice::create_sender_kernels() {
         // Add local sync args FIRST (parsed first by kernel)
         if (global_sync_) {
             // Add local sync configuration args (same as sync core, but no global sync)
-            uint32_t local_sync_val =
+            auto local_sync_val =
                 static_cast<uint32_t>(senders_.size() + 1);  // Expected sync value (all senders + sync core)
             local_args.push_back(sender_memory_map_->get_local_sync_address());
             local_args.push_back(local_sync_val);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -220,12 +220,12 @@ std::string TestProgressMonitor::format_throughput(double packets_per_second) co
 
 std::string TestProgressMonitor::format_duration(double seconds) const {
     if (seconds >= 3600) {
-        uint32_t hours = static_cast<uint32_t>(seconds / 3600);
-        uint32_t minutes = static_cast<uint32_t>((seconds - (hours * 3600)) / 60);
+        auto hours = static_cast<uint32_t>(seconds / 3600);
+        auto minutes = static_cast<uint32_t>((seconds - (hours * 3600)) / 60);
         return std::to_string(hours) + "h" + std::to_string(minutes) + "m";
     } else if (seconds >= 60) {
-        uint32_t minutes = static_cast<uint32_t>(seconds / 60);
-        uint32_t secs = static_cast<uint32_t>(seconds - (minutes * 60));
+        auto minutes = static_cast<uint32_t>(seconds / 60);
+        auto secs = static_cast<uint32_t>(seconds - (minutes * 60));
         return std::to_string(minutes) + "m" + std::to_string(secs) + "s";
     } else {
         return std::to_string(static_cast<uint32_t>(seconds)) + "s";

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
                 vector<uint16_t> tiled_bcast_values;
                 vector<uint16_t> ref_bcast_values;
                 float bcast_1value = 10.0f;
-                uint16_t bcast_1value16 = std::bit_cast<uint16_t>(bfloat16(bcast_1value));
+                auto bcast_1value16 = std::bit_cast<uint16_t>(bfloat16(bcast_1value));
                 unsigned num_bcast_tiles = 0;
                 // build the constant tiles to be broadcast
                 if (bcast_dim == BcastDim::HW) {

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -88,8 +88,8 @@ static float compare_first_col_mse(
     const uint32_t rows = golden_first_col_rm.size() / 32;
     float mse = 0.0f;
     for (uint32_t r = 0; r < rows; ++r) {
-        float a = static_cast<float>(result_rm[(r * 32) + 0]);
-        float b = static_cast<float>(golden_first_col_rm[(r * 32) + 0]);
+        auto a = static_cast<float>(result_rm[(r * 32) + 0]);
+        auto b = static_cast<float>(golden_first_col_rm[(r * 32) + 0]);
         float d = a - b;
         mse += d * d;
     }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -377,7 +377,7 @@ bool RunWriteBWTest(
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, tensor_size_bytes / sizeof(uint32_t));
     std::iota(inputs.begin(), inputs.end(), 0);
 
-    BankedConfig test_config = BankedConfig{
+    auto test_config = BankedConfig{
         .num_pages = num_pages_total,
         .size_bytes = tensor_size_bytes,
         .page_size_bytes = page_size,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -160,7 +160,7 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(mesh_devices.size());
+            auto expected = static_cast<float>(mesh_devices.size());
             EXPECT_EQ(static_cast<float>(data[i]), expected);
         }
     }
@@ -191,7 +191,7 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
         for (int i = 0; i < data.size(); i++) {
-            float expected = static_cast<float>(mesh_devices.size());
+            auto expected = static_cast<float>(mesh_devices.size());
             EXPECT_EQ(static_cast<float>(data[i]), expected);
         }
     }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -123,12 +123,11 @@ void run_full_block_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_b
 }
 
 TEST(CclnewWidthShardedTensorSliceIndexer_Wormhole, width_sharded_test) {
-    constexpr std::size_t shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+    constexpr auto shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
     constexpr std::size_t number_of_cores = 8;
     constexpr std::size_t page_size_jump = 1024;
     constexpr std::size_t pages_per_tensor_row = 32;
-    constexpr std::size_t contiguity =
-        static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
+    constexpr auto contiguity = static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     constexpr std::size_t pages_per_shard_width = 6;
     constexpr std::size_t rows_per_shard_height = 1;
     constexpr std::size_t tensor_address = 0x100000;
@@ -147,12 +146,11 @@ TEST(CclnewWidthShardedTensorSliceIndexer_Wormhole, width_sharded_test) {
 }
 
 TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
-    static constexpr std::size_t shard_type =
-        static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED);
+    static constexpr auto shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED);
     static constexpr std::size_t number_of_cores = 4;
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
-    static constexpr std::size_t contiguity =
+    static constexpr auto contiguity =
         static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 1;
     static constexpr std::size_t rows_per_shard_height = 8;
@@ -172,11 +170,11 @@ TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
 }
 
 TEST(CclnewBlockShardedTensorSliceIndexer_Wormhole, block_sharded_test) {
-    static constexpr std::size_t shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
+    static constexpr auto shard_type = static_cast<std::size_t>(tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
     static constexpr std::size_t number_of_cores = 16;
     static constexpr std::size_t page_size_jump = 1024;
     static constexpr std::size_t pages_per_tensor_row = 32;
-    static constexpr std::size_t contiguity =
+    static constexpr auto contiguity =
         static_cast<std::size_t>(shard_addr_gen_consts::ContiguityType::L1_NO_SHARD_PADDING);
     static constexpr std::size_t pages_per_shard_width = 8;
     static constexpr std::size_t rows_per_shard_height = 8;

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -53,8 +53,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     uint32_t input_buf_size_datums = 1024 * 1024;
     uint32_t output_buf_size_datums = 1024 * 32;
     uint32_t datum_size_bytes = 2;
-    ttnn::QueueId io_cq = ttnn::QueueId(1);                 // Data reads and writes done through CQ0
-    ttnn::QueueId workload_dispatch_cq = ttnn::QueueId(0);  // Workload dispatched through CQ1
+    auto io_cq = ttnn::QueueId(1);                 // Data reads and writes done through CQ0
+    auto workload_dispatch_cq = ttnn::QueueId(0);  // Workload dispatched through CQ1
 
     ttnn::Shape input_shape({1, 1, 1024, 1024});
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[input_buf_size_datums]);
@@ -106,8 +106,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
     uint32_t buf_size_datums = 1024 * 1024;
     uint32_t datum_size_bytes = 2;
     std::vector<uint32_t> inputs = {4, 9, 16, 25, 36, 64};
-    ttnn::QueueId io_cq = ttnn::QueueId(1);
-    ttnn::QueueId workload_dispatch_cq = ttnn::QueueId(0);
+    auto io_cq = ttnn::QueueId(1);
+    auto workload_dispatch_cq = ttnn::QueueId(0);
     ttnn::Shape shape{1, 1, 1024, 1024};
 
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
@@ -120,7 +120,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
                 host_data[i] = bfloat16(static_cast<float>(input_val));
             }
             // Pre-compute expected output: neg(sqrt(input_val)) = -sqrt(input_val)
-            float expected_val = static_cast<float>(-1 * sqrt(input_val));
+            auto expected_val = static_cast<float>(-1 * sqrt(input_val));
             for (uint32_t i = 0; i < buf_size_datums; i++) {
                 expected_data[i] = bfloat16(expected_val);
             }

--- a/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
@@ -346,8 +346,8 @@ void gather_with_blocked_transfers_generic(
     uint32_t output_shard_height = C;
 
     // Cast to byte pointers for arithmetic
-    const uint8_t* input_bytes = static_cast<const uint8_t*>(input_data);
-    uint8_t* output_bytes = static_cast<uint8_t*>(output_data);
+    const auto* input_bytes = static_cast<const uint8_t*>(input_data);
+    auto* output_bytes = static_cast<uint8_t*>(output_data);
 
     // Process each block group
     for (const auto& group : blocked_groups) {

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -260,7 +260,7 @@ TEST_P(EltwiseUnaryOpIfTest, Sigmoid) {
         auto* device = device_;
         const auto& output_spec = input_spec;
         // Add default parameters
-        int32_t vectorMode = static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
+        auto vectorMode = static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
         bool approximateMode = false;
         auto query = ttnn::graph::query_op_constraints(
             ttnn::sigmoid,

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -115,7 +115,7 @@ Node build_node(
 
     // Create boards with internal connections marked (using cached boards)
     for (const auto& board_item : node_descriptor.boards().board()) {
-        TrayId tray_id = TrayId(board_item.tray_id());
+        auto tray_id = TrayId(board_item.tray_id());
         auto board_type = get_board_type_from_string(board_item.board_type());
         template_node.boards.emplace(tray_id, create_board(board_type));
     }
@@ -128,10 +128,10 @@ Node build_node(
         }
 
         for (const auto& conn : port_connections.connections()) {
-            TrayId board_a_id = TrayId(conn.port_a().tray_id());
-            PortId port_a_id = PortId(conn.port_a().port_id());
-            TrayId board_b_id = TrayId(conn.port_b().tray_id());
-            PortId port_b_id = PortId(conn.port_b().port_id());
+            auto board_a_id = TrayId(conn.port_a().tray_id());
+            auto port_a_id = PortId(conn.port_a().port_id());
+            auto board_b_id = TrayId(conn.port_b().tray_id());
+            auto port_b_id = PortId(conn.port_b().port_id());
 
             create_port_connection(
                 template_node.boards.at(board_a_id),
@@ -214,7 +214,7 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
                 throw std::runtime_error("Node child must have host_id mapping: " + child_name);
             }
 
-            HostId host_id = HostId(child_mapping.host_id());
+            auto host_id = HostId(child_mapping.host_id());
             const std::string& node_descriptor_name = child_def.node_ref().node_descriptor();
 
             // Validate deployment node type if deployment descriptor is provided
@@ -261,11 +261,11 @@ std::unique_ptr<ResolvedGraphInstance> build_graph_instance_impl(
         for (const auto& conn : port_connections.connections()) {
             const auto& path_a = conn.port_a().path();
             const auto& path_b = conn.port_b().path();
-            TrayId board_a_id = TrayId(conn.port_a().tray_id());
-            PortId port_a_id = PortId(conn.port_a().port_id());
+            auto board_a_id = TrayId(conn.port_a().tray_id());
+            auto port_a_id = PortId(conn.port_a().port_id());
 
-            TrayId board_b_id = TrayId(conn.port_b().tray_id());
-            PortId port_b_id = PortId(conn.port_b().port_id());
+            auto board_b_id = TrayId(conn.port_b().tray_id());
+            auto port_b_id = PortId(conn.port_b().port_id());
 
             // Resolve paths to HostId using proto data
             HostId host_a_id = resolve_path_from_proto(path_a, graph_instance, cluster_descriptor);
@@ -305,7 +305,7 @@ void populate_deployment_hosts_from_hostnames(
     // Store deployment hosts with just hostname and motherboard (no physical location info)
     deployment_hosts.reserve(hostnames.size());
     for (size_t i = 0; i < hostnames.size(); ++i) {
-        HostId host_id = HostId(i);
+        auto host_id = HostId(i);
         auto it = host_id_to_node.find(host_id);
         if (it == host_id_to_node.end()) {
             throw std::runtime_error("Host ID " + std::to_string(i) + " not found in cluster configuration");

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -171,8 +171,8 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
         }
 
         for (const auto& asic_info : host_node["asic_info"]) {
-            uint32_t tray_id = asic_info["tray_id"].as<uint32_t>();
-            std::string gsd_board_type = asic_info["board_type"].as<std::string>();
+            auto tray_id = asic_info["tray_id"].as<uint32_t>();
+            auto gsd_board_type = asic_info["board_type"].as<std::string>();
 
             auto fsd_key = std::make_pair(hostname, tray_id);
             if (strict_validation) {
@@ -300,15 +300,15 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
             const auto& first_conn = connection_pair[0];
             const auto& second_conn = connection_pair[1];
 
-            std::string hostname_1 = first_conn["host_name"].as<std::string>();
-            uint32_t chan_id_1 = first_conn["chan_id"].as<uint32_t>();
-            uint32_t tray_id_1 = first_conn["tray_id"].as<uint32_t>();
-            uint32_t asic_location_1 = first_conn["asic_location"].as<uint32_t>();
+            auto hostname_1 = first_conn["host_name"].as<std::string>();
+            auto chan_id_1 = first_conn["chan_id"].as<uint32_t>();
+            auto tray_id_1 = first_conn["tray_id"].as<uint32_t>();
+            auto asic_location_1 = first_conn["asic_location"].as<uint32_t>();
 
-            std::string hostname_2 = second_conn["host_name"].as<std::string>();
-            uint32_t chan_id_2 = second_conn["chan_id"].as<uint32_t>();
-            uint32_t tray_id_2 = second_conn["tray_id"].as<uint32_t>();
-            uint32_t asic_location_2 = second_conn["asic_location"].as<uint32_t>();
+            auto hostname_2 = second_conn["host_name"].as<std::string>();
+            auto chan_id_2 = second_conn["chan_id"].as<uint32_t>();
+            auto tray_id_2 = second_conn["tray_id"].as<uint32_t>();
+            auto asic_location_2 = second_conn["asic_location"].as<uint32_t>();
 
             PhysicalChannelEndpoint conn_1{
                 hostname_1, TrayId(tray_id_1), AsicChannel{asic_location_1, ChanId(chan_id_1)}};
@@ -342,15 +342,15 @@ std::set<PhysicalChannelConnection> validate_fsd_against_gsd_impl(
             auto first_conn = connection_pair[0];
             auto second_conn = connection_pair[1];
 
-            std::string hostname_1 = first_conn["host_name"].as<std::string>();
-            uint32_t chan_id_1 = first_conn["chan_id"].as<uint32_t>();
-            uint32_t tray_id_1 = first_conn["tray_id"].as<uint32_t>();
-            uint32_t asic_location_1 = first_conn["asic_location"].as<uint32_t>();
+            auto hostname_1 = first_conn["host_name"].as<std::string>();
+            auto chan_id_1 = first_conn["chan_id"].as<uint32_t>();
+            auto tray_id_1 = first_conn["tray_id"].as<uint32_t>();
+            auto asic_location_1 = first_conn["asic_location"].as<uint32_t>();
 
-            std::string hostname_2 = second_conn["host_name"].as<std::string>();
-            uint32_t chan_id_2 = second_conn["chan_id"].as<uint32_t>();
-            uint32_t tray_id_2 = second_conn["tray_id"].as<uint32_t>();
-            uint32_t asic_location_2 = second_conn["asic_location"].as<uint32_t>();
+            auto hostname_2 = second_conn["host_name"].as<std::string>();
+            auto chan_id_2 = second_conn["chan_id"].as<uint32_t>();
+            auto tray_id_2 = second_conn["tray_id"].as<uint32_t>();
+            auto asic_location_2 = second_conn["asic_location"].as<uint32_t>();
 
             PhysicalChannelEndpoint conn_1{
                 hostname_1, TrayId(tray_id_1), AsicChannel{asic_location_1, ChanId(chan_id_1)}};

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1463,7 +1463,7 @@ tt::tt_metal::AsicTopology build_reset_topology(
 
     tt::tt_metal::AsicID src_asic_id = physical_system_descriptor.get_asic_id(
         reset_host, tt::tt_metal::TrayID(reset_tray_id), tt::tt_metal::ASICLocation(reset_asic_location));
-    uint8_t src_channel = static_cast<uint8_t>(reset_channel);
+    auto src_channel = static_cast<uint8_t>(reset_channel);
 
     auto [dst_asic_id, dst_channel] =
         physical_system_descriptor.get_connected_asic_and_channel(src_asic_id, src_channel);

--- a/tt_metal/api/tt-metalium/shape_base.hpp
+++ b/tt_metal/api/tt-metalium/shape_base.hpp
@@ -19,8 +19,8 @@ namespace detail {
 [[noreturn]] void normalized_index_out_of_range(int32_t index, int32_t full_size, int32_t orig_size);
 
 inline int32_t normalized_index(int32_t index, size_t original_size, size_t container_size) {
-    const int32_t orig_size = static_cast<int32_t>(original_size);
-    const int32_t full_size = static_cast<int32_t>(container_size);
+    const auto orig_size = static_cast<int32_t>(original_size);
+    const auto full_size = static_cast<int32_t>(container_size);
 
     if (index < -full_size || index >= orig_size) {
         normalized_index_out_of_range(index, full_size, orig_size);

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -164,7 +164,7 @@ std::optional<MeshCoordinate> MeshCoordinate::get_neighbor(
     dim = normalize_index(dim, shape.dims());
 
     const auto boundary = static_cast<int32_t>(shape[dim]);
-    const int32_t current_pos = static_cast<int32_t>(value_[dim]);
+    const auto current_pos = static_cast<int32_t>(value_[dim]);
     const int32_t new_pos = current_pos + offset;
 
     MeshCoordinate result = *this;

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -117,12 +117,12 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
     this->dram_view_address_offsets.clear();
 
     for (const auto& dram_view : device_descriptor_yaml["dram_views"]) {
-        size_t channel = dram_view["channel"].as<size_t>();
+        auto channel = dram_view["channel"].as<size_t>();
         if (channel >= get_grid_size(tt::CoreType::DRAM).x) {
             // DRAM can be harvested and we don't create unique soc desc for diff harvesting
             break;
         }
-        size_t address_offset = dram_view["address_offset"].as<size_t>();
+        auto address_offset = dram_view["address_offset"].as<size_t>();
 
         std::vector<CoreCoord> eth_dram_cores;
         std::vector<size_t> eth_endpoints;

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -46,7 +46,7 @@ Shape Shape::to_rank(size_t new_rank) const {
 }
 
 uint32_t Shape::get_normalized_index(std::int64_t index) const {
-    std::int64_t rank = static_cast<std::int64_t>(this->rank());
+    auto rank = static_cast<std::int64_t>(this->rank());
     std::uint64_t normalized_index = index >= 0 ? index : rank + index;
     TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -96,7 +96,7 @@ void PinnedMemoryImpl::initialize_from_devices(
         page_size = static_cast<size_t>(sys_page);
     }
 
-    uintptr_t host_addr = reinterpret_cast<uintptr_t>(host_buffer);
+    auto host_addr = reinterpret_cast<uintptr_t>(host_buffer);
     uintptr_t aligned_base_addr = host_addr & ~(static_cast<uintptr_t>(page_size) - 1);
     host_offset_ = static_cast<size_t>(host_addr - aligned_base_addr);
     size_t mapped_size = buffer_size + host_offset_;

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -79,7 +79,7 @@ void StaticSizedChannelConnectionWriterAdapter::add_local_tensix_connection(
     const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
 
     // Store free slots stream ID
-    constexpr uint32_t relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
+    constexpr auto relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
     this->relay_connection_info.free_slots_stream_id =
         tensix_config.get_channel_credits_stream_id(relay_channel_id, FabricTensixCoreType::RELAY);
 

--- a/tt_metal/fabric/compressed_routing_path.cpp
+++ b/tt_metal/fabric/compressed_routing_path.cpp
@@ -14,7 +14,7 @@ namespace tt::tt_fabric {
 template <>
 void intra_mesh_routing_path_t<1, false>::calculate_chip_to_all_routing_fields(
     const FabricNodeId& /*src_fabric_node_id*/, uint16_t num_chips) {
-    uint64_t* route_ptr = reinterpret_cast<uint64_t*>(&paths);
+    auto* route_ptr = reinterpret_cast<uint64_t*>(&paths);
     route_ptr[0] = 0;
     for (uint16_t hops = 1; hops < num_chips; ++hops) {
         const uint64_t shift_amount = static_cast<uint64_t>(hops - 1) * static_cast<uint64_t>(FIELD_WIDTH);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -811,7 +811,7 @@ void FabricEriscDatamoverBuilder::get_telemetry_compile_time_args(
     const uint8_t stats_mask = telemetry_enabled ? risc_config.telemetry_stats_mask() : 0;
     ct_args.push_back(static_cast<uint32_t>(stats_mask));
 
-    uint32_t bw_telemetry_mode = static_cast<uint32_t>(rtoptions.get_enable_fabric_bw_telemetry() ? 1 : 0);
+    auto bw_telemetry_mode = static_cast<uint32_t>(rtoptions.get_enable_fabric_bw_telemetry() ? 1 : 0);
     ct_args.push_back(bw_telemetry_mode);
 
     // Add telemetry buffer address (16B aligned)
@@ -820,7 +820,7 @@ void FabricEriscDatamoverBuilder::get_telemetry_compile_time_args(
     // Add code profiling arguments (conditionally enabled)
     if (rtoptions.get_enable_fabric_code_profiling_rx_ch_fwd()) {
         // Enable RECEIVER_CHANNEL_FORWARD timer (bit 0)
-        uint32_t code_profiling_enabled_timers = static_cast<uint32_t>(CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD);
+        auto code_profiling_enabled_timers = static_cast<uint32_t>(CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD);
         ct_args.push_back(code_profiling_enabled_timers);
 
         // Add code profiling buffer address (16B aligned)

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -443,7 +443,7 @@ std::map<ChannelTypes, uint32_t> FabricTensixDatamoverConfig::calculate_mux_chan
         auto tensix_cores_for_workers = get_tensix_cores_for_workers(first_device);
 
         uint32_t total_workers = workers_by_column.size();
-        uint32_t num_worker_channels = static_cast<uint32_t>(
+        auto num_worker_channels = static_cast<uint32_t>(
             (total_workers + tensix_cores_for_workers.size() - 1) / tensix_cores_for_workers.size());
 
         log_debug(
@@ -542,7 +542,7 @@ void FabricTensixDatamoverConfig::calculate_buffer_allocations() {
 
     // Set base addresses for each core type with proper L1 alignment
     for (size_t i = 0; i < num_used_riscs_per_tensix_; ++i) {
-        FabricTensixCoreType core_id = static_cast<FabricTensixCoreType>(i);
+        auto core_id = static_cast<FabricTensixCoreType>(i);
         base_l1_addresses_[core_id] = l1_base + (i * space_per_risc_);
     }
 }
@@ -1065,7 +1065,7 @@ tt::tt_fabric::SenderWorkerAdapterSpec FabricTensixDatamoverBuilder::build_conne
 tt::tt_fabric::SenderWorkerAdapterSpec FabricTensixDatamoverBuilder::build_connection_to_relay_channel() const {
     // This method connects to relay's channel (for router-to-relay traffic in UDM mode)
     TT_FATAL(relay_builder_ != nullptr, "Relay builder must not be null in UDM mode");
-    constexpr uint32_t relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
+    constexpr auto relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
     return relay_builder_->build_connection_to_fabric_channel(relay_channel_id);
 }
 

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -58,11 +58,11 @@ static uint32_t get_downstream_mux_channel_id(eth_chan_directions direction, eth
 
 static uint32_t get_upstream_mux_channel_id(eth_chan_directions direction, eth_chan_directions upstream_direction) {
     // Calculate channel based on upstream direction, skipping the current direction in the enum ordering
-    uint32_t upstream_idx = static_cast<uint32_t>(upstream_direction);
-    uint32_t current_idx = static_cast<uint32_t>(direction);
+    auto upstream_idx = static_cast<uint32_t>(upstream_direction);
+    auto current_idx = static_cast<uint32_t>(direction);
 
     // Base channel for inter-mux connections
-    uint32_t base_channel = static_cast<uint32_t>(UdmMuxInterMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
+    auto base_channel = static_cast<uint32_t>(UdmMuxInterMuxChannelId::EAST_OR_WEST_MUX_CHANNEL);
 
     // If upstream comes before current in enum order (E=0, W=1, N=2, S=3), use index as-is
     // Otherwise subtract 1 to account for skipping the current direction
@@ -477,7 +477,7 @@ std::vector<uint32_t> FabricTensixDatamoverMuxConfig::get_compile_time_args(
     auto mux_infos = get_all_mux_connection_infos(fabric_node_id, routing_plane_id, direction);
 
     // Build compile time args - organized by channel type
-    uint32_t num_channel_types = static_cast<uint32_t>(channel_configs_.size());
+    auto num_channel_types = static_cast<uint32_t>(channel_configs_.size());
 
     std::vector<uint32_t> ct_args = {
         static_cast<uint32_t>(num_total_channels_),           // 0: total number of channels across all types
@@ -730,7 +730,7 @@ std::vector<uint32_t> FabricTensixDatamoverRelayConfig::get_compile_time_args(
     TT_FATAL(mux_config != nullptr, "Mux config must exist for relay to connect to it");
 
     // Channel IDs and stream IDs
-    constexpr uint32_t router_to_relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
+    constexpr auto router_to_relay_channel_id = static_cast<uint32_t>(UdmRelayChannelId::ROUTER_CHANNEL);
     const auto router_to_relay_channel_stream_id =
         get_channel_credits_stream_id(tt::tt_fabric::ChannelTypes::ROUTER_CHANNEL, router_to_relay_channel_id);
 
@@ -738,7 +738,7 @@ std::vector<uint32_t> FabricTensixDatamoverRelayConfig::get_compile_time_args(
     auto mux_infos = get_all_mux_connection_infos(fabric_node_id, routing_plane_id, direction);
 
     // Build compile time args - organized by channel type
-    uint32_t num_channel_types = static_cast<uint32_t>(channel_configs_.size());
+    auto num_channel_types = static_cast<uint32_t>(channel_configs_.size());
 
     auto channel_type = tt::tt_fabric::ChannelTypes::RELAY_TO_MUX_CHANNEL;
 
@@ -1189,7 +1189,7 @@ void FabricTensixDatamoverRelayBuilder::create_and_compile(tt::tt_metal::Program
                                                         : tt::tt_metal::DataMovementProcessor::RISCV_1;
 
     // In UDM mode, relay uses NOC selection from UdmNoCSelection enum (NOC 1 = edm_to_local_chip_noc)
-    tt::tt_metal::NOC noc = static_cast<tt::tt_metal::NOC>(UdmNoCSelection::relay_noc);
+    auto noc = static_cast<tt::tt_metal::NOC>(UdmNoCSelection::relay_noc);
 
     // Create the relay kernel
     auto relay_kernel = tt::tt_metal::CreateKernel(

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -93,7 +93,7 @@ std::unordered_map<GlobalNodeId, std::vector<ConnectionData>> get_valid_connecti
     }
 
     const auto& topology_types = device_topology->dim_types();
-    const uint32_t channels_count = static_cast<uint32_t>(channels->count());
+    const auto channels_count = static_cast<uint32_t>(channels->count());
     const auto& policy = channels->policy();
 
     MeshShape mesh_shape = mesh_coord_range.shape();

--- a/tt_metal/fabric/serialization/router_port_directions.cpp
+++ b/tt_metal/fabric/serialization/router_port_directions.cpp
@@ -81,7 +81,7 @@ RouterPortDirectionsData deserialize_router_port_directions_from_bytes(const std
         std::unordered_map<RoutingDirection, std::vector<chan_id_t>> direction_map;
 
         for (const auto& direction_entry : fabric_node_map.direction_entries()) {
-            RoutingDirection direction = static_cast<RoutingDirection>(direction_entry.direction());
+            auto direction = static_cast<RoutingDirection>(direction_entry.direction());
 
             std::vector<chan_id_t> channels;
             for (const auto& channel : direction_entry.channels()) {

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -342,7 +342,7 @@ TopologyMapper::TopologyMapper(
     const std::size_t world_size = *global_context->size();
     if (world_size > 1) {
         // Gather mesh_id and host_rank from all ranks
-        const std::uint32_t local_count = static_cast<std::uint32_t>(local_mesh_binding_.mesh_ids.size());
+        const auto local_count = static_cast<std::uint32_t>(local_mesh_binding_.mesh_ids.size());
         std::vector<std::uint32_t> counts(world_size, 0);
         all_gather_with_timeout(
             global_context,
@@ -545,7 +545,7 @@ std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper:
     }
 
     // Step 2: Gather mesh_id and host_rank from all ranks to know which mesh_ids each MPI rank participates in
-    const std::uint32_t local_count = static_cast<std::uint32_t>(local_mesh_binding_.mesh_ids.size());
+    const auto local_count = static_cast<std::uint32_t>(local_mesh_binding_.mesh_ids.size());
     std::vector<std::uint32_t> counts(world_size, 0);
     all_gather_with_timeout(
         global_context,
@@ -717,7 +717,7 @@ void TopologyMapper::broadcast_mapping_to_all_hosts() {
             mapped_entries.push_back(&info);
         }
     }
-    std::uint32_t count = static_cast<std::uint32_t>(mapped_entries.size());
+    auto count = static_cast<std::uint32_t>(mapped_entries.size());
 
     for (std::size_t peer = 0; peer < world_size; ++peer) {
         if (peer == CONTROLLER_RANK) {
@@ -765,7 +765,7 @@ void TopologyMapper::broadcast_mapping_to_all_hosts() {
             }
 
             // Send size first, then data
-            std::uint32_t record_size = static_cast<std::uint32_t>(record.size());
+            auto record_size = static_cast<std::uint32_t>(record.size());
             distributed_context.ssend(
                 tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&record_size), sizeof(record_size)),
                 Rank{static_cast<int>(peer)},
@@ -1413,7 +1413,7 @@ std::vector<MeshShape> generate_possible_cluster_shapes(std::uint32_t total_numb
     for (std::uint32_t num_chips = total_number_of_chips; num_chips > 0; num_chips--) {
         // Find all divisor pairs (x, y) where x * y = num_chips
         // Only check divisors up to sqrt(num_chips) for efficiency
-        std::uint32_t sqrt_num_chips = static_cast<std::uint32_t>(std::sqrt(num_chips));
+        auto sqrt_num_chips = static_cast<std::uint32_t>(std::sqrt(num_chips));
 
         for (std::uint32_t i = sqrt_num_chips; i > 0; i--) {
             if (num_chips % i == 0) {

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -411,9 +411,9 @@ TopologyMappingResult map_mesh_to_physical(
         // Validate strict mode constraints for fast-path result
         if (strict_mode) {
             for (size_t i = 0; i < n_log; ++i) {
-                size_t phys_i = static_cast<size_t>(mapping[i]);
+                auto phys_i = static_cast<size_t>(mapping[i]);
                 for (const auto& [neigh_log_idx, log_count] : log_conn_count[i]) {
-                    size_t phys_neigh_idx = static_cast<size_t>(mapping[neigh_log_idx]);
+                    auto phys_neigh_idx = static_cast<size_t>(mapping[neigh_log_idx]);
                     auto it = phys_conn_count[phys_i].find(phys_neigh_idx);
                     if (it == phys_conn_count[phys_i].end()) {
                         result.success = false;
@@ -639,7 +639,7 @@ TopologyMappingResult map_mesh_to_physical(
                 if (pk_i == -1) {
                     continue;
                 }
-                size_t pk = static_cast<size_t>(pk_i);
+                auto pk = static_cast<size_t>(pk_i);
                 bool log_connected = std::binary_search(log_adj_idx[li].begin(), log_adj_idx[li].end(), lk);
                 bool phys_connected = std::binary_search(phys_adj_idx[j].begin(), phys_adj_idx[j].end(), pk);
                 if (log_connected && !phys_connected) {
@@ -693,7 +693,7 @@ TopologyMappingResult map_mesh_to_physical(
                         if (pk2_i == -1) {
                             continue;
                         }
-                        size_t pk2 = static_cast<size_t>(pk2_i);
+                        auto pk2 = static_cast<size_t>(pk2_i);
                         bool log_conn2 = std::binary_search(log_adj_idx[v].begin(), log_adj_idx[v].end(), lv);
                         bool phys_conn2 = std::binary_search(phys_adj_idx[pj].begin(), phys_adj_idx[pj].end(), pk2);
                         if (log_conn2 && !phys_conn2) {
@@ -889,9 +889,9 @@ TopologyMappingResult map_mesh_to_physical(
     // Final validation in strict mode
     if (strict_mode) {
         for (size_t i = 0; i < n_log; ++i) {
-            size_t phys_i = static_cast<size_t>(mapping[i]);
+            auto phys_i = static_cast<size_t>(mapping[i]);
             for (const auto& [neigh_log_idx, log_count] : log_conn_count[i]) {
-                size_t phys_neigh_idx = static_cast<size_t>(mapping[neigh_log_idx]);
+                auto phys_neigh_idx = static_cast<size_t>(mapping[neigh_log_idx]);
                 auto it = phys_conn_count[phys_i].find(phys_neigh_idx);
                 if (it == phys_conn_count[phys_i].end()) {
                     result.success = false;

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -114,7 +114,7 @@ void AllocatorImpl::init_compute_and_storage_l1_bank_manager() {
 
     // There is only l1_bank_size bytes available for L1 buffers to be allocated in
     uint64_t l1_bank_size = config_->worker_l1_size - config_->l1_unreserved_base;
-    uint64_t interleaved_address_limit = static_cast<uint64_t>(config_->worker_l1_size - l1_bank_size);
+    auto interleaved_address_limit = static_cast<uint64_t>(config_->worker_l1_size - l1_bank_size);
     uint64_t allocatable_l1_size =
         static_cast<uint64_t>(config_->worker_l1_size) - config_->l1_unreserved_base - config_->l1_small_size;
     // Assuming top down allocation for L1 buffers so the allocatable memory space is the top l1_bank_size bytes of L1

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -516,7 +516,7 @@ bool Buffer::is_valid_partial_region(const BufferRegion& region) const {
 }
 
 DeviceAddr Buffer::page_address(DeviceAddr bank_id, DeviceAddr page_index) const {
-    DeviceAddr num_banks = static_cast<DeviceAddr>(allocator_->get_num_banks(buffer_type_));
+    auto num_banks = static_cast<DeviceAddr>(allocator_->get_num_banks(buffer_type_));
     TT_FATAL(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
     DeviceAddr pages_offset_within_bank = page_index / num_banks;
     auto offset = (round_up(this->page_size(), static_cast<DeviceAddr>(this->alignment())) * pages_offset_within_bank);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -461,11 +461,11 @@ void populate_interleaved_buffer_write_dispatch_cmds(
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
     InterleavedBufferWriteDispatchParams& dispatch_params) {
-    const uint8_t is_dram = uint8_t(buffer.is_dram());
+    const auto is_dram = uint8_t(buffer.is_dram());
     TT_ASSERT(
         dispatch_params.dst_page_index <= CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX,
         "Page offset needs to fit within range of uint16_t, bank_base_address was computed incorrectly!");
-    const uint16_t start_page = uint16_t(dispatch_params.dst_page_index & CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX);
+    const auto start_page = uint16_t(dispatch_params.dst_page_index & CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX);
     const bool flush_prefetch = true;
     command_sequence.add_dispatch_write_paged(
         flush_prefetch,
@@ -529,9 +529,9 @@ void populate_sharded_buffer_write_dispatch_cmds(
         dispatch_params.address,
         data_size_bytes);
 
-    uint8_t* dst = command_sequence.reserve_space<uint8_t*, true>(data_size_bytes);
+    auto* dst = command_sequence.reserve_space<uint8_t*, true>(data_size_bytes);
     // TODO: Expose getter for cmd_write_offsetB?
-    ptrdiff_t dst_offset = reinterpret_cast<ptrdiff_t>(dst - (uint8_t*)command_sequence.data());
+    auto dst_offset = reinterpret_cast<ptrdiff_t>(dst - (uint8_t*)command_sequence.data());
     TT_ASSERT(dst_offset >= 0, "Offset into command sequence is negative");
     if (dispatch_params.write_large_pages()) {
         const auto cur_host_page = *dispatch_params.core_page_mapping_it;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -597,7 +597,7 @@ void MetalContext::clear_launch_messages_on_eth_cores(ChipId device_id) {
         auto factory = hal_->get_dev_msgs_factory(programmable_core_type);
         std::vector<std::byte> init_launch_msg_data(
             dev_msgs::launch_msg_buffer_num_entries * factory.size_of<dev_msgs::launch_msg_t>(), std::byte{0});
-        dev_msgs::go_msg_t go_msg = factory.create<dev_msgs::go_msg_t>();
+        auto go_msg = factory.create<dev_msgs::go_msg_t>();
         go_msg.view().signal() = dev_msgs::RUN_MSG_INIT;
 
         CoreCoord virtual_eth_core =
@@ -1361,7 +1361,7 @@ dev_msgs::core_info_msg_t MetalContext::populate_core_info_msg(
     const metal_SocDescriptor& soc_d = cluster_->get_soc_desc(device_id);
     // Use architecture-defined supported PCIe address bounds
     auto factory = hal_->get_dev_msgs_factory(programmable_core_type);
-    dev_msgs::core_info_msg_t buffer = factory.create<dev_msgs::core_info_msg_t>();
+    auto buffer = factory.create<dev_msgs::core_info_msg_t>();
     auto core_info = buffer.view();
     core_info.noc_pcie_addr_base() = hal_->get_pcie_addr_lower_bound();
     core_info.noc_pcie_addr_end() = hal_->get_pcie_addr_upper_bound();

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -20,7 +20,7 @@ uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val) {
         // 0x7FC0  = 0 (sign) 11111111 (exponent) 1000000 (mantissa)
         return UINT16_C(0x7FC0);
     } else {
-        uint32_t U32 = std::bit_cast<uint32_t>(val);
+        auto U32 = std::bit_cast<uint32_t>(val);
         // Rounding bias = 0111 1111 1111 1111 (0x7FFF) if last bit of mantissa ((U32 >> 16) & 1)
         // is 0, otherwise 1000 0000 0000 0000 (0x8000).
         // This ensures that we round to the nearest even number.
@@ -32,7 +32,7 @@ uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val) {
 }  // namespace
 
 bfloat16 bfloat16::truncate(float float_num) {
-    uint32_t U32 = std::bit_cast<uint32_t>(float_num);
+    auto U32 = std::bit_cast<uint32_t>(float_num);
     return std::bit_cast<bfloat16>(static_cast<uint16_t>(U32 >> 16));
 }
 
@@ -110,8 +110,8 @@ std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bo
         float num_1_float = i * 2;
         float num_2_float = (i * 2) + 1;
 
-        bfloat16 num_1_bfloat16 = bfloat16(num_1_float);
-        bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
+        auto num_1_bfloat16 = bfloat16(num_1_float);
+        auto num_2_bfloat16 = bfloat16(num_2_float);
 
         if (print) {
             std::cout << "num_1_float: " << num_1_float << ", num_1_bfloat16 : " << static_cast<float>(num_1_bfloat16)
@@ -148,8 +148,8 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16(
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 
-        bfloat16 num_1_bfloat16 = bfloat16(num_1_float);
-        bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
+        auto num_1_bfloat16 = bfloat16(num_1_float);
+        auto num_2_bfloat16 = bfloat16(num_2_float);
 
         // pack 2 uint16 into uint32
         vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
@@ -174,7 +174,7 @@ std::vector<std::uint32_t> create_constant_vector_of_bfloat16(size_t num_bytes, 
     const size_t num_elements_vec = std::max<size_t>(1ul, num_bytes / sizeof(std::uint32_t));  // always at least have 1
     std::vector<std::uint32_t> vec(num_elements_vec, 0);
     for (size_t i = 0; i < vec.size(); i++) {
-        bfloat16 num_1_bfloat16 = bfloat16(value);
+        auto num_1_bfloat16 = bfloat16(value);
 
         bfloat16 num_2_bfloat16 = num_elements_vec == 1 ? bfloat16(static_cast<float>(0.0)) : bfloat16(value);
 
@@ -206,8 +206,8 @@ std::vector<uint32_t> create_random_binary_vector_of_bfloat16(size_t num_bytes, 
         num_1_float = (num_1_float > 0.5);
         num_2_float = (num_2_float > 0.5);
 
-        bfloat16 num_1_bfloat16 = bfloat16(num_1_float);
-        bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
+        auto num_1_bfloat16 = bfloat16(num_1_float);
+        auto num_2_bfloat16 = bfloat16(num_2_float);
 
         vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
@@ -373,11 +373,11 @@ bool packed_uint32_t_vector_comparison(
         std::pair<bfloat16, bfloat16> as = unpack_two_bfloat16_from_uint32(vec_a.at(i));
         std::pair<bfloat16, bfloat16> bs = unpack_two_bfloat16_from_uint32(vec_b.at(i));
 
-        float a1 = static_cast<float>(as.first);
-        float b1 = static_cast<float>(bs.first);
+        auto a1 = static_cast<float>(as.first);
+        auto b1 = static_cast<float>(bs.first);
 
-        float a2 = static_cast<float>(as.second);
-        float b2 = static_cast<float>(bs.second);
+        auto a2 = static_cast<float>(as.second);
+        auto b2 = static_cast<float>(bs.second);
 
         if (not(comparison_function(a1, b1) and comparison_function(a2, b2))) {
             if (argfail) {

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -28,7 +28,7 @@ uint8_t get_max_exp(const std::vector<uint32_t>& vec, bool is_exp_a) {
         uint32_t exp = (vec[i] & 0x7f800000) >> 23;
 
         if (is_exp_a) {
-            int32_t se = static_cast<int32_t>(exp);
+            auto se = static_cast<int32_t>(exp);
             // need to rebias from 127 to 15
             se = se - 127 + 15;
 
@@ -250,7 +250,7 @@ uint8_t convert_u32_to_bfp(uint32_t input, uint32_t shared_exp, bool is_exp_a) {
     }
 
     if (is_exp_a) {
-        int32_t se = static_cast<int32_t>(exp);
+        auto se = static_cast<int32_t>(exp);
         // rebias
         se = se - 127 + 15;
         // check for saturation
@@ -383,7 +383,7 @@ std::vector<uint32_t> pack_as_bfp_tiles(
                         } else {
                             data_index = fp32_element_index++;
                         }
-                        float float_num = static_cast<float>(input_data[data_index]);
+                        auto float_num = static_cast<float>(input_data[data_index]);
                         uint32_t uint32_num = *reinterpret_cast<uint32_t*>(&float_num);
                         single_row.push_back(uint32_num);
                     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -149,7 +149,7 @@ void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
     uint8_t* data = ptr + offsetof(TileSliceHostDev<0>, data);
 
     // Read any error codes and handle accordingly
-    tt::CBIndex cb = static_cast<tt::CBIndex>(ts->cb_id);
+    auto cb = static_cast<tt::CBIndex>(ts->cb_id);
     switch (ts->return_code) {
         case DPrintOK: break;  // Continue to print the tile slice
         case DPrintErrorBadPointer: {
@@ -159,7 +159,7 @@ void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
             return;
         }
         case DPrintErrorUnsupportedFormat: {
-            tt::DataFormat data_format = static_cast<tt::DataFormat>(ts->data_format);
+            auto data_format = static_cast<tt::DataFormat>(ts->data_format);
             *stream << fmt::format("Tried printing {}: Unsupported data format ({})\n", cb, data_format);
             return;
         }
@@ -187,22 +187,22 @@ void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
                 count_exceeded = true;
                 break;
             }
-            tt::DataFormat data_format = static_cast<tt::DataFormat>(ts->data_format);
+            auto data_format = static_cast<tt::DataFormat>(ts->data_format);
             switch (data_format) {
                 case tt::DataFormat::Float16_b: {
-                    uint16_t* float16_b_ptr = reinterpret_cast<uint16_t*>(data);
+                    auto* float16_b_ptr = reinterpret_cast<uint16_t*>(data);
                     *stream << bfloat16_to_float(float16_b_ptr[i]);
                     break;
                 }
                 case tt::DataFormat::Float32: {
-                    float* float32_ptr = reinterpret_cast<float*>(data);
+                    auto* float32_ptr = reinterpret_cast<float*>(data);
                     *stream << float32_ptr[i];
                     break;
                 }
                 case tt::DataFormat::Bfp4_b:
                 case tt::DataFormat::Bfp8_b: {
                     // Saved the exponent and data together
-                    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(data);
+                    auto* data_ptr = reinterpret_cast<uint16_t*>(data);
                     uint8_t val = (data_ptr[i] >> 8) & 0xFF;
                     uint8_t exponent = data_ptr[i] & 0xFF;
                     uint32_t bit_val = convert_bfp_to_u32(data_format, val, exponent, false);
@@ -210,27 +210,27 @@ void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
                     break;
                 }
                 case tt::DataFormat::Int8: {
-                    int8_t* data_ptr = reinterpret_cast<int8_t*>(data);
+                    auto* data_ptr = reinterpret_cast<int8_t*>(data);
                     *stream << (int)data_ptr[i];
                     break;
                 }
                 case tt::DataFormat::UInt8: {
-                    uint8_t* data_ptr = reinterpret_cast<uint8_t*>(data);
+                    auto* data_ptr = reinterpret_cast<uint8_t*>(data);
                     *stream << (unsigned int)data_ptr[i];
                     break;
                 }
                 case tt::DataFormat::UInt16: {
-                    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(data);
+                    auto* data_ptr = reinterpret_cast<uint16_t*>(data);
                     *stream << (unsigned int)data_ptr[i];
                     break;
                 }
                 case tt::DataFormat::Int32: {
-                    int32_t* data_ptr = reinterpret_cast<int32_t*>(data);
+                    auto* data_ptr = reinterpret_cast<int32_t*>(data);
                     *stream << (int)data_ptr[i];
                     break;
                 }
                 case tt::DataFormat::UInt32: {
-                    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(data);
+                    auto* data_ptr = reinterpret_cast<uint32_t*>(data);
                     *stream << (unsigned int)data_ptr[i];
                     break;
                 }
@@ -878,7 +878,7 @@ bool DPrintServer::Impl::peek_one_risc_non_blocking(
     // Device is filling the buffer and in the end waits on host to write rpos
     auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         chip_id, virtual_core, base_addr, DPRINT_BUFFER_SIZE);
-    DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
+    auto* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
     uint32_t rpos = l->aux.rpos;
     uint32_t wpos = l->aux.wpos;
     if (rpos < wpos) {
@@ -892,7 +892,7 @@ bool DPrintServer::Impl::peek_one_risc_non_blocking(
         constexpr uint32_t bufsize = sizeof(DebugPrintMemLayout::data);
         // parse the input codes
         while (rpos < wpos) {
-            DPrintTypeID code = static_cast<DPrintTypeID>(l->data[rpos++]);
+            auto code = static_cast<DPrintTypeID>(l->data[rpos++]);
             TT_ASSERT(rpos <= bufsize);
             uint8_t sz = l->data[rpos++];
             TT_ASSERT(rpos <= bufsize);

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -57,8 +57,8 @@ void DumpCoreNocData(ChipId device_id, const umd::CoreDescriptor& logical_core, 
         uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
         auto from_dev = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             device_id, virtual_core, addr, DPRINT_BUFFER_SIZE);
-        DebugPrintMemLayout* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
-        uint32_t* data = reinterpret_cast<uint32_t*>(l->data);
+        auto* l = reinterpret_cast<DebugPrintMemLayout*>(from_dev.data());
+        auto* data = reinterpret_cast<uint32_t*>(l->data);
 
         // Append the data for this core to existing data
         for (int idx = 0; idx < NOC_DATA_SIZE; idx++) {

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -142,7 +142,7 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
         switch (cmd_id) {
             case CQ_DISPATCH_CMD_WRITE_LINEAR:
             case CQ_DISPATCH_CMD_WRITE_LINEAR_H: {
-                CQDispatchCmdLarge* cmd_large = reinterpret_cast<CQDispatchCmdLarge*>(cmd);
+                auto* cmd_large = reinterpret_cast<CQDispatchCmdLarge*>(cmd);
                 stride = sizeof(CQDispatchCmdLarge);
                 cq_file << fmt::format(
                     " (num_mcast_dests={}, noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
@@ -154,7 +154,7 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
             } break;
             case CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST:
                 if (cmd->write_linear_host.is_event) {
-                    uint32_t* event_ptr = (uint32_t*)(cmd + 1);
+                    auto* event_ptr = (uint32_t*)(cmd + 1);
                     cq_file << fmt::format(" (completed_event_id={})", *event_ptr);
                 } else {
                     cq_file << fmt::format(" (length={:#010x})", val(cmd->write_linear_host.length));
@@ -233,7 +233,7 @@ uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream&
         iq_file << fmt::format("{:#010x}: {}", cmd_addr, cmd_id);
         switch (cmd_id) {
             case CQ_PREFETCH_CMD_RELAY_LINEAR: {
-                CQPrefetchCmdLarge* cmd_large = (CQPrefetchCmdLarge*)cmd;
+                auto* cmd_large = (CQPrefetchCmdLarge*)cmd;
                 iq_file << fmt::format(
                     " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
                     val(cmd_large->relay_linear.noc_xy_addr),
@@ -346,7 +346,7 @@ void dump_completion_queue_entries(
             read_data.data(), read_data.size(), page_addr, mmio_device_id, channel);
 
         // Check if this page starts with a valid command id
-        CQDispatchCmd* cmd = (CQDispatchCmd*)read_data.data();
+        auto* cmd = (CQDispatchCmd*)read_data.data();
         if (cmd->base.cmd_id < CQ_DISPATCH_CMD_MAX_COUNT && cmd->base.cmd_id > CQ_DISPATCH_CMD_ILLEGAL) {
             if (last_span_invalid) {
                 if (page_addr == last_span_start + DispatchSettings::TRANSFER_PAGE_SIZE) {
@@ -455,7 +455,7 @@ void dump_issue_queue_entries(
         }
 
         // Check for a valid command id
-        CQPrefetchCmd* cmd = (CQPrefetchCmd*)(read_data.data() + page_offset);
+        auto* cmd = (CQPrefetchCmd*)(read_data.data() + page_offset);
         if (cmd->base.cmd_id < CQ_PREFETCH_CMD_MAX_COUNT && cmd->base.cmd_id != CQ_PREFETCH_CMD_ILLEGAL) {
             if (last_span_invalid) {
                 if (curr_addr == last_span_start + hal.get_alignment(HalMemType::HOST)) {
@@ -513,7 +513,7 @@ void dump_issue_queue_entries(
 
                     // Read the dispatch command
                     uint32_t dispatch_page_offset = dispatch_curr_addr % DispatchSettings::TRANSFER_PAGE_SIZE;
-                    CQDispatchCmd* dispatch_cmd = (CQDispatchCmd*)(read_data.data() + dispatch_page_offset);
+                    auto* dispatch_cmd = (CQDispatchCmd*)(read_data.data() + dispatch_page_offset);
                     if (dispatch_cmd->base.cmd_id < CQ_DISPATCH_CMD_MAX_COUNT) {
                         iq_file << "  ";
                         uint32_t dispatch_cmd_stride =

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -122,8 +122,8 @@ void DeviceCommand<hugepage_write>::add_dispatch_wait(
         wait_cmd->wait.count = count;
         wait_cmd->wait.stream = stream;
     };
-    CQPrefetchCmd* relay_wait_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
-    CQDispatchCmd* wait_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* relay_wait_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
+    auto* wait_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_wait{};
@@ -146,7 +146,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_wait_with_prefetch_stall(
         *stall_cmd = {};
         stall_cmd->base.cmd_id = CQ_PREFETCH_CMD_STALL;
     };
-    CQPrefetchCmd* stall_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* stall_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd stall_cmd{};
@@ -166,7 +166,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_linear(uint32_t noc_xy_ad
         relay_linear_cmd->relay_linear.length = lengthB;
         relay_linear_cmd->relay_linear.addr = addr;
     };
-    CQPrefetchCmdLarge* relay_linear_cmd_dst = this->reserve_space<CQPrefetchCmdLarge*>(increment_sizeB);
+    auto* relay_linear_cmd_dst = this->reserve_space<CQPrefetchCmdLarge*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmdLarge relay_linear_cmd{};
@@ -197,7 +197,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_paged(
         relay_paged_cmd->relay_paged.page_size = page_size;
         relay_paged_cmd->relay_paged.pages = pages;
     };
-    CQPrefetchCmd* relay_paged_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* relay_paged_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_paged_cmd{};
@@ -224,7 +224,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_paged_packed(
         relay_paged_cmd->relay_paged_packed.stride = increment_sizeB;
         relay_paged_cmd->relay_paged_packed.count = num_sub_cmds;
     };
-    CQPrefetchCmd* relay_paged_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* relay_paged_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_paged_cmd{};
@@ -245,7 +245,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_paged_to_ringbuffer(
         paged_to_ringbuffer_cmd->base.cmd_id = CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER;
         paged_to_ringbuffer_cmd->paged_to_ringbuffer = paged_to_ringbuffer_info;
     };
-    CQPrefetchCmd* paged_to_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* paged_to_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd paged_to_ringbuffer_cmd{};
@@ -264,7 +264,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_set_ringbuffer_offset(uint32_t 
         set_ringbuffer_offset_cmd->set_ringbuffer_offset.offset = offset;
         set_ringbuffer_offset_cmd->set_ringbuffer_offset.update_wp = update_wp;
     };
-    CQPrefetchCmd* set_ringbuffer_offset_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* set_ringbuffer_offset_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd set_ringbuffer_offset_cmd{};
@@ -288,7 +288,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_ringbuffer(
         relay_ringbuffer_cmd->relay_ringbuffer.stride = increment_sizeB;
     };
 
-    CQPrefetchCmd* relay_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* relay_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_ringbuffer_cmd{};
@@ -312,7 +312,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
     uint32_t write_offset_index) {
     // payload to prefetch relay inline will always be limited to the length of the cmddat queue, i.e. < 64 bits
     // Conversely if data_sizeB > 32-bits, then the data won't be inline
-    uint32_t payload_sizeB = static_cast<uint32_t>(sizeof(CQDispatchCmdLarge) + (flush_prefetch ? data_sizeB : 0));
+    auto payload_sizeB = static_cast<uint32_t>(sizeof(CQDispatchCmdLarge) + (flush_prefetch ? data_sizeB : 0));
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
     auto initialize_write_cmd = [&](CQDispatchCmdLarge* write_cmd) {
@@ -323,7 +323,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
         write_cmd->write_linear.addr = addr;
         write_cmd->write_linear.length = data_sizeB;
     };
-    CQDispatchCmdLarge* write_cmd_dst = this->reserve_space<CQDispatchCmdLarge*>(sizeof(CQDispatchCmdLarge));
+    auto* write_cmd_dst = this->reserve_space<CQDispatchCmdLarge*>(sizeof(CQDispatchCmdLarge));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmdLarge write_cmd{};
@@ -387,7 +387,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_go_signal_mcast(
         mcast_cmd->mcast.noc_data_start_index = noc_data_start_index;
         mcast_cmd->mcast.wait_stream = wait_stream;
     };
-    CQDispatchCmd* mcast_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* mcast_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd mcast_cmd{};
@@ -409,7 +409,7 @@ void DeviceCommand<hugepage_write>::add_notify_dispatch_s_go_signal_cmd(uint8_t 
         sem_update_cmd->notify_dispatch_s_go_signal.wait = wait;
         sem_update_cmd->notify_dispatch_s_go_signal.index_bitmask = index_bitmask;
     };
-    CQDispatchCmd* dispatch_s_sem_update_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* dispatch_s_sem_update_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd dispatch_s_sem_update_cmd{};
         initialize_sem_update_cmd(&dispatch_s_sem_update_cmd);
@@ -442,7 +442,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged(
         write_cmd->write_paged.page_size = page_size;
         write_cmd->write_paged.pages = pages;
     };
-    CQDispatchCmd* write_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* write_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_cmd{};
@@ -478,7 +478,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_host(
             sizeof(CQDispatchCmd) +
             data_sizeB;  // CQ_DISPATCH_CMD_WRITE_LINEAR_HOST writes dispatch cmd back to completion queue
     };
-    CQDispatchCmd* write_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* write_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_cmd{};
@@ -504,7 +504,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_exec_buf(uint32_t base_addr, ui
         exec_buf_cmd->exec_buf.log_page_size = log_page_size;
         exec_buf_cmd->exec_buf.pages = pages;
     };
-    CQPrefetchCmd* exec_buf_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* exec_buf_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd exec_buf_cmd{};
@@ -523,7 +523,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_set_num_worker_sems(
         set_num_worker_sems_cmd->base.cmd_id = CQ_DISPATCH_SET_NUM_WORKER_SEMS;
         set_num_worker_sems_cmd->set_num_worker_sems.num_worker_sems = num_worker_sems;
     };
-    CQDispatchCmd* set_num_worker_sems_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* set_num_worker_sems_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd set_num_worker_sems_cmd{};
         initialize_set_num_worker_sems_cmd(&set_num_worker_sems_cmd);
@@ -557,7 +557,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_set_go_signal_noc_data(
         set_go_signal_noc_data_cmd->base.cmd_id = CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA;
         set_go_signal_noc_data_cmd->set_go_signal_noc_data.num_words = noc_mcast_unicast_data.size();
     };
-    CQDispatchCmd* set_go_signal_noc_data_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* set_go_signal_noc_data_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd set_go_signal_noc_data_cmd{};
         initialize_set_go_signal_noc_data_cmd(&set_go_signal_noc_data_cmd);
@@ -565,7 +565,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_set_go_signal_noc_data(
     } else {
         initialize_set_go_signal_noc_data_cmd(set_go_signal_noc_data_cmd_dst);
     }
-    uint32_t* noc_mcast_unicast_data_dst = this->reserve_space<uint32_t*>(data_sizeB);
+    auto* noc_mcast_unicast_data_dst = this->reserve_space<uint32_t*>(data_sizeB);
     if (data_sizeB > 0) {
         this->memcpy(noc_mcast_unicast_data_dst, noc_mcast_unicast_data.data(), data_sizeB);
     }
@@ -583,7 +583,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_set_write_offsets(tt::stl::Span
         write_offset_cmd->base.cmd_id = CQ_DISPATCH_CMD_SET_WRITE_OFFSET;
         write_offset_cmd->set_write_offset.offset_count = write_offsets.size();
     };
-    CQDispatchCmd* write_offset_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* write_offset_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_offset_cmd{};
@@ -592,7 +592,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_set_write_offsets(tt::stl::Span
     } else {
         initialize_write_offset_cmd(write_offset_cmd_dst);
     }
-    uint32_t* write_offsets_dst = this->reserve_space<uint32_t*>(data_sizeB);
+    auto* write_offsets_dst = this->reserve_space<uint32_t*>(data_sizeB);
     memcpy(write_offsets_dst, write_offsets.data(), data_sizeB);
     this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
 }
@@ -604,7 +604,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_terminate(DispatcherSelect disp
         *terminate_cmd = {};
         terminate_cmd->base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
     };
-    CQDispatchCmd* terminate_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* terminate_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd terminate_cmd{};
@@ -623,7 +623,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_terminate() {
         *terminate_cmd = {};
         terminate_cmd->base.cmd_id = CQ_PREFETCH_CMD_TERMINATE;
     };
-    CQPrefetchCmd* terminate_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+    auto* terminate_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd terminate_cmd{};
@@ -647,8 +647,8 @@ void DeviceCommand<hugepage_write>::add_prefetch_exec_buf_end() {
         exec_buf_end_cmd->base.cmd_id = CQ_DISPATCH_CMD_EXEC_BUF_END;
     };
 
-    CQPrefetchCmd* prefetch_exec_buf_end_cmd_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
-    CQDispatchCmd* dispatch_exec_buf_end_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* prefetch_exec_buf_end_cmd_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
+    auto* dispatch_exec_buf_end_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd prefetch_exec_buf_end_cmd{};
@@ -728,7 +728,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
         write_packed_cmd->write_packed.addr = common_addr;
         write_packed_cmd->write_packed.size = packed_data_sizeB;
     };
-    CQDispatchCmd* write_packed_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* write_packed_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_packed_cmd{};
@@ -807,7 +807,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
         write_packed_cmd->write_packed.addr = common_addr;
         write_packed_cmd->write_packed.size = packed_data_sizeB;
     };
-    CQDispatchCmd* write_packed_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
+    auto* write_packed_cmd_dst = this->reserve_space<CQDispatchCmd*>(sizeof(CQDispatchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_packed_cmd{};
@@ -917,7 +917,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_inline(
         relay_write->relay_inline.length = lengthB;
         relay_write->relay_inline.stride = tt::align(sizeof(CQPrefetchCmd) + lengthB, this->pcie_alignment);
     };
-    CQPrefetchCmd* relay_write_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
+    auto* relay_write_dst = this->reserve_space<CQPrefetchCmd*>(sizeof(CQPrefetchCmd));
 
     if constexpr (hugepage_write) {
         alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_write{};
@@ -955,7 +955,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large_internal(
         write_packed_large_cmd->write_packed_large.write_offset_index = write_offset_index;
     };
     uint32_t sub_cmd_size = tt::align(sizeof(CQDispatchCmd) + sub_cmds_sizeB, this->l1_alignment);
-    CQDispatchCmd* write_packed_large_cmd_dst = this->reserve_space<CQDispatchCmd*>(sub_cmd_size);
+    auto* write_packed_large_cmd_dst = this->reserve_space<CQDispatchCmd*>(sub_cmd_size);
     char* write_packed_large_sub_cmds_dst = (char*)write_packed_large_cmd_dst + sizeof(CQDispatchCmd);
 
     if constexpr (hugepage_write) {

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -189,7 +189,7 @@ public:
     template <typename CommandPtr, bool data = false>
     CommandPtr reserve_space(uint32_t size_to_writeB) {
         this->validate_cmd_write(size_to_writeB);
-        CommandPtr cmd = (CommandPtr)((char*)this->cmd_region + this->cmd_write_offsetB);
+        auto cmd = (CommandPtr)((char*)this->cmd_region + this->cmd_write_offsetB);
         // Only zero out cmds
         if constexpr (!data) {
             if (zero_init_enable) {

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -46,7 +46,7 @@ std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> WorkerConfigBufferM
     sync_info.need_sync = false;
 
     size_t num_buffer_types = this->reservation_.size();
-    constexpr uint32_t active_eth_idx = static_cast<uint32_t>(HalProgrammableCoreType::ACTIVE_ETH);
+    constexpr auto active_eth_idx = static_cast<uint32_t>(HalProgrammableCoreType::ACTIVE_ETH);
     TT_ASSERT(sizes.size() == num_buffer_types);
     for (uint32_t idx = 0; idx < num_buffer_types; idx++) {
         uint32_t free_index = this->free_index_[idx];
@@ -191,7 +191,7 @@ void WorkerConfigBufferMgr::alloc(uint32_t when_freeable_sync_count) {
 uint32_t WorkerConfigBufferMgr::get_last_slot_addr(HalProgrammableCoreType programmable_core_type) const {
     // TODO: support all programmable core types?
     TT_ASSERT(programmable_core_type != HalProgrammableCoreType::IDLE_ETH);
-    uint32_t index = static_cast<uint32_t>(programmable_core_type);
+    auto index = static_cast<uint32_t>(programmable_core_type);
     return this->reservation_[index].addr;
 }
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -185,7 +185,7 @@ void read_events_from_completion_queue(
         mmio_device_id,
         channel);
 
-    CQDispatchCmd* dispatch_cmd = reinterpret_cast<CQDispatchCmd*>(dispatch_cmd_and_event.data());
+    auto* dispatch_cmd = reinterpret_cast<CQDispatchCmd*>(dispatch_cmd_and_event.data());
     uint32_t expected_padding_value = HugepageDeviceCommand::random_padding_value();
     uint16_t expected_pad1 = (device_id << 8) | cq_id;
 

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -416,7 +416,7 @@ void CaptureLightMetalCompare(
 
     // Calculate num uint32_t elements in buffer, and convert golden void* to vector
     size_t golden_data_len = buffer_ptr->size() / sizeof(uint32_t);
-    const uint32_t* golden_data_uint32 = static_cast<const uint32_t*>(golden_data);
+    const auto* golden_data_uint32 = static_cast<const uint32_t*>(golden_data);
     std::vector<uint32_t> golden_data_vector(golden_data_uint32, golden_data_uint32 + golden_data_len);
 
     log_debug(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1028,8 +1028,7 @@ void writeToCoreControlBuffer(IDevice* device, const CoreCoord& virtual_core, co
                                 dev_msgs::profiler_msg_t::Field::control_vector);
     if (useFastDispatch(device)) {
         if (auto mesh_device = device->get_mesh_device()) {
-            distributed::FDMeshCommandQueue& mesh_cq =
-                dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
+            auto& mesh_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
             const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
             const distributed::DeviceMemoryAddress address = {device_coord, virtual_core, control_vector_addr};
             mesh_cq.enqueue_write_shard_to_core(
@@ -1180,8 +1179,7 @@ void DeviceProfiler::readControlBufferForCore(IDevice* device, const CoreCoord& 
                            dev_msgs::profiler_msg_t::Field::control_vector);
     if (useFastDispatch(device)) {
         if (auto mesh_device = device->get_mesh_device()) {
-            distributed::FDMeshCommandQueue& mesh_cq =
-                dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
+            auto& mesh_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
             const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
             const distributed::DeviceMemoryAddress address = {device_coord, virtual_core, control_vector_addr};
             core_control_buffers[virtual_core].resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -470,7 +470,7 @@ void generate_runtime_args_cmds(
             constants.packed_write_max_unicast_sub_cmds,
             no_stride);
         auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
-        uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
+        auto data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
         // Watcher only: pre-fill the RTA payload region with 0xBEEF0000 | rand16
         // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand
         // This makes any unused runtime-arg slots obvious on device (equality tests likely to fail)
@@ -481,7 +481,7 @@ void generate_runtime_args_cmds(
             thread_local static std::mt19937 gen(std::random_device{}());
             std::uniform_int_distribution<int> dist(0, 65535);
             for (uint32_t count = 0; count < total_words; count++) {
-                uint16_t rnd = static_cast<uint16_t>(dist(gen));
+                auto rnd = static_cast<uint16_t>(dist(gen));
                 const uint32_t known_garbage = 0xBEEF0000 | rnd;
                 command_start_ptr[count] = known_garbage;
             }
@@ -509,7 +509,7 @@ void generate_runtime_args_cmds(
             uint32_t offset = 0;
             for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
                 auto& data = rt_args_data[i][j];
-                uint32_t* data_in_sequence =
+                auto* data_in_sequence =
                     (uint32_t*)((char*)runtime_args_command_sequences.back().data() + data_offset + offset);
                 if (data.first.get().rt_args_data == data.second.get().data()) {
                     // Update the pointer to point into the command sequence. Future RTA updates will modify the command
@@ -1145,7 +1145,7 @@ public:
                     if (not using_prefetcher_cache) {
                         uint32_t relayed_bytes =
                             tt::align(kg_transfer_info.lengths[kernel_idx], HostMemDeviceCommand::PROGRAM_PAGE_SIZE);
-                        uint16_t length_adjust = uint16_t(relayed_bytes - kg_transfer_info.lengths[kernel_idx]);
+                        auto length_adjust = uint16_t(relayed_bytes - kg_transfer_info.lengths[kernel_idx]);
                         uint32_t base_address, page_offset;
                         if (kg_transfer_info.page_offsets[kernel_idx] > CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK) {
                             const uint32_t num_banks =

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -610,7 +610,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                                 if (non_contiguous_cbs) {
                                     // ~used_cbs is always nonzero, because otherwise all CBs are in use and therefore
                                     // contiguous.
-                                    uint32_t first_unused_index = (uint32_t)__builtin_ctz(~used_cbs);
+                                    auto first_unused_index = (uint32_t)__builtin_ctz(~used_cbs);
                                     std::string kernels_str;
                                     for (auto id : kernels) {
                                         std::shared_ptr<Kernel> kernel = handle_to_kernel.at(id);

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -66,7 +66,7 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
     // when MeshCommandQueue + CommandQueue are unified under the same API
     if (dynamic_cast<distributed::MeshDevice*>(device_)) {
         // Multi CQ support for MeshDevice is not currently available
-        distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device_);
+        auto* mesh_device = dynamic_cast<distributed::MeshDevice*>(device_);
         for (uint8_t cq_id = 0; cq_id < mesh_device->num_hw_cqs(); ++cq_id) {
             mesh_device->mesh_command_queue(cq_id).reset_worker_state(
                 cq_id == 0,

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -74,7 +74,7 @@ void check_built_dir(const std::filesystem::path& dir_path, const std::filesyste
 
 std::string get_default_root_path() {
     const std::string emptyString;
-    const std::string home_path = parse_env<std::string>("HOME", emptyString);
+    const auto home_path = parse_env<std::string>("HOME", emptyString);
     if (!home_path.empty() && std::filesystem::exists(home_path)) {
         return home_path + "/.cache/tt-metal-cache/";
     } else {

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -59,7 +59,7 @@ std::map<std::string, std::string> initialize_device_kernel_defines(ChipId devic
     std::map<std::string, std::string> device_kernel_defines;
 
     const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
-    const size_t num_dram_banks = static_cast<size_t>(soc_d.get_num_dram_views());
+    const auto num_dram_banks = static_cast<size_t>(soc_d.get_num_dram_views());
     // # of L1 banks needs to match allocator. For L1BankingAllocator this is the # of storage cores. TODO: when
     // allocator is pulled out of device, use it to get that info here.
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -55,7 +55,7 @@ uint64_t Hal::get_pcie_addr_lower_bound() const { return pcie_addr_lower_bound_;
 uint64_t Hal::get_pcie_addr_upper_bound() const { return pcie_addr_upper_bound_; }
 
 uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programmable_core_type_index) const {
-    uint32_t index = static_cast<uint32_t>(programmable_core_type_index);
+    auto index = static_cast<uint32_t>(programmable_core_type_index);
 
     // TODO: this assumes unused entries occur at the end
     // Assumes unused indices go at the end

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -83,7 +83,7 @@ const ll_api::memory& get_risc_binary(
     if (inserted) {
       // We're the first with PATH. Create and insert.
       lock.unlock();
-      ll_api::memory* mutable_ptr = new ll_api::memory(path, loading);
+      auto* mutable_ptr = new ll_api::memory(path, loading);
       if (update_callback) {
           update_callback(*mutable_ptr);
       }

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -99,7 +99,7 @@ void memory::process_spans(
     const std::function<void(std::vector<uint32_t>::const_iterator, uint64_t addr, uint32_t len)>& callback) const {
     uint32_t offset = 0;
     for (const auto& span : link_spans_) {
-        std::vector<uint32_t>::const_iterator cit = data_.cbegin() + offset;
+        auto cit = data_.cbegin() + offset;
         callback(cit, span.addr, span.len);
         offset += span.len;
     }
@@ -109,7 +109,7 @@ void memory::process_spans(
     const std::function<void(std::vector<uint32_t>::iterator, uint64_t addr, uint32_t len)>& callback) {
     uint32_t offset = 0;
     for (const auto& span : link_spans_) {
-        std::vector<uint32_t>::iterator it = data_.begin() + offset;
+        auto it = data_.begin() + offset;
         callback(it, span.addr, span.len);
         offset += span.len;
     }

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -128,8 +128,8 @@ void verify_tiles(
         for (int i = 0; i < TILE_HEIGHT && tile_match; i++) {
             for (int j = 0; j < TILE_WIDTH; j++) {
                 int idx = tile_elem_idx(tile, i, j);
-                float received = static_cast<float>(received_tiles[idx]);
-                float golden = static_cast<float>(golden_tile[(i * TILE_WIDTH) + j]);
+                auto received = static_cast<float>(received_tiles[idx]);
+                auto golden = static_cast<float>(golden_tile[(i * TILE_WIDTH) + j]);
                 if (received != golden) {
                     tile_match = false;
                     break;

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -208,9 +208,9 @@ int main(int argc, char** argv) {
     // Print partial results so we can see the output is correct (plus or minus some error due to BFP16 precision)
     std::cout << "Partial results: (note we are running under BFP16. It's going to be less accurate)\n";
     size_t n = std::min((size_t)10, (size_t)tile_size * n_tiles);
-    bfloat16* a_bf16 = reinterpret_cast<bfloat16*>(a_data.data());
-    bfloat16* b_bf16 = reinterpret_cast<bfloat16*>(b_data.data());
-    bfloat16* c_bf16 = reinterpret_cast<bfloat16*>(c_data.data());
+    auto* a_bf16 = reinterpret_cast<bfloat16*>(a_data.data());
+    auto* b_bf16 = reinterpret_cast<bfloat16*>(b_data.data());
+    auto* c_bf16 = reinterpret_cast<bfloat16*>(c_data.data());
     for (int i = 0; i < n; i++) {
         std::cout << "  " << static_cast<float>(a_bf16[i]) << " + " << static_cast<float>(b_bf16[i]) << " = "
                   << static_cast<float>(c_bf16[i]) << "\n";

--- a/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
@@ -171,7 +171,7 @@ int main() {
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
         for (size_t i = 0; i < result_vec.size(); ++i) {
             const float expected = static_cast<float>(a_data[i]) + val_to_add;
-            const float actual = static_cast<float>(result_vec[i]);
+            const auto actual = static_cast<float>(result_vec[i]);
             if (std::abs(expected - actual) > eps) {
                 pass = false;
                 fmt::print(stderr, "Result mismatch at index {}: expected {}, got {}\n", i, expected, actual);

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -156,7 +156,7 @@ int main(int /*argc*/, char** /*argv*/) {
                 return x * x * (3 - 2 * x);
             };
             const float expected = smoothstep(0.0f, 1.0f, static_cast<float>(a_data[i]));
-            const float actual = static_cast<float>(result_vec[i]);
+            const auto actual = static_cast<float>(result_vec[i]);
 
             if (std::abs(expected - actual) > eps) {
                 pass = false;

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -153,8 +153,8 @@ int main() {
 
     // Print partial results so we can see the output is correct (plus or minus some error due to BFP16 precision)
     std::cout << "Partial results: (note we are running under BFP16. It's going to be less accurate)\n";
-    bfloat16* c_bf16 = reinterpret_cast<bfloat16*>(result_data.data());
-    bfloat16* golden_bf16 = reinterpret_cast<bfloat16*>(golden_data.data());
+    auto* c_bf16 = reinterpret_cast<bfloat16*>(result_data.data());
+    auto* golden_bf16 = reinterpret_cast<bfloat16*>(golden_data.data());
 
     size_t num_failures = 0;
     auto total_values = result_data.size() * 2;

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -164,7 +164,7 @@ int main(int /*argc*/, char** /*argv*/) {
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
         for (size_t i = 0; i < result_vec.size(); ++i) {
             const float expected = static_cast<float>(a_data[i]) + val_to_add;
-            const float actual = static_cast<float>(result_vec[i]);
+            const auto actual = static_cast<float>(result_vec[i]);
 
             if (std::abs(expected - actual) > eps) {
                 pass = false;

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -147,7 +147,7 @@ int main() {
         constexpr float eps = 5e-2f;
         for (uint32_t i = 0; i < result_vec.size(); ++i) {
             float expected = static_cast<float>(bfloat16(std::exp(static_cast<float>(src0_vec[i]))));
-            float result = static_cast<float>(result_vec[i]);
+            auto result = static_cast<float>(result_vec[i]);
             if (std::abs(expected - result) > eps) {
                 pass = false;
                 fmt::print(stderr, "Result mismatch at index {}: {} != {}\n", i, expected, result);

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -36,13 +36,13 @@ int main() {
     std::vector<uint32_t> src_vec(src_num_values_packed, 0);
     // source vector = {1, 2, 3, ... , 30, 31, 32,   2048}
     for (uint32_t i = 0; i < src_vec.size(); i++) {
-        bfloat16 bfloat_val1 = bfloat16((2 * i) + 1);
-        bfloat16 bfloat_val2 = bfloat16((2 * i) + 2);
+        auto bfloat_val1 = bfloat16((2 * i) + 1);
+        auto bfloat_val2 = bfloat16((2 * i) + 2);
         src_vec[i] = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat_val1, bfloat_val2));
     }
 
     // create pad vector
-    bfloat16 pad_value = bfloat16(2);
+    auto pad_value = bfloat16(2);
     std::vector<uint32_t> pad_vec(
         1, pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(pad_value, pad_value)));
 

--- a/tt_metal/tools/mem_bench/host_utils.hpp
+++ b/tt_metal/tools/mem_bench/host_utils.hpp
@@ -63,9 +63,9 @@ double copy_to_hugepage(
     size_t total_size,
     size_t page_size,
     bool repeating_src_vector) {
-    uint64_t hugepage_addr = reinterpret_cast<uint64_t>(hugepage_base);
+    auto hugepage_addr = reinterpret_cast<uint64_t>(hugepage_base);
     uint64_t hugepage_end = hugepage_addr + hugepage_size;
-    uint64_t src_addr = reinterpret_cast<uint64_t>(src_data.data());
+    auto src_addr = reinterpret_cast<uint64_t>(src_data.data());
     size_t num_pages;
     if (!page_size) {
         num_pages = 1;

--- a/tt_stl/tests/test_small_vector.cpp
+++ b/tt_stl/tests/test_small_vector.cpp
@@ -508,7 +508,7 @@ TEST(SmallVectorEdgeCaseTest, OverAlignedTypesAreProperlyAllocated) {
     // vector's storage.  We check the returned data pointer alignment.
     SmallVector<OverAligned, 2> vec;
     vec.emplace_back(7);
-    std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(vec.data());
+    auto ptrVal = reinterpret_cast<std::uintptr_t>(vec.data());
     EXPECT_EQ(ptrVal % alignof(OverAligned), 0u);
     vec.emplace_back(9);
 

--- a/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
+++ b/tt_stl/tt_stl/llvm/llvm_small_vector.hpp
@@ -753,7 +753,7 @@ public:
 
     iterator erase(const_iterator CI) {
         // Just cast away constness because this is a non-const member function.
-        iterator I = const_cast<iterator>(CI);
+        auto I = const_cast<iterator>(CI);
 
         assert(this->isReferenceToStorage(CI) && "Iterator to erase is out of bounds.");
 
@@ -767,8 +767,8 @@ public:
 
     iterator erase(const_iterator CS, const_iterator CE) {
         // Just cast away constness because this is a non-const member function.
-        iterator S = const_cast<iterator>(CS);
-        iterator E = const_cast<iterator>(CE);
+        auto S = const_cast<iterator>(CS);
+        auto E = const_cast<iterator>(CE);
 
         assert(this->isRangeInStorage(S, E) && "Range to erase is out of bounds.");
 

--- a/ttnn/core/tensor/layout/tensor_layout.cpp
+++ b/ttnn/core/tensor/layout/tensor_layout.cpp
@@ -255,7 +255,7 @@ size_t TensorLayout::compute_consumed_memory_bytes_per_bank(
             physical_shape.height() * physical_shape.width() / page_shape.height() / page_shape.width();
         num_pages_per_bank = div_up(num_pages, num_banks);
     } else if (const auto& shard_spec = memory_config_.shard_spec()) {
-        Shape2D shard_shape = Shape2D(shard_spec->shape);
+        auto shard_shape = Shape2D(shard_spec->shape);
         num_pages_per_bank =
             div_up(shard_shape.height(), page_shape.height()) * div_up(shard_shape.width(), page_shape.width());
     } else {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -489,7 +489,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
         tensor_spec.tensor_layout().get_memory_config());
 
     Tensor output;
-    distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
+    auto* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
     output = allocate_tensor_on_device(tensor_spec, mesh_device);
     output = tt::tt_metal::set_tensor_id(output);
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -327,7 +327,7 @@ bool should_use_scientific_notation(tt::stl::Span<const T> buffer) {
         bool found_nonzero_finite = false;
 
         for (const auto& value : buffer) {
-            double val = static_cast<double>(value);
+            auto val = static_cast<double>(value);
             if (std::isfinite(val) && val != 0.0) {
                 double abs_val = std::abs(val);
                 nonzero_finite_min = std::min(nonzero_finite_min, abs_val);

--- a/ttnn/cpp/ttnn-nanobind/bfloat16_type_caster.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bfloat16_type_caster.hpp
@@ -27,7 +27,7 @@ struct type_caster<::bfloat16> {
             this->value = bfloat16(nanobind::cast<float>(src));
             return true;
         } else if (isinstance<nanobind::int_>(src)) {
-            std::int32_t int_value = nanobind::cast<std::int32_t>(src);
+            auto int_value = nanobind::cast<std::int32_t>(src);
             this->value = ::bfloat16(int_value);
             return true;
         }

--- a/ttnn/cpp/ttnn-nanobind/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/core.cpp
@@ -91,7 +91,7 @@ void py_module(nb::module_& mod) {
                     auto cmp = [](const auto& a, const auto& b) -> bool {
                         return ttsl::ascii_caseless_comp(std::string_view(a), std::string_view(b));
                     };
-                    const std::string sci_mode_str = nb::cast<std::string>(sci_mode);
+                    const auto sci_mode_str = nb::cast<std::string>(sci_mode);
                     if (cmp(sci_mode_str, "true")) {
                         sci_mode_enum = ttnn::SciMode::Enable;
                     } else if (cmp(sci_mode_str, "false")) {

--- a/ttnn/cpp/ttnn-nanobind/profiler.cpp
+++ b/ttnn/cpp/ttnn-nanobind/profiler.cpp
@@ -73,7 +73,7 @@ void ProfilerModule(nb::module_& mod) {
         .def("__eq__", &ttm::ProgramAnalysisData::operator==)
         .def("__lt__", &ttm::ProgramAnalysisData::operator<)
         .def("__repr__", [](const ttm::ProgramAnalysisData& data) {
-            const std::string uid_repr = nb::cast<std::string>(nb::repr(nb::cast(data.program_execution_uid)));
+            const auto uid_repr = nb::cast<std::string>(nb::repr(nb::cast(data.program_execution_uid)));
             return fmt::format(
                 "ProgramAnalysisData(program_execution_uid={}, program_analyses_results_size={}, core_count={}, "
                 "num_available_cores={})",

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -460,7 +460,7 @@ nb::ndarray<Framework> convert_tt_tensor_to_framework_tensor(RowMajorHostBuffer&
     auto shape_vec = ttnn_shape_to_ndarray(row_major_host_buffer.shape);
 
     // HostBuffer usage like this is shallow copy
-    HostBuffer* buffer = new HostBuffer{row_major_host_buffer.buffer};
+    auto* buffer = new HostBuffer{row_major_host_buffer.buffer};
 
     nb::capsule owner(buffer, [](void* p) noexcept { delete static_cast<HostBuffer*>(p); });
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -137,7 +137,7 @@ AllBroadcastProgramFactory::cached_program_t AllBroadcastProgramFactory::create_
             .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
 
     uint32_t buffer_page_size = page_size;
-    uint32_t num_packets_per_page =
+    auto num_packets_per_page =
         static_cast<uint32_t>(std::ceil(static_cast<double>(buffer_page_size) / max_packet_size));
     if (!tilized) {
         if (num_width_shards > 1) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -77,7 +77,7 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     const auto& mesh_view = mesh_device->get_view();
 
     const auto fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
-    const uint32_t src_chip_id = (uint32_t)fabric_node_id.chip_id;
+    const auto src_chip_id = (uint32_t)fabric_node_id.chip_id;
 
     const auto& mapping_shape = mapping_tensor.tensor_spec().logical_shape();
     const auto& metadata_shape = metadata_tensor.tensor_spec().logical_shape();

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -142,7 +142,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
 
     auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
     uint32_t src_mesh_id = *src_fabric_node_id.mesh_id;
-    uint32_t src_chip_id = (uint32_t)src_fabric_node_id.chip_id;
+    auto src_chip_id = (uint32_t)src_fabric_node_id.chip_id;
     uint32_t linearized_mesh_coord = common::get_linearized_index(mesh_coordinate, mesh_view);
 
     log_debug(

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
@@ -134,7 +134,7 @@ BroadcastProgramFactory::cached_program_t BroadcastProgramFactory::create_at(
             .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
 
     uint32_t buffer_page_size = page_size;
-    uint32_t num_packets_per_page =
+    auto num_packets_per_page =
         static_cast<uint32_t>(std::ceil(static_cast<double>(buffer_page_size) / max_packet_size));
     if (!tilized) {
         if (num_width_shards > 1) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1153,8 +1153,9 @@ std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::create_worker_slic
     // Assign slices by assuming that the input tensor is flattened into a 1D Shape
     // Cast to double before division to ensure ceil() rounds up properly.
     // Example: 10 tiles / 3 workers: was ceil(3)=3, now ceil(3.33)=4 tiles per worker.
-    std::size_t optim_worker_slice_len_tiles = static_cast<std::size_t>(
-        ceil(static_cast<double>(total_num_tiles) / num_workers));  // Ceil so that the remainder worker will have a smaller slice
+    auto optim_worker_slice_len_tiles = static_cast<std::size_t>(ceil(
+        static_cast<double>(total_num_tiles) /
+        num_workers));  // Ceil so that the remainder worker will have a smaller slice
 
     if (max_slice_size_in_tiles < optim_worker_slice_len_tiles) {  // Each worker will have a full slice
         for (uint32_t w = 0; w < num_workers; ++w) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -138,7 +138,7 @@ std::pair<const mapping_table_t* const, uint32_t> get_shard_map(uint32_t L1_addr
     // returns a pair where .first holds the shard array map
     // and .second holds the size of the map
     constexpr ShardingInfoType CONSTANT_ARGS{};
-    const mapping_table_t* const map = reinterpret_cast<const mapping_table_t* const>(L1_address);
+    const auto* const map = reinterpret_cast<const mapping_table_t* const>(L1_address);
     constexpr uint32_t incrementation = ((CONSTANT_ARGS.number_of_cores - 1) / 2) + 1;
     return std::pair<const mapping_table_t* const, uint32_t>(map, incrementation);
 }

--- a/ttnn/cpp/ttnn/operations/compute_throttle_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/compute_throttle_utils.cpp
@@ -56,7 +56,7 @@ void throttle_mm_perf(
     // bound)
     const bool mm_throttle_env_enabled = std::getenv("TT_MM_THROTTLE_PERF");
 
-    uint32_t uint_throttle_level = static_cast<uint32_t>(throttle_level);
+    auto uint_throttle_level = static_cast<uint32_t>(throttle_level);
 
     // If environment variable is set, this overrides the throttle level parameter
     if (mm_throttle_env_enabled) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -984,7 +984,7 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
     MeshDevice* device) {
     Conv2dConfig conv_config = conv_config_;
 
-    Conv2dSliceAttr* op_slice_attr = new Conv2dSliceAttr(
+    auto* op_slice_attr = new Conv2dSliceAttr(
         batch_size,
         {input_height, input_width},
         in_channels,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -63,7 +63,7 @@ std::vector<CBInfo> get_cb_info(
     bool is_1d_depthwise_conv,
     bool skip_act_cb_create,
     uint32_t input_channels_padded) {
-    const uint32_t num_cbs = static_cast<uint32_t>(Conv2dCb::COUNT);
+    const auto num_cbs = static_cast<uint32_t>(Conv2dCb::COUNT);
     std::vector<CBInfo> cb_info;
     cb_info.reserve(num_cbs);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -171,12 +171,12 @@ Conv2dDeviceOperation::create_op_performance_model(
     uint32_t conv_activation_h = input_tensor_a_shape[1];
     uint32_t conv_activation_w = input_tensor_a_shape[2];
     uint32_t conv_activation_c = input_tensor_a_shape[3];
-    uint32_t filter_h = (uint32_t)args.sliding_window_config.window_hw.first;   // filter_h
-    uint32_t filter_w = (uint32_t)args.sliding_window_config.window_hw.second;  // filter_W
-    uint32_t stride_h = (uint32_t)args.sliding_window_config.stride_hw.first;
-    uint32_t stride_w = (uint32_t)args.sliding_window_config.stride_hw.second;
-    uint32_t dilation_h = (uint32_t)args.sliding_window_config.dilation_hw.first;
-    uint32_t dilation_w = (uint32_t)args.sliding_window_config.dilation_hw.second;
+    auto filter_h = (uint32_t)args.sliding_window_config.window_hw.first;   // filter_h
+    auto filter_w = (uint32_t)args.sliding_window_config.window_hw.second;  // filter_W
+    auto stride_h = (uint32_t)args.sliding_window_config.stride_hw.first;
+    auto stride_w = (uint32_t)args.sliding_window_config.stride_hw.second;
+    auto dilation_h = (uint32_t)args.sliding_window_config.dilation_hw.first;
+    auto dilation_w = (uint32_t)args.sliding_window_config.dilation_hw.second;
 
     const CoreCoord compute_grid = output_tensor.device()->compute_with_storage_grid_size();
     const int num_cores = compute_grid.x * compute_grid.y;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -291,11 +291,11 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
     const ttnn::Shape ashape_with_channels_padded({ashape[0], ashape[1], ashape[2], input_channels_padded});
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     const uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
-    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
-    uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
-    const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
-    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const auto filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    const auto filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    auto pad_w = (uint32_t)sliding_window_config.get_pad_w();
+    const auto dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
+    const auto dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
     const uint32_t stride_h = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.first;
     const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -24,8 +24,8 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
     const ttnn::operations::sliding_window::SlidingWindowConfig& sliding_window_config,
     uint32_t num_cores_nhw,
     uint32_t act_block_h_ntiles) {
-    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
-    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    auto filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    auto filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
     auto output_shape = sliding_window_config.get_output_shape();
     uint32_t batch_size = output_shape[0];
     uint32_t conv_output_h = output_shape[1];
@@ -132,13 +132,13 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
 
-    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
-    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    const auto filter_h = (uint32_t)sliding_window_config.window_hw.first;   // filter_h
+    const auto filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
     const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
-    const uint32_t dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
-    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
+    const auto dilation_h = (uint32_t)sliding_window_config.dilation_hw.first;
+    const auto dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
 
-    uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
+    auto pad_w = (uint32_t)sliding_window_config.get_pad_w();
 
     uint32_t input_size_w = conv_act_size_w + pad_w;
     if (sliding_window_config.is_transpose) {
@@ -154,8 +154,8 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         "Activation matrix shape must have 3 dimensions but got {}",
         act_matrix_shape.size());
     TT_FATAL(act_matrix_shape[0] == 1, "Activation matrix first dimension must be 1 but got {}", act_matrix_shape[0]);
-    uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
-    uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
+    auto act_matrix_height = (uint32_t)act_matrix_shape[1];
+    auto act_matrix_width = (uint32_t)act_matrix_shape[2];
 
     // TODO: Move all these TT_FATALs/checks to validate?
 
@@ -270,7 +270,7 @@ Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFact
         "output_channels_padded_to_tile_width {} should be less than or equal to weight_matrix_width {}",
         output_channels_padded_to_tile_width,
         weight_matrix_width);
-    uint32_t num_blocks_output_w =
+    auto num_blocks_output_w =
         (uint32_t)std::ceil((double)output_channels_padded_to_tile_width / (double)weight_block_w_datums);
     uint32_t last_block_width_datums = (output_channels_padded_to_tile_width % weight_block_w_datums == 0)
                                            ? weight_block_w_datums

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -1033,7 +1033,7 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv_transpose2d_slice_attr(
     MeshDevice* device,
     bool mirror_kernel) {
     Conv2dConfig conv_config = conv_config_;
-    ConvT2DSliceAttr* op_slice_attr = new ConvT2DSliceAttr(
+    auto* op_slice_attr = new ConvT2DSliceAttr(
         batch_size,
         {input_height, input_width},
         in_channels,

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -539,8 +539,8 @@ uint16_t float_to_uint16(float f) {
     }
 
     // Handle overflow and underflow
-    const float max_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::max());
-    const float min_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::min());
+    const auto max_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::max());
+    const auto min_uint16 = static_cast<float>(std::numeric_limits<uint16_t>::min());
     if (f >= max_uint16) {
         return std::numeric_limits<uint16_t>::max();
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -258,7 +258,7 @@ uint32_t calculate_max_tensors_per_concat(const std::vector<Tensor>& input_tenso
 
         // Safety margin: reduce by 10% for sharded due to potential additional overhead
         uint32_t theoretical_max = (effective_args_limit - base_args) / args_per_tensor;
-        uint32_t safe_max = static_cast<uint32_t>(theoretical_max * 0.9);
+        auto safe_max = static_cast<uint32_t>(theoretical_max * 0.9);
 
         log_debug(
             tt::LogOp, "ttnn.concat: Sharded concat - theoretical_max = {}, safe_max = {}", theoretical_max, safe_max);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -52,7 +52,7 @@ FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const bool src_is_dram = tens_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
 
     // pack bf16 vals
-    uint32_t packed_fill_value = static_cast<std::uint32_t>(fill_value);
+    auto packed_fill_value = static_cast<std::uint32_t>(fill_value);
     if (input_tensor.dtype() == DataType::BFLOAT16) {
         packed_fill_value = pack_two_bfloat16_into_uint32({bfloat16(fill_value), bfloat16(fill_value)});
     } else if (input_tensor.dtype() == DataType::UINT16) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.cpp
@@ -47,7 +47,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
     uint32_t H_padded = output_shape[2], C_padded = output_shape[1];
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> start_dim_offset(num_dims, 0);
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -59,7 +59,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     uint32_t H_padded = output_shape[2], C_padded = output_shape[1];
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> start_dim_offset(num_dims, 0);
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_padded);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -79,7 +79,7 @@ PadRmShardedWidthOnlyProgramFactory::cached_program_t PadRmShardedWidthOnlyProgr
 
     uint32_t padding_value_as_u32;
     if (input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16) {
-        uint16_t bfloat_pad_value_bits = std::bit_cast<uint16_t>(bfloat16(pad_value));
+        auto bfloat_pad_value_bits = std::bit_cast<uint16_t>(bfloat16(pad_value));
         padding_value_as_u32 = *reinterpret_cast<uint32_t*>(&bfloat_pad_value_bits);
     } else if (input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32) {
         padding_value_as_u32 = *reinterpret_cast<const uint32_t*>(&pad_value);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -73,7 +73,7 @@ PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory:
     Buffer* output_buffer = output.buffer();
     TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    auto bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -92,7 +92,7 @@ std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_re
                 it += stride_size;
             } else {
                 const auto start_core = it->value().first;
-                Stride stride = Stride{.core = {0, 0}, .data = 0};
+                auto stride = Stride{.core = {0, 0}, .data = 0};
                 if ((it + 1) == end) {
                     ret_map[output_core].push_back(PageStride{
                         .start_core = start_core,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -37,7 +37,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -58,7 +58,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     auto input_shape = input_tensor.padded_shape();
     auto output_shape = output_tensor.padded_shape();
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -39,7 +39,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     const auto& input_shape = input_tensor.padded_shape();
     const auto& output_shape = output_tensor.padded_shape();
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
@@ -194,7 +194,7 @@ SliceTileProgramFactory::cached_program_t SliceTileProgramFactory::create(
             .set_page_size(src0_cb_index, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input.padded_shape().rank());
+    auto num_dims = static_cast<std::uint32_t>(input.padded_shape().rank());
 
     // Reader compile-time args
     // Data is 32 byte aligned

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -40,7 +40,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tensor_args(
     const auto& input_shape = input_tensor.padded_shape();
     const auto& output_shape = output_tensor.padded_shape();
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
@@ -222,7 +222,7 @@ SliceTileTensorArgsProgramFactory::cached_program_t SliceTileTensorArgsProgramFa
             .set_page_size(tensor_cb_index, single_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_tensor_config);
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
+    auto num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_width = tile_shape[1];
     uint32_t tile_height = tile_shape[0];

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -18,10 +18,10 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
             using T = std::decay_t<decltype(pad_value)>;
             if constexpr (std::is_same_v<T, float>) {
                 if (tensor.dtype() == DataType::BFLOAT16) {
-                    bfloat16 bfloat_pad_value = bfloat16((pad_value));
+                    auto bfloat_pad_value = bfloat16((pad_value));
                     return pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
                 } else if (tensor.dtype() == DataType::UINT16) {
-                    uint16_t uint16_pad_value = static_cast<uint16_t>(pad_value);
+                    auto uint16_pad_value = static_cast<uint16_t>(pad_value);
                     return pack_two_uint16_into_uint32({uint16_pad_value, uint16_pad_value});
                 } else {
                     TT_FATAL(
@@ -32,10 +32,10 @@ uint32_t get_packed_value(const Tensor& tensor, const PadValue& pad_value) {
                 }
             } else if constexpr (std::is_same_v<T, uint32_t>) {
                 if (tensor.dtype() == DataType::BFLOAT16) {
-                    bfloat16 bfloat_pad_value = bfloat16((float)(pad_value));
+                    auto bfloat_pad_value = bfloat16((float)(pad_value));
                     return pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
                 } else if (tensor.dtype() == DataType::UINT16) {
-                    uint16_t uint16_pad_value = static_cast<uint16_t>(pad_value);
+                    auto uint16_pad_value = static_cast<uint16_t>(pad_value);
                     return pack_two_uint16_into_uint32({uint16_pad_value, uint16_pad_value});
                 } else {
                     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_interleaved_program_factory.cpp
@@ -96,7 +96,7 @@ TilizeWithValPaddingMultiCoreInterleavedFactory::create(
      */
     uint32_t packed_pad_value = detail::get_packed_value(a, operation_attributes.pad_value);
     // log2(TILE_WIDTH * data_format_size_in_bytes)
-    uint32_t shift_bits = static_cast<uint32_t>(std::log2(
+    auto shift_bits = static_cast<uint32_t>(std::log2(
         a.element_size() *
         TILE_HEIGHT));  // This gives log2 of bytes per tile row, so in the kernel we
                         // can shift right by this to get number of tiles.

--- a/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.cpp
@@ -10,7 +10,7 @@ namespace ttnn::operations::data_movement {
 ttnn::Tensor UnsqueezeOperation::invoke(const ttnn::Tensor& input_tensor, const int dim) {
     const auto& tensor_shape = input_tensor.logical_shape();
     const uint32_t rank = tensor_shape.rank();
-    const int32_t max_dim = (int)(rank);
+    const auto max_dim = (int)(rank);
     const int32_t min_dim = -(max_dim)-1;
 
     SmallVector<uint32_t> output_shape_vector;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -94,7 +94,7 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
         src_sharded ? a.buffer() : nullptr);
 
     uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
-    uint32_t aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
+    auto aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
     uint32_t output_cb_index;
     CBHandle cb_output;
     std::tie(output_cb_index, cb_output) = create_cb(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -750,7 +750,7 @@ Tensor ExecutePower::invoke(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& output_tensor) {
     TT_FATAL(exponent >= 0.0f, "works for positive exponents only");
-    const uint32_t exponent_floor = static_cast<uint32_t>(std::floor(exponent));
+    const auto exponent_floor = static_cast<uint32_t>(std::floor(exponent));
     if (static_cast<float>(exponent_floor) == exponent) {
         if (output_tensor.has_value()) {
             ttnn::power(input_a, exponent_floor, output_mem_config, output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -165,7 +165,7 @@ void check_zero_point_tensor_args(
 ttnn::Tensor reshape_per_channel_vector_args(
     const ttnn::Tensor& vector, ttnn::Shape tensor_shape, const int32_t axis, const ttnn::DataType out_dtype) {
     // This function is internal use only, use asserts instead of TT_FATAL to convey intented usage
-    const int32_t rank = static_cast<int32_t>(tensor_shape.rank());
+    const auto rank = static_cast<int32_t>(tensor_shape.rank());
     assert(axis >= -rank && axis < rank);
     assert(vector.logical_shape().rank() == 1);
     assert(vector.logical_volume() == tensor_shape[axis]);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -107,7 +107,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         op_type);
     // TODO don't cast T to float when precision needs to be preserved
     const T param0_raw = params[0];
-    float param0 = static_cast<float>(params[0]);
+    auto param0 = static_cast<float>(params[0]);
     switch (op_type) {
         case UnaryOpType::FILL:
             if (input_dtype == DataType::INT32) {
@@ -220,7 +220,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 fmt::format("exp_tile_init<{}u>();", (uint32_t)param0),
                 fmt::format("exp_tile<{1}u>({0});", idst, (uint32_t)param0)};
         case UnaryOpType::SIGMOID: {
-            uint32_t param1 = (uint32_t)params[1];
+            auto param1 = (uint32_t)params[1];
             TT_FATAL(
                 (int32_t)param0 == (int32_t)VecMode::C || (int32_t)param0 == (int32_t)VecMode::RC,
                 "Invalid Vector mode value. Expected vector mode C (2) or RC (4) for sigmoid");

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -144,7 +144,7 @@ GroupingResult group_and_coalesce_transfers(
     // This is critical because the compute kernel expects total_num_blocks blocks from each core
     const uint32_t expected_blocks_per_core = blocked_result.num_logical_blocks;
     for (size_t core_idx = 0; core_idx < per_core_blocked_gather_transfers.size(); core_idx++) {
-        uint32_t core_blocks = static_cast<uint32_t>(per_core_blocked_gather_transfers[core_idx].size());
+        auto core_blocks = static_cast<uint32_t>(per_core_blocked_gather_transfers[core_idx].size());
         TT_FATAL(
             core_blocks == expected_blocks_per_core,
             "Core {} has {} blocks but expected {} blocks per core. "

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -456,7 +456,7 @@ std::vector<BlockedTransferGroup> group_transfers_by_output_column_blocks(
     // Compute per-core output row width (number of columns in each [C x (B*HW_per_core)] shard)
     TT_FATAL(output.is_sharded(), "Output tensor must be sharded for gather operation");
     const auto& output_shard_spec2 = output.shard_spec().value();
-    uint32_t output_shard_width =
+    auto output_shard_width =
         static_cast<uint32_t>(output_shard_spec2.shape[0]);  // columns per output core = B*HW_per_core
 
     // Call the unified implementation and return only the blocked transfers

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -224,10 +224,10 @@ DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
     // -------------------------------------------------------------------------
     // 4) Create compute kernels for dropout
     // -------------------------------------------------------------------------
-    uint32_t uscale = std::bit_cast<uint32_t>(args.scale);
+    auto uscale = std::bit_cast<uint32_t>(args.scale);
 
     // Convert probability (args.prob) to integer representation
-    uint32_t prob_int = static_cast<uint32_t>(static_cast<double>(INT_MAX) * args.prob);
+    auto prob_int = static_cast<uint32_t>(static_cast<double>(INT_MAX) * args.prob);
 
     // Group 1 compile-time arguments
     std::vector<uint32_t> compute_group_1_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -130,7 +130,7 @@ static inline CoreCoord clamped_prev(const std::vector<CoreCoord>& order, uint32
 }
 
 static inline CoreCoord clamped_next(const std::vector<CoreCoord>& order, uint32_t index) {
-    const uint32_t last = static_cast<uint32_t>(order.size() - 1);
+    const auto last = static_cast<uint32_t>(order.size() - 1);
     return order.at(index >= last ? last : index + 1);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.cpp
@@ -60,7 +60,7 @@ get_padded_slice_runtime_args_rm_sharded_output(
         input_row_size_bytes,
         input_page_size,
         output_row_size_bytes);
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.cpp
@@ -73,7 +73,7 @@ get_padded_slice_runtime_args_tile_sharded_output(
 
     uint32_t input_channels_num_elems = input_padded_shape[3];
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
     std::vector<uint32_t> num_output_tiles_per_dim(num_dims);
     std::vector<uint32_t> num_input_tiles_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
@@ -48,7 +48,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
     uint32_t input_row_size_bytes = input_shape[-1] * input_tensor.element_size();
     bool strided = std::any_of(stride.cbegin(), stride.cend(), [](int val) { return val != 1; });
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -55,7 +55,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
     uint32_t output_row_size_bytes = output_shape[-1] * input_tensor.element_size();
     uint32_t input_row_size_bytes = input_shard_shape[1] * input_tensor.element_size();
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
@@ -245,7 +245,7 @@ SliceWriteRMShardedInputProgramFactory::cached_program_t SliceWriteRMShardedInpu
 
     const uint32_t src0_cb_index = tt::CBIndex::c_0;
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -54,7 +54,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
 
     uint32_t num_cores_channels = get_num_cores_channels_from_sharded_tensor(input_tensor);
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(actual_input_shape.rank());
+    auto num_dims = static_cast<std::uint32_t>(actual_input_shape.rank());
     std::vector<uint32_t> num_output_tiles_per_dim(num_dims);
     std::vector<uint32_t> num_input_tiles_per_dim(num_dims);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -207,7 +207,7 @@ RotaryEmbeddingProgramFactory::cached_program_t RotaryEmbeddingProgramFactory::c
         compute_kernel_defines["DECODE_MODE"] = "1";
     }
 
-    const uint16_t bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
+    const auto bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
 
     auto* src_buffer = input.buffer();
     auto* cos_buffer = cos.buffer();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_program_factory.cpp
@@ -67,7 +67,7 @@ RotateHalfProgramFactory::cached_program_t RotateHalfProgramFactory::create(
     CreateCircularBuffer(program, core_range, cb_output_config);
     const uint32_t output_no_mul_cb_index = src_no_mul_cb_index;
 
-    const uint16_t bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
+    const auto bfloat16_scalar = std::bit_cast<uint16_t>(bfloat16(-1.0f));
 
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/elemwise_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/program_factory/elemwise_factory_common.hpp
@@ -49,7 +49,7 @@ inline void set_eltwise_ternary_runtime_args(
         }
     }
 
-    uint32_t num_tiles = static_cast<uint32_t>(condition_tensor.physical_volume() / TILE_HW);
+    auto num_tiles = static_cast<uint32_t>(condition_tensor.physical_volume() / TILE_HW);
     bool row_major = true;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         zero_start_grid ? tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
@@ -64,7 +64,7 @@ MorehArangeOperation::spec_return_value_t MorehArangeOperation::compute_output_s
         return tensor_args.output->tensor_spec();
     }
 
-    uint32_t num_elems = static_cast<uint32_t>(
+    auto num_elems = static_cast<uint32_t>(
         std::ceil((operation_attributes.end - operation_attributes.start) / operation_attributes.step));
 
     if (operation_attributes.untilize_out) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -49,7 +49,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
         TT_FATAL(beta.value().layout() == Layout::ROW_MAJOR, "Beta tensor must have ROW_MAJOR layout");
     }
 
-    uint32_t groupnorm_mode = static_cast<uint32_t>(
+    auto groupnorm_mode = static_cast<uint32_t>(
         reciprocals.has_value() ? GroupNormMode::WELFORD_RECIPROCALS
         : use_welford           ? GroupNormMode::WELFORD_NATIVE
                                 : GroupNormMode::LEGACY);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -50,7 +50,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
     }
 
     // Mode is 0 for legacy groupnorm, 1 for welford groupnorm, 2 for groupnorm with reciprocals
-    uint32_t groupnorm_mode = static_cast<uint32_t>(
+    auto groupnorm_mode = static_cast<uint32_t>(
         reciprocals.has_value() ? GroupNormMode::WELFORD_RECIPROCALS
         : use_welford           ? GroupNormMode::WELFORD_NATIVE
                                 : GroupNormMode::LEGACY);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -82,7 +82,7 @@ void split_and_form_rectangle_grids(
 std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size) {
     uint32_t current_position = 0;
     uint32_t max_tile_span = 0;
-    uint32_t num_groups_before_start_again_at_tile_beginning = static_cast<uint32_t>(-1);
+    auto num_groups_before_start_again_at_tile_beginning = static_cast<uint32_t>(-1);
     bool calc_num_groups_before_start_again_at_tile_beginning = true;
 
     while (current_position < W) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_program_factory.cpp
@@ -415,7 +415,7 @@ LayerNormPostAllGatherProgramFactory::cached_program_t LayerNormPostAllGatherPro
     float winv = 1.0f / (W * num_devices);  // bcast-w scaler
     auto bfloat_winv_value = bfloat16(winv);
     uint32_t packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv_value, bfloat_winv_value});
-    uint32_t eps_bits = std::bit_cast<uint32_t>(operation_attributes.eps);
+    auto eps_bits = std::bit_cast<uint32_t>(operation_attributes.eps);
 
     // Set runtime arguments
     for (uint32_t i = 0; i < num_cores; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -92,7 +92,7 @@ GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFact
         grid_cb_data_format,
         is_sharded ? grid_tensor.buffer() : nullptr);
 
-    const uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[-1] / tt::constants::TILE_WIDTH);
+    const auto in_ntiles_c = (uint32_t)std::ceil((float)input_shape[-1] / tt::constants::TILE_WIDTH);
     const uint32_t input_cb_page_size = in_ntiles_c * tt::constants::TILE_HW * input_tensor.element_size();
     const auto [input_cb_index_0, input_cb_handle_0] = tt::tt_metal::create_cb(
         cb_idx++, program, all_cores, input_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
@@ -115,7 +115,7 @@ GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFact
             cb_idx++, program, all_cores, scalar_cb_page_size, BUFFERING_FACTOR, input_cb_data_format);
     }
 
-    const uint32_t out_ntiles_c = (uint32_t)std::ceil((float)output_shape[-1] / tt::constants::FACE_WIDTH);
+    const auto out_ntiles_c = (uint32_t)std::ceil((float)output_shape[-1] / tt::constants::FACE_WIDTH);
     const uint32_t output_cb_page_size = tt::constants::FACE_WIDTH * output_tensor.element_size();
     const uint32_t output_cb_pages =
         is_sharded ? output_nsticks_per_core * out_ntiles_c : out_ntiles_c * BUFFERING_FACTOR;
@@ -211,7 +211,7 @@ GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFact
 
     // Compute kernels
     const uint32_t channels_per_shard = input_shape[-1];
-    const uint32_t in_nblocks_c = (uint32_t)std::ceil((float)in_ntiles_c / MAX_TILES_PER_REDUCTION);
+    const auto in_nblocks_c = (uint32_t)std::ceil((float)in_ntiles_c / MAX_TILES_PER_REDUCTION);
 
     auto create_compute_kernel = [&](tt::tt_metal::CoreRangeSet cores, uint32_t total_interpolations) {
         // Compute kernel compile-time arguments

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -69,8 +69,8 @@ tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
                 uint32_t y_idx = (((n * grid_h + h) * grid_w + w) * 2) + 1;  // y coordinate
 
                 // Extract normalized coordinates [-1, 1]
-                float x_coord = static_cast<float>(input_buffer[x_idx]);
-                float y_coord = static_cast<float>(input_buffer[y_idx]);
+                auto x_coord = static_cast<float>(input_buffer[x_idx]);
+                auto y_coord = static_cast<float>(input_buffer[y_idx]);
 
                 // Transform to image coordinates - use consistent formula
                 float h_coord_image = ((y_coord + 1.0f) * height_scale) + height_offset;
@@ -102,14 +102,14 @@ tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
                             int16_t h_clamped = static_cast<int16_t>(std::clamp(h_nearest, -32768, 32767));
                             int16_t w_clamped = static_cast<int16_t>(std::clamp(w_nearest, -32768, 32767));
 
-                            uint16_t h_bits = static_cast<uint16_t>(h_clamped);
-                            uint16_t w_bits = static_cast<uint16_t>(w_clamped);
+                            auto h_bits = static_cast<uint16_t>(h_clamped);
+                            auto w_bits = static_cast<uint16_t>(w_clamped);
 
                             output_buffer[output_base + 0] = std::bit_cast<bfloat16>(h_bits);  // h coordinate
                             output_buffer[output_base + 1] = std::bit_cast<bfloat16>(w_bits);  // w coordinate
                         } else {
                             // Store sentinel value for invalid coordinates (use -1)
-                            uint16_t invalid_sentinel = static_cast<uint16_t>(-1);
+                            auto invalid_sentinel = static_cast<uint16_t>(-1);
                             output_buffer[output_base + 0] = std::bit_cast<bfloat16>(invalid_sentinel);  // invalid h
                             output_buffer[output_base + 1] = std::bit_cast<bfloat16>(invalid_sentinel);  // invalid w
                         }
@@ -125,8 +125,8 @@ tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
                     }
                 } else {  // bilinear mode
                     // Get corner pixel coordinates (floor operation)
-                    int32_t h0 = static_cast<int32_t>(std::floor(h_coord_image));
-                    int32_t w0 = static_cast<int32_t>(std::floor(w_coord_image));
+                    auto h0 = static_cast<int32_t>(std::floor(h_coord_image));
+                    auto w0 = static_cast<int32_t>(std::floor(w_coord_image));
                     int32_t h1 = h0 + 1;
                     int32_t w1 = w0 + 1;
 
@@ -158,8 +158,8 @@ tt::tt_metal::HostBuffer create_host_buffer_for_grid_preprocessing(
                     // Store results
                     if constexpr (std::is_same_v<OutputType, bfloat16>) {
                         // Reinterpret int16 bits as bfloat16 for coordinates
-                        uint16_t h0_bits = static_cast<uint16_t>(h0_clamped);
-                        uint16_t w0_bits = static_cast<uint16_t>(w0_clamped);
+                        auto h0_bits = static_cast<uint16_t>(h0_clamped);
+                        auto w0_bits = static_cast<uint16_t>(w0_clamped);
                         output_buffer[base_idx + 0] = std::bit_cast<bfloat16>(h0_bits);
                         output_buffer[base_idx + 1] = std::bit_cast<bfloat16>(w0_bits);
                         // Convert weights to bfloat16

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -133,11 +133,11 @@ FactoryParameters get_factory_parameters(
     // face_r_dim to only tilize the necessary number of rows, thus we can make the in_cb height smaller
     uint32_t num_tilized_rows =
         kernel_size_hw <= tt::constants::FACE_WIDTH ? kernel_size_hw : tt::constants::TILE_HEIGHT;
-    uint32_t in_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / tt::constants::TILE_WIDTH);
+    auto in_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / tt::constants::TILE_WIDTH);
     // For TILE_LAYOUT output, we need to align to TILE_WIDTH instead of FACE_WIDTH
     uint32_t effective_tile_width_for_output =
         (output_layout == Layout::TILE) ? tt::constants::TILE_WIDTH : tt::constants::FACE_WIDTH;
-    uint32_t out_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / effective_tile_width_for_output);
+    auto out_ntiles_c = (uint32_t)std::ceil((float)in_channels / num_shards_c / effective_tile_width_for_output);
 
     bool is_avg_pool = pool_type == Pool2DType::AVG_POOL2D;
     const bool last_tile_is_partial =

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -369,8 +369,8 @@ ArgMaxMultiCoreProgramFactory::cached_program_t ArgMaxMultiCoreProgramFactory::c
              (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0});
     }
 
-    const uint32_t src_offset1 = static_cast<uint32_t>(src_read_size0 * num_cores0);
-    const uint32_t red_dim_offset1 = static_cast<uint32_t>(red_dim_units0 * num_cores0);
+    const auto src_offset1 = static_cast<uint32_t>(src_read_size0 * num_cores0);
+    const auto red_dim_offset1 = static_cast<uint32_t>(red_dim_units0 * num_cores0);
 
     for (uint32_t i = 0; i < num_cores1; ++i) {
         const CoreCoord& core = cores_coords1.at(i);

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -166,7 +166,7 @@ MoeProgramFactory::cached_program_t MoeProgramFactory::create(
             expert_mask_buffer->address(),
         });
 
-    bfloat16 bfloat_identity_scalar = bfloat16(1.0f);
+    auto bfloat_identity_scalar = bfloat16(1.0f);
     uint32_t packed_identity_scalar = pack_two_bfloat16_into_uint32({bfloat_identity_scalar, bfloat_identity_scalar});
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index, Ht, k, packed_identity_scalar};
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -238,7 +238,7 @@ SamplingProgramFactory::cached_program_t SamplingProgramFactory::create(
             input_indices_buffer->address(),
         });
 
-    bfloat16 bfloat_identity_scalar = bfloat16(1.0f);
+    auto bfloat_identity_scalar = bfloat16(1.0f);
     uint32_t packed_identity_scalar = pack_two_bfloat16_into_uint32({bfloat_identity_scalar, bfloat_identity_scalar});
 
     std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -356,8 +356,8 @@ std::vector<uint32_t> generate_op_trace_metadata_bilinear(const SlidingWindowCon
             float w_offset = (0.5f * scale_w_inv) + bilinear_starting_offset;
             for (uint32_t w = 0; w < output_shape[2]; ++w) {
                 // Get top-left input coordinate (this is the "top-left index" needed for bilinear interpolation)
-                const uint32_t top_left_h = static_cast<uint32_t>(std::floor(h_offset));
-                const uint32_t top_left_w = static_cast<uint32_t>(std::floor(w_offset));
+                const auto top_left_h = static_cast<uint32_t>(std::floor(h_offset));
+                const auto top_left_w = static_cast<uint32_t>(std::floor(w_offset));
 
                 // Calculate flattened input index (top-left coordinate for bilinear interpolation)
                 const uint32_t input_idx =
@@ -1129,7 +1129,7 @@ std::vector<uint16_t> remap_nhw_scalar_argument_across_full_grid(
     const auto factor = sliding_window::get_repeat_factor_for_replicating_nhw_config_across_grid(parallel_config);
     if (parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
         const auto broadcast_config_per_row = [](const std::vector<uint16_t>& config, uint32_t num_cols) {
-            const uint32_t num_rows = static_cast<uint32_t>(config.size());
+            const auto num_rows = static_cast<uint32_t>(config.size());
             std::vector<uint16_t> expanded;
             expanded.reserve(num_rows * num_cols);
             for (uint16_t val : config) {


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-auto.html

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs