### PR TITLE
Use multicast when initializing metal context

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1321,13 +1321,13 @@ void MetalContext::initialize_firmware(
                 launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_HOST;
                 prepare_initial_launch_msg();
                 for (const auto& logical_core : dispatch_core_manager_->get_all_logical_dispatch_cores(device_id)) {
-                    auto virtual_core2 = cluster_->get_virtual_coordinate_from_logical_coordinates(
+                    auto virtual_dispatch_core = cluster_->get_virtual_coordinate_from_logical_coordinates(
                         device_id, logical_core, CoreType::WORKER);
-                    auto programmable_core_type = llrt::get_core_type(device_id, virtual_core2);
+                    auto programmable_core_type = llrt::get_core_type(device_id, virtual_dispatch_core);
                     cluster_->write_core(
                         init_launch_msg_data.data(),
                         init_launch_msg_data.size(),
-                        tt_cxy_pair(device_id, virtual_core2),
+                        tt_cxy_pair(device_id, virtual_dispatch_core),
                         hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH));
                 }
             }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1100,36 +1100,26 @@ void MetalContext::initialize_device_bank_to_noc_tables(
     if (end_core.has_value()) {
         // Multicast to all tensix cores in the range [virtual_core, end_core]
         auto start_core = virtual_core;
+        auto core_start = tt_cxy_pair(device_id, start_core);
+        auto core_end = tt_cxy_pair(device_id, end_core.value());
         cluster_->noc_multicast_write(
-            &dram_bank_to_noc_xy_[device_id][0],
+            dram_bank_to_noc_xy_[device_id].data(),
             dram_to_noc_sz_in_bytes,
-            {device_id, start_core},
-            {device_id, end_core.value()},
+            core_start,
+            core_end,
             mem_bank_to_noc_addr);
 
         uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
         cluster_->noc_multicast_write(
-            &l1_bank_to_noc_xy_[device_id][0],
-            l1_to_noc_sz_in_bytes,
-            {device_id, start_core},
-            {device_id, end_core.value()},
-            l1_noc_addr);
+            l1_bank_to_noc_xy_[device_id].data(), l1_to_noc_sz_in_bytes, core_start, core_end, l1_noc_addr);
 
         uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
         cluster_->noc_multicast_write(
-            &dram_bank_offset_map_[device_id][0],
-            dram_offset_sz_in_bytes,
-            {device_id, start_core},
-            {device_id, end_core.value()},
-            dram_offset_addr);
+            dram_bank_offset_map_[device_id].data(), dram_offset_sz_in_bytes, core_start, core_end, dram_offset_addr);
 
         uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
         cluster_->noc_multicast_write(
-            &l1_bank_offset_map_[device_id][0],
-            l1_offset_sz_in_bytes,
-            {device_id, start_core},
-            {device_id, end_core.value()},
-            l1_offset_addr);
+            l1_bank_offset_map_[device_id].data(), l1_offset_sz_in_bytes, core_start, core_end, l1_offset_addr);
     } else {
         // Unicast to single core
         cluster_->write_core(
@@ -1181,11 +1171,13 @@ void MetalContext::initialize_worker_logical_to_virtual_tables(
         "Size of logical to virtual map is greater than available space");
 
     uint64_t logical_col_to_virtual_col_addr = logical_to_virtual_map_addr;
+    auto core_start = tt_cxy_pair(device_id, start_core);
+    auto core_end = tt_cxy_pair(device_id, end_core);
     cluster_->noc_multicast_write(
         worker_logical_col_to_virtual_col_[device_id].data(),
         logical_col_to_virtual_col_sz_in_bytes,
-        {device_id, start_core},
-        {device_id, end_core},
+        core_start,
+        core_end,
         logical_col_to_virtual_col_addr);
 
     // Size of the data in the firmware is the full size of the grid, not the harvested size.
@@ -1194,8 +1186,8 @@ void MetalContext::initialize_worker_logical_to_virtual_tables(
     cluster_->noc_multicast_write(
         worker_logical_row_to_virtual_row_[device_id].data(),
         logical_row_to_virtual_row_sz_in_bytes,
-        {device_id, start_core},
-        {device_id, end_core},
+        core_start,
+        core_end,
         logical_row_to_virtual_row_addr);
 }
 
@@ -1267,24 +1259,16 @@ void MetalContext::initialize_firmware(
                 &zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), launch_msg_buffer_read_ptr_addr);
             cluster_->write_core(&zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), go_message_index_addr);
         } else {
+            auto core_start = tt_cxy_pair(device_id, start_core);
+            auto core_end = tt_cxy_pair(device_id, end_core.value());
             // Multicast to all tensix cores in the range [start_core, tensix_end_core]
             cluster_->noc_multicast_write(
-                init_launch_msg_data.data(),
-                init_launch_msg_data.size(),
-                {device_id, start_core},
-                {device_id, end_core.value()},
-                launch_addr);
-            cluster_->noc_multicast_write(
-                go_msg.data(), go_msg.size(), {device_id, start_core}, {device_id, end_core.value()}, go_addr);
+                init_launch_msg_data.data(), init_launch_msg_data.size(), core_start, core_end, launch_addr);
+            cluster_->noc_multicast_write(go_msg.data(), go_msg.size(), core_start, core_end, go_addr);
             uint32_t zero = 0;
             cluster_->noc_multicast_write(
-                &zero,
-                sizeof(uint32_t),
-                {device_id, start_core},
-                {device_id, end_core.value()},
-                launch_msg_buffer_read_ptr_addr);
-            cluster_->noc_multicast_write(
-                &zero, sizeof(uint32_t), {device_id, start_core}, {device_id, end_core.value()}, go_message_index_addr);
+                &zero, sizeof(uint32_t), core_start, core_end, launch_msg_buffer_read_ptr_addr);
+            cluster_->noc_multicast_write(&zero, sizeof(uint32_t), core_start, core_end, go_message_index_addr);
         }
     };
 
@@ -1347,12 +1331,14 @@ void MetalContext::initialize_firmware(
                         hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH));
                 }
             }
+            auto core_start = tt_cxy_pair(device_id, start_core);
+            auto core_end = tt_cxy_pair(device_id, end_core.value());
 
             cluster_->noc_multicast_write(
                 &jit_build_config.fw_launch_addr_value,
                 sizeof(uint32_t),
-                {device_id, start_core},
-                {device_id, end_core.value()},
+                core_start,
+                core_end,
                 jit_build_config.fw_launch_addr);
 
             break;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1080,7 +1080,10 @@ void MetalContext::generate_worker_logical_to_virtual_map(ChipId device_id) {
 }
 
 void MetalContext::initialize_device_bank_to_noc_tables(
-    ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core) {
+    ChipId device_id,
+    const HalProgrammableCoreType& core_type,
+    CoreCoord virtual_core,
+    std::optional<CoreCoord> end_core) {
     const uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
     const uint32_t l1_to_noc_sz_in_bytes = l1_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
     const uint32_t dram_offset_sz_in_bytes = dram_bank_offset_map_[device_id].size() * sizeof(int32_t);
@@ -1094,31 +1097,72 @@ void MetalContext::initialize_device_bank_to_noc_tables(
             mem_bank_to_noc_size,
         "Size of bank_to_noc table is greater than available space");
 
-    cluster_->write_core(
-        dram_bank_to_noc_xy_[device_id].data(),
-        dram_to_noc_sz_in_bytes,
-        tt_cxy_pair(device_id, virtual_core),
-        mem_bank_to_noc_addr);
-    uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
-    cluster_->write_core(
-        l1_bank_to_noc_xy_[device_id].data(), l1_to_noc_sz_in_bytes, tt_cxy_pair(device_id, virtual_core), l1_noc_addr);
+    if (end_core.has_value()) {
+        // Multicast to all tensix cores in the range [virtual_core, end_core]
+        auto start_core = virtual_core;
+        cluster_->noc_multicast_write(
+            &dram_bank_to_noc_xy_[device_id][0],
+            dram_to_noc_sz_in_bytes,
+            {device_id, start_core},
+            {device_id, end_core.value()},
+            mem_bank_to_noc_addr);
 
-    uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
-    cluster_->write_core(
-        dram_bank_offset_map_[device_id].data(),
-        dram_offset_sz_in_bytes,
-        tt_cxy_pair(device_id, virtual_core),
-        dram_offset_addr);
-    uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
-    cluster_->write_core(
-        l1_bank_offset_map_[device_id].data(),
-        l1_offset_sz_in_bytes,
-        tt_cxy_pair(device_id, virtual_core),
-        l1_offset_addr);
+        uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
+        cluster_->noc_multicast_write(
+            &l1_bank_to_noc_xy_[device_id][0],
+            l1_to_noc_sz_in_bytes,
+            {device_id, start_core},
+            {device_id, end_core.value()},
+            l1_noc_addr);
+
+        uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
+        cluster_->noc_multicast_write(
+            &dram_bank_offset_map_[device_id][0],
+            dram_offset_sz_in_bytes,
+            {device_id, start_core},
+            {device_id, end_core.value()},
+            dram_offset_addr);
+
+        uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
+        cluster_->noc_multicast_write(
+            &l1_bank_offset_map_[device_id][0],
+            l1_offset_sz_in_bytes,
+            {device_id, start_core},
+            {device_id, end_core.value()},
+            l1_offset_addr);
+    } else {
+        // Unicast to single core
+        cluster_->write_core(
+            dram_bank_to_noc_xy_[device_id].data(),
+            dram_to_noc_sz_in_bytes,
+            tt_cxy_pair(device_id, virtual_core),
+            mem_bank_to_noc_addr);
+
+        uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
+        cluster_->write_core(
+            l1_bank_to_noc_xy_[device_id].data(),
+            l1_to_noc_sz_in_bytes,
+            tt_cxy_pair(device_id, virtual_core),
+            l1_noc_addr);
+
+        uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
+        cluster_->write_core(
+            dram_bank_offset_map_[device_id].data(),
+            dram_offset_sz_in_bytes,
+            tt_cxy_pair(device_id, virtual_core),
+            dram_offset_addr);
+
+        uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
+        cluster_->write_core(
+            l1_bank_offset_map_[device_id].data(),
+            l1_offset_sz_in_bytes,
+            tt_cxy_pair(device_id, virtual_core),
+            l1_offset_addr);
+    }
 }
 
 void MetalContext::initialize_worker_logical_to_virtual_tables(
-    ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core) {
+    ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord start_core, CoreCoord end_core) {
     // Generate logical to virtual map for DRAM and L1 banks
     const auto& soc_desc = cluster_->get_soc_desc(device_id);
     const uint32_t logical_col_to_virtual_col_sz_in_bytes =
@@ -1137,19 +1181,21 @@ void MetalContext::initialize_worker_logical_to_virtual_tables(
         "Size of logical to virtual map is greater than available space");
 
     uint64_t logical_col_to_virtual_col_addr = logical_to_virtual_map_addr;
-    cluster_->write_core(
+    cluster_->noc_multicast_write(
         worker_logical_col_to_virtual_col_[device_id].data(),
         logical_col_to_virtual_col_sz_in_bytes,
-        tt_cxy_pair(device_id, virtual_core),
+        {device_id, start_core},
+        {device_id, end_core},
         logical_col_to_virtual_col_addr);
 
     // Size of the data in the firmware is the full size of the grid, not the harvested size.
     // Therefore, we must adjust the address to account for the full grid size.
     uint64_t logical_row_to_virtual_row_addr = logical_to_virtual_map_addr + (firmware_grid_size_x * sizeof(uint8_t));
-    cluster_->write_core(
+    cluster_->noc_multicast_write(
         worker_logical_row_to_virtual_row_[device_id].data(),
         logical_row_to_virtual_row_sz_in_bytes,
-        tt_cxy_pair(device_id, virtual_core),
+        {device_id, start_core},
+        {device_id, end_core},
         logical_row_to_virtual_row_addr);
 }
 
@@ -1158,21 +1204,27 @@ void MetalContext::initialize_firmware(
     const HalProgrammableCoreType& core_type,
     CoreCoord virtual_core,
     dev_msgs::launch_msg_t::View launch_msg,
-    dev_msgs::go_msg_t::ConstView go_msg) {
+    dev_msgs::go_msg_t::ConstView go_msg,
+    std::optional<CoreCoord> end_core) {
     ZoneScoped;
 
-    initialize_device_bank_to_noc_tables(device_id, core_type, virtual_core);
+    TT_FATAL(
+        core_type != HalProgrammableCoreType::TENSIX or end_core.has_value(),
+        "Tensix cores require end_core to be specified for bank to noc table initialization.");
 
+    initialize_device_bank_to_noc_tables(device_id, core_type, virtual_core, end_core);
     if (core_type == HalProgrammableCoreType::TENSIX) {
         // Only need to generate logical to virtual tables for Tensix cores, as only they run the firmware that
         // requires it.
-        initialize_worker_logical_to_virtual_tables(device_id, core_type, virtual_core);
+        initialize_worker_logical_to_virtual_tables(device_id, core_type, virtual_core, end_core.value());
     }
 
     uint32_t core_type_idx = hal_->get_programmable_core_type_index(core_type);
     uint32_t processor_class_count = hal_->get_processor_classes_count(core_type);
     auto jit_build_config =
         hal_->get_jit_build_config(core_type_idx, 0, 0);  // Only the first risc needs to be programmed
+
+    const auto start_core = virtual_core;
 
     // Initialize each entry in the launch_msg ring buffer with the correct dispatch mode - Cores that don't get a valid
     // launch_message during program execution need to at least have the correct dispatch mode.
@@ -1184,31 +1236,56 @@ void MetalContext::initialize_firmware(
     // dispatch cores (Idle Eth) configured with DISPATCH_MODE_HOST
     // worker cores (Tensix and active eth) configured with DISPATCH_MODE_DEV
     // When using Slow Dispatch, all cores initialized with DISPATCH_MODE_HOST
-    const auto write_initial_go_launch_msg = [&]() {
-        size_t launch_msg_size = launch_msg.size();
-        std::vector<std::byte> init_launch_msg_data(
-            dev_msgs::launch_msg_buffer_num_entries * launch_msg_size, std::byte{0});
+    size_t launch_msg_size = launch_msg.size();
+    std::vector<std::byte> init_launch_msg_data(
+        dev_msgs::launch_msg_buffer_num_entries * launch_msg_size, std::byte{0});
+    auto prepare_initial_launch_msg = [&]() {
         for (size_t i = 0; i < dev_msgs::launch_msg_buffer_num_entries; ++i) {
             std::copy(
                 launch_msg.data(),
                 launch_msg.data() + launch_msg_size,
                 init_launch_msg_data.data() + (i * launch_msg_size));
         }
+    };
+    const auto write_initial_go_launch_msg = [&]() {
         auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-        cluster_->write_core(
-            init_launch_msg_data.data(),
-            init_launch_msg_data.size(),
-            tt_cxy_pair(device_id, virtual_core),
-            hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH));
+        uint32_t launch_addr = hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH);
         uint32_t go_addr = hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
-        cluster_->write_core(go_msg.data(), go_msg.size(), tt_cxy_pair(device_id, virtual_core), go_addr);
         uint64_t launch_msg_buffer_read_ptr_addr =
             hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
-        uint32_t zero = 0;
-        cluster_->write_core(
-            &zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), launch_msg_buffer_read_ptr_addr);
         uint32_t go_message_index_addr = hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
-        cluster_->write_core(&zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), go_message_index_addr);
+        // Unicast only to non-tensix cores
+        if (core_type != HalProgrammableCoreType::TENSIX) {
+            cluster_->write_core(
+                init_launch_msg_data.data(),
+                init_launch_msg_data.size(),
+                tt_cxy_pair(device_id, virtual_core),
+                launch_addr);
+            cluster_->write_core(go_msg.data(), go_msg.size(), tt_cxy_pair(device_id, virtual_core), go_addr);
+            uint32_t zero = 0;
+            cluster_->write_core(
+                &zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), launch_msg_buffer_read_ptr_addr);
+            cluster_->write_core(&zero, sizeof(uint32_t), tt_cxy_pair(device_id, virtual_core), go_message_index_addr);
+        } else {
+            // Multicast to all tensix cores in the range [start_core, tensix_end_core]
+            cluster_->noc_multicast_write(
+                init_launch_msg_data.data(),
+                init_launch_msg_data.size(),
+                {device_id, start_core},
+                {device_id, end_core.value()},
+                launch_addr);
+            cluster_->noc_multicast_write(
+                go_msg.data(), go_msg.size(), {device_id, start_core}, {device_id, end_core.value()}, go_addr);
+            uint32_t zero = 0;
+            cluster_->noc_multicast_write(
+                &zero,
+                sizeof(uint32_t),
+                {device_id, start_core},
+                {device_id, end_core.value()},
+                launch_msg_buffer_read_ptr_addr);
+            cluster_->noc_multicast_write(
+                &zero, sizeof(uint32_t), {device_id, start_core}, {device_id, end_core.value()}, go_message_index_addr);
+        }
     };
 
     switch (core_type) {
@@ -1227,14 +1304,20 @@ void MetalContext::initialize_firmware(
                     log_debug(
                         tt::LogMetal,
                         "RISC {} DM{} fw {} binary size: {} in bytes",
-                        virtual_core.str(),
+                        start_core.str(),
                         riscv_id,
                         fw_path,
                         fw_size);
 
                     if (not rtoptions_.get_skip_loading_fw()) {
-                        llrt::test_load_write_read_risc_binary(
-                            binary_mem, device_id, virtual_core, core_type_idx, processor_class, riscv_id);
+                        llrt::test_multicast_write_risc_binary(
+                            binary_mem,
+                            device_id,
+                            start_core,
+                            end_core.value(),
+                            core_type_idx,
+                            processor_class,
+                            riscv_id);
                     }
                 }
             }
@@ -1243,27 +1326,33 @@ void MetalContext::initialize_firmware(
                 // Host always writes launch messages
                 launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_HOST;
             } else {
-                std::unordered_set<CoreCoord> virtual_dispatch_cores;
-                if (dispatch_core_manager_->get_dispatch_core_type() == CoreType::WORKER) {
-                    for (const auto& logical_core : dispatch_core_manager_->get_all_logical_dispatch_cores(device_id)) {
-                        virtual_dispatch_cores.insert(cluster_->get_virtual_coordinate_from_logical_coordinates(
-                            device_id, logical_core, CoreType::WORKER));
-                    }
-                }
-                if (virtual_dispatch_cores.contains(virtual_core)) {
-                    // Dispatch cores - Host writes launch messages
-                    launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_HOST;
-                } else {
-                    // Worker cores - Dispatcher will write launch messages
-                    launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_DEV;
+                // Worker cores - Dispatcher will write launch messages
+                launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_DEV;
+            }
+            prepare_initial_launch_msg();
+            write_initial_go_launch_msg();
+            if (rtoptions_.get_fast_dispatch() and
+                dispatch_core_manager_->get_dispatch_core_type() == CoreType::WORKER) {
+                // Prepare a new launch message, with updated dispatch mode for dispatch cores
+                launch_msg.kernel_config().mode() = dev_msgs::DISPATCH_MODE_HOST;
+                prepare_initial_launch_msg();
+                for (const auto& logical_core : dispatch_core_manager_->get_all_logical_dispatch_cores(device_id)) {
+                    auto virtual_core2 = cluster_->get_virtual_coordinate_from_logical_coordinates(
+                        device_id, logical_core, CoreType::WORKER);
+                    auto programmable_core_type = llrt::get_core_type(device_id, virtual_core2);
+                    cluster_->write_core(
+                        init_launch_msg_data.data(),
+                        init_launch_msg_data.size(),
+                        tt_cxy_pair(device_id, virtual_core2),
+                        hal_->get_dev_addr(programmable_core_type, HalL1MemAddrType::LAUNCH));
                 }
             }
 
-            write_initial_go_launch_msg();
-            cluster_->write_core(
+            cluster_->noc_multicast_write(
                 &jit_build_config.fw_launch_addr_value,
                 sizeof(uint32_t),
-                tt_cxy_pair(device_id, virtual_core),
+                {device_id, start_core},
+                {device_id, end_core.value()},
                 jit_build_config.fw_launch_addr);
 
             break;
@@ -1313,6 +1402,7 @@ void MetalContext::initialize_firmware(
                                                     : dev_msgs::DISPATCH_MODE_DEV;
             // For eth, write the go and launch message before initializing because when using the ETH FW API
             // it will launch immediately. DM0 is not in a reset state as it is running base FW.
+            prepare_initial_launch_msg();
             write_initial_go_launch_msg();
             if (core_type == HalProgrammableCoreType::ACTIVE_ETH) {
                 // Clear the ncrisc_halt message
@@ -1551,11 +1641,15 @@ void MetalContext::initialize_and_launch_firmware(ChipId device_id) {
                 core_info.size(),
                 {static_cast<size_t>(device_id), worker_core},
                 hal_->get_dev_addr(llrt::get_core_type(device_id, worker_core), HalL1MemAddrType::CORE_INFO));
-            initialize_firmware(
-                device_id, HalProgrammableCoreType::TENSIX, worker_core, launch_msg.view(), go_msg.view());
             not_done_cores.insert(worker_core);
         }
     }
+    CoreCoord start_core =
+        cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, CoreCoord(0, 0), CoreType::WORKER);
+    CoreCoord end_core = cluster_->get_virtual_coordinate_from_logical_coordinates(
+        device_id, CoreCoord(logical_grid_size.x - 1, logical_grid_size.y - 1), CoreType::WORKER);
+    initialize_firmware(
+        device_id, HalProgrammableCoreType::TENSIX, start_core, launch_msg.view(), go_msg.view(), end_core);
 
     // Clear erisc sync info
     for (const auto& eth_core : this->get_control_plane().get_active_ethernet_cores(device_id)) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1313,7 +1313,7 @@ void MetalContext::initialize_firmware(
                         fw_size);
 
                     if (not rtoptions_.get_skip_loading_fw()) {
-                        llrt::test_multicast_write_risc_binary(
+                        llrt::test_load_multicast_write_risc_binary(
                             binary_mem,
                             device_id,
                             start_core,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -168,7 +168,7 @@ private:
         CoreCoord virtual_core,
         std::optional<CoreCoord> end_core);
     void initialize_worker_logical_to_virtual_tables(
-        ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core, CoreCoord end_core);
+        ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord start_core, CoreCoord end_core);
     void initialize_firmware(
         ChipId device_id,
         const HalProgrammableCoreType& core_type,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -163,15 +163,19 @@ private:
     void generate_device_bank_to_noc_tables(ChipId device_id);
     void generate_worker_logical_to_virtual_map(ChipId device_id);
     void initialize_device_bank_to_noc_tables(
-        ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core);
+        ChipId device_id,
+        const HalProgrammableCoreType& core_type,
+        CoreCoord virtual_core,
+        std::optional<CoreCoord> end_core);
     void initialize_worker_logical_to_virtual_tables(
-        ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core);
+        ChipId device_id, const HalProgrammableCoreType& core_type, CoreCoord virtual_core, CoreCoord end_core);
     void initialize_firmware(
         ChipId device_id,
         const HalProgrammableCoreType& core_type,
         CoreCoord virtual_core,
         dev_msgs::launch_msg_t::View launch_msg,
-        dev_msgs::go_msg_t::ConstView go_msg);
+        dev_msgs::go_msg_t::ConstView go_msg,
+        std::optional<CoreCoord> end_core = std::nullopt);
     void initialize_and_launch_firmware(ChipId device_id);
     dev_msgs::core_info_msg_t populate_core_info_msg(
         ChipId device_id, HalProgrammableCoreType programmable_core_type) const;

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -250,11 +250,7 @@ bool test_multicast_write_risc_binary(
             tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, false);
 
         tt::tt_metal::MetalContext::instance().get_cluster().noc_multicast_write(
-            &*mem_ptr,
-            len_words * sizeof(uint32_t),
-            tt_cxy_pair(chip_id, start_core),
-            tt_cxy_pair(chip_id, end_core),
-            relo_addr);
+            &*mem_ptr, len_words * sizeof(uint32_t), chip_id, start_core, end_core, relo_addr);
     });
 
     log_debug(tt::LogLLRuntime, "multicast hex to cores {} - {}", start_core.str().c_str(), end_core.str().c_str());

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -227,6 +227,41 @@ bool test_load_write_read_risc_binary(
     return true;
 }
 
+bool test_multicast_write_risc_binary(
+    const ll_api::memory& mem,
+    tt::ChipId chip_id,
+    const CoreCoord& start_core,
+    const CoreCoord& end_core,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx) {
+    TT_ASSERT(
+        tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(start_core, chip_id) and
+        tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(end_core, chip_id));
+
+    uint64_t local_init_addr = tt::tt_metal::MetalContext::instance()
+                                   .hal()
+                                   .get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
+                                   .local_init_addr;
+
+    log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
+    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
+        uint64_t relo_addr =
+            tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, false);
+
+        tt::tt_metal::MetalContext::instance().get_cluster().noc_multicast_write(
+            &*mem_ptr, len_words * sizeof(uint32_t), {chip_id, start_core}, {chip_id, end_core}, relo_addr);
+    });
+
+    log_debug(tt::LogLLRuntime, "multicast hex to cores {} - {}", start_core.str().c_str(), end_core.str().c_str());
+
+    if (std::getenv("TT_METAL_KERNEL_READBACK_ENABLE")) {
+        log_info(tt::LogLLRuntime, "WARNING: Readback after multicast write is not yet supported");
+    }
+
+    return true;
+}
+
 void write_binary_to_address(const ll_api::memory& mem, tt::ChipId chip_id, const CoreCoord& core, uint32_t address) {
     log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t /*addr*/, uint32_t len_words) {

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -250,7 +250,11 @@ bool test_multicast_write_risc_binary(
             tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, false);
 
         tt::tt_metal::MetalContext::instance().get_cluster().noc_multicast_write(
-            &*mem_ptr, len_words * sizeof(uint32_t), {chip_id, start_core}, {chip_id, end_core}, relo_addr);
+            &*mem_ptr,
+            len_words * sizeof(uint32_t),
+            tt_cxy_pair(chip_id, start_core),
+            tt_cxy_pair(chip_id, end_core),
+            relo_addr);
     });
 
     log_debug(tt::LogLLRuntime, "multicast hex to cores {} - {}", start_core.str().c_str(), end_core.str().c_str());

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -227,7 +227,7 @@ bool test_load_write_read_risc_binary(
     return true;
 }
 
-bool test_multicast_write_risc_binary(
+bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
     const CoreCoord& start_core,

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -75,6 +75,16 @@ bool test_load_write_read_risc_binary(
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
+
+bool test_multicast_write_risc_binary(
+    const ll_api::memory& mem,
+    tt::ChipId chip_id,
+    const CoreCoord& start_core,
+    const CoreCoord& end_core,
+    uint32_t core_type_idx,
+    uint32_t processor_class_idx,
+    uint32_t processor_type_idx);
+
 void write_binary_to_address(const ll_api::memory& mem, ChipId chip_id, const CoreCoord& core, uint32_t address);
 
 namespace internal_ {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -76,7 +76,7 @@ bool test_load_write_read_risc_binary(
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
 
-bool test_multicast_write_risc_binary(
+bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
     const CoreCoord& start_core,

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -146,6 +146,13 @@ inline void watcher_sanitize_host_noc_multicast_write(
     const CoreCoord& core_end,
     uint64_t addr,
     uint32_t lbytes) {
+    if (core_start.x > core_end.x || core_start.y > core_end.y) {
+        TT_THROW(
+            "Host watcher: bad multicast write coordinates - start {} must be <= end {} in both x and y",
+            core_start.str(),
+            core_end.str());
+    }
+
     if (not coord_found_p(soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0), core_start) and
         not coord_found_p(virtual_worker_cores, core_start)) {
         TT_THROW("Host watcher: bad multicast write NOC coord {} - start core is not tensix", core_start.str());

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -139,4 +139,32 @@ inline void watcher_sanitize_host_noc_write(
         lbytes);
 }
 
+inline void watcher_sanitize_host_noc_multicast_write(
+    const metal_SocDescriptor& soc_d,
+    const std::unordered_set<CoreCoord>& virtual_worker_cores,
+    const CoreCoord& core_start,
+    const CoreCoord& core_end,
+    uint64_t addr,
+    uint32_t lbytes) {
+    if (not coord_found_p(soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0), core_start) and
+        not coord_found_p(virtual_worker_cores, core_start)) {
+        TT_THROW("Host watcher: bad multicast write NOC coord {} - start core is not tensix", core_start.str());
+    } else if (coord_found_p(virtual_worker_cores, core_start)) {
+        if (!DEBUG_VALID_WORKER_ADDR(addr, lbytes)) {
+            print_stack_trace();
+            TT_THROW("Host watcher: bad multicast write worker address {}", noc_address(core_start, addr, lbytes));
+        }
+    }
+
+    if (not coord_found_p(soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0), core_end) and
+        not coord_found_p(virtual_worker_cores, core_end)) {
+        TT_THROW("Host watcher: bad multicast write NOC coord {} - end core is not tensix", core_end.str());
+    } else if (coord_found_p(virtual_worker_cores, core_end)) {
+        if (!DEBUG_VALID_WORKER_ADDR(addr, lbytes)) {
+            print_stack_trace();
+            TT_THROW("Host watcher: bad multicast write worker address {}", noc_address(core_end, addr, lbytes));
+        }
+    }
+}
+
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -872,6 +872,39 @@ void Cluster::read_reg(std::uint32_t* mem_ptr, tt_cxy_pair target, uint64_t addr
     this->driver_->read_from_device_reg(mem_ptr, target.chip, target_coord, addr, size_in_bytes);
 }
 
+void Cluster::noc_multicast_write(
+    const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core_start, tt_cxy_pair core_end, uint64_t addr) const {
+    TT_FATAL(core_start.chip == core_end.chip, "core_start and core_end must be on the same chip");
+
+    const ChipId chip_id = core_start.chip;
+    const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
+
+    if (rtoptions_.get_watcher_enabled()) {
+        tt::watcher_sanitize_host_noc_multicast_write(
+            soc_desc,
+            this->virtual_worker_cores_.at(chip_id),
+            {core_start.x, core_start.y},
+            {core_end.x, core_end.y},
+            addr,
+            sz_in_bytes);
+    }
+
+    tt::umd::CoreCoord start_coord = soc_desc.get_coord_at(core_start, CoordSystem::TRANSLATED);
+    tt::umd::CoreCoord end_coord = soc_desc.get_coord_at(core_end, CoordSystem::TRANSLATED);
+
+    this->driver_->noc_multicast_write(const_cast<void*>(mem_ptr), sz_in_bytes, chip_id, start_coord, end_coord, addr);
+
+    if (this->cluster_desc_->is_chip_remote(chip_id)) {
+        this->driver_->wait_for_non_mmio_flush(chip_id);
+    }
+}
+
+void Cluster::noc_multicast_write(
+    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, CoreCoord core_start, CoreCoord core_end, uint64_t addr)
+    const {
+    noc_multicast_write(mem_ptr, sz_in_bytes, tt_cxy_pair(chip_id, core_start), tt_cxy_pair(chip_id, core_end), addr);
+}
+
 void Cluster::write_sysmem(
     const void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -875,8 +875,18 @@ void Cluster::read_reg(std::uint32_t* mem_ptr, tt_cxy_pair target, uint64_t addr
 void Cluster::noc_multicast_write(
     const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core_start, tt_cxy_pair core_end, uint64_t addr) const {
     TT_FATAL(core_start.chip == core_end.chip, "core_start and core_end must be on the same chip");
+    noc_multicast_write(
+        mem_ptr,
+        sz_in_bytes,
+        core_start.chip,
+        tt_xy_pair(core_start.x, core_start.y),
+        tt_xy_pair(core_end.x, core_end.y),
+        addr);
+}
 
-    const ChipId chip_id = core_start.chip;
+void Cluster::noc_multicast_write(
+    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, CoreCoord core_start, CoreCoord core_end, uint64_t addr)
+    const {
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
     if (rtoptions_.get_watcher_enabled()) {
@@ -897,12 +907,6 @@ void Cluster::noc_multicast_write(
     if (this->cluster_desc_->is_chip_remote(chip_id)) {
         this->driver_->wait_for_non_mmio_flush(chip_id);
     }
-}
-
-void Cluster::noc_multicast_write(
-    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, CoreCoord core_start, CoreCoord core_end, uint64_t addr)
-    const {
-    noc_multicast_write(mem_ptr, sz_in_bytes, tt_cxy_pair(chip_id, core_start), tt_cxy_pair(chip_id, core_end), addr);
 }
 
 void Cluster::write_sysmem(

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -189,6 +189,17 @@ public:
         return read_hex_vec;
     }
 
+    // NOC multicast write wrappers
+    void noc_multicast_write(
+        const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core_start, tt_cxy_pair core_end, uint64_t addr) const;
+    void noc_multicast_write(
+        const void* mem_ptr,
+        uint32_t sz_in_bytes,
+        ChipId chip_id,
+        CoreCoord core_start,
+        CoreCoord core_end,
+        uint64_t addr) const;
+
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
         auto tlb_configuration = driver_->get_tlb_configuration(target.chip, target_coord);


### PR DESCRIPTION
Ticket
#32135

Problem description
During MetalContext initialization, within a single device currently the FW loading and initialization is done by unicasting to each tensix (worker) core. This can be sped up by using NOC multicast instead.

What's changed
Implement use of multicasts to initialize all worker cores simultaneously instead of individual commands per core. Performance measurement by Tracy Profiler on two different systems (N150 (single device card) and WH 6U Galaxy (32 devices). The reported numbers are meant as extremely rough guidelines as the sample size for the measurements is very small.
MetalContext::initialize_and_launch_firmware runtime shows similar improvement on both, from ~ 6.2 ms to 3.4 ms (45% savings). The overall runtime of MetalContext::initialize on the Galaxy 6u system went from ~900 ms to ~800 ms ( ~ 11 %). On N150 card no improvement in MetalContext::initialize runtime was observed.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/metal-context-init-noc-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/metal-context-init-noc-multicast)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs