### PR TITLE
Rename launch_on_device to launch

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
@@ -126,7 +126,7 @@ ttml_cross_entropy_bw(
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
@@ -127,7 +127,7 @@ ttml_cross_entropy_fw(
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
@@ -190,7 +190,7 @@ ttml::metal::ops::layernorm_bw::device::LayerNormBackwardDeviceOperation::tensor
         .preallocated_dbeta_components = preallocated_dbeta_components,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
@@ -197,7 +197,7 @@ ttml::metal::ops::layernorm_fw::device::LayerNormForwardDeviceOperation::tensor_
         .preallocated_rstd = preallocated_rstd,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
@@ -121,7 +121,7 @@ ttml::metal::ops::profiler_no_op::device::ProfilerNoopOperation::tensor_return_v
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
@@ -159,7 +159,7 @@ ttml::metal::ops::rmsnorm_bw::device::RMSNormBackwardDeviceOperation::tensor_ret
         .preallocated_dgamma_components = preallocated_dgamma_components,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
@@ -157,7 +157,7 @@ ttml::metal::ops::rmsnorm_fw::device::RMSNormForwardDeviceOperation::tensor_retu
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
@@ -252,7 +252,7 @@ ttml::metal::ops::sdpa_fw::device::SDPAForwardDeviceOperation::tensor_return_val
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
@@ -122,7 +122,7 @@ ttml::metal::ops::silu_bw::device::SiLUBackwardDeviceOperation::tensor_return_va
         .preallocated_da = preallocated_da,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
@@ -132,7 +132,7 @@ ttml::metal::ops::softmax::device::SoftmaxDeviceOperation::tensor_return_value_t
         .preallocated_output = preallocated_output,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
@@ -139,7 +139,7 @@ ttml::metal::ops::swiglu_fw::device::SwiGLUForwardDeviceOperation::tensor_return
     auto tensor_args = OperationType::tensor_args_t{
         .input = input_tensor, .w1 = m1, .w2 = m2, .w3 = m3, .preallocated_swiglu = preallocated_swiglu};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.cpp
@@ -134,7 +134,7 @@ ttml::metal::optimizers::sgd_fused::device::SGDFusedDeviceOperation::tensor_retu
         .momentum_buffer = momentum_buffer,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -483,8 +483,15 @@ ttnn::MeshDevice* get_mesh_device(
     return mesh_device;
 }
 
+/**
+ * Launch an operation on a mesh device.
+ *
+ * @param operation_attributes The operation attributes.
+ * @param tensor_args The tensor arguments.
+ * @return Outputs are allocated but values are not immediately available till the operation is complete.
+ */
 template <DeviceOperationConcept device_operation_t>
-typename device_operation_t::tensor_return_value_t launch_on_device(
+typename device_operation_t::tensor_return_value_t launch(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     std::vector<std::reference_wrapper<const Tensor>> input_tensors;
@@ -492,7 +499,7 @@ typename device_operation_t::tensor_return_value_t launch_on_device(
         [&input_tensors](const Tensor& t) { input_tensors.push_back(std::cref(t)); }, tensor_args);
 
     tt::tt_metal::GraphTracker::instance().track_function_start(
-        get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
+        detail::get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
 
     auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     if (first_tensor.has_value()) [[likely]] {
@@ -504,7 +511,7 @@ typename device_operation_t::tensor_return_value_t launch_on_device(
 
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
 
-    ttnn::MeshDevice* mesh_device = get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
+    ttnn::MeshDevice* mesh_device = detail::get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
 
     if (!mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
         mesh_device_operation_utils::filter_tensor_shards(
@@ -549,7 +556,7 @@ typename device_operation_t::tensor_return_value_t launch_on_device(
         }
     }
 
-    launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
+    detail::launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
         operation_attributes, tensor_args, tensor_return_value, mesh_device);
 
     tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
@@ -562,9 +569,11 @@ template <DeviceOperationConcept device_operation_t>
 typename device_operation_t::tensor_return_value_t invoke(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
-    return launch_on_device<device_operation_t>(operation_attributes, tensor_args);
+    return launch<device_operation_t>(operation_attributes, tensor_args);
 }
 
 }  // namespace detail
+
+using ttnn::device_operation::detail::launch;
 
 }  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -91,6 +91,6 @@ ttnn::operations::bernoulli::BernoulliDeviceOperation::tensor_return_value_t ber
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input, output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
@@ -136,7 +136,7 @@ std::vector<ttnn::Tensor> all_broadcast(
     log_debug(tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", num_devices, num_links);
     log_debug(tt::LogOp, "DEBUG: line_fabric is created");
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .num_links = num_links,
             .ring_size = num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -178,7 +178,7 @@ ttnn::Tensor all_gather(
     tt::tt_fabric::Topology topology,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     using OperationType = ttnn::operations::ccl::AllGatherDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .memory_config = memory_config,
             .dim = dim,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -174,7 +174,7 @@ ttnn::Tensor all_to_all_combine(
     const CoreRangeSet& worker_core_range_set,
     uint32_t output_shard_dim) {
     using OperationType = ttnn::operations::ccl::AllToAllCombineDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = memory_config,
             .axis = axis,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -173,7 +173,7 @@ ttnn::operations::ccl::AllToAllDispatchDeviceOperation::tensor_return_value_t al
     ttnn::operations::ccl::AllToAllDispatchDeviceOperation::AllToAllTransferType impl,
     uint32_t output_concat_dim) {
     using OperationType = ttnn::operations::ccl::AllToAllDispatchDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .worker_core_range_set = worker_core_range_set,
             .output_mem_config = memory_config,

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
@@ -130,7 +130,7 @@ ttnn::operations::ccl::broadcast::BroadcastDeviceOperation::tensor_return_value_
     log_debug(tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", num_devices, num_links);
     log_debug(tt::LogOp, "DEBUG: line_fabric is created");
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t(
             sender_coord,
             num_links,

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -108,7 +108,7 @@ ttnn::Tensor mesh_partition(
     const ttnn::MemoryConfig& memory_config,
     const std::optional<ttnn::Tensor>& optional_output_tensor) {
     using OperationType = ttnn::operations::ccl::MeshPartitionDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .dim = (dim < 0 ? uint32_t(input_tensor.logical_shape().rank() + dim) : (uint32_t)dim),
             .cluster_axis = cluster_axis,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
@@ -113,7 +113,7 @@ ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduc
     uint32_t num_links,
     tt::tt_fabric::Topology topology) {
     using OperationType = ttnn::operations::ccl::ReduceScatterDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .memory_config = memory_config,
             .dim = dim,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
@@ -219,7 +219,7 @@ ttnn::operations::ccl::ReduceToRootOp::tensor_return_value_t reduce_to_root(
     const std::optional<Tensor>& optional_intermediate_tensor,
     const std::optional<std::vector<ttnn::CoreCoord>>& input_mux_cores) {
     using OperationType = ttnn::operations::ccl::ReduceToRootOp;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             root_coord,
             scale_fp32,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -283,7 +283,7 @@ ttnn::operations::conv::conv2d::Conv2dDeviceOperation::tensor_return_value_t con
     operation_attributes.pre_op_l1_allocation_size_bytes =
         device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -141,7 +141,7 @@ ttnn::operations::copy::TypecastDeviceOperation::tensor_return_value_t typecast(
     const std::optional<Tensor>& preallocated_output,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::copy::TypecastDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .input_dtype = input.dtype(),
             .output_dtype = output_dtype,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -277,7 +277,7 @@ ttnn::operations::data_movement::bcast::BcastDeviceOperation::tensor_return_valu
     bool in_place,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::data_movement::bcast::BcastDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .math_op = bcast_op, .dim = bcast_dim, .output_mem_config = output_mem_config, .in_place = in_place},
         OperationType::tensor_args_t{

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -95,7 +95,7 @@ ttnn::Tensor clone(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::data_movement::clone::CloneOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             dtype.value_or(input.dtype()),
             memory_config.value_or(input.memory_config()),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -409,7 +409,7 @@ ttnn::operations::data_movement::concat::ConcatDeviceOperation::tensor_return_va
     const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ttnn::operations::data_movement::concat::ConcatDeviceOperation;
     uint32_t normalized_dim = input_tensors[0].padded_shape().get_normalized_index(dim);
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .dim = normalized_dim,
             .groups = groups,

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -124,7 +124,7 @@ ttnn::operations::data_movement::copy::CopyDeviceOperation::tensor_return_value_
     const std::optional<Tensor>& preallocated_output,
     bool backwards) {
     using OperationType = ttnn::operations::data_movement::copy::CopyDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{output_mem_config, output_dtype, backwards},
         OperationType::tensor_args_t{input, preallocated_output});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
@@ -46,7 +46,7 @@ tensor_return_value_t FillPadDeviceOperation::create_output_tensors(
 namespace ttnn::prim {
 ttnn::Tensor fill_pad(const Tensor& input, float fill_value, const MemoryConfig& output_memory_config) {
     using OperationType = ttnn::operations::data_movement::fill_pad::FillPadDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .fill_value = fill_value,
             .output_mem_config = output_memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
@@ -95,7 +95,7 @@ ttnn::Tensor fill_rm(
     float val_lo,
     const MemoryConfig& output_memory_config) {
     using OperationType = ttnn::operations::data_movement::fill_rm::FillRMDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .N = N,
             .C = C,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -135,6 +135,6 @@ ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
     auto operation_attributes = OperationType::operation_attributes_t{
         .stride_h = stride_h, .stride_w = stride_w, .is_sharded = is_sharded, .is_dram_interleaved = is_dram_interleaved};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
@@ -154,7 +154,7 @@ ttnn::operations::data_movement::gather::tensor_return_value_t gather(
         OperationType::operation_attributes_t{dim, sparse_grad, output_memory_config, sub_core_grids};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, input_index_tensor, output_tensors};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.cpp
@@ -81,7 +81,7 @@ ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation::tenso
     const tt::tt_metal::MemoryConfig& output_mem_config,
     int64_t dim) {
     using OperationType = ttnn::operations::data_movement::indexed_fill::IndexedFillDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .dim = dim,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/moe_expert_token_remap_device_operation.cpp
@@ -120,7 +120,7 @@ ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation::tensor_retu
     const std::optional<ttnn::Tensor>& optional_output_reduced_tensor,
     uint32_t reduction_size) {
     using OperationType = ttnn::operations::data_movement::MoeExpertTokenRemapDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.output_mem_config = output_mem_config, .reduction_size = reduction_size},
         OperationType::tensor_args_t{
             .topk_tensor = topk_tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -79,7 +79,7 @@ ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation::tensor_return_v
     const std::optional<ttnn::MemoryConfig>& output_mem_config,
     const std::optional<ttnn::Tensor>& optional_output_routing_weights) {
     using OperationType = ttnn::operations::data_movement::MoeRoutingRemapDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .non_zero_weight_size = non_zero_weight_size,
             .expert_parallel_size = expert_parallel_size,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -76,7 +76,7 @@ ttnn::operations::data_movement::move::MoveDeviceOperation::tensor_return_value_
         const bool ranges_overlap = (src_base < dst_base + copy_size_bytes) && (dst_base < src_base + copy_size_bytes);
         backwards = src_and_dst_in_l1 && ranges_overlap && (dst_base > src_base);
     }
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .move_op_parallelization_strategy = move_op_parallelization_strategy,

--- a/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/non_zero_indices/device/non_zero_indices_device_operation.cpp
@@ -57,7 +57,7 @@ namespace ttnn::prim {
 ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation::tensor_return_value_t nonzero(
     const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& memory_config) {
     using OperationType = ttnn::operations::data_movement::nonzero::NonZeroIndicesDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.output_memory_config = memory_config},
         OperationType::tensor_args_t{.input = input_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -197,7 +197,7 @@ ttnn::operations::data_movement::pad::PadDeviceOperation::tensor_return_value_t 
     bool use_multicore,
     const std::optional<ttnn::Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::data_movement::pad::PadDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             output_logical_shape, output_padded_shape, input_tensor_start, pad_value, output_mem_config, use_multicore},
         OperationType::tensor_args_t{input, preallocated_output});

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -95,11 +95,12 @@ ttnn::operations::data_movement::PermuteDeviceOperation::tensor_return_value_t p
     std::optional<Tensor> optional_output_tensor,
     const std::optional<float>& pad_value) {
     using OperationType = ttnn::operations::data_movement::PermuteDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .dims = dims,
             .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
             .pad_value = pad_value},
-        OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = std::move(optional_output_tensor)});
+        OperationType::tensor_args_t{
+            .input_tensor = input_tensor, .optional_output_tensor = std::move(optional_output_tensor)});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -93,7 +93,7 @@ ttnn::operations::data_movement::repeat::RepeatDeviceOperation::tensor_return_va
     bool m_is_last_dim,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ttnn::operations::data_movement::repeat::RepeatDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .m_num_repeats = m_num_repeats, .m_is_last_dim = m_is_last_dim, .m_output_mem_config = output_mem_config},
         OperationType::tensor_args_t{.input = input});

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -110,7 +110,7 @@ ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation::tens
     const tt::tt_metal::Shape& padded_output_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ttnn::operations::data_movement::reshape_on_device::ReshapeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{logical_output_shape, padded_output_shape, output_mem_config},
         OperationType::tensor_args_t{input_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -95,7 +95,7 @@ ttnn::operations::data_movement::reshape::ReshapeDeviceOperation::tensor_return_
     bool recreate_mapping_tensor,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     using OperationType = ttnn::operations::data_movement::reshape::ReshapeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             logical_output_shape, padded_output_shape, output_mem_config, recreate_mapping_tensor, sub_core_grid},
         OperationType::tensor_args_t{input});

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.cpp
@@ -95,7 +95,7 @@ ttnn::Tensor scatter(
     const operations::data_movement::scatter::ScatterReductionType& reduction,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     using OperationType = ttnn::operations::data_movement::scatter::ScatterDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{dim, output_memory_config, reduction, sub_core_grid},
         OperationType::tensor_args_t{input_tensor, index_tensor, source_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -112,7 +112,7 @@ ttnn::operations::data_movement::InterleavedToShardedDeviceOperation::tensor_ret
     bool keep_l1_aligned,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::data_movement::InterleavedToShardedDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{output_mem_config, output_dtype, keep_l1_aligned},
         OperationType::tensor_args_t{input_tensor, preallocated_output});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation.cpp
@@ -229,7 +229,7 @@ ttnn::operations::data_movement::reshard::ReshardDeviceOperation::tensor_return_
     const tt::tt_metal::MemoryConfig& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
     using OperationType = ttnn::operations::data_movement::reshard::ReshardDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = memory_config,
         },

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -104,14 +104,9 @@ ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation::tensor_ret
     const tt::tt_metal::DataType& output_dtype,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::data_movement::ShardedToInterleavedDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            .output_mem_config = output_mem_config,
-            .output_dtype = output_dtype,
-            .num_slices = 1,
-            .slice_index = 0},
-        OperationType::tensor_args_t{
-            .input_tensor = input_tensor,
-            .preallocated_output = preallocated_output});
+            .output_mem_config = output_mem_config, .output_dtype = output_dtype, .num_slices = 1, .slice_index = 0},
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .preallocated_output = preallocated_output});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -114,7 +114,7 @@ interleaved_to_sharded_partial(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype) {
     using OperationType = ttnn::operations::data_movement::InterleavedToShardedPartialDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .grid_size = grid_size,
             .shard_spec = shard_spec,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_device_operation.cpp
@@ -95,14 +95,12 @@ sharded_to_interleaved_partial(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const tt::tt_metal::DataType& output_dtype) {
     using OperationType = ttnn::operations::data_movement::ShardedToInterleavedPartialDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .num_slices = num_slices,
             .slice_index = slice_index,
             .output_mem_config = output_mem_config,
             .output_dtype = output_dtype},
-        OperationType::tensor_args_t{
-            .input_tensor = input_tensor,
-            .cache_tensor = cache_tensor});
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .cache_tensor = cache_tensor});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -288,7 +288,7 @@ ttnn::operations::data_movement::slice::SliceDeviceOperation::tensor_return_valu
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::data_movement::slice::SliceDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             slice_start, slice_end, step, output_mem_config, use_tensor_args, slice_dim, num_devices, sub_core_grids},
         OperationType::tensor_args_t{input, std::move(start_tensor), std::move(end_tensor), preallocated_output});

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
@@ -158,7 +158,7 @@ ttnn::operations::data_movement::sort::SortDeviceOperation::tensor_return_value_
     const MemoryConfig& output_memory_config,
     const std::vector<std::optional<Tensor>>& output_tensors) {
     using OperationType = ttnn::operations::data_movement::sort::SortDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{dim, descending, stable, output_memory_config},
         OperationType::tensor_args_t{input_tensor, output_tensors});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_device_operation.cpp
@@ -88,7 +88,8 @@ namespace ttnn::prim {
 std::vector<ttnn::Tensor> split(
     const Tensor& input_tensor, int num_splits, int dim, const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ttnn::operations::data_movement::split::SplitDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
-        OperationType::operation_attributes_t{num_splits, dim, output_mem_config}, OperationType::tensor_args_t{input_tensor});
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{num_splits, dim, output_mem_config},
+        OperationType::tensor_args_t{input_tensor});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -144,7 +144,7 @@ ttnn::Tensor tilize(
     bool use_low_perf,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::data_movement::TilizeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
             .output_dtype = output_dtype.value_or(input_tensor.dtype()),

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -155,7 +155,7 @@ ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation::tensor_ret
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::data_movement::TilizeWithValPaddingDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_padded_shape = output_padded_shape,
             .pad_value = pad_value,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -288,7 +288,7 @@ ttnn::Tensor transpose(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const std::optional<float>& pad_value) {
     using OperationType = ttnn::operations::data_movement::transpose::TransposeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .dim = dim,
             .output_mem_config = output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -341,7 +341,7 @@ ttnn::operations::data_movement::UntilizeDeviceOperation::tensor_return_value_t 
     bool enough_space_height,
     uint32_t pf_type) {
     using OperationType = ttnn::operations::data_movement::UntilizeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = std::move(output_mem_config),
             .use_multicore = use_multicore,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -215,7 +215,7 @@ ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingD
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::data_movement::untilize_with_unpadding::UntilizeWithUnpaddingDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_tensor_end = output_tensor_end,
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
@@ -121,7 +121,7 @@ ttnn::operations::debug::ApplyDeviceDelayDeviceOperation::tensor_return_value_t 
         .delays = delays, .worker_core_range_set = subdevice_core_range_set, .mesh_device = &mesh_device};
     auto tensor_args = OperationType::tensor_args_t{};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -486,7 +486,7 @@ ttnn::operations::binary::BinaryDeviceOperation::tensor_return_value_t binary(
         std::nullopt};
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a_arg, input_tensor_b_arg, optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 ttnn::operations::binary::BinaryDeviceOperation::tensor_return_value_t binary(
@@ -518,7 +518,7 @@ ttnn::operations::binary::BinaryDeviceOperation::tensor_return_value_t binary(
         std::nullopt};
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a_arg, std::nullopt, optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -494,7 +494,7 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         is_where_op};
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
@@ -534,7 +534,7 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         false};
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -535,7 +535,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
+    return ttnn::device_operation::launch<OperationType>(attributes, args);
 }
 
 ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
@@ -579,7 +579,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
+    return ttnn::device_operation::launch<OperationType>(attributes, args);
 }
 
 ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
@@ -615,7 +615,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .input_tensor_c = std::nullopt,
         .optional_output_tensor = optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
+    return ttnn::device_operation::launch<OperationType>(attributes, args);
 }
 
 ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary(
@@ -650,7 +650,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .input_tensor_c = input_c,
         .optional_output_tensor = optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(attributes, args);
+    return ttnn::device_operation::launch<OperationType>(attributes, args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -207,6 +207,6 @@ ttnn::operations::unary::UnaryDeviceOperation::tensor_return_value_t unary(
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 } // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -121,6 +121,6 @@ ttnn::operations::embedding::EmbeddingsDeviceOperation::tensor_return_value_t em
         .optional_output_tensor = optional_output_tensor,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -110,7 +110,7 @@ ttnn::Tensor embedding_backward(
     uint32_t num_embeddings,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::embedding_backward::EmbeddingBackwardDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_mem_config = output_mem_config,
             .output_dtype = output_dtype,

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -45,6 +45,6 @@ ttnn::operations::examples::ExampleDeviceOperation::tensor_return_value_t exampl
     auto operation_attributes = OperationType::operation_attributes_t{true, 42};
     auto tensor_args = OperationType::tensor_args_t{input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -67,6 +67,6 @@ ttnn::operations::examples::ExampleMultipleReturnDeviceOperation::tensor_return_
     auto operation_attributes = OperationType::operation_attributes_t{true, 42, return_output1, return_output2};
     auto tensor_args = OperationType::tensor_args_t{input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.cpp
@@ -134,7 +134,7 @@ ttnn::operations::experimental::broadcast_to::BcastToOperation::tensor_return_va
         output_shape, memory_config.value_or(input.memory_config()), subtile_broadcast_type};
     auto tensor_args = OperationType::tensor_args_t{input, output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.cpp
@@ -159,7 +159,7 @@ ttnn::operations::experimental::ccl::all_gather_concat_heads_fused::AllGatherCon
 
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .buffer_tensor = buffer_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
@@ -249,7 +249,7 @@ all_gather_matmul_async(
         persistent_output_buffer,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.cpp
@@ -163,7 +163,7 @@ all_reduce_async(
         &mesh_device);
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .buffer_tensor = buffer_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
@@ -252,7 +252,7 @@ ttnn::operations::experimental::ccl::AllToAllAsyncDeviceOperation::tensor_return
         .persistent_intermediate_buffer = persistent_intermediate_buffer,
         .persistent_output_buffer = persistent_output_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -187,7 +187,7 @@ all_to_all_async_generic(
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .persistent_output_buffer = persistent_output_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
@@ -159,7 +159,7 @@ ttnn::operations::experimental::ccl::deepseek_minimal_broadcast::DeepseekMinimal
         .sub_device_id = sub_device_id};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -216,7 +216,7 @@ ttnn::operations::experimental::ccl::llama_all_gather_matmul_async::LlamaAllGath
     auto tensor_args =
         OperationType::tensor_args_t{.input0 = input0, .input1 = input1, .intermediate = intermediate_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
@@ -150,7 +150,7 @@ ttnn::operations::experimental::ccl::LlamaReduceScatterDeviceOperation::tensor_r
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .intermediate_packet_buffer = intermediate_packet_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
@@ -191,7 +191,7 @@ llama_reduce_scatter_create_heads(
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .intermediate_packet_buffer = intermediate_packet_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -196,7 +196,7 @@ ttnn::operations::experimental::ccl::Matmul_RS::tensor_return_value_t llama_rs_m
         .matmul_output_tensors = std::move(matmul_output_tensors),
         .second_weight_tensor = second_weight_tensor_arg};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
@@ -209,7 +209,7 @@ ttnn::operations::experimental::ccl::matmul_reduce_scatter_async::MatmulReduceSc
         .persistent_intermediate = persistent_intermediate_buffer,
         .persistent_output = persistent_output_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
@@ -176,7 +176,7 @@ neighbor_pad_async(
 
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .preallocated_output = std::nullopt};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation.cpp
@@ -311,7 +311,7 @@ ttnn::operations::experimental::ccl::reduce_scatter_minimal_async::detail::Reduc
         num_buffers_per_channel};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, optional_intermediate_tensor, optional_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -317,7 +317,7 @@ ttnn::operations::fused::normalization::RMSAllGatherDeviceOperation::tensor_retu
         .stats = stats,
         .preallocated_output = persistent_output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation.cpp
@@ -61,7 +61,7 @@ ttnn::operations::experimental::ccl::recv_async::RecvAsyncDeviceOperation::tenso
     auto operation_attributes = OperationType::operation_attributes_t(mesh_socket);
     auto tensor_args = OperationType::tensor_args_t{.output_tensor = output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation.cpp
@@ -63,7 +63,7 @@ ttnn::operations::experimental::ccl::send_async::SendAsyncDeviceOperation::tenso
     auto operation_attributes = OperationType::operation_attributes_t(mesh_socket);
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
@@ -118,7 +118,7 @@ slice_reshard_async(
         num_devices);
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.cpp
@@ -119,7 +119,7 @@ strided_all_gather_async(
         mm_block_wt};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, persistent_output_buffer};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -157,7 +157,7 @@ ttnn::operations::experimental::ccl::strided_all_gather_minimal_matmul_async::St
         ag_op};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, weight_tensor, persistent_output_buffer, bias};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
@@ -110,7 +110,7 @@ ttnn::operations::experimental::cnn::to_chw::ConvertToCHWDeviceOperation::tensor
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -86,7 +86,7 @@ ttnn::operations::experimental::cnn::ConvertToHWCDeviceOperation::tensor_return_
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -243,7 +243,7 @@ ttnn::operations::experimental::conv3d::Conv3dDeviceOperation::tensor_return_val
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .weight_tensor = weight_tensor, .bias_tensor = bias_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -153,7 +153,7 @@ ttnn::operations::experimental::dropout::DropoutDeviceOperation::tensor_return_v
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -166,7 +166,7 @@ ttnn::operations::experimental::matmul::attn_matmul::AttnMatmulDeviceOperation::
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, std::move(optional_output_tensor)};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -286,7 +286,7 @@ group_attn_matmul(
         .preallocated_output = std::move(preallocated_output),
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -141,7 +141,7 @@ ttnn::operations::experimental::padded_slice::PaddedSliceDeviceOperation::tensor
         .output_mem_config = output_mem_config};
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -109,7 +109,7 @@ paged_fill_cache(
         .batch_idx_tensor_opt = batch_idx_tensor,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -309,7 +309,7 @@ paged_fused_update_cache(
             update_idxs_tensor.has_value() ? std::optional<Tensor>(update_idxs_tensor.value()) : std::nullopt,
         .page_table = page_table.has_value() ? std::optional<Tensor>(page_table.value()) : std::nullopt};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -257,7 +257,7 @@ paged_update_cache(
             update_idxs_tensor.has_value() ? std::optional<Tensor>(update_idxs_tensor.value()) : std::nullopt,
         .page_table = page_table.has_value() ? std::optional<Tensor>(page_table.value()) : std::nullopt};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
@@ -69,7 +69,7 @@ ttnn::operations::experimental::plusone::tensor_return_value_t plus_one(
         .sub_core_grids = sub_core_grids, .skip_negative_entries = skip_negative_entries};
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/deepseek_grouped_gate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/deepseek_grouped_gate_device_operation.cpp
@@ -100,7 +100,7 @@ deepseek_grouped_gate(
         output_mem_config.value_or(scores.memory_config())};
     auto tensor_args = OperationType::tensor_args_t{scores, bias};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -81,7 +81,7 @@ ttnn::operations::experimental::reduction::detail::FastReduceNCDeviceOperation::
         .dim = dim, .output_mem_config = output_mem_config, .compute_kernel_config = compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.cpp
@@ -59,7 +59,7 @@ ttnn::operations::experimental::reduction::IntImgDeviceOperation::tensor_return_
     auto operation_attributes = OperationType::operation_attributes_t{};
     auto tensor_args = OperationType::tensor_args_t{input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -144,7 +144,7 @@ ttnn::operations::experimental::slice_write::SliceWriteDeviceOperation::tensor_r
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor, .output = output_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
@@ -103,7 +103,7 @@ ttnn::operations::experimental::ssm::hc_sum_reduce::HCSumReduceDeviceOperation::
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -103,7 +103,7 @@ ttnn::operations::experimental::ssm::prefix_scan::PrefixScanDeviceOperation::ten
     };
     auto tensor_args = OperationType::tensor_args_t{.a = a, .bx = bx, .h_prev = h_prev};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
@@ -176,7 +176,7 @@ repeat_and_interleave_eltwise_mul(
     };
     auto tensor_args = OperationType::tensor_args_t{.a = a, .b = b, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.hpp
@@ -54,7 +54,7 @@ struct ExecuteTestHangDeviceOperation {
 namespace ttnn {
 struct TestHangOp {
     static Tensor invoke(const Tensor& input) {
-        return device_operation::detail::launch_on_device<ttnn::prim::ExecuteTestHangDeviceOperation>({}, {input});
+        return device_operation::launch<ttnn::prim::ExecuteTestHangDeviceOperation>({}, {input});
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation.cpp
@@ -352,7 +352,7 @@ ttnn::operations::experimental::ccl::all_reduce_create_qkv_heads::tensor_return_
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .buffer_tensor = buffer_tensor, .batch_offset_tensor = batch_offset_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -109,7 +109,7 @@ ttnn::operations::experimental::transformer::ConcatenateHeadsDeviceOperation::te
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -174,7 +174,7 @@ ttnn::operations::experimental::create_qkv_heads::tensor_return_value_t create_q
     auto tensor_args =
         OperationType::tensor_args_t{.input = input_tensor, .preallocated_outputs = preallocated_outputs};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -268,7 +268,7 @@ std::tuple<Tensor, Tensor, Tensor> create_qkv_heads_from_separate_tensors(
         .input_tensor_kv = input_tensor_kv,
         .optional_output_tensors = optional_output_tensors};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_device_operation.cpp
@@ -203,7 +203,7 @@ fused_rmsnorm_post_all_gather(
         .rope_sin = rope_sin.has_value() ? std::optional<Tensor>(rope_sin.value()) : std::nullopt,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -116,7 +116,7 @@ ttnn::operations::experimental::nlp_concat_heads::tensor_return_value_t nlp_conc
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/nlp_concat_heads_boltz_device_operation.cpp
@@ -130,7 +130,7 @@ ttnn::operations::experimental::nlp_concat_heads_boltz::tensor_return_value_t nl
     auto operation_attributes = OperationType::operation_attributes_t{memory_config};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, std::move(optional_output_tensor)};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -151,7 +151,7 @@ ttnn::operations::experimental::nlp_concat_heads_decode::tensor_return_value_t n
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input_tensor, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -273,7 +273,7 @@ std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads(
         .input_tensor_kv = input_tensor_kv,
         .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
@@ -270,7 +270,7 @@ std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads_boltz(
         .input_tensor_kv = input_tensor_kv,
         .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -221,7 +221,7 @@ std::vector<Tensor> nlp_create_qkv_heads_decode(
         .output_mem_config = output_mem_config};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .batch_offset = batch_offset};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -87,7 +87,7 @@ ttnn::operations::experimental::transformer::qkv_heads_falcon7b::tensor_return_v
     auto operation_attributes = OperationType::operation_attributes_t{output_mem_config};
     auto tensor_args = OperationType::tensor_args_t{input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
@@ -120,7 +120,7 @@ std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads_segformer(
     auto tensor_args =
         OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensors = optional_output_tensors};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/nlp_create_qkv_heads_vit_device_operation.cpp
@@ -111,7 +111,7 @@ std::vector<Tensor> nlp_create_qkv_heads_vit(
     auto tensor_args =
         OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensors = optional_output_tensors};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -156,7 +156,7 @@ ttnn::operations::experimental::transformer::nlp_kv_cache_load_slice::tensor_ret
     auto operation_attributes = OperationType::operation_attributes_t{output_tensor_start, output_tensor_end};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -176,7 +176,7 @@ ttnn::operations::experimental::transformer::rotary_embedding::tensor_return_val
     };
     auto tensor_args = OperationType::tensor_args_t{.input = input, .cos = cos, .sin = sin};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -218,7 +218,7 @@ tt::tt_metal::Tensor rotary_embedding_llama(
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .cos_cache = cos_cache, .sin_cache = sin_cache, .trans_mat = trans_mat};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/rotary_embedding_llama_fused_qk_device_operation.cpp
@@ -180,7 +180,7 @@ rotary_embedding_llama_fused_qk(
         .trans_mat = trans_mat,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -67,7 +67,7 @@ ttnn::operations::experimental::transformer::rotate_half::tensor_return_value_t 
     auto operation_attributes = OperationType::operation_attributes_t{.output_mem_config = output_mem_config};
     auto tensor_args = OperationType::tensor_args_t{.input = input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -153,7 +153,7 @@ std::vector<Tensor> split_query_key_value_and_split_heads(
     auto tensor_args = OperationType::tensor_args_t{
         input_tensor, optional_output_tensors.value_or(std::vector<std::optional<ttnn::Tensor>>{})};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -149,7 +149,7 @@ ttnn::operations::experimental::gelu_backward::GeluBackwardDeviceOperation::tens
     auto tensor_args = OperationType::tensor_args_t{
         .grad_output = grad_output, .input = input, .preallocated_input_grad = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/where.hpp
@@ -30,8 +30,7 @@ struct WhereOperation {
         if constexpr (std::is_same_v<T, Tensor> and std::is_same_v<U, Tensor>) {
             auto [operation_attributes, tensor_args] = WhereDeviceOperation::invoke(
                 condition, value_true, value_false, output_dtype, memory_config, std::move(output_tensor));
-            return ttnn::device_operation::detail::launch_on_device<WhereDeviceOperation>(
-                operation_attributes, tensor_args);
+            return ttnn::device_operation::launch<WhereDeviceOperation>(operation_attributes, tensor_args);
 
         } else {
             TT_FATAL((!std::is_same_v<T, Tensor> || !std::is_same_v<U, Tensor>), "Scalar values are not supported!");

--- a/ttnn/cpp/ttnn/operations/full/device/full_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/full_device_operation.cpp
@@ -84,6 +84,6 @@ ttnn::operations::full::FullOperation::tensor_return_value_t full(
     };
     auto tensor_args = OperationType::tensor_args_t{};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/full_like/device/full_like_device_operation.cpp
@@ -75,6 +75,6 @@ ttnn::operations::full_like::FullLikeOperation::tensor_return_value_t moreh_full
         memory_config.value_or(input.memory_config())};
     auto tensor_args = OperationType::tensor_args_t{input};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -110,6 +110,6 @@ ttnn::operations::generic::GenericOpDeviceOperation::tensor_return_value_t gener
 
     auto tensor_args = OperationType::tensor_args_t{.io_tensors = io_tensors, .output_tensor = io_tensors.back()};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -58,7 +58,7 @@ ttnn::Tensor index_fill(
     const std::variant<float, int> value,
     const std::optional<MemoryConfig>& memory_config) {
     using OperationType = ttnn::operations::index_fill::IndexFillOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{dim, value, memory_config.value_or(input.memory_config())},
         OperationType::tensor_args_t{input, index});
 }

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -190,15 +190,13 @@ ttnn::operations::kv_cache::UpdateKVCacheOperation::tensor_return_value_t update
     const ttnn::operations::kv_cache::UpdateCacheOpType op_type,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     using OperationType = ttnn::operations::kv_cache::UpdateKVCacheOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .batch_idx = batch_idx,
             .update_idx = update_index,
             .batch_offset = batch_offset,
             .op_type = op_type,
             .compute_kernel_config = compute_kernel_config},
-        OperationType::tensor_args_t{
-            .cache = cache,
-            .input = input});
+        OperationType::tensor_args_t{.cache = cache, .input = input});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_device_operation.cpp
@@ -83,6 +83,6 @@ ttnn::operations::moreh::moreh_abs_pow::MorehAbsPowOperation::tensor_return_valu
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     const OperationType::tensor_args_t tensor_args{input, output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.cpp
@@ -159,6 +159,6 @@ ttnn::operations::moreh::moreh_adam::MorehAdamOperation::tensor_return_value_t m
         exp_avg_sq_in,
         max_exp_avg_sq_in,
         {param_out, exp_avg_out, exp_avg_sq_out, max_exp_avg_sq_out}};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -170,7 +170,7 @@ ttnn::operations::moreh::moreh_adamw::MorehAdamWDeviceOperation::tensor_return_v
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     using OperationType = ttnn::operations::moreh::moreh_adamw::MorehAdamWDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .lr = lr.value_or(0.001f),
             .beta1 = beta1.value_or(0.9f),

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
@@ -107,7 +107,7 @@ ttnn::operations::moreh::moreh_arange::MorehArangeOperation::tensor_return_value
         OperationType::operation_attributes_t{start, end, step, untilize_out, mesh_device, dtype, memory_config};
     auto tensor_args = OperationType::tensor_args_t{output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_device_operation.cpp
@@ -63,6 +63,6 @@ moreh_clip_grad_norm_step1(
         memory_config.value_or(inputs.at(0).memory_config()),
         compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{inputs, tmp_pow_sum};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_device_operation.cpp
@@ -70,6 +70,6 @@ moreh_clip_grad_norm_step2(
     auto operation_attributes = OperationType::operation_attributes_t{
         norm_type, memory_config.value_or(tmp_pow_sum.memory_config()), compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{tmp_pow_sum, total_norm};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_device_operation.cpp
@@ -64,6 +64,6 @@ moreh_clip_grad_norm_step3(
     auto operation_attributes = OperationType::operation_attributes_t{
         memory_config.value_or(inputs.at(0).memory_config()), compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{inputs, clip_coef_clamped};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_device_operation.cpp
@@ -83,6 +83,6 @@ ttnn::operations::moreh::moreh_dot::MorehDotOperation::tensor_return_value_t mor
         memory_config.value_or(input_a.memory_config()),
         init_device_compute_kernel_config(input_a.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input_a, input_b, output};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_device_operation.cpp
@@ -102,6 +102,6 @@ namespace ttnn::prim {
     using OperationType = ::ttnn::operations::moreh::moreh_dot_backward::MorehDotBackwardOperation;
     auto operation_attributes = OperationType::operation_attributes_t{memory_config.value_or(input.memory_config())};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input, other, {input_grad, other_grad}};
-    return ::ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ::ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
@@ -179,6 +179,6 @@ ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation::tensor_return_val
     using OperationType = ttnn::operations::moreh::moreh_getitem::MorehGetItemOperation;
     auto operation_attributes = OperationType::operation_attributes_t{index_dims, memory_config.value_or(input.memory_config())};
     auto tensor_args = OperationType::tensor_args_t{input, index_tensors, output};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -180,6 +180,6 @@ ttnn::operations::moreh::moreh_group_norm::MorehGroupNormOperation::tensor_retur
         rstd_memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input, gamma, beta, output, mean, rstd};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -172,6 +172,6 @@ moreh_group_norm_backward_gamma_beta_grad(
         beta_grad_memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     OperationType::tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma_grad, beta_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
@@ -113,6 +113,6 @@ moreh_group_norm_backward_input_grad(
         input_grad_memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     OperationType::tensor_args_t tensor_args{output_grad, input, mean, rstd, gamma, input_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -147,6 +147,6 @@ ttnn::operations::moreh::moreh_layer_norm::MorehLayerNormOperation::tensor_retur
         memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input, gamma, beta, output, mean, rstd};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -76,6 +76,6 @@ ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad::MorehLayerNo
         memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input, mean, rstd, gamma_grad, beta_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
@@ -71,6 +71,6 @@ ttnn::operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBac
         memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input, mean, rstd, input_grad, gamma};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/device/moreh_linear_backward_device_operation.cpp
@@ -83,7 +83,7 @@ moreh_bias_add_backward(
         init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, bias, bias_grad};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -188,6 +188,6 @@ ttnn::operations::moreh::moreh_matmul::MorehMatmulOperation::tensor_return_value
         output_memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config)};
     auto tensor_args = OperationType::tensor_args_t{input, other, output, bias};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/moreh_mean_device_operation.cpp
@@ -122,6 +122,6 @@ ttnn::operations::moreh::moreh_mean::MorehMeanOperation::tensor_return_value_t m
         memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input, output};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
@@ -76,6 +76,6 @@ ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackwardOperation::tensor
         memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step1/device/moreh_nll_loss_step1_device_operation.cpp
@@ -78,6 +78,6 @@ moreh_nll_loss_step1(
         memory_config.value_or(target_tensor.memory_config()),
         compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{target_tensor, weight_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_step2/device/moreh_nll_loss_step2_device_operation.cpp
@@ -131,6 +131,6 @@ moreh_nll_loss_step2(
         memory_config.value_or(input_tensor.memory_config()),
         compute_kernel_config};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, target_tensor, weight_tensor, divisor_tensor, output_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/device/moreh_nll_loss_backward_device_operation.cpp
@@ -128,6 +128,6 @@ moreh_nll_loss_backward(
         init_device_compute_kernel_config(target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args =
         OperationType::tensor_args_t{target_tensor, output_grad_tensor, weight_tensor, divisor_tensor, input_grad_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_device_operation.cpp
@@ -125,6 +125,6 @@ ttnn::operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreduce
         memory_config.value_or(target_tensor.memory_config()),
         init_device_compute_kernel_config(target_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{target_tensor, output_grad_tensor, weight_tensor, input_grad_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -196,7 +196,7 @@ ttnn::operations::moreh::moreh_norm::MorehNormOperation::tensor_return_value_t m
     };
     auto tensor_args = OperationType::tensor_args_t{input, output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_device_operation.cpp
@@ -76,6 +76,6 @@ ttnn::operations::moreh::moreh_norm_backward::MorehNormBackwardOperation::tensor
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
     };
     auto tensor_args = OperationType::tensor_args_t{input, output, output_grad, input_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/device/moreh_sgd_device_operation.cpp
@@ -127,6 +127,6 @@ ttnn::operations::moreh::moreh_sgd::MorehSgdOperation::tensor_return_value_t mor
         momentum_buffer_out_memory_config.value_or(param_in.memory_config()),
         init_device_compute_kernel_config(param_in.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{param_in, grad, momentum_buffer_in, param_out, momentum_buffer_out};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp
@@ -212,6 +212,6 @@ ttnn::operations::moreh::moreh_softmax::MorehSoftmaxOperation::tensor_return_val
         init_device_compute_kernel_config(
             input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, is_fp32)};
     auto tensor_args = OperationType::tensor_args_t{input, output};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/moreh_softmax_backward_device_operation.cpp
@@ -200,6 +200,6 @@ moreh_softmax_backward(
         init_device_compute_kernel_config(
             output_grad_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_tensor, output_grad_tensor, input_grad_tensor};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
@@ -140,6 +140,6 @@ ttnn::operations::moreh::moreh_sum::MorehSumOperation::tensor_return_value_t mor
         memory_config.value_or(input.memory_config()),
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{input, output};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_device_operation.cpp
@@ -147,6 +147,6 @@ ttnn::operations::moreh::moreh_sum_backward::MorehSumBackwardOperation::tensor_r
         memory_config.value_or(output_grad.memory_config()),
         init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
     auto tensor_args = OperationType::tensor_args_t{output_grad, input, input_grad};
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -189,6 +189,6 @@ ttnn::operations::normalization::BatchNormOperation::tensor_return_value_t batch
         input.dtype()};
     OperationType::tensor_args_t tensor_args{input, batch_mean, batch_var, std::move(weight), std::move(bias), std::move(output)};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -128,6 +128,6 @@ ttnn::operations::normalization::RunningStatistics::tensor_return_value_t runnin
         batch_mean.dtype()};
     OperationType::tensor_args_t tensor_args{batch_mean, batch_var, std::move(running_mean), std::move(running_var)};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -290,6 +290,6 @@ ttnn::operations::normalization::group_norm::GroupNormDeviceOperation::tensor_re
         .negative_mask = std::move(negative_mask),
         .reciprocals = std::move(reciprocals)};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -439,6 +439,6 @@ ttnn::operations::normalization::layer_norm::LayerNormDeviceOperation::tensor_re
         .stats = stats,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather/layernorm_post_all_gather_device_operation.cpp
@@ -217,6 +217,6 @@ layernorm_post_all_gather(
         .beta = beta,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -91,6 +91,6 @@ layernorm_pre_all_gather(
         .program_config = program_config};
     auto tensor_args = OperationType::tensor_args_t{.input = input, .preallocated_output = preallocated_output};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -639,6 +639,6 @@ ttnn::operations::normalization::softmax::SoftmaxDeviceOperation::tensor_return_
         numeric_stable};
     auto tensor_args = OperationType::tensor_args_t{input_tensor, mask};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp
@@ -297,7 +297,7 @@ ttnn::operations::point_to_point::PointToPointOp::tensor_return_value_t point_to
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     const std::optional<ttnn::Tensor>& optional_intermediate_tensor) {
     using OperationType = ttnn::operations::point_to_point::PointToPointOp;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{receiver_coord, sender_coord, topology, input_tensor.tensor_spec()},
         OperationType::tensor_args_t{input_tensor, optional_output_tensor, optional_intermediate_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -227,7 +227,7 @@ std::vector<ttnn::Tensor> pool2d(
     bool return_indices,
     uint32_t memory_used) {
     using OperationType = ttnn::operations::pool::Pool2D;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .sliding_window_config_ = sliding_window_config,
             .pool_type_ = pool_type,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
@@ -329,7 +329,7 @@ ttnn::Tensor grid_sample(
     bool batch_output_channels,
     const std::optional<MemoryConfig>& memory_config) {
     using OperationType = ttnn::operations::pool::grid_sample::GridSampleOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .mode = mode,
             .padding_mode = padding_mode,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.cpp
@@ -170,7 +170,7 @@ ttnn::Tensor upsample(
     const DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<ttnn::operations::sliding_window::SlidingWindowConfig>& sliding_window_config) {
     using OperationType = ttnn::operations::pool::upsample::UpsampleOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .scale_factor_h = scale_factor_h,
             .scale_factor_w = scale_factor_w,

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
@@ -110,6 +110,6 @@ ttnn::operations::dram_prefetcher::DramPrefetcherOperation::tensor_return_value_
     };
     auto tensor_args = OperationType::tensor_args_t{.input_tensors = tensors};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -70,8 +70,9 @@ ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
     float to,
     uint32_t seed) {
     using OperationType = ttnn::operations::rand::RandDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
-        OperationType::operation_attributes_t{shape, dtype, layout, memory_config, std::addressof(device), from, to, seed},
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            shape, dtype, layout, memory_config, std::addressof(device), from, to, seed},
         OperationType::tensor_args_t{});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
@@ -123,7 +123,7 @@ ttnn::Tensor accumulation(
     const std::optional<MemoryConfig>& memory_config,
     ttnn::operations::reduction::accumulation::AccumulationOp op) {
     using OperationType = ttnn::operations::reduction::accumulation::AccumulationDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             (dim < 0) ? (dim + input_tensor.logical_shape().rank()) : dim,
             dtype.has_value() ? dtype.value()

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -97,7 +97,7 @@ ttnn::Tensor ema_device(
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<Tensor> optional_output_tensor) {
     using OperationType = ttnn::operations::reduction::ema::EmaDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .alpha = alpha,
             .grid_size = grid_size,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -194,7 +194,7 @@ ttnn::Tensor argmax(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::optional<Tensor> optional_output_tensor) {
     using OperationType = ttnn::operations::reduction::argmax::ArgMaxDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .output_dtype = output_dtype,
             .dim = dim,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -124,7 +124,7 @@ ttnn::Tensor reduce(
     const ttnn::DeviceComputeKernelConfig& compute_kernel_config,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::reduction::generic::ReduceDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             reduce_math,
             reduce_dim,

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.cpp
@@ -155,6 +155,6 @@ ttnn::Tensor manual_seed(
         tensor_args.user_ids = std::get<Tensor>(user_ids.value());
     }
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
@@ -95,9 +95,10 @@ ttnn::Tensor moe(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
     const std::optional<Tensor>& preallocated_output_tensor) {
     using OperationType = ttnn::operations::reduction::moe::MoeDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            .k = k, .output_memory_config = memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG)},
+            .k = k,
+            .output_memory_config = memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG)},
         OperationType::tensor_args_t{
             .input = input_tensor,
             .expert_mask = expert_mask_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -58,7 +58,7 @@ ProdAllDeviceOperation::tensor_return_value_t ProdAllDeviceOperation::create_out
 namespace ttnn::prim {
 ttnn::Tensor prod_all(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
     using OperationType = ttnn::operations::reduction::prod_all::ProdAllDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.output_mem_config = output_mem_config},
         OperationType::tensor_args_t{.input = input});
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
@@ -65,7 +65,7 @@ ProdNcDeviceOperation::tensor_return_value_t ProdNcDeviceOperation::create_outpu
 namespace ttnn::prim {
 ttnn::Tensor prod_nc(const ttnn::Tensor& input, const ttnn::Tensor& output, int64_t dim) {
     using OperationType = ttnn::operations::reduction::prod_nc::ProdNcDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.dim = dim},
         OperationType::tensor_args_t{.input = input, .output = output});
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -123,7 +123,7 @@ ttnn::Tensor sampling(
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& preallocated_output_tensor) {
     using OperationType = ttnn::operations::reduction::sampling::SamplingDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.seed = seed, .sub_core_grids = sub_core_grids},
         OperationType::tensor_args_t{
             .input_values = input_values_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -209,7 +209,7 @@ ttnn::operations::reduction::topk::TopKDeviceOperation::tensor_return_value_t to
     const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors) {
     using OperationType = ttnn::operations::reduction::topk::TopKDeviceOperation;
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .k = k,
             .dim = dim,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -155,7 +155,7 @@ ttnn::operations::sliding_window::halo::HaloDeviceOperation::tensor_return_value
     p_config.shard_scheme = input_tensor.memory_config().memory_layout();
     p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .config = config,
             .parallel_config = p_config,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_device_operation.cpp
@@ -215,7 +215,7 @@ joint_scaled_dot_product_attention(
         .joint_k = joint_tensor_k,
         .joint_v = joint_tensor_v};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -231,7 +231,7 @@ ring_distributed_sdpa(
         .v = input_tensor_v,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -374,7 +374,7 @@ ring_joint_scaled_dot_product_attention(
         .gathered_k = persistent_output_buffer_k,
         .gathered_v = persistent_output_buffer_v};
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -478,7 +478,7 @@ ttnn::operations::transformer::sdpa::SDPAOperation::tensor_return_value_t sdpa(
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {
     using OperationType = ttnn::operations::transformer::sdpa::SDPAOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .scale = scale,
             .output_mem_config = output_mem_config,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -433,7 +433,7 @@ ttnn::operations::transformer::sdpa_decode::SdpaDecodeDeviceOperation::tensor_re
         .attention_sink = attention_sink,
     };
 
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(operation_attributes, tensor_args);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
@@ -213,7 +213,7 @@ windowed_scaled_dot_product_attention(
     ttnn::DeviceComputeKernelConfig compute_kernel_config) {
     using OperationType =
         ttnn::operations::transformer::sdpa_windowed::WindowedScaledDotProductAttentionDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .scale = scale,
             .output_mem_config = output_mem_config,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -61,7 +61,7 @@ ttnn::Tensor uniform(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::uniform::UniformDeviceOperation;
-    return ttnn::device_operation::detail::launch_on_device<OperationType>(
+    return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             from,
             to,


### PR DESCRIPTION
### Ticket
None

### Problem description
It is weird to launch a device operation with device_operation::detail::launch_on_device

### What's changed
Move function to device_operation and rename to launch

```cpp
outputs device_operation::launch<T>(params, inputs);
```