### PR TITLE
Modernize loop convert

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -90,7 +90,6 @@ Checks: >
   -misc-use-internal-linkage,
   -modernize-avoid-bind,
   -modernize-avoid-c-arrays,
-  -modernize-loop-convert,
   -modernize-macro-to-enum,
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -303,8 +303,8 @@ int main(int argc, char** argv) {
             log_info(LogTest, "Help: {}", ss.str().c_str());
             exit(0);
         }
-        for (uint32_t idx = 0; idx < operators.size(); idx++) {
-            pass &= run_unit_test(operators[idx], arg_tile_factor, arg_use_DRAM);
+        for (const auto& op_name : operators) {
+            pass &= run_unit_test(op_name, arg_tile_factor, arg_use_DRAM);
         }
     }
 

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -374,8 +374,7 @@ TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplication) {
 
     std::vector<Shape2D> global_buffer_shapes = {{64, 256}, {128, 128}, {256, 2048}, {32, 512}, {512, 1024}};
 
-    for (int i = 0; i < global_buffer_shapes.size(); i++) {
-        auto global_buffer_shape = global_buffer_shapes[i];
+    for (auto global_buffer_shape : global_buffer_shapes) {
         Shape2D shard_shape = {0, global_buffer_shape.width() / mesh_device_->num_cols()};
         // Mesh-Level Sharding Parameters for the MeshBufferView that will be read to verify correctness
         Shape2D global_buffer_read_shape = {
@@ -425,8 +424,7 @@ TEST_F(MeshBufferTestSuite, ColMajorShardingAndReplication) {
 
     std::vector<Shape2D> global_buffer_shapes = {{256, 64}, {1024, 1024}, {128, 32}, {512, 64}, {2048, 256}};
 
-    for (int i = 0; i < global_buffer_shapes.size(); i++) {
-        auto global_buffer_shape = global_buffer_shapes[i];
+    for (auto global_buffer_shape : global_buffer_shapes) {
         Shape2D shard_shape = {global_buffer_shape.height() / mesh_device_->num_rows(), 0};
         uint32_t global_buffer_size = global_buffer_shape.height() * global_buffer_shape.width() * sizeof(uint32_t);
         Shape2D global_buffer_read_shape = {

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -193,12 +193,12 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
                         output_bufs[(col_idx * worker_grid_size.y) + row_idx],
                         device_coord);
                     if (device_coord[0] <= (num_rows_in_workload - 1)) {
-                        for (int i = 0; i < dst_vec.size(); i++) {
-                            EXPECT_EQ(static_cast<float>(dst_vec[i]), (2 * iter + 5));
+                        for (auto val : dst_vec) {
+                            EXPECT_EQ(static_cast<float>(val), (2 * iter + 5));
                         }
                     } else {
-                        for (int i = 0; i < dst_vec.size(); i++) {
-                            EXPECT_EQ(static_cast<float>(dst_vec[i]), (iter + 2) * (iter + 3));
+                        for (auto val : dst_vec) {
+                            EXPECT_EQ(static_cast<float>(val), (iter + 2) * (iter + 3));
                         }
                     }
                 }

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -227,8 +227,8 @@ TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
                         output_bufs[(col_idx * worker_grid_size.y) + row_idx],
                         MeshCoordinate(logical_y, logical_x));
                     auto expected_value = expected_values[logical_x + (logical_y * mesh_device_->num_cols())];
-                    for (int i = 0; i < dst_vec.size(); i++) {
-                        EXPECT_EQ(static_cast<float>(dst_vec[i]), expected_value);
+                    for (auto val : dst_vec) {
+                        EXPECT_EQ(static_cast<float>(val), expected_value);
                     }
                 }
             }

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -68,8 +68,7 @@ struct CBConfig {
 std::vector<CBHandle> initialize_dummy_circular_buffers(
     Program& program, const CoreRangeSet& cr_set, const std::vector<CBConfig>& cb_configs) {
     std::vector<CBHandle> cb_handles;
-    for (uint32_t i = 0; i < cb_configs.size(); i++) {
-        const CBConfig& cb_config = cb_configs[i];
+    for (const auto& cb_config : cb_configs) {
         const uint32_t cb_id = cb_config.cb_id;
         const uint32_t cb_num_pages = cb_config.num_pages;
         const uint32_t page_size = cb_config.page_size;
@@ -141,10 +140,10 @@ void verify_cb_config(
                         cb_config_vector);
 
                     uint32_t cb_addr = l1_unreserved_base;
-                    for (uint32_t i = 0; i < golden_cb_config.size(); i++) {
-                        const uint32_t index = golden_cb_config[i].cb_id * sizeof(uint32_t);
-                        const uint32_t cb_num_pages = golden_cb_config[i].num_pages;
-                        const uint32_t cb_size = cb_num_pages * golden_cb_config[i].page_size;
+                    for (const auto& config : golden_cb_config) {
+                        const uint32_t index = config.cb_id * sizeof(uint32_t);
+                        const uint32_t cb_num_pages = config.num_pages;
+                        const uint32_t cb_size = cb_num_pages * config.page_size;
                         const bool addr_match = cb_config_vector.at(index) == cb_addr;
                         const bool size_match = cb_config_vector.at(index + 1) == cb_size;
                         const bool num_pages_match = cb_config_vector.at(index + 2) == cb_num_pages;
@@ -558,12 +557,12 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
                     output_bufs[(col_idx * worker_grid_size.y) + row_idx],
                     device_coord);
                 if (device_coord[0] <= num_rows_in_mesh_workload - 1) {
-                    for (int i = 0; i < dst_vec.size(); i++) {
-                        EXPECT_EQ(static_cast<float>(dst_vec[i]), 5);
+                    for (auto val : dst_vec) {
+                        EXPECT_EQ(static_cast<float>(val), 5);
                     }
                 } else {
-                    for (int i = 0; i < dst_vec.size(); i++) {
-                        EXPECT_EQ(static_cast<float>(dst_vec[i]), 6);
+                    for (auto val : dst_vec) {
+                        EXPECT_EQ(static_cast<float>(val), 6);
                     }
                 }
             }

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -235,11 +235,11 @@ bool test_socket_send_recv(
         }
         // Increment the source vector for the next iteration
         // This is to ensure that the data is different for each transaction
-        for (int i = 0; i < src_vec.size(); i++) {
-            src_vec[i]++;
+        for (unsigned int& val : src_vec) {
+            val++;
         }
-        for (int i = 0; i < src_vec_per_core.size(); i++) {
-            src_vec_per_core[i]++;
+        for (unsigned int& val : src_vec_per_core) {
+            val++;
         }
     }
     return is_data_match;

--- a/tests/tt_metal/test_utils/bfloat_utils.hpp
+++ b/tests/tt_metal/test_utils/bfloat_utils.hpp
@@ -27,8 +27,8 @@ auto create_random_vector_of_bfp(uint32_t num_bytes, bool is_exp_a, int rand_max
     int float_data_size = num_tiles * num_float_in_tile;
 
     std::vector<float> fp32_vec(float_data_size, 0);
-    for (int i = 0; i < fp32_vec.size(); i++) {
-        fp32_vec.at(i) = rand_float() + offset;
+    for (float& val : fp32_vec) {
+        val = rand_float() + offset;
     }
 
     std::vector<uint32_t> packed_result =
@@ -59,8 +59,8 @@ inline std::vector<uint32_t> create_constant_vector_of_bfp8(uint32_t num_bytes, 
     int float_data_size = num_tiles * num_float_in_tile;
 
     std::vector<float> fp32_vec(float_data_size, 0);
-    for (int i = 0; i < fp32_vec.size(); i++) {
-        fp32_vec.at(i) = value;
+    for (float& val : fp32_vec) {
+        val = value;
     }
 
     std::vector<uint32_t> packed_result =

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -836,9 +836,9 @@ void RunTestUnicastTGGateways(BaseFabricFixture* fixture) {
     for (const auto& mmio_chip_id : mmio_chip_ids) {
         const auto& tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_chip_id);
-        for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+        for (const auto& tunnel : tunnels_from_mmio) {
             // idx 0 in the tunnel is the mmio chip itself
-            const auto remote_chip_id = tunnels_from_mmio[t][1];
+            const auto remote_chip_id = tunnel[1];
             log_info(tt::LogTest, "Running tests for chips: {} and {}", mmio_chip_id, remote_chip_id);
             run_unicast_test_bw_chips(fixture, mmio_chip_id, remote_chip_id, 1);
             run_unicast_test_bw_chips(fixture, remote_chip_id, mmio_chip_id, 1);
@@ -1079,14 +1079,10 @@ void RunTestMCastConnAPI(
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
     for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
-        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
-            log_info(
-                tt::LogTest,
-                "Checking Status of {} Rx on physical device {}",
-                routing_direction,
-                physical_end_device_ids[i]);
+        for (int device_id : physical_end_device_ids) {
+            log_info(tt::LogTest, "Checking Status of {} Rx on physical device {}", routing_direction, device_id);
 
-            const auto& receiver_device = fixture->get_device(physical_end_device_ids[i]);
+            const auto& receiver_device = fixture->get_device(device_id);
             std::vector<uint32_t> recv_status;
 
             tt_metal::detail::ReadFromDeviceL1(
@@ -1623,10 +1619,10 @@ void RunTest2DMCastConnAPI(
     uint64_t sender_bytes =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
-    for (uint32_t i = 0; i < rx_physical_device_ids.size(); i++) {
-        log_info(tt::LogTest, "Checking Status of Rx on physical device {}", rx_physical_device_ids[i]);
+    for (unsigned int rx_physical_device_id : rx_physical_device_ids) {
+        log_info(tt::LogTest, "Checking Status of Rx on physical device {}", rx_physical_device_id);
 
-        const auto& receiver_device = fixture->get_device(rx_physical_device_ids[i]);
+        const auto& receiver_device = fixture->get_device(rx_physical_device_id);
         std::vector<uint32_t> recv_status;
 
         tt_metal::detail::ReadFromDeviceL1(
@@ -1845,8 +1841,8 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
     for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
-        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
-            const auto& receiver_device = fixture->get_device(physical_end_device_ids[i]);
+        for (int device_id : physical_end_device_ids) {
+            const auto& receiver_device = fixture->get_device(device_id);
 
             log_info(
                 tt::LogTest,
@@ -1854,7 +1850,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
                 routing_direction,
                 receiver_logical_core.x,
                 receiver_logical_core.y,
-                physical_end_device_ids[i]);
+                device_id);
 
             std::vector<uint32_t> recv_status;
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1052,7 +1052,7 @@ void RunTestMCastConnAPI(
     fixture->WaitForSingleProgramDone(sender_device, sender_program);
 
     // Wait for receivers to finish
-    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+    for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
             auto receiver_device = fixture->get_device(physical_end_device_ids[i]);
             fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
@@ -1078,7 +1078,7 @@ void RunTestMCastConnAPI(
     uint64_t sender_bytes =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
-    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+    for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (int device_id : physical_end_device_ids) {
             log_info(tt::LogTest, "Checking Status of {} Rx on physical device {}", routing_direction, device_id);
 
@@ -1814,7 +1814,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     log_info(tt::LogTest, "Sender Finished");
 
     // Wait for receivers to finish
-    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+    for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
             auto receiver_device = fixture->get_device(physical_end_device_ids[i]);
             fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
@@ -1840,7 +1840,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     uint64_t sender_bytes =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
-    for (auto [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
+    for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
         for (int device_id : physical_end_device_ids) {
             const auto& receiver_device = fixture->get_device(device_id);
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -612,16 +612,16 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         };
 
         log_info(LogTest, "Waiting for senders to complete");
-        for (auto i = 0; i < devices.size(); i++) {
-            for (const auto& [core, _] : device_senders_map[devices[i]]) {
-                wait_for_worker_completion(devices[i]->get_devices()[0], core);
+        for (const auto& device : devices) {
+            for (const auto& [core, _] : device_senders_map[device]) {
+                wait_for_worker_completion(device->get_devices()[0], core);
             }
         }
 
         log_info(LogTest, "Senders done, waiting for receivers to complete");
-        for (auto i = 0; i < devices.size(); i++) {
-            for (const auto& [core, _] : device_receivers_map[devices[i]]) {
-                wait_for_worker_completion(devices[i]->get_devices()[0], core);
+        for (const auto& device : devices) {
+            for (const auto& [core, _] : device_receivers_map[device]) {
+                wait_for_worker_completion(device->get_devices()[0], core);
             }
         }
 
@@ -649,13 +649,13 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     };
 
     log_info(LogTest, "Programs done, validating results");
-    for (auto i = 0; i < devices.size(); i++) {
-        for (const auto& [core, _] : device_senders_map[devices[i]]) {
-            validate_worker_results(devices[i]->get_devices()[0], core);
+    for (const auto& device : devices) {
+        for (const auto& [core, _] : device_senders_map[device]) {
+            validate_worker_results(device->get_devices()[0], core);
         }
 
-        for (const auto& [core, _] : device_receivers_map[devices[i]]) {
-            validate_worker_results(devices[i]->get_devices()[0], core);
+        for (const auto& [core, _] : device_receivers_map[device]) {
+            validate_worker_results(device->get_devices()[0], core);
         }
     }
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
@@ -109,8 +109,7 @@ void check_connections(
     uint32_t expected_channel_count,
     GlobalNodeId expected_parent_instance_id,
     const std::unordered_set<std::string>& expected_node_names) {
-    for (size_t idx = 0; idx < connections.size(); ++idx) {
-        const auto connection_id = connections[idx];
+    for (unsigned int connection_id : connections) {
         const auto& connection = desc.get_connection(connection_id);
 
         EXPECT_EQ(connection.count, expected_channel_count);

--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -65,9 +65,9 @@ TEST(FreeListOptTest, AllocationAndDeallocation) {
     std::vector<std::optional<tt::tt_metal::DeviceAddr>> allocations(10);
 
     // Deallocate in order
-    for(size_t i = 0; i < allocations.size(); i++) {
-        allocations[i] = allocator.allocate(1_KiB);
-        ASSERT_TRUE(allocations[i].has_value());
+    for(auto & allocation : allocations) {
+        allocation = allocator.allocate(1_KiB);
+        ASSERT_TRUE(allocation.has_value());
     }
 
     for(size_t i = allocations.size(); i > 0; i--) {
@@ -75,13 +75,13 @@ TEST(FreeListOptTest, AllocationAndDeallocation) {
     }
 
     // Deallocate in reverse order
-    for(size_t i = 0; i < allocations.size(); i++) {
-        allocations[i] = allocator.allocate(1_KiB);
-        ASSERT_TRUE(allocations[i].has_value());
+    for(auto & allocation : allocations) {
+        allocation = allocator.allocate(1_KiB);
+        ASSERT_TRUE(allocation.has_value());
     }
 
-    for(size_t i = 0; i < allocations.size(); i++) {
-        allocator.deallocate(allocations[i].value());
+    for(auto & allocation : allocations) {
+        allocator.deallocate(allocation.value());
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -98,7 +98,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationCompute) {
 }
 
 TEST_F(MeshDispatchFixture, TensixPassOnNormalKernelCreation) {
-    for (const auto& mesh_device : this->devices_) {
+    for ([[maybe_unused]] const auto& mesh_device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);

--- a/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
+++ b/tests/tt_metal/tt_metal/api/test_duplicate_kernel.cpp
@@ -31,8 +31,7 @@ using namespace tt;
 
 // Ensures we cannot create duplicate kernels
 TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationDataflow) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        std::shared_ptr<distributed::MeshDevice> mesh_device = this->devices_.at(id);
+    for (const auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -40,7 +39,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationDataflow) {
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
-        CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
+        CoreCoord compute_grid = device->compute_with_storage_grid_size();
         EXPECT_THROW(
             {
                 tt_metal::CreateKernel(
@@ -61,8 +60,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationDataflow) {
 }
 
 TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationCompute) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        std::shared_ptr<distributed::MeshDevice> mesh_device = this->devices_.at(id);
+    for (const auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -70,7 +68,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationCompute) {
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
-        CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
+        CoreCoord compute_grid = device->compute_with_storage_grid_size();
         std::vector<uint32_t> compute_kernel_args = {};
         EXPECT_THROW(
             {
@@ -100,8 +98,7 @@ TEST_F(MeshDispatchFixture, TensixFailOnDuplicateKernelCreationCompute) {
 }
 
 TEST_F(MeshDispatchFixture, TensixPassOnNormalKernelCreation) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        std::shared_ptr<distributed::MeshDevice> mesh_device = this->devices_.at(id);
+    for (const auto& mesh_device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -135,15 +132,14 @@ TEST_F(MeshDispatchFixture, TensixPassOnNormalKernelCreation) {
 }
 
 TEST_F(MeshDispatchFixture, TensixPassOnMixedOverlapKernelCreation) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        std::shared_ptr<distributed::MeshDevice> mesh_device = this->devices_.at(id);
+    for (const auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = CreateProgram();
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        CoreCoord compute_grid = this->devices_.at(id)->compute_with_storage_grid_size();
+        CoreCoord compute_grid = device->compute_with_storage_grid_size();
         std::vector<uint32_t> compute_kernel_args = {};
         EXPECT_NO_THROW({
             tt_metal::CreateKernel(

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -32,7 +32,7 @@ using namespace tt;
 
 // Ensures we can successfully create kernels on available compute grid
 TEST_F(MeshDispatchFixture, TensixCreateKernelsOnComputeCores) {
-    for (auto mesh_device : this->devices_) {
+    for (const auto& mesh_device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -55,7 +55,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
     if (this->IsSlowDispatch()) {
         GTEST_SKIP() << "This test is only supported in fast dispatch mode";
     }
-    for (auto mesh_device : this->devices_) {
+    for (const auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
 
         distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -32,8 +32,7 @@ using namespace tt;
 
 // Ensures we can successfully create kernels on available compute grid
 TEST_F(MeshDispatchFixture, TensixCreateKernelsOnComputeCores) {
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto mesh_device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -56,8 +55,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
     if (this->IsSlowDispatch()) {
         GTEST_SKIP() << "This test is only supported in fast dispatch mode";
     }
-    for (unsigned int id = 0; id < this->devices_.size(); id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
 
         distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -48,12 +48,12 @@ using namespace tt::tt_metal;
 // and incrementing by 1.0f for each element.
 void inc_populate(std::vector<std::uint32_t>& vec, float start_from) {
     float val = start_from;
-    for (std::uint32_t i = 0; i < vec.size(); i++) {
+    for (unsigned int& elem : vec) {
         bfloat16 num_1_bfloat16 = bfloat16(val);
         val = val + 1.0f;
         bfloat16 num_2_bfloat16 = bfloat16(val);
         val = val + 1.0f;
-        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        elem = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -399,8 +399,8 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
         uint32_t buf_size = num_pages * config.page_size;
         vector<uint32_t> src(buf_size / sizeof(uint32_t), 0);
 
-        for (uint32_t i = 0; i < src.size(); i++) {
-            src[i] = rand();
+        for (unsigned int& val : src) {
+            val = rand();
         }
 
         BufferType buftype = BufferType::DRAM;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -35,8 +35,8 @@ using std::vector;
 namespace local_test_functions {
 
 void FinishAllCqs(vector<std::reference_wrapper<distributed::MeshCommandQueue>>& cqs) {
-    for (uint i = 0; i < cqs.size(); i++) {
-        distributed::Finish(cqs[i]);
+    for (auto& cq : cqs) {
+        distributed::Finish(cq);
     }
 }
 }  // namespace local_test_functions

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -167,16 +167,15 @@ void initialize_dummy_kernels(Program& program, const CoreRangeSet& cr_set) {
 
 void initialize_dummy_semaphores(
     Program& program, const std::variant<CoreRange, CoreRangeSet>& core_ranges, const vector<uint32_t>& init_values) {
-    for (uint32_t i = 0; i < init_values.size(); i++) {
-        CreateSemaphore(program, core_ranges, init_values[i]);
+    for (unsigned int init_value : init_values) {
+        CreateSemaphore(program, core_ranges, init_value);
     }
 }
 
 std::vector<CBHandle> initialize_dummy_circular_buffers(
     Program& program, const CoreRangeSet& cr_set, const std::vector<CBConfig>& cb_configs) {
     std::vector<CBHandle> cb_handles;
-    for (uint32_t i = 0; i < cb_configs.size(); i++) {
-        const CBConfig& cb_config = cb_configs[i];
+    for (const auto& cb_config : cb_configs) {
         const uint32_t cb_id = cb_config.cb_id;
         const uint32_t cb_num_pages = cb_config.num_pages;
         const uint32_t page_size = cb_config.page_size;
@@ -213,10 +212,10 @@ bool cb_config_successful(
                 cb_config_vector);
 
             uint32_t cb_addr = l1_unreserved_base;
-            for (uint32_t i = 0; i < program_config.cb_config_vector.size(); i++) {
-                const uint32_t index = program_config.cb_config_vector[i].cb_id * sizeof(uint32_t);
-                const uint32_t cb_num_pages = program_config.cb_config_vector[i].num_pages;
-                const uint32_t cb_size = cb_num_pages * program_config.cb_config_vector[i].page_size;
+            for (const auto& config : program_config.cb_config_vector) {
+                const uint32_t index = config.cb_id * sizeof(uint32_t);
+                const uint32_t cb_num_pages = config.num_pages;
+                const uint32_t cb_size = cb_num_pages * config.page_size;
                 const bool addr_match = cb_config_vector.at(index) == cb_addr;
                 const bool size_match = cb_config_vector.at(index + 1) == cb_size;
                 const bool num_pages_match = cb_config_vector.at(index + 2) == cb_num_pages;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -122,8 +122,7 @@ inline void verify_kernel_coordinates(
 
     const auto& sub_device_origin = mesh_device->worker_cores(hal_core_type, sub_device_id).bounding_box().start_coord;
     for (const auto& cr : cr_set.ranges()) {
-        for (auto core = cr.begin(); core != cr.end(); ++core) {
-            const auto& logical_coord = *core;
+        for (const auto& logical_coord : cr) {
             const auto& virtual_coord = mesh_device->virtual_core_from_logical_core(logical_coord, core_type);
             CoreCoord relative_coord{logical_coord.x - sub_device_origin.x, logical_coord.y - sub_device_origin.y};
             for (const auto& device : mesh_device->get_devices()) {

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -255,9 +255,9 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         auto& sender_program = programs[sender_device->id()];
         auto& receiver_program = programs[receiver_device->id()];
         CoreCoord sender_receiver_core;
-        for (uint32_t j = 0; j < sender_receivers.size(); ++j) {
-            if (std::get<1>(sender_receivers[j])->get_devices()[0]->id() == sender_device->id()) {
-                sender_receiver_core = sender_device->ethernet_core_from_logical_core(std::get<3>(sender_receivers[j]));
+        for (const auto& sender_receiver : sender_receivers) {
+            if (std::get<1>(sender_receiver)->get_devices()[0]->id() == sender_device->id()) {
+                sender_receiver_core = sender_device->ethernet_core_from_logical_core(std::get<3>(sender_receiver));
             }
         }
         auto sender_ethernet_config = tt_metal::EthernetConfig{
@@ -302,10 +302,9 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         ////////////////////////////////////////////////////////////////////////////
         // Clear expected value at ethernet L1 address
         CoreCoord receiver_sender_core;
-        for (uint32_t j = 0; j < sender_receivers.size(); ++j) {
-            if (std::get<0>(sender_receivers[j])->get_devices()[0]->id() == receiver_device->id()) {
-                receiver_sender_core =
-                    receiver_device->ethernet_core_from_logical_core(std::get<2>(sender_receivers[j]));
+        for (const auto& sender_receiver : sender_receivers) {
+            if (std::get<0>(sender_receiver)->get_devices()[0]->id() == receiver_device->id()) {
+                receiver_sender_core = receiver_device->ethernet_core_from_logical_core(std::get<2>(sender_receiver));
             }
         }
 
@@ -342,8 +341,8 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
 
     std::vector<std::thread> ths;
     ths.reserve(sender_receivers.size());
-    for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
-        const auto& device = std::get<0>(sender_receivers[i]);
+    for (const auto& sender_receiver : sender_receivers) {
+        const auto& device = std::get<0>(sender_receiver);
         workloads[device->get_devices()[0]->id()].add_program(
             device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {
@@ -408,9 +407,9 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& eth_sender_core = std::get<2>(sender_receivers[i]);
         CoreCoord eth_receiver_core;
-        for (uint32_t j = 0; j < sender_receivers.size(); ++j) {
-            if (std::get<1>(sender_receivers[j])->id() == device->id()) {
-                eth_receiver_core = std::get<3>(sender_receivers[j]);
+        for (const auto& sender_receiver : sender_receivers) {
+            if (std::get<1>(sender_receiver)->id() == device->id()) {
+                eth_receiver_core = std::get<3>(sender_receiver);
                 break;
             }
         }
@@ -499,8 +498,8 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
 
     std::vector<std::thread> ths;
     ths.reserve(sender_receivers.size());
-    for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
-        const auto& device = std::get<0>(sender_receivers[i]);
+    for (const auto& sender_receiver : sender_receivers) {
+        const auto& device = std::get<0>(sender_receiver);
         workloads[device->get_devices()[0]->id()].add_program(
             device_range, std::move(programs[device->get_devices()[0]->id()]));
         ths.emplace_back([&] {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -402,8 +402,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleTile) {
                 MatmulTileStimuli stimuli;
                 create_test_stimuli(stimuli, 1, 1, 1);
 
-                for (unsigned int id = 0; id < devices_.size(); id++) {
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                for (const auto& device : devices_) {
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -437,11 +437,11 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiTile) {
                 MatmulTileStimuli stimuli;
                 create_test_stimuli(stimuli, M, K, N);
 
-                for (unsigned int id = 0; id < devices_.size(); id++) {
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                for (const auto& device : devices_) {
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                     log_info(LogTest, "Multi tile with no bias passed");
                     matmul_config.with_bias = true;
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                     log_info(LogTest, "Multi tile with bias passed");
                 }
             }
@@ -478,8 +478,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlock) {
                 MatmulTileStimuli stimuli;
                 create_test_stimuli(stimuli, M, K, N);
 
-                for (unsigned int id = 0; id < devices_.size(); id++) {
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                for (const auto& device : devices_) {
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -515,8 +515,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShort) {
                 MatmulTileStimuli stimuli;
                 create_test_stimuli(stimuli, M, K, N);
 
-                for (unsigned int id = 0; id < devices_.size(); id++) {
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                for (const auto& device : devices_) {
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }
@@ -552,8 +552,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulBlockInitShortWithDt) {
                 MatmulTileStimuli stimuli;
                 create_test_stimuli(stimuli, M, K, N);
 
-                for (unsigned int id = 0; id < devices_.size(); id++) {
-                    matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
+                for (const auto& device : devices_) {
+                    matmul_tile(this, device, matmul_config, stimuli.a, stimuli.w, stimuli.t);
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -411,8 +411,8 @@ bool matmul_large_block(
     set_math_fid_masks(math_fid_mask, math_fidelity);
     // If we're testing LoFi/HiFi2 we generate matching golden (trunc LSB).
     // Note that this will work only for multiplying with identity matrix
-    for (auto i = 0; i < golden.size(); i++) {
-        golden[i] = std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(golden[i]) & math_fid_mask));
+    for (auto& val : golden) {
+        val = std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(val) & math_fid_mask));
     }
 
     if (output_rm) {
@@ -443,18 +443,18 @@ TEST_F(MeshDispatchFixture, TensixMatmulLargeBlock) {
             continue;
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < devices_.size(); id++) {
+        for (const auto& device : devices_) {
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, devices_.at(id), false, false, MathFidelity(i)));
+                this, device, false, false, MathFidelity(i)));
             log_info(LogTest, "Tilized input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, devices_.at(id), true, false, MathFidelity(i)));
+                this, device, true, false, MathFidelity(i)));
             log_info(LogTest, "Row major input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, devices_.at(id), false, true, MathFidelity(i)));
+                this, device, false, true, MathFidelity(i)));
             log_info(LogTest, "Tilized input, Row major output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
-                this, devices_.at(id), true, true, MathFidelity(i)));
+                this, device, true, true, MathFidelity(i)));
             log_info(LogTest, "Row major input, Row major output Passed");
         }
     }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -611,9 +611,8 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiCoreSingleDRAM) {
         GTEST_SKIP();
     }
 
-    for (unsigned int id = 0; id < devices_.size(); id++) {
-        ASSERT_TRUE(
-            unit_tests_common::matmul::test_matmul_multi_core_X_dram::matmul_multi_core_single_dram(devices_.at(id)));
+    for (const auto& device : devices_) {
+        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_multi_core_X_dram::matmul_multi_core_single_dram(device));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -583,9 +583,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiCoreMultiDRAMIn0MCastIn1MCast) {
         log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
-    for (unsigned int id = 0; id < devices_.size(); id++) {
+    for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast::
-                        matmul_multi_core_multi_dram_in0_mcast_in1_mcast(devices_.at(id)));
+                        matmul_multi_core_multi_dram_in0_mcast_in1_mcast(device));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -478,9 +478,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiCoreMultiDRAMIn0MCast) {
         GTEST_SKIP();
     }
 
-    for (unsigned int id = 0; id < devices_.size(); id++) {
+    for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_multi_core_multi_dram_inX_mcast::
-                        matmul_multi_core_multi_dram_inX_mcast(devices_.at(id), 0));
+                        matmul_multi_core_multi_dram_inX_mcast(device, 0));
     }
 }
 
@@ -490,9 +490,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulMultiCoreMultiDRAMIn1MCast) {
         GTEST_SKIP();
     }
 
-    for (unsigned int id = 0; id < devices_.size(); id++) {
+    for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_multi_core_multi_dram_inX_mcast::
-                        matmul_multi_core_multi_dram_inX_mcast(devices_.at(id), 1));
+                        matmul_multi_core_multi_dram_inX_mcast(device, 1));
     }
 }
 

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -269,9 +269,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleCoreSmall) {
     int out_subblock_h = 4;
     int out_subblock_w = 4;
 
-    for (unsigned int id = 0; id < devices_.size(); id++) {
+    for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_single_core::matmul_single_core(
-            this, devices_.at(id), M, N, K, out_subblock_h, out_subblock_w));
+            this, device, M, N, K, out_subblock_h, out_subblock_w));
     }
 }
 
@@ -285,9 +285,9 @@ TEST_F(MeshDispatchFixture, TensixMatmulSingleCore) {
     uint32_t N = 16;
     int out_subblock_h = 4;
     int out_subblock_w = 2;
-    for (unsigned int id = 0; id < devices_.size(); id++) {
+    for (const auto& device : devices_) {
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_single_core::matmul_single_core(
-            this, devices_.at(id), M, N, K, out_subblock_h, out_subblock_w));
+            this, device, M, N, K, out_subblock_h, out_subblock_w));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -431,8 +431,8 @@ void run_single_core_reduce_program(
         uint32_t uint32_scaler = *reinterpret_cast<uint32_t*>(&scaler);
         uint32_scaler &= (0xFFFFFFFF & (srcb_fid_mask << 16));
         scaler = *reinterpret_cast<float*>(&uint32_scaler);
-        for (auto i = 0; i < u16_src0_vec.size(); i++) {
-            u16_src0_vec[i] = u16_src0_vec[i] & srca_fid_mask;
+        for (unsigned short& val : u16_src0_vec) {
+            val &= srca_fid_mask;
         }
     }
     // recover a linear view of input vector for consumption by gold_ function

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -1516,8 +1516,8 @@ bool validation_single_core(
 
     std::vector<float> result_vec;
     result_vec.reserve(result_untilized.size());
-    for (int i = 0; i < result_untilized.size(); ++i) {
-        result_vec.push_back(to_float(static_cast<bfloat16>(result_untilized[i])));
+    for (auto val : result_untilized) {
+        result_vec.push_back(to_float(static_cast<bfloat16>(val)));
     }
 
     // for (int i=0; i<result_vec.size(); ++i) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -367,7 +367,7 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (size_t i = 0; i < vec.size(); i++) {
+    for (unsigned int& elem : vec) {
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 
@@ -375,7 +375,7 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
         bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
 
         // pack 2 uint16 into uint32
-        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        elem = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
     return vec;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -378,14 +378,13 @@ void get_optimal_dram_bank_to_reader_assignment(
 void get_l1_writer_core_coords_wormhole_b0(
     std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
     // Place writers horizontally next to DRAM readers in logical space (no column harvesting for WH)
-    for (int i = 0; i < all_dram_reader_cores.size(); ++i) {
-        auto dram_reader_core = all_dram_reader_cores[i];
+    for (auto dram_reader_core : all_dram_reader_cores) {
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x + 1, dram_reader_core.y));
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x + 2, dram_reader_core.y));
     }
     std::set<CoreRange> all_cores_set;
-    for (int i = 0; i < all_cores_ordered.size(); ++i) {
-        all_cores_set.insert(CoreRange(all_cores_ordered[i]));
+    for (auto core : all_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
     }
     all_cores = CoreRangeSet(all_cores_set);
 }
@@ -394,28 +393,26 @@ void get_l1_writer_core_coords_blackhole(
     std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
     // Place writers horizontally next to DRAM readers in logical space (column harvesting enabled for BH incrementing
     // in logical space can lead to physical physical columns being skipped when placing writers next to readers)
-    for (int i = 0; i < all_dram_reader_cores.size(); ++i) {
-        auto dram_reader_core = all_dram_reader_cores[i];
+    for (auto dram_reader_core : all_dram_reader_cores) {
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x + 1, dram_reader_core.y));
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x + 2, dram_reader_core.y));
     }
     std::set<CoreRange> all_cores_set;
-    for (int i = 0; i < all_cores_ordered.size(); ++i) {
-        all_cores_set.insert(CoreRange(all_cores_ordered[i]));
+    for (auto core : all_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
     }
     all_cores = CoreRangeSet(all_cores_set);
 }
 
 void get_l1_writer_core_coords_grayskull(
     std::vector<CoreCoord>& all_dram_reader_cores, CoreRangeSet& all_cores, std::vector<CoreCoord>& all_cores_ordered) {
-    for (int i = 0; i < all_dram_reader_cores.size(); ++i) {
-        auto dram_reader_core = all_dram_reader_cores[i];
+    for (auto dram_reader_core : all_dram_reader_cores) {
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x, dram_reader_core.y + 1));
         all_cores_ordered.push_back(CoreCoord(dram_reader_core.x + 1, dram_reader_core.y + 1));
     }
     std::set<CoreRange> all_cores_set;
-    for (int i = 0; i < all_cores_ordered.size(); ++i) {
-        all_cores_set.insert(CoreRange(all_cores_ordered[i]));
+    for (auto core : all_cores_ordered) {
+        all_cores_set.insert(CoreRange(core));
     }
     all_cores = CoreRangeSet(all_cores_set);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -474,9 +474,9 @@ inline bool DeviceData::validate_host(
     uint32_t* results = (uint32_t*)this->base_data_addr[static_cast<int>(tt::CoreType::PCIE)];
 
     int fail_count = 0;
-    for (int data_index = 0; data_index < host_data.data.size(); data_index++) {
+    for (unsigned int val : host_data.data) {
         validated_cores.insert(this->host_core);
-        if (host_data.data[data_index] != results[host_data_index] && fail_count < 20) {
+        if (val != results[host_data_index] && fail_count < 20) {
             if (!failed) {
                 log_fatal(tt::LogTest, "Data mismatch - First 20 host data failures: [idx] expected->read");
             }
@@ -485,7 +485,7 @@ inline bool DeviceData::validate_host(
                 tt::LogTest,
                 "  [{:02d}] 0x{:08x}->0x{:08x}",
                 host_data_index,
-                (unsigned int)host_data.data[data_index],
+                (unsigned int)val,
                 (unsigned int)results[host_data_index]);
 
             failed = true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
@@ -691,8 +691,7 @@ void BandwidthResultsManager::compare_summary_results_with_golden() {
             golden_csv_entries_.size());
     }
 
-    for (int i = 0; i < bandwidth_results_summary_.size(); i++) {
-        BandwidthResultSummary& test_result = bandwidth_results_summary_[i];
+    for (auto& test_result : bandwidth_results_summary_) {
         auto bandwidth_stat_location =
             std::find(stat_order_.begin(), stat_order_.end(), BandwidthStatistics::BandwidthMean);
         if (bandwidth_stat_location == stat_order_.end()) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -135,12 +135,12 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
     TensorSpec output_tensor_spec(
         ttnn::Shape({1, 8, 1024, 192}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+    for (auto& mesh_device : mesh_devices) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
         std::vector<bfloat16> output_data(output_tensor_spec.logical_shape().volume(), bfloat16(0));
         output_tensors.push_back(
-            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
+            Tensor::from_vector(std::move(output_data), output_tensor_spec).to_device(mesh_device.get()));
     }
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
     auto aggregated_output_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(output_tensors);
@@ -159,9 +159,9 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
 
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = output_tensors[dev_idx].to_vector<bfloat16>();
-        for (int i = 0; i < data.size(); i++) {
+        for (auto val : data) {
             float expected = static_cast<float>(mesh_devices.size());
-            EXPECT_EQ(static_cast<float>(data[i]), expected);
+            EXPECT_EQ(static_cast<float>(val), expected);
         }
     }
 }
@@ -172,9 +172,9 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     std::vector<ttnn::Tensor> tensors;
     TensorSpec tensor_spec(
         ttnn::Shape({1, 8, 1024, 768}), TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), MemoryConfig{}));
-    for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+    for (auto& mesh_device : mesh_devices) {
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(1)));
-        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_device.get()));
     }
 
     auto aggregated_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(tensors);
@@ -190,9 +190,9 @@ TEST_F(MeshDevice1x4Fixture, AllReduce) {
     auto disaggregated_output_tensors = tt::tt_metal::experimental::unit_mesh::disaggregate(all_reduced_tensor);
     for (int dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
         auto data = disaggregated_output_tensors[dev_idx].to_vector<bfloat16>();
-        for (int i = 0; i < data.size(); i++) {
+        for (auto val : data) {
             float expected = static_cast<float>(mesh_devices.size());
-            EXPECT_EQ(static_cast<float>(data[i]), expected);
+            EXPECT_EQ(static_cast<float>(val), expected);
         }
     }
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -45,9 +45,9 @@ namespace tt::tt_metal {
 template <typename ADDRgen, typename ADDRgenInfo>
 void run_full_width_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_base_address) {
     uint32_t rows[7] = {0, 1, 31, 32, 33, 66, 10000};
-    for (int i = 0; i < std::size(rows); i++) {
-        uint32_t page = constants.pages_per_tensor_row * rows[i];
-        uint32_t base_address = constants.pages_per_shard_width * rows[i] * constants.page_size_jump;
+    for (unsigned int row : rows) {
+        uint32_t page = constants.pages_per_tensor_row * row;
+        uint32_t base_address = constants.pages_per_shard_width * row * constants.page_size_jump;
         for (int j = 0; j < constants.number_of_cores; j++) {
             uint64_t l1_address = base_address;
             for (int k = 0; k < constants.pages_per_shard_width; k++) {
@@ -70,8 +70,7 @@ void run_full_width_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_b
 template <typename ADDRgen, typename ADDRgenInfo>
 void run_full_height_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_base_address) {
     uint32_t width_pages[5] = {0, 1, 31, 30, 14};
-    for (int i = 0; i < std::size(width_pages); i++) {
-        uint32_t page = width_pages[i];
+    for (unsigned int page : width_pages) {
         uint32_t base_address = page * constants.page_size_jump;
         for (int j = 0; j < constants.number_of_cores; j++) {
             uint32_t l1_address = base_address;
@@ -96,12 +95,11 @@ void run_full_block_test(ADDRgen addrgen, ADDRgenInfo constants, uint32_t bank_b
     uint32_t random_height_offsets[4] = {0, 1, 5, 7};
     uint32_t cores_per_block_row = ((constants.pages_per_tensor_row - 1) / constants.pages_per_shard_width) + 1;
     uint32_t cores_height = constants.number_of_cores / cores_per_block_row;
-    for (int i = 0; i < std::size(random_width_offsets); i++) {
-        for (int j = 0; j < std::size(random_height_offsets); j++) {
-            uint64_t outer_page = random_width_offsets[i] + (random_height_offsets[j] * constants.pages_per_tensor_row);
-            uint64_t l1_address =
-                (random_width_offsets[i] + random_height_offsets[j] * constants.pages_per_shard_width) *
-                constants.page_size_jump;
+    for (unsigned int random_width_offset : random_width_offsets) {
+        for (unsigned int random_height_offset : random_height_offsets) {
+            uint64_t outer_page = random_width_offset + (random_height_offset * constants.pages_per_tensor_row);
+            uint64_t l1_address = (random_width_offset + random_height_offset * constants.pages_per_shard_width) *
+                                  constants.page_size_jump;
             for (int h = 0; h < cores_height; h++) {
                 uint64_t page = outer_page;
                 for (int w = 0; w < cores_per_block_row; w++) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -273,8 +273,8 @@ TEST_P(TensorDistribution2x4Test2D, FullyReplicated) {
     std::vector<Tensor> device_tensors = get_device_tensors(sharded_tensor);
     EXPECT_EQ(device_tensors.size(), num_devices);
 
-    for (int i = 0; i < device_tensors.size(); i++) {
-        EXPECT_THAT(device_tensors[i].to_vector<float>(), Pointwise(FloatEq(), test_data));
+    for (const auto& device_tensor : device_tensors) {
+        EXPECT_THAT(device_tensor.to_vector<float>(), Pointwise(FloatEq(), test_data));
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unit_mesh_utils.cpp
@@ -85,9 +85,7 @@ TEST_F(UnitMeshUtils2x4Test, AggregateAndDisaggregate) {
 
     ASSERT_THAT(disaggregated_tensors, SizeIs(unit_meshes.size()));
 
-    for (size_t i = 0; i < disaggregated_tensors.size(); i++) {
-        const auto& tensor = disaggregated_tensors[i];
-
+    for (const auto& tensor : disaggregated_tensors) {
         EXPECT_NE(tensor.device(), nullptr);
         EXPECT_EQ(tensor.device()->shape().mesh_size(), 1);
         EXPECT_EQ(tensor.logical_shape(), shape);

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -413,8 +413,7 @@ static tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_factory_sys
     tt::scaleout_tools::fsd::proto::FactorySystemDescriptor fsd;
 
     // Add host information from deployment hosts (indexed by host_id)
-    for (size_t i = 0; i < deployment_hosts.size(); ++i) {
-        const auto& deployment_host = deployment_hosts[i];
+    for (const auto& deployment_host : deployment_hosts) {
         auto* host = fsd.add_hosts();
         host->set_hostname(deployment_host.hostname);
         host->set_hall(deployment_host.hall);

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -135,11 +135,11 @@ std::vector<CoreCoord> reassign_dram_interface_cores_for_wormhole(
     // Merge both groups based on original indices (maintain ordering by dram bank_id here)
     std::vector<CoreCoord> shifted_dram_interface_workers;
     shifted_dram_interface_workers.reserve(num_dram_banks);
-    for (int i = 0; i < indices_g1_realloc.size(); ++i) {
-        shifted_dram_interface_workers.push_back(dram_interface_workers_g1[indices_g1_realloc[i]]);
+    for (int i : indices_g1_realloc) {
+        shifted_dram_interface_workers.push_back(dram_interface_workers_g1[i]);
     }
-    for (int i = 0; i < indices_g2_realloc.size(); ++i) {
-        shifted_dram_interface_workers.push_back(dram_interface_workers_g2[indices_g2_realloc[i]]);
+    for (int i : indices_g2_realloc) {
+        shifted_dram_interface_workers.push_back(dram_interface_workers_g2[i]);
     }
     return shifted_dram_interface_workers;
 }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -274,15 +274,14 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
             TT_FATAL(
                 config.mesh_shape().has_value(), "Mesh shape must be provided when physical device ids are supplied");
             const auto& supplied_ids = config.physical_device_ids();
-            for (int i = 0; i < supplied_ids.size(); i++) {
+            for (int supplied_id : supplied_ids) {
                 auto fabric_node_id =
-                    MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
-                        supplied_ids[i]);
+                    MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(supplied_id);
                 TT_FATAL(
                     !mesh_graph.is_switch_mesh(fabric_node_id.mesh_id),
                     "Cannot create devices on tt-switch meshes. Device {} maps to mesh_id {} which is a switch. "
                     "Use get_compute_mesh_ids() to get valid compute mesh IDs.",
-                    supplied_ids[i],
+                    supplied_id,
                     *fabric_node_id.mesh_id);
                 fabric_node_ids.push_back(fabric_node_id);
             }

--- a/tt_metal/fabric/builder/multi_pool_channel_allocator.cpp
+++ b/tt_metal/fabric/builder/multi_pool_channel_allocator.cpp
@@ -53,10 +53,10 @@ void MultiPoolChannelAllocator::emit_ct_args(
     // Step 1: Emit number of pools
     // a bit hacky for now
     size_t num_pools = 0;
-    for (size_t i = 0; i < pool_allocators_.size(); ++i) {
-        if (implements_static_channel_allocator(pool_allocators_[i].get())) {
+    for (const auto& pool_allocator : pool_allocators_) {
+        if (implements_static_channel_allocator(pool_allocator.get())) {
             auto [num_sender_channels, num_receiver_channels] =
-                get_static_channel_allocator_num_channels(pool_allocators_[i].get());
+                get_static_channel_allocator_num_channels(pool_allocator.get());
             num_pools += num_sender_channels + num_receiver_channels;
         } else {
             num_pools++;
@@ -86,10 +86,10 @@ void MultiPoolChannelAllocator::emit_ct_args(
     }
 
     // Emit the sender channel to pool index
-    for (size_t i = 0; i < pool_allocators_.size(); ++i) {
+    for (const auto& pool_allocator : pool_allocators_) {
         TT_FATAL(
-            dynamic_cast<FabricStaticSizedChannelsAllocator*>(pool_allocators_[i].get()) ||
-                dynamic_cast<FabricRemoteChannelsAllocator*>(pool_allocators_[i].get()),
+            dynamic_cast<FabricStaticSizedChannelsAllocator*>(pool_allocator.get()) ||
+                dynamic_cast<FabricRemoteChannelsAllocator*>(pool_allocator.get()),
             "Non static sized channel allocators not supported in the code below yet");
     }
     for (size_t i = 0; i < num_used_sender_channels; ++i) {

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -304,10 +304,7 @@ std::vector<bool> ComputeMeshRouterBuilder::get_child_builder_variant_sender_cha
 
     // Iterate through variant's internal channels in order (0, 1, 2, ...)
     // For each variant channel, look up its corresponding router channel and get the injection flag
-    for (size_t variant_internal_ch = 0; variant_internal_ch < variant_to_router_channel_map.size();
-         ++variant_internal_ch) {
-        auto router_channel_opt = variant_to_router_channel_map.at(variant_internal_ch);
-
+    for (auto router_channel_opt : variant_to_router_channel_map) {
         if (router_channel_opt.has_value()) {
             // Channel is externally-facing, get injection status from router
             size_t router_channel_id = *router_channel_opt;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2280,10 +2280,7 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
             auto tensix_info = tensix_config.get_worker_tensix_info(physical_chip_id, core_coord);
 
             // Populate worker-specific tensix mux connection for ALL eth channel indices
-            for (uint8_t eth_chan = 0;
-                 eth_chan < tt::tt_fabric::tensix_fabric_connections_l1_info_t::MAX_FABRIC_ENDPOINTS;
-                 eth_chan++) {
-                auto& connection_info = worker_connections.read_only[eth_chan];
+            for (auto& connection_info : worker_connections.read_only) {
                 fill_tensix_connection_info_fields(
                     connection_info,
                     tensix_info.tensix_core,

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -1096,8 +1096,8 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_compile_time_args() c
         ct_args.push_back(relay_config_typed->get_relay_termination_signal_address());
     } else if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::MUX) {
         // Add sender_channel_is_traffic_injection_channel_array to ct args for MUX mode
-        for (size_t i = 0; i < sender_channel_is_traffic_injection_channel_array.size(); i++) {
-            ct_args.push_back(sender_channel_is_traffic_injection_channel_array[i] ? 1 : 0);
+        for (bool is_injection : sender_channel_is_traffic_injection_channel_array) {
+            ct_args.push_back(is_injection ? 1 : 0);
         }
     }
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -90,8 +90,7 @@ std::pair<TrayID, ASICLocation> get_asic_position(
             auto mmio_device = cluster_desc->get_closest_mmio_capable_chip(chip_id);
             auto tunnels_from_mmio_device = llrt::discover_tunnels_from_mmio_device(cluster);
             const auto& tunnels = tunnels_from_mmio_device.at(mmio_device);
-            for (auto tunnel = 0; tunnel < tunnels.size(); tunnel++) {
-                const auto& devices_on_tunnel = tunnels[tunnel];
+            for (const auto& devices_on_tunnel : tunnels) {
                 auto device_it = std::find(devices_on_tunnel.begin(), devices_on_tunnel.end(), chip_id);
                 if (device_it != devices_on_tunnel.end()) {
                     asic_location = ASICLocation{static_cast<unsigned int>(device_it - devices_on_tunnel.begin())};

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -371,8 +371,7 @@ TopologyMapper::TopologyMapper(
         }
 
         // Decode and populate mesh_host_rank_to_mpi_rank_ from gathered data
-        for (std::size_t idx = 0; idx < gathered.size(); ++idx) {
-            const auto encoded = gathered[idx];
+        for (const auto encoded : gathered) {
             if (encoded == sentinel) {
                 continue;
             }
@@ -580,8 +579,7 @@ std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper:
     // Build an ordered map from MPI rank to (mesh_id, host_rank) pairs for deterministic iteration
     std::map<int, std::map<MeshId, MeshHostRankId>> mpi_rank_to_mesh_bindings;
     mesh_host_rank_to_mpi_rank_.clear();
-    for (std::size_t idx = 0; idx < gathered.size(); ++idx) {
-        const auto encoded = gathered[idx];
+    for (const auto encoded : gathered) {
         if (encoded == sentinel) {
             continue;
         }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -334,8 +334,7 @@ std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeListOpt::available_addresses(
     std::vector<std::pair<DeviceAddr, DeviceAddr>> addresses;
 
     for (size_t i = size_segregated_index; i < size_segregated_count; i++) {
-        for (size_t j = 0; j < free_blocks_segregated_by_size_[i].size(); j++) {
-            size_t block_index = free_blocks_segregated_by_size_[i][j];
+        for (size_t block_index : free_blocks_segregated_by_size_[i]) {
             if (block_size_[block_index] >= alloc_size) {
                 addresses.push_back(
                     {block_address_[block_index] + offset_bytes_,
@@ -441,16 +440,16 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
             out << "  Size class " << i << ": (" << size_t(size_segregated_base * (size_t{1} << i))
                 << " - inf) blocks: ";
         }
-        for (size_t j = 0; j < free_blocks_segregated_by_size_[i].size(); j++) {
-            out << free_blocks_segregated_by_size_[i][j] << " ";
+        for (size_t block_id : free_blocks_segregated_by_size_[i]) {
+            out << block_id << " ";
         }
 
         out << std::endl;
     }
 
     out << "Free slots in block table: ";
-    for (size_t i = 0; i < free_meta_block_indices_.size(); i++) {
-        out << free_meta_block_indices_[i] << " ";
+    for (unsigned long free_meta_block_index : free_meta_block_indices_) {
+        out << free_meta_block_index << " ";
     }
     out << std::endl;
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1045,8 +1045,8 @@ void MetalContext::generate_device_bank_to_noc_tables(ChipId device_id) {
     l1_bank_to_noc_xy_[device_id].clear();
     l1_bank_to_noc_xy_[device_id].reserve(hal_->get_num_nocs() * l1_noc_coord_per_bank.size());
     for (unsigned int noc = 0; noc < hal_->get_num_nocs(); noc++) {
-        for (unsigned int bank_id = 0; bank_id < l1_noc_coord_per_bank.size(); bank_id++) {
-            auto l1_noc_coords = virtual_noc0_coordinate(device_id, noc, l1_noc_coord_per_bank[bank_id]);
+        for (const auto& noc_coord : l1_noc_coord_per_bank) {
+            auto l1_noc_coords = virtual_noc0_coordinate(device_id, noc, noc_coord);
             uint16_t noc_x = l1_noc_coords.x;
             uint16_t noc_y = l1_noc_coords.y;
             uint16_t xy = ((noc_y << hal_->get_noc_addr_node_id_bits()) | noc_x) << hal_->get_noc_coord_reg_offset();

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -132,9 +132,9 @@ std::vector<bfloat16> create_random_vector_of_bfloat16_native(
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<bfloat16> vec(num_bytes / sizeof(bfloat16), 0);
-    for (size_t i = 0; i < vec.size(); i++) {
+    for (auto& elem : vec) {
         float num_1_float = rand_float() + offset;
-        vec[i] = bfloat16(num_1_float);
+        elem = bfloat16(num_1_float);
     }
     return vec;
 }
@@ -144,7 +144,7 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16(
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, rand_max_float), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (size_t i = 0; i < vec.size(); i++) {
+    for (unsigned int& elem : vec) {
         float num_1_float = rand_float() + offset;
         float num_2_float = rand_float() + offset;
 
@@ -152,7 +152,7 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16(
         bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
 
         // pack 2 uint16 into uint32
-        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        elem = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
 
     return vec;
@@ -173,12 +173,12 @@ std::vector<std::uint32_t> create_random_vector_of_bfloat16_0_2(size_t num_bytes
 std::vector<std::uint32_t> create_constant_vector_of_bfloat16(size_t num_bytes, float value) {
     const size_t num_elements_vec = std::max<size_t>(1ul, num_bytes / sizeof(std::uint32_t));  // always at least have 1
     std::vector<std::uint32_t> vec(num_elements_vec, 0);
-    for (size_t i = 0; i < vec.size(); i++) {
+    for (unsigned int& elem : vec) {
         bfloat16 num_1_bfloat16 = bfloat16(value);
 
         bfloat16 num_2_bfloat16 = num_elements_vec == 1 ? bfloat16(static_cast<float>(0.0)) : bfloat16(value);
 
-        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        elem = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
 
     return vec;
@@ -199,7 +199,7 @@ std::vector<uint32_t> create_random_binary_vector_of_bfloat16(size_t num_bytes, 
     auto rand_float = std::bind(std::uniform_real_distribution<float>(0, 1), std::mt19937(seed));
 
     std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
-    for (size_t i = 0; i < vec.size(); i++) {
+    for (unsigned int& elem : vec) {
         float num_1_float = rand_float();
         float num_2_float = rand_float();
 
@@ -209,7 +209,7 @@ std::vector<uint32_t> create_random_binary_vector_of_bfloat16(size_t num_bytes, 
         bfloat16 num_1_bfloat16 = bfloat16(num_1_float);
         bfloat16 num_2_bfloat16 = bfloat16(num_2_float);
 
-        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        elem = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
     return vec;
 }
@@ -300,8 +300,8 @@ bfloat16 bfloat16_identity_transform(const bfloat16& input) { return input; }
 std::vector<bfloat16> unpack_uint32_vec_into_bfloat16_vec(
     const std::vector<std::uint32_t>& data, const std::function<bfloat16(const bfloat16&)>& transform) {
     std::vector<bfloat16> result;
-    for (size_t i = 0; i < data.size(); i++) {
-        auto unpacked = unpack_two_bfloat16_from_uint32(data[i]);
+    for (unsigned int packed : data) {
+        auto unpacked = unpack_two_bfloat16_from_uint32(packed);
         result.push_back(transform(unpacked.first));
         result.push_back(transform(unpacked.second));
     }

--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -6,6 +6,8 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <cstddef>
+#include <functional>
+#include <numeric>
 #include <ostream>
 
 #include <tt_stl/assert.hpp>
@@ -24,11 +26,7 @@ std::ostream& operator<<(std::ostream& os, TensorLayoutType layout) {
 TensAddr::TensAddr(const std::vector<std::uint32_t>& shape) : sh(shape) {}
 
 std::uint32_t TensAddr::numel() const {
-    std::uint32_t prod = 1;
-    for (int j = 0; j < sh.size(); j++) {
-        prod *= sh[j];
-    }
-    return prod;
+    return std::accumulate(sh.begin(), sh.end(), std::uint32_t{1}, std::multiplies<>{});
 }
 
 int TensAddr::offs(int n, int c, int h, int w) {

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -200,10 +200,10 @@ void DeviceManager::init_profiler() const {
         detail::InitDeviceProfiler(dev);
         log_info(tt::LogMetal, "Profiler started on device {}", mmio_device_id);
         if (not this->skip_remote_devices_) {
-            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+            for (const auto& tunnel : tunnels_from_mmio) {
                 // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
                     auto* mmio_device = get_device(mmio_controlled_device_id);
                     detail::InitDeviceProfiler(mmio_device);
                     log_info(tt::LogMetal, "Profiler started on remote device {}", mmio_device->id());
@@ -363,8 +363,8 @@ void DeviceManager::initialize_host(IDevice* dev) const {
 
 void DeviceManager::init_fabric(const std::vector<tt_metal::IDevice*>& active_devices) const {
     std::vector<std::shared_future<tt_metal::IDevice*>> events;
-    for (uint32_t i = 0; i < active_devices.size(); i++) {
-        const auto& dev = active_devices[i];
+    events.reserve(active_devices.size());
+    for (auto* dev : active_devices) {
         events.emplace_back(detail::async([dev]() {
             if (dev->compile_fabric()) {
                 return dev;
@@ -435,10 +435,10 @@ void DeviceManager::initialize_active_devices() {
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         populate_cq_static_args(dev);
         if (not this->skip_remote_devices_) {
-            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+            for (const auto& tunnel : tunnels_from_mmio) {
                 // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
                     auto* device = get_device(mmio_controlled_device_id);
                     populate_cq_static_args(device);
                 }
@@ -459,10 +459,10 @@ void DeviceManager::initialize_active_devices() {
         auto tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         if (not this->skip_remote_devices_) {
-            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+            for (const auto& tunnel : tunnels_from_mmio) {
                 // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
                     auto* device = get_device(mmio_controlled_device_id);
                     create_cq_program(device);
                 }
@@ -487,10 +487,10 @@ void DeviceManager::initialize_active_devices() {
         dev->init_command_queue_device();
         log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
         if (not this->skip_remote_devices_) {
-            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+            for (const auto& tunnel : tunnels_from_mmio) {
                 // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
                     auto* device = get_device(mmio_controlled_device_id);
                     device->init_command_queue_device();
                     log_info(tt::LogMetal, "Command Queue initialized on Device {}", device->id());
@@ -711,10 +711,10 @@ void DeviceManager::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
 
         auto tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(dev->id());
-        for (auto i = 0; i < tunnels_from_mmio.size(); i++) {
+        for (const auto& tunnel : tunnels_from_mmio) {
             // Need to poll on devices from farthest to the closest.
-            for (auto j = tunnels_from_mmio[i].size() - 1; j > 0; j--) {
-                wait_for_handshake(get_device(tunnels_from_mmio[i][j]));
+            for (auto j = tunnel.size() - 1; j > 0; j--) {
+                wait_for_handshake(get_device(tunnel[j]));
             }
         }
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -565,8 +565,8 @@ void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs
 void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     // If we already had nodes from a previous run, clear them (since we could have a different # of devices or CQs).
     if (!node_id_to_kernel.empty()) {
-        for (int idx = 0; idx < node_id_to_kernel.size(); idx++) {
-            delete node_id_to_kernel[idx];
+        for (auto& kernel : node_id_to_kernel) {
+            delete kernel;
         }
         node_id_to_kernel.clear();
         command_queue_compile_group.clear();
@@ -786,9 +786,9 @@ void configure_dispatch_cores(IDevice* device) {
         }
     }
     // Configure cores for all nodes corresponding to this device
-    for (int idx = 0; idx < node_id_to_kernel.size(); idx++) {
-        if (node_id_to_kernel[idx]->GetDeviceId() == device->id()) {
-            node_id_to_kernel[idx]->ConfigureCore();
+    for (auto& kernel : node_id_to_kernel) {
+        if (kernel->GetDeviceId() == device->id()) {
+            kernel->ConfigureCore();
         }
     }
 }
@@ -816,8 +816,8 @@ const std::unordered_set<TerminationInfo>& get_registered_termination_cores(Chip
 
 void reset_topology_state() {
     // TODO: https://github.com/tenstorrent/tt-metal/issues/24439
-    for (int idx = 0; idx < node_id_to_kernel.size(); idx++) {
-        delete node_id_to_kernel[idx];
+    for (auto& kernel : node_id_to_kernel) {
+        delete kernel;
     }
     node_id_to_kernel.clear();
     command_queue_compile_group.clear();

--- a/tt_metal/impl/profiler/profiler_state_manager.cpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.cpp
@@ -65,6 +65,7 @@ void ProfilerStateManager::cleanup_device_profilers() {
     std::vector<std::thread> threads(this->device_profiler_map.size());
 
     uint32_t i = 0;
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto it = this->device_profiler_map.begin(); it != this->device_profiler_map.end(); ++it) {
         threads[i] = std::thread([it]() {
             DeviceProfiler& profiler = it->second;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2667,8 +2667,7 @@ void set_core_go_message_mapping_on_device(
         MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();
     uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
-    for (size_t i = 0; i < core_go_message_mapping.size(); ++i) {
-        const auto& [core_range_set, go_msg_offset] = core_go_message_mapping[i];
+    for (const auto& [core_range_set, go_msg_offset] : core_go_message_mapping) {
         for (const auto& core_range : core_range_set.ranges()) {
             CoreCoord virtual_start = device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
             CoreCoord virtual_end = device->virtual_core_from_logical_core(core_range.end_coord, CoreType::WORKER);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -164,8 +164,8 @@ void JitBuildEnv::init(
 
     // Defines
     this->defines_ = "";
-    for (auto it = device_kernel_defines.begin(); it != device_kernel_defines.end(); ++it) {
-        this->defines_ += "-D" + it->first + "=" + it->second + " ";
+    for (const auto& device_kernel_define : device_kernel_defines) {
+        this->defines_ += "-D" + device_kernel_define.first + "=" + device_kernel_define.second + " ";
     }
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 
@@ -272,8 +272,8 @@ void JitBuildEnv::init(
         root_ + "tt_metal/api/"};
 
     std::ostringstream oss;
-    for (size_t i = 0; i < includeDirs.size(); ++i) {
-        oss << "-I" << includeDirs[i] << " ";
+    for (const auto& includeDir : includeDirs) {
+        oss << "-I" << includeDir << " ";
     }
     this->includes_ = oss.str();
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -127,8 +127,8 @@ namespace {
 
 std::string data_format_vec_to_string(const vector<DataFormat>& formats) {
     std::string formats_string;
-    for (int i = 0; i < formats.size(); i++) {
-        formats_string += to_string((int)formats[i]) + ",";
+    for (const auto& format : formats) {
+        formats_string += to_string((int)format) + ",";
     }
     return formats_string;
 }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1124,7 +1124,7 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
 
             const uint8_t num_cores_to_reserve = std::min(num_routing_planes, static_cast<uint8_t>(cores.size()));
             uint8_t num_reserved_cores = 0;
-            for (auto i = 0; i < cores.size(); i++) {
+            for (const auto eth_core : cores) {
                 if (num_reserved_cores == num_cores_to_reserve) {
                     pairs_done.insert(std::make_pair(chip_id, connected_chip_id));
                     pairs_done.insert(std::make_pair(connected_chip_id, chip_id));
@@ -1141,7 +1141,6 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                     break;
                 }
 
-                const auto eth_core = cores[i];
                 const auto connected_core =
                     std::get<1>(this->get_connected_ethernet_core(std::make_tuple(chip_id, eth_core)));
                 if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -267,8 +267,8 @@ int main() {
 
     // =========== Step 10: Verify Outputs ===========
     bool pass = true;
-    for (int i = 0; i < add_dst_vec.size(); i++) {
-        pass &= (static_cast<float>(add_dst_vec[i]) == workload_0_src0_val + workload_0_src1_val);
+    for (auto val : add_dst_vec) {
+        pass &= (static_cast<float>(val) == workload_0_src0_val + workload_0_src1_val);
     }
     for (int i = 0; i < mul_sub_dst_vec.size(); i++) {
         if (i < mul_sub_dst_vec.size() / 2) {

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -132,8 +132,8 @@ int main() {
     }
 
     fmt::print("Original tensor values: ");
-    for (uint32_t src_vec_idx = 0; src_vec_idx < src_vec.size(); src_vec_idx++) {
-        fmt::print("{:0.1f} ", static_cast<float>(src_vec[src_vec_idx]));
+    for (auto val : src_vec) {
+        fmt::print("{:0.1f} ", static_cast<float>(val));
     }
     fmt::print("\n");
 

--- a/tt_stl/tests/test_small_vector.cpp
+++ b/tt_stl/tests/test_small_vector.cpp
@@ -279,6 +279,7 @@ TEST_F(SmallVectorIntTest, ForwardAndReverseIterators) {
     Vec vec{1, 2, 3, 4};
     // Sum elements via forward iterators.
     int sum = 0;
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto* it = vec.begin(); it != vec.end(); ++it) {
         sum += *it;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -129,10 +129,10 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
     auto output_placements = input_topology.placements();
 
     // For each distribution dimension, if sharded on the gather dim, make it replicated
-    for (size_t i = 0; i < output_placements.size(); i++) {
-        if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placements[i])) {
+    for (auto& output_placement : output_placements) {
+        if (auto* shard = std::get_if<tt::tt_metal::distributed::MeshMapperConfig::Shard>(&output_placement)) {
             if (shard->dim == static_cast<int>(operation_attributes.dim)) {
-                output_placements[i] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+                output_placement = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -273,7 +273,7 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
     uint32_t link_id = 0;
     uint32_t tokens_per_core_start = 0;
     log_debug(tt::LogOp, "Runtime arguments are being calculated for MeshCoordinate {}", mesh_coordinate);
-    for (uint32_t i = 0; i < sender_cores.size(); i++) {
+    for (const auto& sender_core : sender_cores) {
         std::vector<uint32_t> writer_runtime_args = {
             output_tensor.buffer()->address(),
             (uint32_t)cross_device_semaphore.address(),
@@ -289,7 +289,7 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
         log_debug(
             tt::LogOp,
             "Setting runtime args for core {}. It will operate on tokens {} to {}. Global semaphore address: {}",
-            sender_cores.at(i),
+            sender_core,
             reader_runtime_args[3],
             reader_runtime_args[4],
             (uint32_t)cross_device_semaphore.address());
@@ -297,10 +297,10 @@ AllToAllCombineDeviceOperation::AllToAllCombineFromSparse::create_at(
         for (const auto& neighbor_coordinate : neighbors) {
             const auto neighbor_fabric_id = mesh_device->get_fabric_node_id(neighbor_coordinate);
             append_fabric_connection_rt_args(
-                fabric_node_id, neighbor_fabric_id, link_id, program, sender_cores.at(i), writer_runtime_args);
+                fabric_node_id, neighbor_fabric_id, link_id, program, sender_core, writer_runtime_args);
         }
-        SetRuntimeArgs(program, ternary_reader_kernel_id, sender_cores.at(i), reader_runtime_args);
-        SetRuntimeArgs(program, unary_writer_kernel_id, sender_cores.at(i), writer_runtime_args);
+        SetRuntimeArgs(program, ternary_reader_kernel_id, sender_core, reader_runtime_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, sender_core, writer_runtime_args);
         link_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_program_factory.cpp
@@ -419,7 +419,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
 
     uint32_t link_id = 0;
     uint32_t tokens_per_core_start = 0;
-    for (uint32_t i = 0; i < sender_cores.size(); i++) {
+    for (const auto& sender_core : sender_cores) {
         std::vector<uint32_t> writer_runtime_args = {
             input_tensor.buffer()->address(),
             indices_tensor.buffer()->address(),
@@ -445,7 +445,7 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
                 mesh_coordinate[1],
                 neighbor_coordinate[0],
                 neighbor_coordinate[1],
-                sender_cores.at(i),
+                sender_core,
                 link_id,
                 reader_runtime_args[6],
                 reader_runtime_args[7]);
@@ -454,12 +454,12 @@ AllToAllDispatchDeviceOperation::AllToAllDispatchSparse::create_at(
                 mesh_device->get_fabric_node_id(neighbor_coordinate),
                 link_id,
                 program,
-                sender_cores.at(i),
+                sender_core,
                 writer_runtime_args);
         }
 
-        tt::tt_metal::SetRuntimeArgs(program, ternary_reader_kernel_id, sender_cores.at(i), reader_runtime_args);
-        tt::tt_metal::SetRuntimeArgs(program, binary_writer_kernel_id, sender_cores.at(i), writer_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, ternary_reader_kernel_id, sender_core, reader_runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, binary_writer_kernel_id, sender_core, writer_runtime_args);
         link_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.cpp
@@ -849,19 +849,19 @@ tt::tt_metal::KernelHandle generate_multi_command_stream_kernel_ct_args(
 
     {  // CT ARGS
         std::vector<uint32_t> ct_args = {my_chip_id.value_or(0xFFFF), reserved_packet_header_CB_index};
-        for (size_t i = 0; i < tensors.size(); i++) {
+        for (const auto *tensor : tensors) {
             std::ranges::copy(
                 std::array<uint32_t, 4>{
                     static_cast<uint32_t>(
-                        tensors[i]->buffer()->buffer_layout()),  // TODO: refactor out to generate_tensor_ct_args
-                    static_cast<uint32_t>(tensors[i]->buffer()->buffer_type()),
-                    static_cast<uint32_t>(tensors[i]->layout()),
+                        tensor->buffer()->buffer_layout()),  // TODO: refactor out to generate_tensor_ct_args
+                    static_cast<uint32_t>(tensor->buffer()->buffer_type()),
+                    static_cast<uint32_t>(tensor->layout()),
                     static_cast<uint32_t>(0)},
                 std::back_inserter(ct_args));
         }
-        for (size_t i = 0; i < tensors.size(); i++) {
+        for (const auto *tensor : tensors) {
             std::ranges::copy(
-                ttnn::ccl::emit_address_generator_compile_time_args(*tensors[i]), std::back_inserter(ct_args));
+                ttnn::ccl::emit_address_generator_compile_time_args(*tensor), std::back_inserter(ct_args));
         }
 
         datamovement_kernel_config.compile_args = ct_args;

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -155,12 +155,12 @@ std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_rt_args(IDevice const* d, T
     std::vector<uint32_t> args;
     auto const& [row_map, col_map] = shard_noc_cores_from_shard_spec(d, t.shard_spec().value());
     args.push_back(row_map.size());
-    for (uint32_t i = 0; i < row_map.size(); i++) {
-        args.push_back(row_map.at(i));
+    for (unsigned int row : row_map) {
+        args.push_back(row);
     }
     args.push_back(col_map.size());
-    for (uint32_t i = 0; i < col_map.size(); i++) {
-        args.push_back(col_map.at(i));
+    for (unsigned int col : col_map) {
+        args.push_back(col);
     }
 
     return args;

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
@@ -383,8 +383,8 @@ static std::vector<HostNocTransferBurstGrouping> densely_pack_noc_transfers(tt::
 
     size_t group_size_bytes = 0;
     transfer_burst_groupings.push_back({});
-    for (size_t i = 0; i < transfer_infos.size(); i++) {
-        group_size_bytes += transfer_infos[i].noc_transfer_size_bytes;
+    for (const auto& transfer_info : transfer_infos) {
+        group_size_bytes += transfer_info.noc_transfer_size_bytes;
         bool create_new_group = group_size_bytes >= cb_size_bytes;
         if (create_new_group) {
             transfer_burst_groupings.push_back({});
@@ -398,7 +398,7 @@ static std::vector<HostNocTransferBurstGrouping> densely_pack_noc_transfers(tt::
         }
 
         group.num_transfers_per_packet++;
-        group.transfer_infos.push_back(transfer_infos[i]);
+        group.transfer_infos.push_back(transfer_info);
     }
 
     return transfer_burst_groupings;

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
@@ -11,15 +11,13 @@ namespace shard_builder {
 uint32_t get_sharding_core_count(const tt::tt_metal::Tensor& t) {
     uint32_t core_count = 0;
     const auto core_ranges = t.buffer()->shard_spec().grid().ranges();
-    for (uint32_t cr = 0; cr < core_ranges.size(); cr++) {
+    for (const auto& core_range : core_ranges) {
         TT_FATAL(
-            core_ranges.at(cr).start_coord.x <= core_ranges.at(cr).end_coord.x,
-            "end coordinates left of start coordinates in shard");
+            core_range.start_coord.x <= core_range.end_coord.x, "end coordinates left of start coordinates in shard");
         TT_FATAL(
-            core_ranges.at(cr).start_coord.y <= core_ranges.at(cr).end_coord.y,
-            "end coordinates above of start coordinates in shard");
-        core_count += (core_ranges.at(cr).end_coord.x - core_ranges.at(cr).start_coord.x + 1) *
-                      (core_ranges.at(cr).end_coord.y - core_ranges.at(cr).start_coord.y + 1);
+            core_range.start_coord.y <= core_range.end_coord.y, "end coordinates above of start coordinates in shard");
+        core_count += (core_range.end_coord.x - core_range.start_coord.x + 1) *
+                      (core_range.end_coord.y - core_range.start_coord.y + 1);
     }
     return core_count;
 }
@@ -36,30 +34,24 @@ std::vector<CoreCoord> get_shard_cores(const tt::tt_metal::Tensor& t) {
            t.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) &&
           shard_spec.orientation == ShardOrientation::COL_MAJOR));
     bool is_dram = t.memory_config().is_dram();
-    for (uint32_t cr = 0; cr < core_ranges.size(); cr++) {
+    for (const auto& core_range : core_ranges) {
         TT_FATAL(
-            core_ranges.at(cr).start_coord.x <= core_ranges.at(cr).end_coord.x,
-            "end coordinates left of start coordinates in shard");
-        TT_FATAL(core_ranges.at(cr).end_coord.x <= 0xFF, "sharding coordinates out of range");
+            core_range.start_coord.x <= core_range.end_coord.x, "end coordinates left of start coordinates in shard");
+        TT_FATAL(core_range.end_coord.x <= 0xFF, "sharding coordinates out of range");
         TT_FATAL(
-            core_ranges.at(cr).start_coord.y <= core_ranges.at(cr).end_coord.y,
-            "end coordinates above of start coordinates in shard");
-        TT_FATAL(core_ranges.at(cr).end_coord.y <= 0xFF, "sharding coordinates out of range");
+            core_range.start_coord.y <= core_range.end_coord.y, "end coordinates above of start coordinates in shard");
+        TT_FATAL(core_range.end_coord.y <= 0xFF, "sharding coordinates out of range");
         if (shard_grid_transposed) {
-            for (uint32_t x_index = core_ranges.at(cr).start_coord.x; x_index <= core_ranges.at(cr).end_coord.x;
-                 x_index++) {
-                for (uint32_t y_index = core_ranges.at(cr).start_coord.y; y_index <= core_ranges.at(cr).end_coord.y;
-                     y_index++) {
+            for (uint32_t x_index = core_range.start_coord.x; x_index <= core_range.end_coord.x; x_index++) {
+                for (uint32_t y_index = core_range.start_coord.y; y_index <= core_range.end_coord.y; y_index++) {
                     CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
                                                  : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
                     coordinates.push_back(noc_core);
                 }
             }
         } else {
-            for (uint32_t y_index = core_ranges.at(cr).start_coord.y; y_index <= core_ranges.at(cr).end_coord.y;
-                 y_index++) {
-                for (uint32_t x_index = core_ranges.at(cr).start_coord.x; x_index <= core_ranges.at(cr).end_coord.x;
-                     x_index++) {
+            for (uint32_t y_index = core_range.start_coord.y; y_index <= core_range.end_coord.y; y_index++) {
+                for (uint32_t x_index = core_range.start_coord.x; x_index <= core_range.end_coord.x; x_index++) {
                     CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
                                                  : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
                     coordinates.push_back(noc_core);
@@ -85,20 +77,16 @@ std::vector<uint32_t> generate_run_time_args(const tt::tt_metal::Tensor& t) {
     bool last = false;
     uint32_t held_value = 0;
     uint32_t concatenated_core = 0;
-    for (uint32_t cr = 0; cr < core_ranges.size(); cr++) {
+    for (const auto& core_range : core_ranges) {
         TT_FATAL(
-            core_ranges.at(cr).start_coord.x <= core_ranges.at(cr).end_coord.x,
-            "end coordinates left of start coordinates in shard");
-        TT_FATAL(core_ranges.at(cr).end_coord.x <= 0xFF, "sharding coordinates out of range");
+            core_range.start_coord.x <= core_range.end_coord.x, "end coordinates left of start coordinates in shard");
+        TT_FATAL(core_range.end_coord.x <= 0xFF, "sharding coordinates out of range");
         TT_FATAL(
-            core_ranges.at(cr).start_coord.y <= core_ranges.at(cr).end_coord.y,
-            "end coordinates above of start coordinates in shard");
-        TT_FATAL(core_ranges.at(cr).end_coord.y <= 0xFF, "sharding coordinates out of range");
+            core_range.start_coord.y <= core_range.end_coord.y, "end coordinates above of start coordinates in shard");
+        TT_FATAL(core_range.end_coord.y <= 0xFF, "sharding coordinates out of range");
         if (shard_grid_transposed) {
-            for (uint32_t x_index = core_ranges.at(cr).start_coord.x; x_index <= core_ranges.at(cr).end_coord.x;
-                 x_index++) {
-                for (uint32_t y_index = core_ranges.at(cr).start_coord.y; y_index <= core_ranges.at(cr).end_coord.y;
-                     y_index++) {
+            for (uint32_t x_index = core_range.start_coord.x; x_index <= core_range.end_coord.x; x_index++) {
+                for (uint32_t y_index = core_range.start_coord.y; y_index <= core_range.end_coord.y; y_index++) {
                     CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
                                                  : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
                     concatenated_core = (noc_core.x & 0xFF) << 8 | (noc_core.y & 0xFF);
@@ -111,10 +99,8 @@ std::vector<uint32_t> generate_run_time_args(const tt::tt_metal::Tensor& t) {
                 }
             }
         } else {
-            for (uint32_t y_index = core_ranges.at(cr).start_coord.y; y_index <= core_ranges.at(cr).end_coord.y;
-                 y_index++) {
-                for (uint32_t x_index = core_ranges.at(cr).start_coord.x; x_index <= core_ranges.at(cr).end_coord.x;
-                     x_index++) {
+            for (uint32_t y_index = core_range.start_coord.y; y_index <= core_range.end_coord.y; y_index++) {
+                for (uint32_t x_index = core_range.start_coord.x; x_index <= core_range.end_coord.x; x_index++) {
                     CoreCoord noc_core = is_dram ? CoreCoord(x_index, y_index)
                                                  : device->worker_core_from_logical_core(CoreCoord(x_index, y_index));
                     concatenated_core = (noc_core.x & 0xFF) << 8 | (noc_core.y & 0xFF);

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -309,9 +309,7 @@ TypecastSubgridProgramFactory::cached_program_t TypecastSubgridProgramFactory::c
     uint32_t tile_start_id = 0;
     auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
 
-    for (uint32_t i = 0; i < cores.size(); i++) {
-        CoreCoord core = cores[i];
-
+    for (auto core : cores) {
         tt::tt_metal::SetRuntimeArgs(
             program, typecast_reader_kernel_id, core, {src_buffer->address(), ntiles_per_core, tile_start_id});
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -192,13 +192,12 @@ Fold::MultiCoreDRAMFold::cached_program_t fold_multi_core_tiled_interleaved(
     const uint32_t patch_size = stride_h * stride_w;         // Size of each patch
     const uint32_t output_width = input_width / stride_w;    // Output width
     // Configure runtime arguments for each core
-    for (auto i = 0; i < cores.size(); i++) {
+    for (auto core : cores) {
         uint32_t curr_input_height_idx = block_start_id;
         uint32_t curr_output_height_idx = curr_input_height_idx / stride_h;
         uint32_t patch_height_offset = curr_input_height_idx % stride_h;
         uint32_t output_offset = (patch_size * curr_output_height_idx * output_width) +
                                  (patch_height_offset * stride_w);  // Total output height * width
-        CoreCoord core = cores[i];
         if (!full_cores.contains(core)) {
             continue;
         }
@@ -420,8 +419,7 @@ void Fold::MultiCoreDRAMFold::override_runtime_arguments(
     auto* dst_dram_buffer = output_tensor.buffer();
 
     // Update runtime arguments for each core
-    for (auto i = 0; i < cores_with_rtargs.size(); i++) {
-        CoreCoord core = cores_with_rtargs[i];
+    for (auto core : cores_with_rtargs) {
         {
             auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer->address();

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -195,8 +195,8 @@ ttnn::Tensor ExecutePermute::invoke(
         for (int i = 0; i < additional_ranks; i++) {
             new_order.push_back(i);
         }
-        for (int i = 0; i < dims.size(); i++) {
-            new_order.push_back(dims[i] + additional_ranks);
+        for (unsigned int dim : dims) {
+            new_order.push_back(dim + additional_ranks);
         }
         return new_order;
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -20,9 +20,9 @@ ttnn::Tensor SqueezeOperation::invoke(const ttnn::Tensor& input_tensor, const tt
     auto dims = dim;
 
     // handle negative dimensions
-    for (size_t i = 0; i < dims.size(); ++i) {
-        if (dims[i] < 0) {
-            dims[i] += input_tensor_rank;
+    for (int& dim : dims) {
+        if (dim < 0) {
+            dim += input_tensor_rank;
         }
     }
     // Sort the dimensions in descending order to avoid issues with modifying new_shape in loop

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -134,9 +134,7 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
     // Run-time args
     auto cores =
         corerange_to_cores(shard_spec.grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        CoreCoord core = cores[i];
-
+    for (auto core : cores) {
         // Reader run-time args
         uint32_t num_tiles_to_read = num_tiles_per_block * num_blocks_per_core;
         std::vector<uint32_t> reader_run_time_args = {num_tiles_to_read};

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -183,8 +183,7 @@ UntilizeMultiCoreParallelizeColumnProgramFactory::create(
 
     auto nsticks_per_core = ntiles_per_column * TILE_HEIGHT;
 
-    for (uint32_t i = 0; i < cores.size(); i++) {
-        CoreCoord core = cores[i];
+    for (auto core : cores) {
         if (!full_cores.contains(core)) {
             continue;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -149,9 +149,7 @@ UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t UntilizeMultiCoreS
 
     auto nsticks_per_core = ntiles_per_column * TILE_HEIGHT;
 
-    for (uint32_t i = 0; i < cores.size(); i++) {
-        CoreCoord core = cores[i];
-
+    for (auto core : cores) {
         // reader runtime args
         auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
         const std::array reader_rt_args = {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -393,9 +393,7 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
     uint32_t tile_start_id = 0;
     auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
 
-    for (uint32_t i = 0; i < cores.size(); i++) {
-        CoreCoord core = cores[i];
-
+    for (auto core : cores) {
         tt::tt_metal::SetRuntimeArgs(
             program, unary_reader_kernel_id, core, {src_buffer->address(), ntiles_per_core, tile_start_id});
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.cpp
@@ -604,8 +604,7 @@ void AllToAllAsyncProgram::override_runtime_arguments(
         }
 
         // Update receiver runtime args
-        for (uint32_t i = 0; i < shared_vars.receiver_worker_cores.size(); i++) {
-            const auto core = shared_vars.receiver_worker_cores[i];
+        for (const auto& core : shared_vars.receiver_worker_cores) {
             auto& receiver_writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
             receiver_writer_runtime_args[0] = tensor_args.persistent_output_buffer.buffer()->address();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -390,9 +390,9 @@ std::vector<ttnn::Tensor> composite_all_gather(
     std::optional<uint32_t> cluster_axis) {
     std::vector<ttnn::Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
-    for (size_t i = 0; i < input_tensors.size(); i++) {
+    for (const auto& input_tensor : input_tensors) {
         output_tensors.push_back(
-            composite_all_gather(input_tensors[i], dim, num_links, memory_config, subdevice_id, cluster_axis));
+            composite_all_gather(input_tensor, dim, num_links, memory_config, subdevice_id, cluster_axis));
     }
     return output_tensors;
 }
@@ -462,11 +462,11 @@ ttnn::Tensor composite_all_to_all(
     input_tensor.deallocate();
 
     // Step 2: Slice out the index range each device cares about, along out_dim
-    for (size_t i = 0; i < broadcasted_tensors.size(); i++) {
-        temp_tensor = ttnn::mesh_partition(
-            broadcasted_tensors[i], out_dim, /* cluster_axis */ std::nullopt, interim_memory_config);
-        broadcasted_tensors[i].deallocate();
-        broadcasted_tensors[i] = temp_tensor;
+    for (auto& broadcasted_tensor : broadcasted_tensors) {
+        temp_tensor =
+            ttnn::mesh_partition(broadcasted_tensor, out_dim, /* cluster_axis */ std::nullopt, interim_memory_config);
+        broadcasted_tensor.deallocate();
+        broadcasted_tensor = temp_tensor;
     }
 
     // Step 3: Concatenate along in_dim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -483,9 +483,7 @@ process_agmm_fusion_program_and_create_override_variables(
     auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
     auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
     auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
-    for (uint32_t i = 0; i < all_cores_vec.size(); ++i) {
-        auto core = all_cores_vec[i];
-
+    for (auto core : all_cores_vec) {
         auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
         auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
         bool core_is_in_all_worker_cores = all_worker_cores_iter != worker_cores_vec.end();
@@ -690,8 +688,7 @@ inline void override_agmm_fusion_program_parameters(
 
     if (not src1_sharded) {
         auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
-        for (uint32_t i = 0; i < override_variables.cores.size(); ++i) {
-            const auto& core = override_variables.cores[i];
+        for (const auto& core : override_variables.cores) {
             auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
             /* in1 */

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -186,8 +186,8 @@ std::vector<std::vector<ReadRequest>> distribute_work_evenly(
 std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
     // create a flattened schedule
     std::vector<ReadRequest> schedule_flattened;
-    for (uint32_t i = 0; i < schedule.size(); ++i) {
-        schedule_flattened.insert(schedule_flattened.end(), schedule[i].begin(), schedule[i].end());
+    for (const auto& chunk : schedule) {
+        schedule_flattened.insert(schedule_flattened.end(), chunk.begin(), chunk.end());
     }
     return schedule_flattened;
 }
@@ -195,10 +195,9 @@ std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequ
 std::string schedule_to_string(const std::vector<std::vector<ReadRequest>>& schedule) {
     auto flattened_schedule = flatten_schedule(schedule);
     std::string result = "{";
-    for (uint32_t i = 0; i < flattened_schedule.size(); ++i) {
-        result += "{" + std::to_string(flattened_schedule[i].bank_id) + ", " +
-                  std::to_string(flattened_schedule[i].read_offset) + ", " +
-                  std::to_string(flattened_schedule[i].read_size) + "}, ";
+    for (const auto& entry : flattened_schedule) {
+        result += "{" + std::to_string(entry.bank_id) + ", " + std::to_string(entry.read_offset) + ", " +
+                  std::to_string(entry.read_size) + "}, ";
     }
     result += "}";
     return result;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_program_factory.cpp
@@ -197,8 +197,8 @@ uint32_t find_atomic_inc_core(std::vector<std::vector<ReadRequest>> schedule) {
 std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
     // create a flattened schedule
     std::vector<ReadRequest> schedule_flattened;
-    for (uint32_t i = 0; i < schedule.size(); ++i) {
-        schedule_flattened.insert(schedule_flattened.end(), schedule[i].begin(), schedule[i].end());
+    for (const auto& chunk : schedule) {
+        schedule_flattened.insert(schedule_flattened.end(), chunk.begin(), chunk.end());
     }
     return schedule_flattened;
 }
@@ -206,10 +206,9 @@ std::vector<ReadRequest> flatten_schedule(const std::vector<std::vector<ReadRequ
 std::string schedule_to_string(const std::vector<std::vector<ReadRequest>>& schedule) {
     auto flattened_schedule = flatten_schedule(schedule);
     std::string result = "{";
-    for (uint32_t i = 0; i < flattened_schedule.size(); ++i) {
-        result += "{" + std::to_string(flattened_schedule[i].bank_id) + ", " +
-                  std::to_string(flattened_schedule[i].read_offset) + ", " +
-                  std::to_string(flattened_schedule[i].read_size) + "}, ";
+    for (const auto& entry : flattened_schedule) {
+        result += "{" + std::to_string(entry.bank_id) + ", " + std::to_string(entry.read_offset) + ", " +
+                  std::to_string(entry.read_size) + "}, ";
     }
     result += "}";
     return result;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_op.cpp
@@ -229,8 +229,8 @@ std::vector<Tensor> ring_attention_all_gather_async_impl(
 
     std::vector<std::optional<Tensor>> optional_output_tensors;
     optional_output_tensors.reserve(persistent_output_buffer.size());
-    for (size_t i = 0; i < persistent_output_buffer.size(); ++i) {
-        optional_output_tensors.push_back(persistent_output_buffer[i]);
+    for (const auto& buffer : persistent_output_buffer) {
+        optional_output_tensors.push_back(buffer);
     }
 
     return tt::tt_metal::operation::run(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_program_factory.cpp
@@ -356,16 +356,14 @@ void RecvAsyncMeshWorkloadFactory::override_runtime_arguments(
         const auto& output_tensor = tensor_args.output_tensor;
 
         if (!socket_storage_in_dram) {
-            for (uint32_t core_idx = 0; core_idx < receiver_core_coords.size(); ++core_idx) {
-                const auto& receiver_core_coord = receiver_core_coords[core_idx];
+            for (const auto& receiver_core_coord : receiver_core_coords) {
                 auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, receiver_core_coord);
 
                 writer_runtime_args[0] = mesh_socket.get_config_buffer()->address();
                 writer_runtime_args[1] = output_tensor.buffer()->address();
             }
         } else {
-            for (uint32_t core_idx = 0; core_idx < receiver_core_coords.size(); ++core_idx) {
-                const auto& receiver_core_coord = receiver_core_coords[core_idx];
+            for (const auto& receiver_core_coord : receiver_core_coords) {
                 auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, receiver_core_coord);
                 auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, receiver_core_coord);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -547,8 +547,8 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                 for (uint32_t d = 0; d < ring_size; d++) {
                     reader_rt_args.push_back(device_k_block_counts[d]);
                     reader_rt_args.push_back(device_chunk_widths[d].size());
-                    for (uint32_t c = 0; c < device_chunk_widths[d].size(); c++) {
-                        reader_rt_args.push_back(device_chunk_widths[d][c]);
+                    for (unsigned int width : device_chunk_widths[d]) {
+                        reader_rt_args.push_back(width);
                     }
                 }
                 if (fuse_op) {
@@ -635,8 +635,8 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
                 for (uint32_t d = 0; d < ring_size; d++) {
                     writer_rt_args.push_back(device_k_block_counts[d]);
                     writer_rt_args.push_back(device_chunk_widths[d].size());
-                    for (uint32_t c = 0; c < device_chunk_widths[d].size(); c++) {
-                        writer_rt_args.push_back(device_chunk_widths[d][c]);
+                    for (unsigned int width : device_chunk_widths[d]) {
+                        writer_rt_args.push_back(width);
                     }
                 }
                 detail::strided_fabric_mux_connection_rt_args(

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -66,9 +66,7 @@ PlusOneProgramFactory::cached_program_t PlusOneProgramFactory::create(
 
     auto cores = corerange_to_cores(all_cores, num_cores, true);
 
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
-
+    for (const auto& core : cores) {
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {src_buffer->address()});
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -15,8 +15,8 @@ SliceWriteDeviceOperation::program_factory_t SliceWriteDeviceOperation::select_p
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
     bool has_step = false;
-    for (uint32_t i = 0; i < operation_attributes.step.size(); i++) {
-        if (operation_attributes.step[i] != 1) {
+    for (unsigned int step_val : operation_attributes.step) {
+        if (step_val != 1) {
             has_step = true;
             break;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_program_factory.cpp
@@ -269,18 +269,18 @@ AllReduceCreateQkvHeadsMeshWorkloadFactory::create_at(
     vcores_noc_x_coords.reserve(v_cores_vector.size());
     vcores_noc_y_coords.reserve(v_cores_vector.size());
 
-    for (uint32_t i = 0; i < q_cores_vector.size(); i++) {
-        auto worker_core = mesh_device->worker_core_from_logical_core(q_cores_vector[i]);
+    for (auto core : q_cores_vector) {
+        auto worker_core = mesh_device->worker_core_from_logical_core(core);
         qcores_noc_x_coords.push_back(worker_core.x);
         qcores_noc_y_coords.push_back(worker_core.y);
     }
-    for (uint32_t i = 0; i < k_cores_vector.size(); i++) {
-        auto worker_core = mesh_device->worker_core_from_logical_core(k_cores_vector[i]);
+    for (auto core : k_cores_vector) {
+        auto worker_core = mesh_device->worker_core_from_logical_core(core);
         kcores_noc_x_coords.push_back(worker_core.x);
         kcores_noc_y_coords.push_back(worker_core.y);
     }
-    for (uint32_t i = 0; i < v_cores_vector.size(); i++) {
-        auto worker_core = mesh_device->worker_core_from_logical_core(v_cores_vector[i]);
+    for (auto core : v_cores_vector) {
+        auto worker_core = mesh_device->worker_core_from_logical_core(core);
         vcores_noc_x_coords.push_back(worker_core.x);
         vcores_noc_y_coords.push_back(worker_core.y);
     }
@@ -834,8 +834,7 @@ void AllReduceCreateQkvHeadsMeshWorkloadFactory::override_runtime_arguments(
         auto& reduction_reader_args_by_core = GetRuntimeArgs(program, shared_vars.reduction_reader_kernel_id);
         auto& reduction_writer_args_by_core = GetRuntimeArgs(program, shared_vars.reduction_writer_kernel_id);
 
-        for (uint32_t i = 0; i < shared_vars.output_cores_vec.size(); i++) {
-            const auto& core = shared_vars.output_cores_vec[i];
+        for (const auto& core : shared_vars.output_cores_vec) {
             auto& reader_args = reduction_reader_args_by_core[core.x][core.y];
             reader_args[0] = q_base_addr;
             reader_args[1] = k_base_addr;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -380,9 +381,9 @@ inline std::vector<uint32_t> get_multi_dim_per_core_factor(
         if (in0_block_w % per_core_factor_k != 0) {
             continue;
         }
-        for (auto it = factors.crbegin(); it != factors.crend(); ++it) {
-            uint32_t per_core_factor_m = std::get<0>(it->second);
-            uint32_t per_core_factor_n = std::get<1>(it->second);
+        for (const auto& factor : std::ranges::reverse_view(factors)) {
+            uint32_t per_core_factor_m = std::get<0>(factor.second);
+            uint32_t per_core_factor_n = std::get<1>(factor.second);
 
             size = get_estimated_size_of_cbs(
                 per_core_factor_m,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -2219,9 +2219,7 @@ process_gather_in0_program_and_create_override_variables(
     auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
     auto worker_cores_vec = corerange_to_cores(all_worker_cores, std::nullopt, row_major);
     auto hop_cores_vec = corerange_to_cores(hop_cores, std::nullopt, row_major);
-    for (uint32_t i = 0; i < all_cores_vec.size(); ++i) {
-        auto core = all_cores_vec[i];
-
+    for (auto core : all_cores_vec) {
         auto all_worker_cores_iter = std::find(worker_cores_vec.begin(), worker_cores_vec.end(), core);
         auto hop_cores_iter = std::find(hop_cores_vec.begin(), hop_cores_vec.end(), core);
         bool core_is_in_all_worker_cores = all_worker_cores_iter != worker_cores_vec.end();
@@ -2590,8 +2588,7 @@ inline void override_gather_in0_program_parameters(
         }
     }
     auto& writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
-    for (uint32_t i = 0; i < override_variables.cores.size(); ++i) {
-        const auto& core = override_variables.cores[i];
+    for (const auto& core : override_variables.cores) {
         auto& writer_runtime_args = writer_runtime_args_by_core[core.x][core.y];
 
         /* in1 */

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -647,9 +647,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     }
 
     std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
-    for (uint32_t i = 0; i < mcast_receiver_coords.size(); ++i) {
-        auto core = mcast_receiver_coords[i];
-
+    for (auto core : mcast_receiver_coords) {
         // in0 receivers rt args
         std::vector<uint32_t> mm_in0_receiver_args;
         // mcast receiver - 3
@@ -691,9 +689,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     uint32_t curr_storage_core = 0;
 
     // for all the cores in the rect grid, we send one rt arg to determine if they are worker core
-    for (uint32_t i = 0; i < all_cores_in_rect_grid_vec.size(); ++i) {
-        auto core = all_cores_in_rect_grid_vec[i];
-
+    for (auto core : all_cores_in_rect_grid_vec) {
         if (std::find(all_worker_cores.ranges().begin(), all_worker_cores.ranges().end(), core) ==
             all_worker_cores.ranges().end()) {  // not worker
             // in1 reader rt args

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
@@ -25,8 +25,7 @@ void MorehGetItemOperation::validate_inputs(
 
     // validate index tensors
     uint32_t index_size = index_tensors[0].logical_shape()[-1];
-    for (uint32_t i = 0; i < index_tensors.size(); i++) {
-        const auto& index_tensor = index_tensors[i];
+    for (const auto& index_tensor : index_tensors) {
         TT_FATAL(index_tensor.storage_type() == StorageType::DEVICE, "Operands to getitem need to be on device!");
         TT_FATAL(index_tensor.buffer() != nullptr, "Operands to getitem need to be allocated in buffers on device!");
         TT_FATAL(index_tensor.dtype() == DataType::INT32, "Index tensor must be of type INT32!");
@@ -108,15 +107,14 @@ MorehGetItemOperation::spec_return_value_t MorehGetItemOperation::compute_output
         // index_dims = 1,2
         // output: (10, 1, 100, 40)
         SmallVector<uint32_t> output_size_vec;
-        for (int dim = 0; dim < output_shape.size(); dim++) {
-            output_size_vec.push_back(output_shape[dim]);
+        for (unsigned int dim : output_shape) {
+            output_size_vec.push_back(dim);
         }
 
         auto index = index_tensors[0];
         uint32_t index_size = index.logical_shape()[-1];
 
-        for (uint32_t i = 0; i < index_dims.size(); i++) {
-            uint32_t out_put_dim = index_dims[i];
+        for (unsigned int out_put_dim : index_dims) {
             output_size_vec[out_put_dim] = 1;
         }
         output_size_vec[index_dims.back()] = index_size;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -125,8 +125,8 @@ MorehGetItemOperation::MorehGetItemRmFactory::cached_program_t MorehGetItemOpera
 
     std::vector<uint32_t> reader_compile_time_args;
     tt::tt_metal::TensorAccessorArgs(input_5d.buffer()).append_to(reader_compile_time_args);
-    for (uint32_t dim = 0; dim < 5; dim++) {
-        index_info[dim].args.append_to(reader_compile_time_args);
+    for (auto& dim : index_info) {
+        dim.args.append_to(reader_compile_time_args);
     }
     auto reader_kernel_id = CreateReadKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -166,8 +166,8 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
 
         std::vector<uint32_t> reader_compile_time_args;
         tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-        for (uint32_t dim = 0; dim < 5; dim++) {
-            index_info[dim].args.append_to(reader_compile_time_args);
+        for (const auto& info : index_info) {
+            info.args.append_to(reader_compile_time_args);
         }
         auto reader_kernel_id = CreateReadKernel(
             program,
@@ -390,8 +390,8 @@ MorehGetItemOperation::MorehGetItemTilizedFactory::create(
 
         std::vector<uint32_t> reader_compile_time_args;
         tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
-        for (uint32_t dim = 0; dim < 5; dim++) {
-            index_info[dim].args.append_to(reader_compile_time_args);
+        for (const auto& info : index_info) {
+            info.args.append_to(reader_compile_time_args);
         }
         auto reader_kernel_id = CreateReadKernel(
             program,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.hpp
@@ -191,11 +191,10 @@ auto create_override_runtime_arguments_callback(
             {
                 uint32_t rt_idx = 0;
                 auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                for (uint32_t idx = 0; idx < input_tensors.size(); idx++) {
-                    runtime_args[rt_idx++] = input_tensors.at(idx).buffer()->address();
+                for (const auto& input_tensor : input_tensors) {
+                    runtime_args[rt_idx++] = input_tensor.buffer()->address();
                 }
-                for (uint32_t idx = 0; idx < optional_input_tensors.size(); idx++) {
-                    const auto& optional_input_tensor = optional_input_tensors.at(idx);
+                for (const auto& optional_input_tensor : optional_input_tensors) {
                     runtime_args[rt_idx++] =
                         optional_input_tensor.has_value() ? optional_input_tensor.value().buffer()->address() : 0;
                 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -800,12 +800,12 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
                 }
 
                 std::vector<uint32_t> mcast_noc_xy;
-                for (size_t c = 0; c < group.size(); ++c) {
-                    CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+                for (const auto& core : group) {
+                    CoreCoord coord = device->worker_core_from_logical_core(core);
                     mcast_noc_xy.push_back(coord.x);
                 }
-                for (size_t c = 0; c < group.size(); ++c) {
-                    CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+                for (const auto& core : group) {
+                    CoreCoord coord = device->worker_core_from_logical_core(core);
                     mcast_noc_xy.push_back(coord.y);
                 }
                 mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -1017,12 +1017,12 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
             }
 
             std::vector<uint32_t> mcast_noc_xy;
-            for (size_t c = 0; c < group.size(); ++c) {
-                CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+            for (const auto& core : group) {
+                CoreCoord coord = device->worker_core_from_logical_core(core);
                 mcast_noc_xy.push_back(coord.x);
             }
-            for (size_t c = 0; c < group.size(); ++c) {
-                CoreCoord coord = device->worker_core_from_logical_core(group[c]);
+            for (const auto& core : group) {
+                CoreCoord coord = device->worker_core_from_logical_core(core);
                 mcast_noc_xy.push_back(coord.y);
             }
             mcast_sender_args.insert(mcast_sender_args.end(), mcast_noc_xy.begin(), mcast_noc_xy.end());

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -424,14 +424,14 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
         }
     } else {
         for (const auto& core_group : core_coords2D) {
-            for (size_t j = 0; j < core_group.size(); ++j) {
-                if (mcast_sender_core_ranges.contains(CoreRange(core_group[j]))) {
+            for (const auto& core : core_group) {
+                if (mcast_sender_core_ranges.contains(CoreRange(core))) {
                     group_index += 1;
                 }
                 if (group_index >= static_cast<int>(mcast_groups.size())) {
                     mcast_groups.push_back(std::vector<CoreCoord>());  // Add a new group
                 }
-                mcast_groups[group_index].push_back(core_group[j]);
+                mcast_groups[group_index].push_back(core);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -522,11 +522,11 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     }
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
 
-    for (int i = 0; i < outputs.size(); ++i) {
+    for (const auto& output : outputs) {
         TT_FATAL(
-            outputs[i].memory_config().is_sharded(),
+            output.memory_config().is_sharded(),
             "Output memory config needs to be sharded, but got {}",
-            outputs[i].memory_config());
+            output.memory_config());
     }
 
     /**

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -284,8 +284,8 @@ static std::vector<Tensor> pool2d_invoke(
 
     // format and return the result
     if (memory_config.has_value() && memory_config.value() != out_memory_config) {
-        for (int i = 0; i < output_tensors.size(); i++) {
-            output_tensors[i] = ttnn::to_memory_config(output_tensors[i], memory_config.value(), std::nullopt);
+        for (auto& output_tensor : output_tensors) {
+            output_tensor = ttnn::to_memory_config(output_tensor, memory_config.value(), std::nullopt);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -258,9 +258,7 @@ UpsampleBilinearProgramFactory::cached_program_t UpsampleBilinearProgramFactory:
 
     uint32_t total_sticks_processed = 0;
 
-    for (uint32_t i = 0; i < logical_cores.size(); ++i) {
-        const tt::tt_metal::CoreCoord& core_coord = logical_cores[i];
-
+    for (const auto& core_coord : logical_cores) {
         // Calculate actual output sticks for this core
         uint32_t out_sticks_this_core = std::min(max_out_sticks_per_core, total_output_sticks - total_sticks_processed);
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -180,8 +180,7 @@ ArgMaxSingleCoreProgramFactory::cached_program_t ArgMaxSingleCoreProgramFactory:
 
     // Runtime args
     const auto cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false);
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
+    for (const auto& core : cores) {
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {src_buffer->address(), dst_buffer->address()});
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -40,11 +40,11 @@ std::pair<ttnn::SmallVector<int>, ttnn::SmallVector<int>> split_height_width_dim
     ttnn::SmallVector<int> non_height_width_dims{}, height_width_dims{};
     const auto& input_shape = input_tensor_arg.logical_shape();
     int rank = input_shape.size();
-    for (int i = 0; i < dim.size(); i++) {
-        if (dim[i] >= (rank - 2)) {
-            height_width_dims.push_back(dim[i]);
+    for (int d : dim) {
+        if (d >= (rank - 2)) {
+            height_width_dims.push_back(d);
         } else {
-            non_height_width_dims.push_back(dim[i]);
+            non_height_width_dims.push_back(d);
         }
     }
     return {non_height_width_dims, height_width_dims};

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -599,23 +599,22 @@ static GatherConfig reduce_flattened_transfers(const std::vector<DestinationTran
     GatherRoute current_route;
     current_route.header.noc_x = transfers[0].noc_x;
     current_route.header.noc_y = transfers[0].noc_y;
-    for (size_t i = 0; i < transfers.size(); i++) {
-        const auto& t = transfers[i];
-        bool same_core = (t.noc_x == current_route.header.noc_x) && (t.noc_y == current_route.header.noc_y);
+    for (const auto& xfer : transfers) {
+        bool same_core = (xfer.noc_x == current_route.header.noc_x) && (xfer.noc_y == current_route.header.noc_y);
         if (!same_core) {
             current_route.header.num_transfers = static_cast<uint16_t>(current_route.transfers.size());
             TT_FATAL(current_route.header.num_transfers > 0, "Route cannot have zero transfers");
             output.routes.push_back(current_route);
 
             current_route = GatherRoute();
-            current_route.header.noc_x = t.noc_x;
-            current_route.header.noc_y = t.noc_y;
+            current_route.header.noc_x = xfer.noc_x;
+            current_route.header.noc_y = xfer.noc_y;
         }
 
         GatherTransfer transfer{};
-        transfer.src_id = t.src_id;
-        transfer.dst_id = t.dst_id;
-        transfer.size = t.size;
+        transfer.src_id = xfer.src_id;
+        transfer.dst_id = xfer.dst_id;
+        transfer.size = xfer.size;
         current_route.transfers.push_back(transfer);
     }
     current_route.header.num_transfers = static_cast<uint16_t>(current_route.transfers.size());

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -281,8 +281,8 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
             D);
 
         // Check valid seqlen
-        for (int i = 0; i < operation_attributes.cur_pos.size(); i++) {
-            TT_FATAL(operation_attributes.cur_pos[i] < k_shape[-2], "cur_pos must be <= K sequence dim");
+        for (unsigned int cur_pos_val : operation_attributes.cur_pos) {
+            TT_FATAL(cur_pos_val < k_shape[-2], "cur_pos must be <= K sequence dim");
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -1005,8 +1005,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     if (num_active_cores < num_cores_available) {
         log_debug(tt::LogOp, "idle cores {}", core_group_idle.size());
         // Set the rest of the cores to idle
-        for (uint32_t i = 0; i < core_group_idle.size(); ++i) {
-            CoreCoord core = core_group_idle[i];
+        for (auto core : core_group_idle) {
             log_debug(tt::LogOp, "Setting core {} to idle", core);
             // reader runtime args
             std::vector<uint32_t> reader_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
### Ticket
NA

### Problem description
The following clang-tidy check is disabled:
https://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html

### Why its good
- Readability: less boilerplate, fewer moving parts (no iterators, no indexes).
- Fewer bugs: avoids off-by-one, signed/unsigned, iterator increment mistakes.
- Often enables const-correctness: auto const& is easy to express.
- Plays nicely with C++20 ranges (later): range-for is the “native” shape.
- Eliminate unnecessary bounds checking (at)
- Saves 100 lines of code

### What's changed
- Enable check
- Apply automatic FIXITs

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs