### PR TITLE
Modernize Conv2d slice attribute classes

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -416,24 +416,280 @@ public:
         tt::tt_metal::DataType output_dtype,
         Tensor& weight_tensor,
         OptionalRefTensor bias_tensor,
-        Conv2dConfig& conv_config,
+        const Conv2dConfig& conv_config,
         const DeviceComputeKernelConfig& compute_config,
-        MeshDevice* device);
+        MeshDevice* device) :
+        batch_size(batch_size),
+        input_shape(input_shape),
+        input_channels(input_channels),
+        output_channels(output_channels),
+        kernel_size(kernel_size),
+        stride(stride),
+        padding_n4(padding_n4),
+        dilation(dilation),
+        groups(groups),
+        input_layout(input_layout),
+        input_dtype(input_dtype),
+        output_dtype(output_dtype),
+        weight_tensor(weight_tensor),
+        bias_tensor(bias_tensor),
+        conv_config(conv_config),
+        compute_config(compute_config),
+        device(device) {}
+
     std::tuple<std::tuple<IOShape, IOShape>, std::array<uint32_t, 4>> get_input_slice_and_padding(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const {
+        auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+        auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+        auto [input_height, input_width] = input_shape;
+
+        // Calculate required input slice range based on output slice
+        // Formula: input_start = (output_start * stride) - padding
+        // Formula: input_end = ((output_end - 1) * stride) - padding + dilated_kernel_size
+        int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
+        int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
+                                     ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
+        int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
+        int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
+                                    ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+
+        // Calculate padding needed if input slice extends beyond input tensor
+        uint32_t pad_top = std::max<int>(0, -input_slice_height_start);
+        uint32_t pad_bottom = std::max<int>(0, input_slice_height_end - input_height);
+        uint32_t pad_left = std::max<int>(0, -input_slice_width_start);
+        uint32_t pad_right = std::max<int>(0, input_slice_width_end - input_width);
+
+        // Clamp input slice to valid input tensor bounds
+        input_slice_height_start = std::max<int>(0, input_slice_height_start);
+        input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
+        input_slice_width_start = std::max<int>(0, input_slice_width_start);
+        input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
+
+        // Calculate full output dimensions
+        auto [output_height, output_width] = calculate_output_image_size(
+            std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+        // Special handling for edges: if output slice starts/ends at tensor boundary,
+        // use the full original padding and reset input slice to tensor boundary
+        if (output_slice_height_start == 0) {
+            pad_top = padding_n4[0];
+            input_slice_height_start = 0;
+        }
+        if (output_slice_height_end == output_height) {
+            pad_bottom = padding_n4[1];
+            input_slice_height_end = input_height;
+        }
+        if (output_slice_width_start == 0) {
+            pad_left = padding_n4[2];
+            input_slice_width_start = 0;
+        }
+        if (output_slice_width_end == output_width) {
+            pad_right = padding_n4[3];
+            input_slice_width_end = input_width;
+        }
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+        // Apply width rounding and adjust right padding if necessary
+        uint32_t width_rounding_value =
+            (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+
+        if (output_slice_width % width_rounding_value != 0 && !single_slice) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            log_trace(
+                tt::LogOp,
+                "Conv2d DRAM Slicing: Additional padding of {} added to the right side.",
+                additional_padded_width);
+            pad_right += additional_padded_width * stride[1];  // Adjust right padding
+        }
+
+        return {
+            {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
+            {pad_top, pad_bottom, pad_left, pad_right}};
+    }
+
     std::tuple<IOShape, IOShape> get_input_slice(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
+    }
+
     uint32_t get_L1_usage(
         const IOShape& output_slice_start,
         const IOShape& output_slice_end,
-        const op_slicing::Op2DSliceConfig& slice_config) const override;
+        const op_slicing::Op2DSliceConfig& slice_config) const override {
+        // Remove this->conv_config from scope so that for each slice, conv_config can be calculated independently.
+        auto conv_config = this->conv_config;
+        bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
+        TT_FATAL(!mm_conv, "Conv2D DRAM with matmul should never use the slicing code path.");
+
+        auto [input_slicing, slice_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slicing;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+        auto input_slice_height = input_slice_height_end - input_slice_height_start;
+        auto input_slice_width = input_slice_width_end - input_slice_width_start;
+
+        auto [output_slice_height, output_slice_width] = calculate_output_image_size(
+            {input_slice_height, input_slice_width}, kernel_size, stride, slice_padding, dilation);
+        auto compute_grid = device->compute_with_storage_grid_size();
+        log_trace(
+            tt::LogOp,
+            "Conv2D DRAM Auto Slice Max Input Size : {}x{}, Max Output Size : {}x{}",
+            input_slice_height,
+            input_slice_width,
+            output_slice_height,
+            output_slice_width);
+
+        auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
+        if (!conv_config.shard_layout.has_value()) {
+            conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
+        }
+        auto conv_L1_usage = calculate_L1_usage_for_conv_op(
+            batch_size,
+            input_channels,
+            output_channels,
+            input_slice_height,
+            input_slice_width,
+            output_slice_height,
+            output_slice_width,
+            kernel_size,
+            stride,
+            slice_padding,
+            dilation,
+            groups,
+            bias_tensor.has_value(),
+            input_dtype,
+            output_dtype,
+            input_layout,
+            compute_grid,
+            false,
+            conv_config.shard_layout.value(),
+            compute_config,
+            conv_config,
+            sliced_input_tensor_memory_config);
+
+        log_trace(
+            tt::LogOp,
+            "Conv DRAM Auto slicing: num_slices = {}, input_memory_config = {}, L1 usage = {}",
+            slice_config.num_slices,
+            sliced_input_tensor_memory_config,
+            conv_L1_usage);
+        return std::max(conv_L1_usage.halo_input_size + conv_L1_usage.halo_output_size, conv_L1_usage.total_size);
+    }
+
     tt::tt_metal::MemoryConfig get_input_memory_config(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        auto compute_grid_size = device->compute_with_storage_grid_size();
+        auto conv_config = this->conv_config;
+
+        auto [input_start, input_end] = get_input_slice(output_slice_start, output_slice_end);
+        uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
+        uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
+        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+        uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+
+        if (!conv_config.shard_layout.has_value()) {
+            if (!conv_config.weights_dtype.has_value()) {
+                conv_config.weights_dtype = weight_tensor.dtype();
+            }
+            conv_config = determine_conv_config_for_auto_shard(
+                conv_config,
+                false,
+                batch_size,
+                input_channels,
+                output_channels,
+                output_slice_height,
+                output_slice_width,
+                weight_tensor.logical_shape()[3],
+                input_slice_height,
+                input_slice_width,
+                device->compute_with_storage_grid_size(),
+                input_layout,
+                input_dtype,
+                output_dtype,
+                std::nullopt,
+                kernel_size,
+                stride,
+                dilation,
+                padding_n4,
+                groups,
+                bias_tensor.has_value(),
+                compute_config);
+        }
+        TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
+
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
+            conv_config.shard_layout.value(),
+            shard_orientation,
+            batch_size,
+            ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
+            ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
+            false,
+            compute_grid_size,
+            input_layout,
+            single_slice ? BufferType::L1 : BufferType::DRAM));
+        return sliced_input_tensor_memory_config;
+    }
+
+    std::string name() const override { return "Conv2D"; }
+
     std::vector<ttnn::Tensor> run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,
         const IOShape& output_slice_start,
-        const IOShape& output_slice_end) override;
-    std::string name() const override;
+        const IOShape& output_slice_end) override {
+        // Use helper function to calculate slice bounds and padding
+        auto [input_slicing, this_op_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slicing;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+        // Calculate dimensions directly from result
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+
+        if (!conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
+            conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
+        }
+        auto conv_config_l1 = conv_config;
+
+        conv_config_l1.deallocate_activation = true;
+        conv_config_l1.reallocate_halo_output = true;
+
+        // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
+        conv_config_l1.output_layout = Layout::TILE;
+
+        auto conv2d_result = conv2d_L1(
+            sliced_input_tensor,
+            weight_tensor,
+            device,
+            input_channels,
+            output_channels,
+            batch_size,
+            input_slice_height,
+            input_slice_width,
+            kernel_size,
+            stride,
+            this_op_padding,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config_l1,
+            compute_config,
+            std::nullopt);
+        weight_tensor = std::get<3>(conv2d_result);
+        if (bias_tensor.has_value()) {
+            bias_tensor->get() = std::get<4>(conv2d_result).value();
+        }
+        return {std::get<0>(conv2d_result)};
+    }
 };
 
 // This function is used for DRAM Slicing
@@ -674,294 +930,6 @@ ResultWithOptions Conv2dOperation::invoke(
         return_weights_and_bias);
 }
 
-Conv2dSliceAttr::Conv2dSliceAttr(
-    uint32_t batch_size,
-    IOShape input_shape,
-    uint32_t input_channels,
-    uint32_t output_channels,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 4> padding_n4,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    Layout input_layout,
-    DataType input_dtype,
-    DataType output_dtype,
-    Tensor& weight_tensor,
-    OptionalRefTensor bias_tensor,
-    Conv2dConfig& conv_config,
-    const DeviceComputeKernelConfig& compute_config,
-    MeshDevice* device) :
-    batch_size(batch_size),
-    input_shape(input_shape),
-    input_channels(input_channels),
-    output_channels(output_channels),
-    kernel_size(kernel_size),
-    stride(stride),
-    padding_n4(padding_n4),
-    dilation(dilation),
-    groups(groups),
-    input_layout(input_layout),
-    input_dtype(input_dtype),
-    output_dtype(output_dtype),
-    weight_tensor(weight_tensor),
-    bias_tensor(bias_tensor),
-    conv_config(conv_config),
-    compute_config(compute_config),
-    device(device) {}
-
-std::tuple<std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape>, std::array<uint32_t, 4>>
-Conv2dSliceAttr::get_input_slice_and_padding(
-    const Conv2dSliceAttr::IOShape& output_slice_start, const Conv2dSliceAttr::IOShape& output_slice_end) const {
-    auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
-    auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
-    auto [input_height, input_width] = input_shape;
-
-    // Calculate required input slice range based on output slice
-    // Formula: input_start = (output_start * stride) - padding
-    // Formula: input_end = ((output_end - 1) * stride) - padding + dilated_kernel_size
-    int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
-    int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
-                                 ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
-    int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
-    int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
-                                ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
-
-    // Calculate padding needed if input slice extends beyond input tensor
-    uint32_t pad_top = std::max<int>(0, -input_slice_height_start);
-    uint32_t pad_bottom = std::max<int>(0, input_slice_height_end - input_height);
-    uint32_t pad_left = std::max<int>(0, -input_slice_width_start);
-    uint32_t pad_right = std::max<int>(0, input_slice_width_end - input_width);
-
-    // Clamp input slice to valid input tensor bounds
-    input_slice_height_start = std::max<int>(0, input_slice_height_start);
-    input_slice_height_end = std::min<int>(input_height, input_slice_height_end);
-    input_slice_width_start = std::max<int>(0, input_slice_width_start);
-    input_slice_width_end = std::min<int>(input_width, input_slice_width_end);
-
-    // Calculate full output dimensions
-    auto [output_height, output_width] = calculate_output_image_size(
-        std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
-
-    // Special handling for edges: if output slice starts/ends at tensor boundary,
-    // use the full original padding and reset input slice to tensor boundary
-    if (output_slice_height_start == 0) {
-        pad_top = padding_n4[0];
-        input_slice_height_start = 0;
-    }
-    if (output_slice_height_end == output_height) {
-        pad_bottom = padding_n4[1];
-        input_slice_height_end = input_height;
-    }
-    if (output_slice_width_start == 0) {
-        pad_left = padding_n4[2];
-        input_slice_width_start = 0;
-    }
-    if (output_slice_width_end == output_width) {
-        pad_right = padding_n4[3];
-        input_slice_width_end = input_width;
-    }
-    uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
-    uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
-    uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
-    // Apply width rounding and adjust right padding if necessary
-    uint32_t width_rounding_value =
-        (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-
-    bool single_slice =
-        (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
-
-    if (output_slice_width % width_rounding_value != 0 && !single_slice) {
-        uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
-        log_trace(
-            tt::LogOp,
-            "Conv2d DRAM Slicing: Additional padding of {} added to the right side.",
-            additional_padded_width);
-        pad_right += additional_padded_width * stride[1];  // Adjust right padding
-    }
-
-    return {
-        {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
-        {pad_top, pad_bottom, pad_left, pad_right}};
-}
-
-std::tuple<Conv2dSliceAttr::IOShape, Conv2dSliceAttr::IOShape> Conv2dSliceAttr::get_input_slice(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
-}
-
-uint32_t Conv2dSliceAttr::get_L1_usage(
-    const IOShape& output_slice_start,
-    const IOShape& output_slice_end,
-    const op_slicing::Op2DSliceConfig& slice_config) const {
-    // Remove this->conv_config from scope so that for each slice, conv_config can be calculated independently.
-    auto conv_config = this->conv_config;
-    bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding_n4, dilation, groups, conv_config);
-    TT_FATAL(!mm_conv, "Conv2D DRAM with matmul should never use the slicing code path.");
-
-    auto [input_slicing, slice_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slicing;
-    auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
-    auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
-    auto input_slice_height = input_slice_height_end - input_slice_height_start;
-    auto input_slice_width = input_slice_width_end - input_slice_width_start;
-
-    auto [output_slice_height, output_slice_width] = calculate_output_image_size(
-        {input_slice_height, input_slice_width}, kernel_size, stride, slice_padding, dilation);
-    auto compute_grid = device->compute_with_storage_grid_size();
-    log_trace(
-        tt::LogOp,
-        "Conv2D DRAM Auto Slice Max Input Size : {}x{}, Max Output Size : {}x{}",
-        input_slice_height,
-        input_slice_width,
-        output_slice_height,
-        output_slice_width);
-
-    auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
-    if (!conv_config.shard_layout.has_value()) {
-        conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
-    }
-    auto conv_L1_usage = calculate_L1_usage_for_conv_op(
-        batch_size,
-        input_channels,
-        output_channels,
-        input_slice_height,
-        input_slice_width,
-        output_slice_height,
-        output_slice_width,
-        kernel_size,
-        stride,
-        slice_padding,
-        dilation,
-        groups,
-        bias_tensor.has_value(),
-        input_dtype,
-        output_dtype,
-        input_layout,
-        compute_grid,
-        false,
-        conv_config.shard_layout.value(),
-        compute_config,
-        conv_config,
-        sliced_input_tensor_memory_config);
-
-    log_trace(
-        tt::LogOp,
-        "Conv DRAM Auto slicing: num_slices = {}, input_memory_config = {}, L1 usage = {}",
-        slice_config.num_slices,
-        sliced_input_tensor_memory_config,
-        conv_L1_usage);
-    return std::max(conv_L1_usage.halo_input_size + conv_L1_usage.halo_output_size, conv_L1_usage.total_size);
-}
-
-tt::tt_metal::MemoryConfig Conv2dSliceAttr::get_input_memory_config(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    auto conv_config = this->conv_config;
-
-    auto [input_start, input_end] = get_input_slice(output_slice_start, output_slice_end);
-    uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
-    uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
-    uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
-    uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
-
-    bool single_slice =
-        (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
-
-    if (!conv_config.shard_layout.has_value()) {
-        if (!conv_config.weights_dtype.has_value()) {
-            conv_config.weights_dtype = weight_tensor.dtype();
-        }
-        conv_config = determine_conv_config_for_auto_shard(
-            conv_config,
-            false,
-            batch_size,
-            input_channels,
-            output_channels,
-            output_slice_height,
-            output_slice_width,
-            weight_tensor.logical_shape()[3],
-            input_slice_height,
-            input_slice_width,
-            device->compute_with_storage_grid_size(),
-            input_layout,
-            input_dtype,
-            output_dtype,
-            std::nullopt,
-            kernel_size,
-            stride,
-            dilation,
-            padding_n4,
-            groups,
-            bias_tensor.has_value(),
-            compute_config);
-    }
-    TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
-
-    ShardOrientation shard_orientation =
-        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
-    auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
-        conv_config.shard_layout.value(),
-        shard_orientation,
-        batch_size,
-        ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
-        ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
-        false,
-        compute_grid_size,
-        input_layout,
-        single_slice ? BufferType::L1 : BufferType::DRAM));
-    return sliced_input_tensor_memory_config;
-}
-
-std::string Conv2dSliceAttr::name() const { return "Conv2D"; }
-
-std::vector<ttnn::Tensor> Conv2dSliceAttr::run_L1_op(
-    const ttnn::Tensor& sliced_input_tensor, const IOShape& output_slice_start, const IOShape& output_slice_end) {
-    // Use helper function to calculate slice bounds and padding
-    auto [input_slicing, this_op_padding] = get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slicing;
-    auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
-    auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
-    // Calculate dimensions directly from result
-    uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
-    uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
-
-    if (!conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
-        conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
-    }
-    auto conv_config_l1 = conv_config;
-
-    conv_config_l1.deallocate_activation = true;
-    conv_config_l1.reallocate_halo_output = true;
-
-    // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
-    conv_config_l1.output_layout = Layout::TILE;
-
-    auto conv2d_result = conv2d_L1(
-        sliced_input_tensor,
-        weight_tensor,
-        device,
-        input_channels,
-        output_channels,
-        batch_size,
-        input_slice_height,
-        input_slice_width,
-        kernel_size,
-        stride,
-        this_op_padding,
-        dilation,
-        groups,
-        output_dtype,
-        bias_tensor,
-        conv_config_l1,
-        compute_config,
-        std::nullopt);
-    weight_tensor = std::get<3>(conv2d_result);
-    if (bias_tensor.has_value()) {
-        bias_tensor->get() = std::get<4>(conv2d_result).value();
-    }
-    return {std::get<0>(conv2d_result)};
-}
 
 std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
     uint32_t batch_size,
@@ -982,9 +950,7 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
     const Conv2dConfig& conv_config_,
     const DeviceComputeKernelConfig& compute_config,
     MeshDevice* device) {
-    Conv2dConfig conv_config = conv_config_;
-
-    Conv2dSliceAttr* op_slice_attr = new Conv2dSliceAttr(
+    return std::unique_ptr<op_slicing::OpSliceAttr>(new Conv2dSliceAttr(
         batch_size,
         {input_height, input_width},
         in_channels,
@@ -999,10 +965,8 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv2d_slice_attr(
         conv_output_dtype,
         weight_tensor,
         bias_tensor,
-        conv_config,
+        conv_config_,
         compute_config,
-        device);
-
-    return std::unique_ptr<op_slicing::OpSliceAttr>(op_slice_attr);
+        device));
 }
 }  // namespace ttnn::operations::conv::conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -381,25 +381,423 @@ public:
         DataType output_dtype,
         Tensor& weight_tensor,
         OptionalRefTensor bias_tensor,
-        conv2d::Conv2dConfig& conv_config,
+        const conv2d::Conv2dConfig& conv_config,
         const DeviceComputeKernelConfig& compute_config,
         MeshDevice* device,
-        bool mirror_kernel);
+        bool mirror_kernel) :
+        batch_size(batch_size),
+        input_shape(input_shape),
+        input_channels(input_channels),
+        output_channels(output_channels),
+        kernel_size(kernel_size),
+        stride(stride),
+        padding_n4(padding_n4),
+        output_padding(output_padding),
+        dilation(dilation),
+        groups(groups),
+        input_layout(input_layout),
+        input_dtype(input_dtype),
+        output_dtype(output_dtype),
+        weight_tensor(weight_tensor),
+        bias_tensor(bias_tensor),
+        conv_config(conv_config),
+        compute_config(compute_config),
+        device(device),
+        mirror_kernel(mirror_kernel) {}
+
     std::tuple<IOShape, IOShape> get_input_slice(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
+    }
+
     InputWithPadding get_input_slice_and_padding(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const {
+        int output_slice_height_start, output_slice_width_start;
+        int output_slice_height_end, output_slice_width_end;
+        std::tie(output_slice_height_start, output_slice_width_start) = output_slice_start;
+        std::tie(output_slice_height_end, output_slice_width_end) = output_slice_end;
+
+        auto [input_height, input_width] = input_shape;
+        auto [output_height, output_width] = calculate_ct2d_output_image_size(
+            {input_height, input_width}, kernel_size, stride, padding_n4, output_padding, dilation);
+
+        int base_pad_height = dilation[0] * (kernel_size[0] - 1);
+        int base_pad_width = dilation[1] * (kernel_size[1] - 1);
+        int actual_pad_top = base_pad_height - padding_n4[0];
+        int actual_pad_bottom = base_pad_height - padding_n4[1];
+        int actual_pad_left = base_pad_width - padding_n4[2];
+        int actual_pad_right = base_pad_width - padding_n4[3];
+
+        int input_slice_height_start = tt::div_up((output_slice_height_start - actual_pad_top), (int)stride[0]);
+        int input_slice_width_start = tt::div_up((output_slice_width_start - actual_pad_left), (int)stride[1]);
+        int unpadded_output_height_start = std::max<int>(0, output_slice_height_start - actual_pad_top);
+        int unpadded_output_width_start = std::max<int>(0, output_slice_width_start - actual_pad_left);
+        int pad_top_offset = unpadded_output_height_start % (int)stride[0] == 0
+                                 ? 0
+                                 : stride[0] - (unpadded_output_height_start % (int)stride[0]);
+        int pad_left_offset = unpadded_output_width_start % (int)stride[1] == 0
+                                  ? 0
+                                  : stride[1] - (unpadded_output_width_start % (int)stride[1]);
+        int expanded_input_height_end =
+            output_slice_height_end - actual_pad_top + ((int)kernel_size[0] - 1) * dilation[0];
+        int expanded_input_width_end =
+            output_slice_width_end - actual_pad_left + ((int)kernel_size[1] - 1) * dilation[1];
+
+        int pad_bottom_offset =
+            output_slice_height_end < output_height ? (expanded_input_height_end - 1) % (int)stride[0] : 0;
+        int pad_right_offset =
+            output_slice_width_end < output_width ? (expanded_input_width_end - 1) % (int)stride[1] : 0;
+
+        int input_slice_height_end = ((expanded_input_height_end - 1) / stride[0]) + 1;
+        int input_slice_width_end = ((expanded_input_width_end - 1) / stride[1]) + 1;
+
+        int pad_top = std::max<int>({0, actual_pad_top - output_slice_height_start, pad_top_offset});
+        int pad_bottom = std::max<int>({0, expanded_input_height_end - output_height, pad_bottom_offset});
+        int pad_left = std::max<int>({0, actual_pad_left - output_slice_width_start, pad_left_offset});
+        int pad_right = std::max<int>({0, expanded_input_width_end - output_width, pad_right_offset});
+
+        input_slice_height_start = std::max<int>(0, input_slice_height_start);
+        input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
+        input_slice_width_start = std::max<int>(0, input_slice_width_start);
+        input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
+
+        log_debug(
+            tt::LogOp,
+            "Conv2d Transpose DRAM Slicing: Output Slice H: ({}-{}), W: ({}-{}); Input Slice H: ({}-{}), W: ({}-{}); "
+            "Padding {},{},{},{}, Offsets {},{},{},{}",
+            output_slice_height_start,
+            output_slice_height_end,
+            output_slice_width_start,
+            output_slice_width_end,
+            input_slice_height_start,
+            input_slice_height_end,
+            input_slice_width_start,
+            input_slice_width_end,
+            pad_top,
+            pad_bottom,
+            pad_left,
+            pad_right,
+            pad_top_offset,
+            pad_bottom_offset,
+            pad_left_offset,
+            pad_right_offset);
+
+        std::array<uint32_t, 2> this_output_pad = {0, 0};
+        if (output_slice_height_start == 0) {
+            pad_top = actual_pad_top;
+            input_slice_height_start = 0;
+        }
+        if (output_slice_height_end == output_height) {
+            pad_bottom = actual_pad_bottom;
+            input_slice_height_end = std::get<0>(input_shape);
+            this_output_pad[0] = output_padding[0];
+        }
+        if (output_slice_width_start == 0) {
+            pad_left = actual_pad_left;
+            input_slice_width_start = 0;
+        }
+        if (output_slice_width_end == output_width) {
+            pad_right = actual_pad_right;
+            input_slice_width_end = std::get<1>(input_shape);
+            this_output_pad[1] = output_padding[1];
+        }
+
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+        uint32_t width_rounding_value =
+            (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+
+        if (output_slice_width % width_rounding_value != 0 && !single_slice) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            log_debug(
+                tt::LogOp,
+                "Conv2d Transpose DRAM Slicing: Additional padding of {} added to the right side.",
+                additional_padded_width);
+            this_output_pad[1] += additional_padded_width;
+            output_slice_width += additional_padded_width;
+        }
+        auto this_op_padding = std::array<uint32_t, 4>(
+            {base_pad_height - pad_top,
+             base_pad_height - pad_bottom,
+             base_pad_width - pad_left,
+             base_pad_width - pad_right});
+        log_debug(tt::LogOp, "Final Padding = {},{},{},{}", pad_top, pad_bottom, pad_left, pad_right);
+        log_debug(tt::LogOp, "Padding args = {}", this_op_padding);
+        return {
+            {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
+            this_op_padding,
+            this_output_pad};
+    }
+
     uint32_t get_L1_usage(
         const IOShape& output_slice_start,
         const IOShape& output_slice_end,
-        const op_slicing::Op2DSliceConfig& slice_config) const override;
+        const op_slicing::Op2DSliceConfig& slice_config) const override {
+        auto conv_config = this->conv_config;
+        auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
+        if (!conv_config.shard_layout.has_value()) {
+            conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
+        }
+        auto [input_slice, this_slice_padding, this_output_padding] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+        uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+
+        auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+        auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+        uint32_t output_slice_height = output_slice_height_end - output_slice_height_start;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+
+        auto shard_shape = sliced_input_tensor_memory_config.shard_spec().value().shape;
+        // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
+        const tt::tt_metal::DataType conv_input_dtype = (input_dtype == tt::tt_metal::DataType::FLOAT32)
+                                                            ? tt::tt_metal::DataType::FLOAT32
+                                                            : tt::tt_metal::DataType::BFLOAT16;
+        const uint32_t input_datum_size = conv_input_dtype == tt::tt_metal::DataType::FLOAT32 ? 4 : 2;
+        uint32_t input_size = shard_shape[0] * shard_shape[1] * input_datum_size;
+
+        sliding_window::ParallelConfig parallel_config = {
+            .grid = sliced_input_tensor_memory_config.shard_spec().value().grid,
+            .shard_scheme = sliced_input_tensor_memory_config.memory_layout(),
+            .shard_orientation = sliced_input_tensor_memory_config.shard_spec().value().orientation};
+        // Create SlidingWindowConfig for precise halo calculation
+        sliding_window::SlidingWindowConfig slice_halo_config;
+        slice_halo_config.batch_size = batch_size;
+        slice_halo_config.input_hw = {input_slice_height, input_slice_width};
+        slice_halo_config.window_hw = {kernel_size[0], kernel_size[1]};
+        slice_halo_config.stride_hw = {stride[0], stride[1]};
+        slice_halo_config.padding = this_slice_padding;
+        slice_halo_config.output_pad_hw = {this_output_padding.at(0), this_output_padding.at(1)};
+        slice_halo_config.dilation_hw = {dilation[0], dilation[1]};
+        slice_halo_config.num_cores_nhw = get_num_cores_channels_from_parallel_config(parallel_config);
+        slice_halo_config.core_range_set = sliced_input_tensor_memory_config.shard_spec().value().grid;
+        slice_halo_config.snap_to_tile = true;
+        const uint32_t input_channels_alignment = get_input_channels_alignment(
+            conv_config.shard_layout.value(),
+            conv_config.output_layout,
+            slice_config.num_slices > 1,
+            false,  // Matmul based convs should never take the slicing route.
+            std::nullopt);
+        uint32_t precise_max_halo_bytes =
+            sliding_window::calculate_precise_halo_output_elems(slice_halo_config, shard_shape) * input_datum_size;
+        auto compute_grid = device->compute_with_storage_grid_size();
+
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+
+        sliding_window::ParallelConfig output_parallel_config =
+            determine_output_parallel_config(parallel_config, compute_grid, output_channels, shard_orientation, false);
+
+        uint32_t padded_in_channels = tt::round_up(
+            input_channels, tt::constants::TILE_WIDTH * get_num_cores_channels_from_parallel_config(parallel_config));
+        uint32_t padded_out_channels = tt::round_up(
+            output_channels,
+            tt::constants::TILE_WIDTH * get_num_cores_channels_from_parallel_config(output_parallel_config));
+        ttnn::Shape folded_weights_shape(
+            {1, 1, padded_in_channels * kernel_size[0] * kernel_size[1], padded_out_channels});
+
+        auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = get_conv_configs(
+            conv_config,
+            compute_config,
+            parallel_config,
+            output_parallel_config,
+            padded_in_channels,
+            output_channels,
+            batch_size,
+            output_slice_height,
+            output_slice_width,
+            kernel_size,
+            compute_grid);
+        const uint32_t in_channels_padded = tt::round_up(
+            input_channels, get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);
+        conv_op_l1_usage l1_usage = calculate_L1_usage(
+            compute_config,
+            opt_conv_op_block_config,
+            opt_conv_op_parallel_config,
+            folded_weights_shape,
+            slice_halo_config,
+            dilation,
+            conv_config,
+            input_dtype,
+            output_dtype,
+            output_slice_width,
+            bias_tensor.has_value(),
+            false,
+            in_channels_padded);
+        log_debug(
+            tt::LogOp,
+            "Conv Transpose DRAM Auto slicing: num_slices = {}, input_shard_shape = {}, precise_max_halo_bytes = {}, "
+            "conv "
+            "size = "
+            "{}",
+            slice_config.num_slices,
+            sliced_input_tensor_memory_config.shard_spec().value(),
+            precise_max_halo_bytes,
+            l1_usage);
+        return std::max(
+            precise_max_halo_bytes + l1_usage.tensor_allocation_size + l1_usage.CB_allocation_size,
+            input_size + precise_max_halo_bytes);
+    }
+
     tt::tt_metal::MemoryConfig get_input_memory_config(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        auto compute_grid_size = device->compute_with_storage_grid_size();
+        auto conv_config = this->conv_config;
+        auto [input_slice, this_slice_padding, this_slice_out_padding] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_start, input_end] = input_slice;
+        uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
+        uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
+        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+        uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
+        uint32_t width_rounding_value =
+            (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+
+        if ((output_slice_width % width_rounding_value != 0) && !single_slice) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            output_slice_width += additional_padded_width;
+        }
+
+        if (!conv_config.shard_layout.has_value()) {
+            if (!conv_config.weights_dtype.has_value()) {
+                conv_config.weights_dtype = weight_tensor.dtype();
+            }
+            auto conv2d_dims = compute_conv_transpose2d_dimensions(
+                input_slice_height,
+                input_slice_width,
+                kernel_size,
+                stride,
+                this_slice_padding,
+                this_slice_out_padding,
+                dilation);
+            TT_ASSERT(
+                conv2d_dims.output_height == output_slice_height,
+                "Calculated output slice height {} from input slice does not match provided output slice height {}.",
+                conv2d_dims.output_height,
+                output_slice_height);
+
+            TT_ASSERT(
+                conv2d_dims.output_width == output_slice_width,
+                "Calculated output slice width {} from input slice does not match provided output slice width {}.",
+                conv2d_dims.output_width,
+                output_slice_width);
+
+            conv_config = determine_conv_config_for_auto_shard(
+                conv_config,
+                false,
+                batch_size,
+                input_channels,
+                output_channels,
+                output_slice_height,
+                output_slice_width,
+                weight_tensor.logical_shape()[3],
+                conv2d_dims.full_input_height,
+                conv2d_dims.full_input_width,
+                device->compute_with_storage_grid_size(),
+                input_layout,
+                input_dtype,
+                output_dtype,
+                std::nullopt,
+                kernel_size,
+                stride,
+                dilation,
+                padding_n4,
+                groups,
+                bias_tensor.has_value(),
+                compute_config);
+        }
+        TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
+
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
+            conv_config.shard_layout.value(),
+            shard_orientation,
+            batch_size,
+            ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
+            ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
+            false,
+            compute_grid_size,
+            input_layout,
+            BufferType::DRAM));
+        return sliced_input_tensor_memory_config;
+    }
+
     std::vector<ttnn::Tensor> run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,
         const IOShape& output_slice_start,
-        const IOShape& output_slice_end) override;
-    std::string name() const override;
+        const IOShape& output_slice_end) override {
+        int output_slice_height_start, output_slice_width_start;
+        int output_slice_height_end, output_slice_width_end;
+        std::tie(output_slice_height_start, output_slice_width_start) = output_slice_start;
+        std::tie(output_slice_height_end, output_slice_width_end) = output_slice_end;
+        auto [input_slices, this_op_padding, this_output_pad] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slices;
+        uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
+        uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
+        log_debug(
+            tt::LogOp,
+            "Conv input {}, padding {}, out_pad {}, dilation {}, kernel {}, stride {}, output slice {}x{}",
+            sliced_input_tensor.logical_shape(),
+            this_op_padding,
+            this_output_pad,
+            dilation,
+            kernel_size,
+            stride,
+            output_slice_height_end - output_slice_height_start,
+            output_slice_width_end - output_slice_width_start);
+
+        if (!this->conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
+            this->conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
+        }
+        auto conv_config_l1 = conv_config;
+
+        conv_config_l1.deallocate_activation = true;
+        conv_config_l1.reallocate_halo_output = true;
+
+        // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
+        conv_config_l1.output_layout = Layout::TILE;
+
+        auto conv2d_result = conv_transpose2d_L1(
+            sliced_input_tensor,
+            weight_tensor,
+            device,
+            input_channels,
+            output_channels,
+            batch_size,
+            input_slice_height,
+            input_slice_width,
+            kernel_size,
+            stride,
+            this_op_padding,
+            this_output_pad,
+            dilation,
+            groups,
+            output_dtype,
+            bias_tensor,
+            conv_config_l1,
+            compute_config,
+            std::nullopt,
+            mirror_kernel);
+        weight_tensor = std::get<3>(conv2d_result);
+        if (bias_tensor.has_value()) {
+            bias_tensor->get() = std::get<4>(conv2d_result).value();
+        }
+        return {std::get<0>(conv2d_result)};
+    }
+
+    std::string name() const override { return "ConvTranspose2D"; }
 };
 
 // This function is used for DRAM Slicing
@@ -588,430 +986,6 @@ ConvT2dExecutionPath determine_conv_transpose2d_execution_path(
     return ConvT2dExecutionPath::DRAM;
 }
 
-ConvT2DSliceAttr::ConvT2DSliceAttr(
-    uint32_t batch_size,
-    IOShape input_shape,
-    uint32_t input_channels,
-    uint32_t output_channels,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 4> padding_n4,
-    std::array<uint32_t, 2> output_padding,
-    std::array<uint32_t, 2> dilation,
-    uint32_t groups,
-    Layout input_layout,
-    DataType input_dtype,
-    DataType output_dtype,
-    Tensor& weight_tensor,
-    OptionalRefTensor bias_tensor,
-    Conv2dConfig& conv_config,
-    const DeviceComputeKernelConfig& compute_config,
-    MeshDevice* device,
-    bool mirror_kernel) :
-    batch_size(batch_size),
-    input_shape(input_shape),
-    input_channels(input_channels),
-    output_channels(output_channels),
-    kernel_size(kernel_size),
-    stride(stride),
-    padding_n4(padding_n4),
-    output_padding(output_padding),
-    dilation(dilation),
-    groups(groups),
-    input_layout(input_layout),
-    input_dtype(input_dtype),
-    output_dtype(output_dtype),
-    weight_tensor(weight_tensor),
-    bias_tensor(bias_tensor),
-    conv_config(conv_config),
-    compute_config(compute_config),
-    device(device),
-    mirror_kernel(mirror_kernel) {}
-
-std::tuple<ConvT2DSliceAttr::IOShape, ConvT2DSliceAttr::IOShape> ConvT2DSliceAttr::get_input_slice(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
-}
-
-uint32_t ConvT2DSliceAttr::get_L1_usage(
-    const IOShape& output_slice_start,
-    const IOShape& output_slice_end,
-    const op_slicing::Op2DSliceConfig& slice_config) const {
-    auto conv_config = this->conv_config;
-    auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
-    if (!conv_config.shard_layout.has_value()) {
-        conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
-    }
-    auto [input_slice, this_slice_padding, this_output_padding] =
-        get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slice;
-    auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
-    auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
-    uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
-    uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
-
-    auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
-    auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
-    uint32_t output_slice_height = output_slice_height_end - output_slice_height_start;
-    uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
-
-    auto shard_shape = sliced_input_tensor_memory_config.shard_spec().value().shape;
-    // Output of halo op is always ROW_MAJOR, so input for convs is either DataType::FLOAT32 or DataType::BFLOAT16
-    const tt::tt_metal::DataType conv_input_dtype = (input_dtype == tt::tt_metal::DataType::FLOAT32)
-                                                        ? tt::tt_metal::DataType::FLOAT32
-                                                        : tt::tt_metal::DataType::BFLOAT16;
-    const uint32_t input_datum_size = conv_input_dtype == tt::tt_metal::DataType::FLOAT32 ? 4 : 2;
-    uint32_t input_size = shard_shape[0] * shard_shape[1] * input_datum_size;
-
-    sliding_window::ParallelConfig parallel_config = {
-        .grid = sliced_input_tensor_memory_config.shard_spec().value().grid,
-        .shard_scheme = sliced_input_tensor_memory_config.memory_layout(),
-        .shard_orientation = sliced_input_tensor_memory_config.shard_spec().value().orientation};
-    // Create SlidingWindowConfig for precise halo calculation
-    sliding_window::SlidingWindowConfig slice_halo_config;
-    slice_halo_config.batch_size = batch_size;
-    slice_halo_config.input_hw = {input_slice_height, input_slice_width};
-    slice_halo_config.window_hw = {kernel_size[0], kernel_size[1]};
-    slice_halo_config.stride_hw = {stride[0], stride[1]};
-    slice_halo_config.padding = this_slice_padding;
-    slice_halo_config.output_pad_hw = {this_output_padding.at(0), this_output_padding.at(1)};
-    slice_halo_config.dilation_hw = {dilation[0], dilation[1]};
-    slice_halo_config.num_cores_nhw = get_num_cores_channels_from_parallel_config(parallel_config);
-    slice_halo_config.core_range_set = sliced_input_tensor_memory_config.shard_spec().value().grid;
-    slice_halo_config.snap_to_tile = true;
-    const uint32_t input_channels_alignment = get_input_channels_alignment(
-        conv_config.shard_layout.value(),
-        conv_config.output_layout,
-        slice_config.num_slices > 1,
-        false,  // Matmul based convs should never take the slicing route.
-        std::nullopt);
-    uint32_t precise_max_halo_bytes =
-        sliding_window::calculate_precise_halo_output_elems(slice_halo_config, shard_shape) * input_datum_size;
-    auto compute_grid = device->compute_with_storage_grid_size();
-
-    ShardOrientation shard_orientation =
-        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
-
-    sliding_window::ParallelConfig output_parallel_config =
-        determine_output_parallel_config(parallel_config, compute_grid, output_channels, shard_orientation, false);
-
-    uint32_t padded_in_channels = tt::round_up(
-        input_channels, tt::constants::TILE_WIDTH * get_num_cores_channels_from_parallel_config(parallel_config));
-    uint32_t padded_out_channels = tt::round_up(
-        output_channels,
-        tt::constants::TILE_WIDTH * get_num_cores_channels_from_parallel_config(output_parallel_config));
-    ttnn::Shape folded_weights_shape({1, 1, padded_in_channels * kernel_size[0] * kernel_size[1], padded_out_channels});
-
-    auto [opt_conv_op_parallel_config, opt_conv_op_block_config, conv_out_memory_config] = get_conv_configs(
-        conv_config,
-        compute_config,
-        parallel_config,
-        output_parallel_config,
-        padded_in_channels,
-        output_channels,
-        batch_size,
-        output_slice_height,
-        output_slice_width,
-        kernel_size,
-        compute_grid);
-    const uint32_t in_channels_padded = tt::round_up(
-        input_channels, get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);
-    conv_op_l1_usage l1_usage = calculate_L1_usage(
-        compute_config,
-        opt_conv_op_block_config,
-        opt_conv_op_parallel_config,
-        folded_weights_shape,
-        slice_halo_config,
-        dilation,
-        conv_config,
-        input_dtype,
-        output_dtype,
-        output_slice_width,
-        bias_tensor.has_value(),
-        false,
-        in_channels_padded);
-    log_debug(
-        tt::LogOp,
-        "Conv Transpose DRAM Auto slicing: num_slices = {}, input_shard_shape = {}, precise_max_halo_bytes = {}, conv "
-        "size = "
-        "{}",
-        slice_config.num_slices,
-        sliced_input_tensor_memory_config.shard_spec().value(),
-        precise_max_halo_bytes,
-        l1_usage);
-    return std::max(
-        precise_max_halo_bytes + l1_usage.tensor_allocation_size + l1_usage.CB_allocation_size,
-        input_size + precise_max_halo_bytes);
-};
-
-tt::tt_metal::MemoryConfig ConvT2DSliceAttr::get_input_memory_config(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    auto conv_config = this->conv_config;
-    auto [input_slice, this_slice_padding, this_slice_out_padding] =
-        get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_start, input_end] = input_slice;
-    uint32_t input_slice_height = std::get<0>(input_end) - std::get<0>(input_start);
-    uint32_t input_slice_width = std::get<1>(input_end) - std::get<1>(input_start);
-    uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
-    uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
-    uint32_t width_rounding_value =
-        (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-
-    bool single_slice =
-        (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
-
-    if ((output_slice_width % width_rounding_value != 0) && !single_slice) {
-        uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
-        output_slice_width += additional_padded_width;
-    }
-
-    if (!conv_config.shard_layout.has_value()) {
-        if (!conv_config.weights_dtype.has_value()) {
-            conv_config.weights_dtype = weight_tensor.dtype();
-        }
-        auto conv2d_dims = compute_conv_transpose2d_dimensions(
-            input_slice_height,
-            input_slice_width,
-            kernel_size,
-            stride,
-            this_slice_padding,
-            this_slice_out_padding,
-            dilation);
-        TT_ASSERT(
-            conv2d_dims.output_height == output_slice_height,
-            "Calculated output slice height {} from input slice does not match provided output slice height {}.",
-            conv2d_dims.output_height,
-            output_slice_height);
-
-        TT_ASSERT(
-            conv2d_dims.output_width == output_slice_width,
-            "Calculated output slice width {} from input slice does not match provided output slice width {}.",
-            conv2d_dims.output_width,
-            output_slice_width);
-
-        conv_config = determine_conv_config_for_auto_shard(
-            conv_config,
-            false,
-            batch_size,
-            input_channels,
-            output_channels,
-            output_slice_height,
-            output_slice_width,
-            weight_tensor.logical_shape()[3],
-            conv2d_dims.full_input_height,
-            conv2d_dims.full_input_width,
-            device->compute_with_storage_grid_size(),
-            input_layout,
-            input_dtype,
-            output_dtype,
-            std::nullopt,
-            kernel_size,
-            stride,
-            dilation,
-            padding_n4,
-            groups,
-            bias_tensor.has_value(),
-            compute_config);
-    }
-    TT_FATAL(conv_config.shard_layout.has_value(), " Conv2D DRAM Slicing must have a shard layout set.");
-
-    ShardOrientation shard_orientation =
-        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
-    auto sliced_input_tensor_memory_config = std::get<1>(determine_input_memory_config(
-        conv_config.shard_layout.value(),
-        shard_orientation,
-        batch_size,
-        ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
-        ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
-        false,
-        compute_grid_size,
-        input_layout,
-        BufferType::DRAM));
-    return sliced_input_tensor_memory_config;
-}
-
-ConvT2DSliceAttr::InputWithPadding ConvT2DSliceAttr::get_input_slice_and_padding(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    int output_slice_height_start, output_slice_width_start;
-    int output_slice_height_end, output_slice_width_end;
-    std::tie(output_slice_height_start, output_slice_width_start) = output_slice_start;
-    std::tie(output_slice_height_end, output_slice_width_end) = output_slice_end;
-
-    auto [input_height, input_width] = input_shape;
-    auto [output_height, output_width] = calculate_ct2d_output_image_size(
-        {input_height, input_width}, kernel_size, stride, padding_n4, output_padding, dilation);
-
-    int base_pad_height = dilation[0] * (kernel_size[0] - 1);
-    int base_pad_width = dilation[1] * (kernel_size[1] - 1);
-    int actual_pad_top = base_pad_height - padding_n4[0];
-    int actual_pad_bottom = base_pad_height - padding_n4[1];
-    int actual_pad_left = base_pad_width - padding_n4[2];
-    int actual_pad_right = base_pad_width - padding_n4[3];
-
-    int input_slice_height_start = tt::div_up((output_slice_height_start - actual_pad_top), (int)stride[0]);
-    int input_slice_width_start = tt::div_up((output_slice_width_start - actual_pad_left), (int)stride[1]);
-    int unpadded_output_height_start = std::max<int>(0, output_slice_height_start - actual_pad_top);
-    int unpadded_output_width_start = std::max<int>(0, output_slice_width_start - actual_pad_left);
-    int pad_top_offset = unpadded_output_height_start % (int)stride[0] == 0
-                             ? 0
-                             : stride[0] - (unpadded_output_height_start % (int)stride[0]);
-    int pad_left_offset = unpadded_output_width_start % (int)stride[1] == 0
-                              ? 0
-                              : stride[1] - (unpadded_output_width_start % (int)stride[1]);
-    int expanded_input_height_end = output_slice_height_end - actual_pad_top + ((int)kernel_size[0] - 1) * dilation[0];
-    int expanded_input_width_end = output_slice_width_end - actual_pad_left + ((int)kernel_size[1] - 1) * dilation[1];
-
-    int pad_bottom_offset =
-        output_slice_height_end < output_height ? (expanded_input_height_end - 1) % (int)stride[0] : 0;
-    int pad_right_offset = output_slice_width_end < output_width ? (expanded_input_width_end - 1) % (int)stride[1] : 0;
-
-    int input_slice_height_end = ((expanded_input_height_end - 1) / stride[0]) + 1;
-    int input_slice_width_end = ((expanded_input_width_end - 1) / stride[1]) + 1;
-
-    int pad_top = std::max<int>({0, actual_pad_top - output_slice_height_start, pad_top_offset});
-    int pad_bottom = std::max<int>({0, expanded_input_height_end - output_height, pad_bottom_offset});
-    int pad_left = std::max<int>({0, actual_pad_left - output_slice_width_start, pad_left_offset});
-    int pad_right = std::max<int>({0, expanded_input_width_end - output_width, pad_right_offset});
-
-    input_slice_height_start = std::max<int>(0, input_slice_height_start);
-    input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
-    input_slice_width_start = std::max<int>(0, input_slice_width_start);
-    input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
-
-    log_debug(
-        tt::LogOp,
-        "Conv2d Transpose DRAM Slicing: Output Slice H: ({}-{}), W: ({}-{}); Input Slice H: ({}-{}), W: ({}-{}); "
-        "Padding {},{},{},{}, Offsets {},{},{},{}",
-        output_slice_height_start,
-        output_slice_height_end,
-        output_slice_width_start,
-        output_slice_width_end,
-        input_slice_height_start,
-        input_slice_height_end,
-        input_slice_width_start,
-        input_slice_width_end,
-        pad_top,
-        pad_bottom,
-        pad_left,
-        pad_right,
-        pad_top_offset,
-        pad_bottom_offset,
-        pad_left_offset,
-        pad_right_offset);
-
-    std::array<uint32_t, 2> this_output_pad = {0, 0};
-    if (output_slice_height_start == 0) {
-        pad_top = actual_pad_top;
-        input_slice_height_start = 0;
-    }
-    if (output_slice_height_end == output_height) {
-        pad_bottom = actual_pad_bottom;
-        input_slice_height_end = std::get<0>(input_shape);
-        this_output_pad[0] = output_padding[0];
-    }
-    if (output_slice_width_start == 0) {
-        pad_left = actual_pad_left;
-        input_slice_width_start = 0;
-    }
-    if (output_slice_width_end == output_width) {
-        pad_right = actual_pad_right;
-        input_slice_width_end = std::get<1>(input_shape);
-        this_output_pad[1] = output_padding[1];
-    }
-
-    uint32_t input_slice_height = input_slice_height_end - input_slice_height_start;
-    uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
-    uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
-
-    bool single_slice =
-        (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
-    uint32_t width_rounding_value =
-        (conv_config.output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-
-    if (output_slice_width % width_rounding_value != 0 && !single_slice) {
-        uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
-        log_debug(
-            tt::LogOp,
-            "Conv2d Transpose DRAM Slicing: Additional padding of {} added to the right side.",
-            additional_padded_width);
-        this_output_pad[1] += additional_padded_width;
-        output_slice_width += additional_padded_width;
-    }
-    auto this_op_padding = std::array<uint32_t, 4>(
-        {base_pad_height - pad_top,
-         base_pad_height - pad_bottom,
-         base_pad_width - pad_left,
-         base_pad_width - pad_right});
-    log_debug(tt::LogOp, "Final Padding = {},{},{},{}", pad_top, pad_bottom, pad_left, pad_right);
-    log_debug(tt::LogOp, "Padding args = {}", this_op_padding);
-    return {
-        {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
-        this_op_padding,
-        this_output_pad};
-}
-std::vector<ttnn::Tensor> ConvT2DSliceAttr::run_L1_op(
-    const ttnn::Tensor& sliced_input_tensor, const IOShape& output_slice_start, const IOShape& output_slice_end) {
-    int output_slice_height_start, output_slice_width_start;
-    int output_slice_height_end, output_slice_width_end;
-    std::tie(output_slice_height_start, output_slice_width_start) = output_slice_start;
-    std::tie(output_slice_height_end, output_slice_width_end) = output_slice_end;
-    auto [input_slices, this_op_padding, this_output_pad] =
-        get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slices;
-    uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
-    uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
-    log_debug(
-        tt::LogOp,
-        "Conv input {}, padding {}, out_pad {}, dilation {}, kernel {}, stride {}, output slice {}x{}",
-        sliced_input_tensor.logical_shape(),
-        this_op_padding,
-        this_output_pad,
-        dilation,
-        kernel_size,
-        stride,
-        output_slice_height_end - output_slice_height_start,
-        output_slice_width_end - output_slice_width_start);
-
-    if (!this->conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
-        this->conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
-    }
-    auto conv_config_l1 = conv_config;
-
-    conv_config_l1.deallocate_activation = true;
-    conv_config_l1.reallocate_halo_output = true;
-
-    // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
-    conv_config_l1.output_layout = Layout::TILE;
-
-    auto conv2d_result = conv_transpose2d_L1(
-        sliced_input_tensor,
-        weight_tensor,
-        device,
-        input_channels,
-        output_channels,
-        batch_size,
-        input_slice_height,
-        input_slice_width,
-        kernel_size,
-        stride,
-        this_op_padding,
-        this_output_pad,
-        dilation,
-        groups,
-        output_dtype,
-        bias_tensor,
-        conv_config_l1,
-        compute_config,
-        std::nullopt,
-        mirror_kernel);
-    weight_tensor = std::get<3>(conv2d_result);
-    if (bias_tensor.has_value()) {
-        bias_tensor->get() = std::get<4>(conv2d_result).value();
-    }
-    return {std::get<0>(conv2d_result)};
-}
-std::string ConvT2DSliceAttr::name() const { return "ConvTranspose2D"; }
 
 std::unique_ptr<op_slicing::OpSliceAttr> get_conv_transpose2d_slice_attr(
     uint32_t batch_size,
@@ -1034,8 +1008,7 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv_transpose2d_slice_attr(
     const DeviceComputeKernelConfig& compute_config,
     MeshDevice* device,
     bool mirror_kernel) {
-    Conv2dConfig conv_config = conv_config_;
-    ConvT2DSliceAttr* op_slice_attr = new ConvT2DSliceAttr(
+    return std::unique_ptr<op_slicing::OpSliceAttr>(new ConvT2DSliceAttr(
         batch_size,
         {input_height, input_width},
         in_channels,
@@ -1051,11 +1024,10 @@ std::unique_ptr<op_slicing::OpSliceAttr> get_conv_transpose2d_slice_attr(
         conv_output_dtype,
         std::ref(weight_tensor),
         bias_tensor.has_value() ? std::make_optional(std::ref(bias_tensor.value())) : std::nullopt,
-        conv_config,
+        conv_config_,
         compute_config,
         device,
-        mirror_kernel);
-    return std::unique_ptr<op_slicing::OpSliceAttr>(op_slice_attr);
+        mirror_kernel));
 }
 ResultWithOptions ConvTranpose2dOperation::invoke(
     const ttnn::Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -384,27 +384,190 @@ public:
         Layout input_layout,
         Layout output_layout,
         std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-        MeshDevice* device);
+        MeshDevice* device) :
+        batch_size(batch_size),
+        input_shape(input_shape),
+        channels(channels),
+        kernel_size(kernel_size),
+        stride(stride),
+        padding_n4(padding_n4),
+        dilation(dilation),
+        ceil_mode(ceil_mode),
+        count_include_pad(count_include_pad),
+        divisor_override(divisor_override),
+        return_indices(return_indices),
+        pool_type(pool_type),
+        dtype(dtype),
+        input_layout(input_layout),
+        output_layout(output_layout),
+        compute_kernel_config(compute_kernel_config),
+        device(device) {
+        shard_layout = applied_shard_scheme.value_or(TensorMemoryLayout::HEIGHT_SHARDED);
+        sliding_window_config = sliding_window::SlidingWindowConfig{
+            .batch_size = batch_size,
+            .channels = channels,
+            .input_hw = {std::get<0>(input_shape), std::get<1>(input_shape)},
+            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+            .stride_hw = {stride.at(0), stride.at(1)},
+            .padding = padding_n4,
+            .dilation_hw = {dilation.at(0), dilation.at(1)},
+            .ceil_mode = ceil_mode,
+        };
+        auto full_output_shape = sliding_window_config.get_output_shape();
+        this->output_shape = IOShape{full_output_shape[1], full_output_shape[2]};
+        this->ceil_pad = {
+            sliding_window_config.get_ceil_pad_hw().first, sliding_window_config.get_ceil_pad_hw().second};
+    }
 
-    std::tuple<
-        std::tuple<Pool2dSliceAttr::IOShape, Pool2dSliceAttr::IOShape>,
-        std::array<uint32_t, 4>,
-        std::array<uint32_t, 2>,
-        uint32_t>
-    get_input_slice_and_padding(const IOShape& output_slice_start, const IOShape& output_slice_end) const;
+    std::tuple<std::tuple<IOShape, IOShape>, std::array<uint32_t, 4>, std::array<uint32_t, 2>, uint32_t>
+    get_input_slice_and_padding(const IOShape& output_slice_start, const IOShape& output_slice_end) const {
+        auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
+        auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
+        int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
+        int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
+                                     ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
+        int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
+        int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
+                                    ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+
+        int pad_top = std::max<int>(0, -input_slice_height_start);
+        int pad_bottom = std::max<int>(0, input_slice_height_end - std::get<0>(input_shape));
+        int pad_left = std::max<int>(0, -input_slice_width_start);
+        int pad_right = std::max<int>(0, input_slice_width_end - std::get<1>(input_shape));
+
+        input_slice_height_start = std::max<int>(0, input_slice_height_start);
+        input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
+        input_slice_width_start = std::max<int>(0, input_slice_width_start);
+        input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
+
+        std::array<uint32_t, 2> this_ceil_pad = {0, 0};
+        auto [output_height, output_width] = output_shape;
+        if (output_slice_height_start == 0) {
+            pad_top = padding_n4[0];
+            input_slice_height_start = 0;
+        }
+        if (output_slice_height_end == output_height) {
+            pad_bottom = padding_n4[1];
+            input_slice_height_end = std::get<0>(input_shape);
+            this_ceil_pad[0] = ceil_pad[0];
+        }
+        if (output_slice_width_start == 0) {
+            pad_left = padding_n4[2];
+            input_slice_width_start = 0;
+        }
+        if (output_slice_width_end == output_width) {
+            pad_right = padding_n4[3];
+            input_slice_width_end = std::get<1>(input_shape);
+            this_ceil_pad[1] = ceil_pad[1];
+        }
+        uint32_t width_rounding_value = (output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+        uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
+        uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
+        if (output_slice_width % width_rounding_value != 0) {
+            uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
+            log_trace(
+                tt::LogOp,
+                "Pool2d Slicing: Additional output width of {} added to the right side.",
+                additional_padded_width);
+
+            output_slice_width += additional_padded_width;
+            pad_right = (output_slice_width - 1) * stride[1] - input_slice_width +
+                        ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
+        }
+        return {
+            {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
+            {pad_top, pad_bottom, pad_left, pad_right},
+            this_ceil_pad,
+            output_slice_width};
+    }
+
     std::tuple<IOShape, IOShape> get_input_slice(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
+    }
+
     uint32_t get_L1_usage(
         const IOShape& output_slice_start,
         const IOShape& output_slice_end,
-        const op_slicing::Op2DSliceConfig& slice_config) const override;
+        const op_slicing::Op2DSliceConfig& slice_config) const override {
+        return 0;
+    }
+
     tt::tt_metal::MemoryConfig get_input_memory_config(
-        const IOShape& output_slice_start, const IOShape& output_slice_end) const override;
+        const IOShape& output_slice_start, const IOShape& output_slice_end) const override {
+        auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
+        uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
+        uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+
+        uint32_t input_nhw_rounding_value =
+            (input_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
+        uint32_t input_slice_nhw =
+            tt::round_up(batch_size * input_slice_height * input_slice_width, input_nhw_rounding_value);
+        auto sliced_input_tensor_memory_config = std::get<0>(get_pool_input_memory_config(
+            sliding_window_config,
+            shard_layout,
+            batch_size,
+            channels,
+            ttnn::Shape({1, 1, input_slice_nhw, channels}),
+            ttnn::Shape({batch_size, output_slice_height, this_output_width, channels}),
+            device->compute_with_storage_grid_size(),
+            dtype,
+            input_layout,
+            dtype,
+            output_layout,
+            pool_type,
+            count_include_pad,
+            divisor_override,
+            return_indices));
+
+        return sliced_input_tensor_memory_config;
+    }
+
     std::vector<ttnn::Tensor> run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,
         const IOShape& output_slice_start,
-        const IOShape& output_slice_end) override;
-    std::string name() const override;
+        const IOShape& output_slice_end) override {
+        auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
+            get_input_slice_and_padding(output_slice_start, output_slice_end);
+        auto [input_slice_start, input_slice_end] = input_slice;
+        auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
+        auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
+
+        int input_slice_height = input_slice_height_end - input_slice_height_start;
+        int input_slice_width = input_slice_width_end - input_slice_width_start;
+        auto this_ceil_mode = ceil_mode;
+        if (this_ceil_pad[0] > 0 || this_ceil_pad[1] > 0) {
+            this_ceil_mode = true;
+        }
+        return pool2d_L1(
+            sliced_input_tensor,
+            pool_type,
+            batch_size,
+            input_slice_height,
+            input_slice_width,
+            channels,
+            kernel_size,
+            stride,
+            this_slice_padding,
+            dilation,
+            this_ceil_mode,
+            count_include_pad,
+            divisor_override,
+            std::nullopt,
+            std::nullopt,
+            compute_kernel_config,
+            true, /* deallocate_input to save L1 */
+            true, /* reallocate_halo_output to save L1 */
+            return_indices,
+            dtype,
+            output_layout,
+            this_ceil_pad);
+    }
+
+    std::string name() const override { return "Pool2D"; }
 };
 
 static std::vector<Tensor> pool2d_DRAM(
@@ -734,204 +897,5 @@ Tensor AvgPool2DOp::invoke(
     // Average pool always returns just the tensor, never indices
     return result.at(0);
 }
-
-Pool2dSliceAttr::Pool2dSliceAttr(
-    uint32_t batch_size,
-    IOShape input_shape,
-    uint32_t channels,
-    std::array<uint32_t, 2> kernel_size,
-    std::array<uint32_t, 2> stride,
-    std::array<uint32_t, 4> padding_n4,
-    std::array<uint32_t, 2> dilation,
-    bool ceil_mode,
-    bool count_include_pad,
-    std::optional<int32_t> divisor_override,
-    std::optional<const TensorMemoryLayout> applied_shard_scheme,
-    bool return_indices,
-    Pool2DType pool_type,
-    DataType dtype,
-    Layout input_layout,
-    Layout output_layout,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-    MeshDevice* device) :
-    batch_size(batch_size),
-    input_shape(input_shape),
-    channels(channels),
-    kernel_size(kernel_size),
-    stride(stride),
-    padding_n4(padding_n4),
-    dilation(dilation),
-    ceil_mode(ceil_mode),
-    count_include_pad(count_include_pad),
-    divisor_override(divisor_override),
-    return_indices(return_indices),
-    pool_type(pool_type),
-    dtype(dtype),
-    input_layout(input_layout),
-    output_layout(output_layout),
-    compute_kernel_config(compute_kernel_config),
-    device(device) {
-    shard_layout = applied_shard_scheme.value_or(TensorMemoryLayout::HEIGHT_SHARDED);
-    sliding_window_config = sliding_window::SlidingWindowConfig{
-        .batch_size = batch_size,
-        .channels = channels,
-        .input_hw = {std::get<0>(input_shape), std::get<1>(input_shape)},
-        .window_hw = {kernel_size.at(0), kernel_size.at(1)},
-        .stride_hw = {stride.at(0), stride.at(1)},
-        .padding = padding_n4,
-        .dilation_hw = {dilation.at(0), dilation.at(1)},
-        .ceil_mode = ceil_mode,
-    };
-    auto full_output_shape = sliding_window_config.get_output_shape();
-    this->output_shape = IOShape{full_output_shape[1], full_output_shape[2]};
-    this->ceil_pad = {sliding_window_config.get_ceil_pad_hw().first, sliding_window_config.get_ceil_pad_hw().second};
-}
-
-std::tuple<
-    std::tuple<Pool2dSliceAttr::IOShape, Pool2dSliceAttr::IOShape>,
-    std::array<uint32_t, 4>,
-    std::array<uint32_t, 2>,
-    uint32_t>
-Pool2dSliceAttr::get_input_slice_and_padding(const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    auto [output_slice_height_start, output_slice_width_start] = output_slice_start;
-    auto [output_slice_height_end, output_slice_width_end] = output_slice_end;
-    int input_slice_height_start = (output_slice_height_start * stride[0]) - padding_n4[0];
-    int input_slice_height_end = ((output_slice_height_end - 1) * stride[0]) - padding_n4[0] +
-                                 ((kernel_size[0] - 1) * (dilation[0] - 1)) + kernel_size[0];
-    int input_slice_width_start = (output_slice_width_start * stride[1]) - padding_n4[2];
-    int input_slice_width_end = ((output_slice_width_end - 1) * stride[1]) - padding_n4[2] +
-                                ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
-
-    int pad_top = std::max<int>(0, -input_slice_height_start);
-    int pad_bottom = std::max<int>(0, input_slice_height_end - std::get<0>(input_shape));
-    int pad_left = std::max<int>(0, -input_slice_width_start);
-    int pad_right = std::max<int>(0, input_slice_width_end - std::get<1>(input_shape));
-
-    input_slice_height_start = std::max<int>(0, input_slice_height_start);
-    input_slice_height_end = std::min<int>(std::get<0>(input_shape), input_slice_height_end);
-    input_slice_width_start = std::max<int>(0, input_slice_width_start);
-    input_slice_width_end = std::min<int>(std::get<1>(input_shape), input_slice_width_end);
-
-    std::array<uint32_t, 2> this_ceil_pad = {0, 0};
-    auto [output_height, output_width] = output_shape;
-    if (output_slice_height_start == 0) {
-        pad_top = padding_n4[0];
-        input_slice_height_start = 0;
-    }
-    if (output_slice_height_end == output_height) {
-        pad_bottom = padding_n4[1];
-        input_slice_height_end = std::get<0>(input_shape);
-        this_ceil_pad[0] = ceil_pad[0];
-    }
-    if (output_slice_width_start == 0) {
-        pad_left = padding_n4[2];
-        input_slice_width_start = 0;
-    }
-    if (output_slice_width_end == output_width) {
-        pad_right = padding_n4[3];
-        input_slice_width_end = std::get<1>(input_shape);
-        this_ceil_pad[1] = ceil_pad[1];
-    }
-    uint32_t width_rounding_value = (output_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-    uint32_t output_slice_width = output_slice_width_end - output_slice_width_start;
-    uint32_t input_slice_width = input_slice_width_end - input_slice_width_start;
-    if (output_slice_width % width_rounding_value != 0) {
-        uint32_t additional_padded_width = width_rounding_value - (output_slice_width % width_rounding_value);
-        log_trace(
-            tt::LogOp,
-            "Pool2d Slicing: Additional output width of {} added to the right side.",
-            additional_padded_width);
-
-        output_slice_width += additional_padded_width;
-        pad_right = (output_slice_width - 1) * stride[1] - input_slice_width +
-                    ((kernel_size[1] - 1) * (dilation[1] - 1)) + kernel_size[1];
-    }
-    return {
-        {{input_slice_height_start, input_slice_width_start}, {input_slice_height_end, input_slice_width_end}},
-        {pad_top, pad_bottom, pad_left, pad_right},
-        this_ceil_pad,
-        output_slice_width};
-}
-std::tuple<Pool2dSliceAttr::IOShape, Pool2dSliceAttr::IOShape> Pool2dSliceAttr::get_input_slice(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    return std::get<0>(get_input_slice_and_padding(output_slice_start, output_slice_end));
-}
-
-uint32_t Pool2dSliceAttr::get_L1_usage(
-    const IOShape& output_slice_start,
-    const IOShape& output_slice_end,
-    const op_slicing::Op2DSliceConfig& slice_config) const {
-    return 0;
-}
-tt::tt_metal::MemoryConfig Pool2dSliceAttr::get_input_memory_config(
-    const IOShape& output_slice_start, const IOShape& output_slice_end) const {
-    auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
-        get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slice;
-    uint32_t input_slice_height = std::get<0>(input_slice_end) - std::get<0>(input_slice_start);
-    uint32_t input_slice_width = std::get<1>(input_slice_end) - std::get<1>(input_slice_start);
-    uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
-
-    uint32_t input_nhw_rounding_value = (input_layout == tt::tt_metal::Layout::TILE) ? tt::constants::TILE_HEIGHT : 1;
-    uint32_t input_slice_nhw =
-        tt::round_up(batch_size * input_slice_height * input_slice_width, input_nhw_rounding_value);
-    auto sliced_input_tensor_memory_config = std::get<0>(get_pool_input_memory_config(
-        sliding_window_config,
-        shard_layout,
-        batch_size,
-        channels,
-        ttnn::Shape({1, 1, input_slice_nhw, channels}),
-        ttnn::Shape({batch_size, output_slice_height, this_output_width, channels}),
-        device->compute_with_storage_grid_size(),
-        dtype,
-        input_layout,
-        dtype,
-        output_layout,
-        pool_type,
-        count_include_pad,
-        divisor_override,
-        return_indices));
-
-    return sliced_input_tensor_memory_config;
-}
-std::vector<ttnn::Tensor> Pool2dSliceAttr::run_L1_op(
-    const ttnn::Tensor& sliced_input_tensor, const IOShape& output_slice_start, const IOShape& output_slice_end) {
-    auto [input_slice, this_slice_padding, this_ceil_pad, this_output_width] =
-        get_input_slice_and_padding(output_slice_start, output_slice_end);
-    auto [input_slice_start, input_slice_end] = input_slice;
-    auto [input_slice_height_start, input_slice_width_start] = input_slice_start;
-    auto [input_slice_height_end, input_slice_width_end] = input_slice_end;
-
-    int input_slice_height = input_slice_height_end - input_slice_height_start;
-    int input_slice_width = input_slice_width_end - input_slice_width_start;
-    auto this_ceil_mode = ceil_mode;
-    if (this_ceil_pad[0] > 0 || this_ceil_pad[1] > 0) {
-        this_ceil_mode = true;
-    }
-    return pool2d_L1(
-        sliced_input_tensor,
-        pool_type,
-        batch_size,
-        input_slice_height,
-        input_slice_width,
-        channels,
-        kernel_size,
-        stride,
-        this_slice_padding,
-        dilation,
-        this_ceil_mode,
-        count_include_pad,
-        divisor_override,
-        std::nullopt,
-        std::nullopt,
-        compute_kernel_config,
-        true, /* deallocate_input to save L1 */
-        true, /* reallocate_halo_output to save L1 */
-        return_indices,
-        dtype,
-        output_layout,
-        this_ceil_pad);
-}
-std::string Pool2dSliceAttr::name() const { return "Pool2D"; }
 
 }  // namespace ttnn::operations::pool


### PR DESCRIPTION
Refactor Conv2dSliceAttr and ConvT2DSliceAttr to follow modern C++ practices:
- Use const-correct constructor parameters (const Conv2dConfig&)
- Eliminate unnecessary config copies in factory functions
- Merge inline implementations since classes are file-local
- Simplify unique_ptr construction by removing intermediate variables

  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20616770036)
  - [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20616770812)
  - [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20617468488)
  - [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20616769244)