### PR TITLE
Fix tilize for uint8 data type

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -39,8 +39,8 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::FLOAT32 or
             input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32 or
-            input_tensor_a.dtype() == DataType::UINT16,
-        "data type must be bfloat16, float32, uint32, int32, or uint16");
+            input_tensor_a.dtype() == DataType::UINT16 or input_tensor_a.dtype() == DataType::UINT8,
+        "data type must be bfloat16, float32, uint32, int32, uint16, or uint8");
 
     uint32_t stick_size = stick_s * input_tensor_a.element_size();  // Assuming bfloat16 dataformat
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -27,7 +27,7 @@ TilizeMultiCoreBlockProgramFactory::cached_program_t TilizeMultiCoreBlockProgram
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::UINT8;
 
     IDevice* device = a.device();
     CoreCoord grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_interleaved_program_factory.cpp
@@ -28,7 +28,7 @@ TilizeMultiCoreInterleavedProgramFactory::cached_program_t TilizeMultiCoreInterl
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
-    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::UINT8;
 
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -26,7 +26,7 @@ TilizeMultiCoreShardedProgramFactory::cached_program_t TilizeMultiCoreShardedPro
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
-    bool fp32_llk_acc = input.dtype() == DataType::FLOAT32;
+    bool fp32_llk_acc = input.dtype() == DataType::FLOAT32 || input.dtype() == DataType::UINT8;
 
     auto shard_spec = input.shard_spec().value();
     uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
@@ -38,7 +38,7 @@ TilizeSingleCoreProgramFactory::cached_program_t TilizeSingleCoreProgramFactory:
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32;
+    bool fp32_llk_acc = a.dtype() == DataType::FLOAT32 || a.dtype() == DataType::UINT8;
 
     uint32_t num_tiles = a.physical_volume() / TILE_HW;
 


### PR DESCRIPTION
### Ticket
#30331 

### Problem description
Tilize operation was not producing correct output for uint8 data type.

### What's changed
This PR adds support for uint8 data type in the tilize operation. The fix enables FP32 destination accumulation mode (`fp32_dest_acc_en` = true) for uint8 tensors, matching the existing pattern used in unary operations (see `unary.cpp`). 
This is required because the tilize operation uses ELWADD to move data from SrcA to DEST, which writes floating-point data to the DEST registers. 

Got the provided tests passing on WH. Will update the description after testing on BH.
```
PASSED tests/ttnn/unit_tests/operations/test_tilize_uint8.py::test_tilize_2D[W=32-H=32-use_multicore=True-in_dtype=DataType.UINT8]
PASSED tests/ttnn/unit_tests/operations/test_tilize_uint8.py::test_tilize_2D[W=32-H=32-use_multicore=True-in_dtype=DataType.UINT16]
================================================================== 2 passed in 0.70s ===============================================

```
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/fix_tilize_for_uint8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/fix_tilize_for_uint8)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/fix_tilize_for_uint8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/fix_tilize_for_uint8)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/fix_tilize_for_uint8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/fix_tilize_for_uint8)
- [ ] New/Existing tests provide coverage for changes