### PR TITLE
Implement nice pause with exponential backoff

### DIFF
--- a/tt_metal/common/multi_producer_single_consumer_queue.hpp
+++ b/tt_metal/common/multi_producer_single_consumer_queue.hpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <tt_stl/tt_pause.hpp>
 
 template <typename T>
 class MultiProducerSingleConsumerQueue {
@@ -66,8 +67,7 @@ public:
         // thus overwrite data that's being read. Stall until head
         // has progressed (data has been read).
         std::unique_lock<std::mutex> lock(this->queue_mutex);
-        while (tail.load()->next == head.load()) {
-        };
+        ttsl::nice_spin_until([this] { return tail.load()->next != head.load(); });
         tail.load()->data = std::make_shared<T>(std::move(value));
         tail.store(tail.load()->next);
     }
@@ -81,8 +81,7 @@ public:
         // thus overwrite data that's being read. Stall until head
         // has progressed (data has been read).
         std::unique_lock<std::mutex> lock(this->queue_mutex);
-        while (tail.load()->next == head.load()) {
-        };
+        ttsl::nice_spin_until([this] { return tail.load()->next != head.load(); });
         tail.load()->data = std::move(value);
         tail.store(tail.load()->next);
     }

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -12,6 +12,7 @@
 #include <sys/resource.h>  // Needed for setting process priorities
 #include <numa.h>
 #include <tt-metalium/device.hpp>
+#include <tt_stl/tt_pause.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_types.hpp"
 #include "tt_metal/common/thread_pool.hpp"
@@ -133,9 +134,7 @@ public:
         // has progressed (data has been read).
         // A stall is only required when the ring_buffer_ backing the queue
         // is full. Realistically, this should never happen, given the size
-        while (tail_.load()->next == head_.load()) {
-            ;
-        }
+        ttsl::nice_spin_until([this] { return tail_.load()->next != head_.load(); });
         tail_.load()->data = std::move(task);
         tail_.store(tail_.load()->next);
     }

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         test_span.cpp
         test_strong_type.cpp
         test_small_vector.cpp
+        test_tt_pause.cpp
         test_type_visitor.cpp
 )
 target_link_libraries(

--- a/tt_stl/tests/test_tt_pause.cpp
+++ b/tt_stl/tests/test_tt_pause.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <tt_stl/tt_pause.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace ttsl {
+namespace {
+
+TEST(TTPauseTest, PauseDoesNotCrash) {
+    // Simply verify that pause can be called without crashing
+    for (int i = 0; i < 1000; ++i) {
+        pause();
+    }
+}
+
+TEST(TTNiceSpinUntilTest, ImmediateReturnWhenPredicateTrue) {
+    // Predicate is immediately true, should return without spinning
+    auto start = std::chrono::high_resolution_clock::now();
+    nice_spin_until([] { return true; });
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    // Should complete almost instantly (less than 1ms)
+    EXPECT_LT(duration.count(), 1000);
+}
+
+TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithAtomicFlag) {
+    std::atomic<bool> flag{false};
+
+    std::thread setter([&flag] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        flag.store(true);
+    });
+
+    auto start = std::chrono::high_resolution_clock::now();
+    nice_spin_until([&flag] { return flag.load(); });
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    // Should have waited at least ~10ms for the flag
+    EXPECT_GE(duration.count(), 9);
+
+    setter.join();
+}
+
+TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithCounter) {
+    std::atomic<int> counter{0};
+
+    std::thread incrementer([&counter] {
+        for (int i = 0; i < 5; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            counter.fetch_add(1);
+        }
+    });
+
+    nice_spin_until([&counter] { return counter.load() >= 5; });
+    EXPECT_GE(counter.load(), 5);
+
+    incrementer.join();
+}
+
+TEST(TTNiceSpinUntilTest, CustomNSpinsParameter) {
+    std::atomic<int> call_count{0};
+
+    // With N_SPINS=10, we should hit the sleep branch more frequently
+    auto predicate = [&call_count] {
+        call_count.fetch_add(1);
+        return call_count.load() >= 50;
+    };
+
+    nice_spin_until<10>(predicate);
+    EXPECT_GE(call_count.load(), 50);
+}
+
+TEST(TTNiceSpinUntilTest, CustomMaxWaitUSParameter) {
+    std::atomic<bool> flag{false};
+
+    std::thread setter([&flag] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        flag.store(true);
+    });
+
+    // Use custom parameters: N_SPINS=50, MAX_WAIT_US=8
+    nice_spin_until<50, 8>([&flag] { return flag.load(); });
+    EXPECT_TRUE(flag.load());
+
+    setter.join();
+}
+
+TEST(TTNiceSpinUntilTest, PredicateWithArguments) {
+    std::atomic<int> value{0};
+
+    std::thread setter([&value] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        value.store(42);
+    });
+
+    // Predicate that takes an argument
+    auto check_value = [&value](int expected) { return value.load() == expected; };
+
+    nice_spin_until(check_value, 42);
+    EXPECT_EQ(value.load(), 42);
+
+    setter.join();
+}
+
+TEST(TTNiceSpinUntilTest, PredicateWithMultipleArguments) {
+    std::atomic<int> a{0};
+    std::atomic<int> b{0};
+
+    std::thread setter([&a, &b] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        a.store(10);
+        b.store(20);
+    });
+
+    // Predicate that takes multiple arguments
+    auto check_sum = [&a, &b](int expected_a, int expected_b) {
+        return a.load() == expected_a && b.load() == expected_b;
+    };
+
+    nice_spin_until(check_sum, 10, 20);
+    EXPECT_EQ(a.load(), 10);
+    EXPECT_EQ(b.load(), 20);
+
+    setter.join();
+}
+
+TEST(TTNiceSpinUntilTest, ExponentialBackoffBehavior) {
+    // This test verifies the exponential backoff by checking that the function
+    // doesn't consume excessive CPU time when waiting for a longer duration
+    std::atomic<bool> flag{false};
+
+    std::thread setter([&flag] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        flag.store(true);
+    });
+
+    auto start = std::chrono::high_resolution_clock::now();
+    nice_spin_until([&flag] { return flag.load(); });
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    // Should have waited approximately 100ms
+    EXPECT_GE(duration.count(), 95);
+    EXPECT_LT(duration.count(), 200);
+
+    setter.join();
+}
+
+TEST(TTNiceSpinUntilTest, ZeroSpinsGoesDirectlyToSleep) {
+    // With N_SPINS=1, should hit sleep on every iteration
+    std::atomic<bool> flag{false};
+
+    std::thread setter([&flag] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        flag.store(true);
+    });
+
+    nice_spin_until<1, 4>([&flag] { return flag.load(); });
+    EXPECT_TRUE(flag.load());
+
+    setter.join();
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tt_stl/tt_pause.hpp
+++ b/tt_stl/tt_stl/tt_pause.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <utility>
+
+// Platform-specific headers for pause/yield intrinsics.
+//
+// x86_64:  immintrin.h provides _mm_pause() on GCC, Clang, and MSVC.
+//
+// AArch64: Clang provides __yield() via arm_acle.h (ACLE Section 7.4).
+//          MSVC provides __yield() via intrin.h.
+//          GCC does NOT provide __yield() in its aarch64 arm_acle.h --
+//          hint intrinsics were never implemented for the aarch64 backend.
+//          See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105416
+//          For GCC aarch64, we fall back to inline assembly below.
+//
+// RISC-V:  __builtin_riscv_pause() is a compiler builtin in GCC (12+)
+//          and Clang for RISC-V targets -- no header required. For older
+//          toolchains we emit the raw instruction encoding (0x0100000F).
+//          PAUSE is a HINT (Zihintpause extension); it executes as a
+//          NOP on cores that don't implement the extension.
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__clang__)
+#include <arm_acle.h>
+#endif
+#endif
+
+namespace ttsl {
+
+/**
+ * @brief Issues a pause/yield hint to the processor.
+ *
+ * On x86_64, this calls _mm_pause() which hints to the processor that the
+ * code is in a spin-wait loop. On ARM64, this issues the YIELD instruction
+ * (via __yield() on Clang/MSVC, or inline asm on GCC). On RISC-V, this
+ * issues the PAUSE hint instruction (Zihintpause extension).
+ *
+ * This helps reduce power consumption and improve performance of other
+ * threads sharing the same core during busy-wait loops.
+ */
+__attribute__((always_inline)) inline void pause() {
+#if defined(__x86_64__) || defined(_M_X64)
+    _mm_pause();
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__clang__) || defined(_MSC_VER)
+    __yield();
+#else
+    // GCC aarch64: __yield() is not provided in GCC's arm_acle.h.
+    // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105416
+    __asm__ volatile("yield");
+#endif
+#elif defined(__riscv) || defined(__riscv_xlen)
+#if defined(__has_builtin) && __has_builtin(__builtin_riscv_pause)
+    __builtin_riscv_pause();
+#else
+    // PAUSE encoded as FENCE W,0 (Zihintpause). Executes as NOP without the extension.
+    __asm__ volatile(".4byte 0x0100000F");
+#endif
+#else
+    // Fallback for other architectures - do nothing
+#endif
+}
+
+/**
+ * @brief Spins with TT_PAUSE() until the predicate evaluates to true.
+ *
+ * This function implements a "nice" spin loop that uses exponential backoff
+ * to reduce impact on system resources. Every N_SPINS iterations, it sleeps
+ * for an increasing duration (starting at 1us, doubling each time up to
+ * MAX_WAIT_US).
+ *
+ * @tparam N_SPINS Number of pause iterations between sleeps (default: 100)
+ * @tparam MAX_WAIT_US Maximum sleep duration in microseconds (default: 16)
+ * @param predicate A callable that returns true when the wait should end
+ */
+template <uint32_t N_SPINS = 100, uint32_t MAX_WAIT_US = 16, typename... Ts>
+__attribute__((flatten)) inline void nice_spin_until(auto predicate, Ts&&... args) {
+    uint32_t counter = 0;
+    uint32_t sleep_us = 1;
+    while (!predicate(std::forward<Ts>(args)...)) {
+        ++counter;
+        if (counter < N_SPINS) {
+            pause();
+        } else {
+            counter = 0;
+            std::this_thread::sleep_for(std::chrono::microseconds(sleep_us));
+            sleep_us = std::min(sleep_us * 2, MAX_WAIT_US);
+        }
+    }
+}
+
+}  // namespace ttsl

--- a/tt_stl/tt_stl/tt_pause.hpp
+++ b/tt_stl/tt_stl/tt_pause.hpp
@@ -83,7 +83,7 @@ __attribute__((always_inline)) inline void pause() {
  * @param predicate A callable that returns true when the wait should end
  */
 template <uint32_t N_SPINS = 100, uint32_t MAX_WAIT_US = 16, typename... Ts>
-__attribute__((flatten)) inline void nice_spin_until(auto predicate, Ts&&... args) {
+__attribute__((flatten)) inline void nice_spin_until(auto predicate, const Ts&... args) {
     uint32_t counter = 0;
     uint32_t sleep_us = 1;
     while (!predicate(args...)) {

--- a/tt_stl/tt_stl/tt_pause.hpp
+++ b/tt_stl/tt_stl/tt_pause.hpp
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <cstdint>
 #include <thread>
-#include <utility>
 
 // Platform-specific headers for pause/yield intrinsics.
 //
@@ -87,7 +86,7 @@ template <uint32_t N_SPINS = 100, uint32_t MAX_WAIT_US = 16, typename... Ts>
 __attribute__((flatten)) inline void nice_spin_until(auto predicate, Ts&&... args) {
     uint32_t counter = 0;
     uint32_t sleep_us = 1;
-    while (!predicate(std::forward<Ts>(args)...)) {
+    while (!predicate(args...)) {
         ++counter;
         if (counter < N_SPINS) {
             pause();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Busy wait loops with no decay logic.

### What's changed
Implement exponential backoff (with a cap) and intrinsic sleep hints for busy wait loops to have less contention.

Currently soliciting feedback.

## Benchmarks:

### Method
* Installed a kernel module onto a local machine for getting the fine-grained CPU power draw.
* Created 3 benchmark functions locally. All check for an atomic flag to be flipped by a secondary thread. The only differences are Raw Spin, Spin with `ttsl::pause`, and Spin with `ttsl::nice_spin_until`.
* Benchmark call wrapped in a utility which gets the cpu-socket total energy consumption and timestamps.
* Test cases run for 30 seconds, 5x back-to-back. Highest test and lowest test are dropped. Mean reported of the remaining 3 tests. Idle test done with a `sleep 30` call. Values reported to 3 significant digits.

### Data and Results
Test variance was < 1W for each category, even without dropping the "outliers"

| Test          | Sleep 30 | Raw Spin | TT_PAUSE spin | TT_NICE_SPIN_UNTIL |
| -             | -        | -        |       -       | -  |
| Avg Power (W) | 22.6 | 46.4 | 41.3 | 30.5 |
| P - P_Idle (W)   | - | 23.8 | 18.8 | 7.94 |
| Host Power Savings | - | - | **10.9%** | **34.3%** |

During times we are otherwise busy-waiting, this PR can reduce host side power consumption by double digit percent. 

### Checklist
- [x] Single Card Perf https://github.com/tenstorrent/tt-metal/actions/runs/22084285818

#### old

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nsexton/0-mm_pause)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-mm_pause)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-mm_pause)
- [x] New/Existing tests provide coverage for changes


#### Model tests

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-mm_pause)
  - [x] `models-mandatory` preset (runs:
      - [x] [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20653138170) and
      - [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20701876264))
      - [x] [Frequent model and ttnn tests with tracy](https://github.com/tenstorrent/tt-metal/actions/runs/20701888588)
  - [x] `models-extended` preset (runs:
      the mandatory tests, plus 
      - [x] [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/20700955757)
      - [x] [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/20701903088) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-mm_pause)
  - [x] `models-mandatory` preset (runs:
      - [x] [Unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20700985825))
  - [ ] `models-extended` preset
      - [ ] [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/20700988207) and
      - [ ] [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/20700989875) tests)
        - Falcon 7b: 25-80% perf improvement on kv cache ops
        - Resnet: 30-33% perf improvement on batch_size128_224x224_batchsize128's
         - test_perf_vision_cross_attention_transformer.py ::test_perf_gemma_vision[wormhole_b0-15-1-8-device_params0] - AssertionError: Failed because it's too fast
         - gemma3 op-to-op had a perf threshold failure by a tiny amount.
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-mm_pause)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-mm_pause)
  - [x] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/runs/20701007298))
  - [ ] `models-extended` preset
      - [ ] [Demo](https://github.com/tenstorrent/tt-metal/actions/runs/20701008863) and
      - [ ] [Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/20701010134) tests)
  - [ ] other selection - specify runs