### PR TITLE
[skip ci] #33448: update doc to note GN limitation and remove TODO

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -101,7 +101,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
 
             Limitations:
               - :attr:`input_tensor` is a 4D tensor of shape [N, 1, H*W, C] and is allocated on the device
-              - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must divide evenly into :attr:`num_groups`.
+              - For the :attr:`input_tensor`, H*W must be a multiple of the tile size (32) and C must be a multiple of the tile size and divide evenly into :attr:`num_groups`.
               - For the :attr:`input_mask`, C must match the number of groups, H must match a tile's height, and W must be a multiple of a tile's width.
               - :attr:`gamma` and :attr:`beta` must be provided
               - :attr:`inplace` is not supported for TILE-layout inputs and requires input and output layouts to be identical.

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -139,7 +139,7 @@ def determine_expected_group_norm_sharded_config_and_grid_size(
     Returns: (MemoryConfig, CoreGrid)
     """
     assert num_channels % num_groups == 0
-    assert num_channels % 32 == 0  # TODO: remove this later
+    assert num_channels % 32 == 0
     group_size = num_channels // num_groups
     compute_with_storage_grid_size = device.compute_with_storage_grid_size()
     device_grid_size = [compute_with_storage_grid_size.x, compute_with_storage_grid_size.y]


### PR DESCRIPTION
### Ticket
Link to Github Issue #33448

### Problem description
A TODO and omitted info from a doc string lead to confusion.

### What's changed
Remove the TODO and add info about a limitation in the group_norm doc string.