### PR TITLE
[skip ci] Add model select to blackhole multi-card demos+nightly pipeline

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -28,9 +28,14 @@ on:
         required: false
         type: boolean
         default: false
+      model:
+        required: false
+        type: string
+        default: 'all'
 
 jobs:
   multi-card-demo-tests:
+    if: ${{ inputs.model == 'all' || inputs.model == 'llama3.1-8b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -150,36 +155,82 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+  generate-large-models-matrix:
+    if: ${{ inputs.num_devices >= 4 && (inputs.model == 'all' || inputs.model == 'llama3.3-70b' || inputs.model == 'qwen3-32b') }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate filtered matrix
+        id: generate
+        run: |
+          # Define all test groups
+          all_tests='[
+            {
+              "name": "llama3.3-70b ${{ inputs.runner-label }} batch-32 performance",
+              "model": "llama3.3-70b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k \"performance and ci-32\" --max_seq_len 131072",
+              "owner_id": "U03PUAKE719",
+              "owner_name": "Miguel Tairum"
+            },
+            {
+              "name": "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)",
+              "model": "llama3.3-70b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k \"prefill-llama3_70b-2-131072-2-2-1-1-False\"",
+              "owner_id": "U08GELBB1AP",
+              "owner_name": "Ambrose Ling"
+            },
+            {
+              "name": "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)",
+              "model": "llama3.3-70b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k \"decode-llama3_70b-2-131072-2-10-1-1-False\"",
+              "owner_id": "U08GELBB1AP",
+              "owner_name": "Ambrose Ling"
+            },
+            {
+              "name": "qwen3-32b ${{ inputs.runner-label }} batch-32 performance",
+              "model": "qwen3-32b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k \"performance and ci-32\" --max_seq_len 40960",
+              "owner_id": "U08GELBB1AP",
+              "owner_name": "Ambrose Ling"
+            },
+            {
+              "name": "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf prefill",
+              "model": "qwen3-32b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"prefill-qwen3_32b-2-40960-2-2-1-1-False\"",
+              "owner_id": "U08GELBB1AP",
+              "owner_name": "Ambrose Ling"
+            },
+            {
+              "name": "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf decode",
+              "model": "qwen3-32b",
+              "arch": "blackhole",
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"decode-qwen3_32b-2-40960-2-10-1-1-False\"",
+              "owner_id": "U08GELBB1AP",
+              "owner_name": "Ambrose Ling"
+            }
+          ]'
+
+          # Filter based on model input
+          model_filter="${{ inputs.model }}"
+          if [ "$model_filter" == "all" ]; then
+            filtered_tests="$all_tests"
+          else
+            filtered_tests=$(echo "$all_tests" | jq -c "[.[] | select(.model == \"$model_filter\")]")
+          fi
+
+          echo "matrix={\"test-group\":$filtered_tests}" >> $GITHUB_OUTPUT
   multi-card-demo-tests-large:
-    if: ${{ inputs.num_devices >= 4 }}
+    needs: generate-large-models-matrix
+    if: ${{ inputs.num_devices >= 4 && (inputs.model == 'all' || inputs.model == 'llama3.3-70b' || inputs.model == 'qwen3-32b') }}
     strategy:
       fail-fast: false
-      matrix:
-        test-group:
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-32 performance"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --max_seq_len 131072
-            owner_id: U03PUAKE719 # Miguel Tairum
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_70b-2-131072-2-2-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_70b-2-131072-2-10-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b ${{ inputs.runner-label }} batch-32 performance"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --max_seq_len 40960
-            owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf prefill"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-qwen3_32b-2-40960-2-2-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
-          - name: "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf decode"
-            arch: blackhole
-            cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k "decode-qwen3_32b-2-40960-2-10-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
+      matrix: ${{ fromJSON(needs.generate-large-models-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on:
       - "in-service"

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -224,6 +224,7 @@ jobs:
             filtered_tests=$(echo "$all_tests" | jq -c "[.[] | select(.model == \"$model_filter\")]")
           fi
 
+          echo "Filtered tests: $filtered_tests"
           echo "matrix={\"test-group\":$filtered_tests}" >> $GITHUB_OUTPUT
   multi-card-demo-tests-large:
     needs: generate-large-models-matrix
@@ -313,27 +314,67 @@ jobs:
           owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+  generate-tt-dit-matrix:
+    if: ${{ (inputs.runner-label == 'P300-viommu' || inputs.runner-label == 'BH-QB-GE') && (inputs.model == 'all' || inputs.model == 'flux.1-dev' || inputs.model == 'wan2.2-t2v-a14b') }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate filtered matrix
+        id: generate
+        env:
+          RUNNER_LABEL: ${{ inputs.runner-label }}
+          MODEL_FILTER: ${{ inputs.model }}
+        run: |
+          # Define all test groups with model and runner-label fields for filtering
+          all_tests='[
+            {
+              "name": "Flux.1-dev P300-viommu performance (1x2sp0tp1)",
+              "model": "flux.1-dev",
+              "arch": "blackhole",
+              "runner-label": "P300-viommu",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"1x2sp0tp1\"",
+              "owner_id": "U08TED0JM9D",
+              "owner_name": "Samuel Adesoye"
+            },
+            {
+              "name": "Flux.1-dev BH-QB-GE performance (2x2sp0tp1)",
+              "model": "flux.1-dev",
+              "arch": "blackhole",
+              "runner-label": "BH-QB-GE",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"2x2sp0tp1\"",
+              "owner_id": "U08TED0JM9D",
+              "owner_name": "Samuel Adesoye"
+            },
+            {
+              "name": "Wan2.2-T2V-A14B BH-QB-GE performance",
+              "model": "wan2.2-t2v-a14b",
+              "arch": "blackhole",
+              "runner-label": "BH-QB-GE",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"1x4sp0tp1 and resolution_480p\"",
+              "owner_id": "U08TED0JM9D",
+              "owner_name": "Samuel Adesoye"
+            }
+          ]'
+
+          # Filter by runner-label first
+          filtered_by_runner=$(echo "$all_tests" | jq -c "[.[] | select(.[\"runner-label\"] == \"$RUNNER_LABEL\")]")
+
+          # Then filter by model if not 'all'
+          if [ "$MODEL_FILTER" == "all" ]; then
+            filtered_tests="$filtered_by_runner"
+          else
+            filtered_tests=$(echo "$filtered_by_runner" | jq -c "[.[] | select(.model == \"$MODEL_FILTER\")]")
+          fi
+
+          echo "Filtered tests: $filtered_tests"
+          echo "matrix={\"test-group\":$filtered_tests}" >> $GITHUB_OUTPUT
   multi-card-demo-tt_dit-tests:
-    if: ${{ inputs.runner-label == 'P300-viommu' || inputs.runner-label == 'BH-QB-GE' }}
+    needs: generate-tt-dit-matrix
+    if: ${{ (inputs.runner-label == 'P300-viommu' || inputs.runner-label == 'BH-QB-GE') && (inputs.model == 'all' || inputs.model == 'flux.1-dev' || inputs.model == 'wan2.2-t2v-a14b') }}
     strategy:
       fail-fast: false
-      matrix:
-        test-group:
-          - name: "Flux.1-dev ${{ inputs.runner-label }} performance"
-            arch: blackhole
-            cmd: |
-              if [ "${{ inputs.runner-label }}" == "P300-viommu" ]; then
-                HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k "1x2sp0tp1"
-              else
-                HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k "2x2sp0tp1"
-              fi
-            owner_id: U08TED0JM9D # Samuel Adesoye
-          - name: "Wan2.2-T2V-A14B ${{ inputs.runner-label }} performance"
-            arch: blackhole
-            cmd: |
-              if [ "${{ inputs.runner-label }}" == "P300-viommu" ]; then echo "Skipping - not supported on viommu"; exit 0; fi
-              HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "1x4sp0tp1 and resolution_480p"
-            owner_id: U08TED0JM9D # Samuel Adesoye
+      matrix: ${{ fromJSON(needs.generate-tt-dit-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on:
       - "in-service"

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -219,7 +219,7 @@ jobs:
           # Filter based on model input
           model_filter="${{ inputs.model }}"
           if [ "$model_filter" == "all" ]; then
-            filtered_tests="$all_tests"
+            filtered_tests=$(echo "$all_tests" | jq -c '.')
           else
             filtered_tests=$(echo "$all_tests" | jq -c "[.[] | select(.model == \"$model_filter\")]")
           fi
@@ -362,7 +362,7 @@ jobs:
 
           # Then filter by model if not 'all'
           if [ "$MODEL_FILTER" == "all" ]; then
-            filtered_tests="$filtered_by_runner"
+            filtered_tests=$(echo "$filtered_by_runner" | jq -c '.')
           else
             filtered_tests=$(echo "$filtered_by_runner" | jq -c "[.[] | select(.model == \"$MODEL_FILTER\")]")
           fi

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -8,12 +8,28 @@ on:
         required: false
         type: boolean
         default: false
+      model:
+        description: 'Select model to test'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - llama3.1-8b
+          - llama3.3-70b
+          - qwen3-32b
+          - Flux.1-dev
+          - Wan2.2-T2V-A14B
   workflow_call:
     inputs:
       regenerate-ttnn-cache:
         required: false
         type: boolean
         default: false
+      model:
+        required: false
+        type: string
+        default: 'all'
 
 jobs:
   build-artifact:
@@ -61,3 +77,4 @@ jobs:
       extra-tag: ${{ matrix.test-group.extra-tag }}
       num_devices: ${{ matrix.test-group.num_devices }}
       regenerate-ttnn-cache: ${{ inputs.regenerate-ttnn-cache || false  }}
+      model: ${{ inputs.model || 'all' }}

--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -18,8 +18,8 @@ on:
           - llama3.1-8b
           - llama3.3-70b
           - qwen3-32b
-          - Flux.1-dev
-          - Wan2.2-T2V-A14B
+          - flux.1-dev
+          - wan2.2-t2v-a14b
   workflow_call:
     inputs:
       regenerate-ttnn-cache:

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -55,6 +55,18 @@ on:
         required: false
         type: boolean
         default: true
+      nightly-multi-card-model:
+        description: 'Select model to test (for multi-card demo tests only)'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - llama3.1-8b
+          - llama3.3-70b
+          - qwen3-32b
+          - flux.1-dev
+          - wan2.2-t2v-a14b
   workflow_call:
   schedule:
     - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC
@@ -156,6 +168,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       extra-tag: ${{ matrix.test-group.extra-tag }}
       num_devices: ${{ matrix.test-group.num_devices }}
+      model: ${{ inputs.nightly-multi-card-model || 'all' }}
   blackhole-multi-card-unit-tests:
     if: ${{ github.event_name == 'schedule' || inputs.run_bh_multi_card_nightly_unit_tests }}
     needs: [build-artifact, blackhole-multi-card-tests-matrix]


### PR DESCRIPTION
### Ticket
None

### Problem description
Devs may not need to test their changes on all models in BH multi-card pipeline.
Other model pipelines (e.g. galaxy) already have model select functionality.

### What's changed
Add model select to BH multi-card pipeline: https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-multi-card-demo-tests.yaml and BH nightly https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml

Update the tt-dit job matrix due to the models running only on specific runner types:
- flux test differs based on p300 vs quietbox 2 (BH QB GE)
- wan2.2 test only runs on quietbox 2 (BH QB GE) 

### Checklist

- [x] llama3.1 8b https://github.com/tenstorrent/tt-metal/actions/runs/20664101401
- [x] llama3.3 70b https://github.com/tenstorrent/tt-metal/actions/runs/20664294360
- [x] qwen32b https://github.com/tenstorrent/tt-metal/actions/runs/20664297853
- [x] flux https://github.com/tenstorrent/tt-metal/actions/runs/20664300905
- [x] wan2.2 https://github.com/tenstorrent/tt-metal/actions/runs/20664303441
- [x] all models https://github.com/tenstorrent/tt-metal/actions/runs/20664484746
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/20664854925