### PR TITLE
Add fedora to CI

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -135,14 +135,15 @@ on:
         type: boolean
         default: false
         description: "Build Python Wheel"
-      distro:
+      platform:
         required: false
-        type: string
-        default: "ubuntu"
-      version:
-        required: false
-        type: string
-        default: "22.04"
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+          - "Fedora 43"
+        description: "Platform to build for"
       architecture:
         required: false
         type: string
@@ -169,12 +170,38 @@ on:
         description: "Enable Link Time Optimization (LTO)"
 
 jobs:
+  parse-platform:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs:
+      distro: ${{ steps.parse.outputs.distro }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - id: parse
+        run: |
+          case "${{ inputs.platform }}" in
+            "Ubuntu 22.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=22.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Ubuntu 24.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=24.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Fedora 43")
+              echo "distro=fedora" >> "$GITHUB_OUTPUT"
+              echo "version=43" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   build-docker-image:
+    needs: [parse-platform]
+    if: ${{ !cancelled() && (needs.parse-platform.result == 'success' || needs.parse-platform.result == 'skipped') }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     secrets: inherit
     with:
-      distro: ${{ inputs.distro }}
-      version: ${{ inputs.version }}
+      distro: ${{ github.event_name == 'workflow_dispatch' && needs.parse-platform.outputs.distro || inputs.distro || 'ubuntu' }}
+      version: ${{ github.event_name == 'workflow_dispatch' && needs.parse-platform.outputs.version || inputs.version || '22.04' }}
       architecture: ${{ inputs.architecture }}
 
   download-artifacts:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -36,19 +36,15 @@ on:
         value: ${{ jobs.check-docker-images.outputs.manylinux-tag }}
   workflow_dispatch:
     inputs:
-      distro:
+      platform:
         required: false
         type: choice
-        default: "ubuntu"
+        default: "Ubuntu 22.04"
         options:
-            - "ubuntu"
-      version:
-        required: false
-        type: choice
-        default: "22.04"
-        options:
-            - "22.04"
-            - "24.04"
+            - "Ubuntu 22.04"
+            - "Ubuntu 24.04"
+            - "Fedora 43"
+        description: "Platform to build Docker images for"
       architecture:
         required: false
         type: choice
@@ -56,16 +52,34 @@ on:
         options:
             - "amd64"
 
-env:
-  CI_BUILD_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-build-${{ inputs.architecture }}
-  CI_TEST_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-test-${{ inputs.architecture }}
-  DEV_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
-  BASIC_DEV_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-basic-dev-${{ inputs.architecture }}
-  BASIC_TTNN_RUNTIME_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-basic-ttnn-runtime-${{ inputs.architecture }}
-  MANYLINUX_IMAGE_NAME: manylinux-${{ inputs.architecture }}
-
 jobs:
+  parse-platform:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs:
+      distro: ${{ steps.parse.outputs.distro }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - id: parse
+        run: |
+          case "${{ inputs.platform }}" in
+            "Ubuntu 22.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=22.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Ubuntu 24.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=24.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Fedora 43")
+              echo "distro=fedora" >> "$GITHUB_OUTPUT"
+              echo "version=43" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   check-docker-images:
+    needs: [parse-platform]
+    if: ${{ !cancelled() && (needs.parse-platform.result == 'success' || needs.parse-platform.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
@@ -81,6 +95,24 @@ jobs:
       manylinux-exists: ${{ steps.images.outputs.manylinux-exists }}
       manylinux-tag: ${{ steps.tags.outputs.manylinux-tag }}
     steps:
+      - name: Set environment variables
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DISTRO="${{ needs.parse-platform.outputs.distro }}"
+            VERSION="${{ needs.parse-platform.outputs.version }}"
+          else
+            DISTRO="${{ inputs.distro || 'ubuntu' }}"
+            VERSION="${{ inputs.version || '20.04' }}"
+          fi
+          ARCH="${{ inputs.architecture || 'amd64' }}"
+
+          echo "CI_BUILD_IMAGE_NAME=${DISTRO}-${VERSION}-ci-build-${ARCH}" >> $GITHUB_ENV
+          echo "CI_TEST_IMAGE_NAME=${DISTRO}-${VERSION}-ci-test-${ARCH}" >> $GITHUB_ENV
+          echo "DEV_IMAGE_NAME=${DISTRO}-${VERSION}-dev-${ARCH}" >> $GITHUB_ENV
+          echo "BASIC_DEV_IMAGE_NAME=${DISTRO}-${VERSION}-basic-dev-${ARCH}" >> $GITHUB_ENV
+          echo "BASIC_TTNN_RUNTIME_IMAGE_NAME=${DISTRO}-${VERSION}-basic-ttnn-runtime-${ARCH}" >> $GITHUB_ENV
+          echo "MANYLINUX_IMAGE_NAME=manylinux-${ARCH}" >> $GITHUB_ENV
+
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -102,7 +102,7 @@ jobs:
             VERSION="${{ needs.parse-platform.outputs.version }}"
           else
             DISTRO="${{ inputs.distro || 'ubuntu' }}"
-            VERSION="${{ inputs.version || '20.04' }}"
+            VERSION="${{ inputs.version || '22.04' }}"
           fi
           ARCH="${{ inputs.architecture || 'amd64' }}"
 

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -3,12 +3,73 @@ name: "Build TT-Metalium across all configs"
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      platform:
+        required: false
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+          - "Fedora 43"
+        description: "Platform to build for"
 
 permissions:
   packages: write
 
 jobs:
+  parse-platform:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs:
+      distro: ${{ steps.parse.outputs.distro }}
+      version: ${{ steps.parse.outputs.version }}
+      toolchain: ${{ steps.parse.outputs.toolchain }}
+      enable-lto: ${{ steps.parse.outputs.enable-lto }}
+    steps:
+      - id: parse
+        run: |
+          case "${{ inputs.platform }}" in
+            "Ubuntu 22.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=22.04" >> "$GITHUB_OUTPUT"
+              echo "toolchain=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake" >> "$GITHUB_OUTPUT"
+              echo "enable-lto=false" >> "$GITHUB_OUTPUT"
+              ;;
+            "Ubuntu 24.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=24.04" >> "$GITHUB_OUTPUT"
+              echo "toolchain=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake" >> "$GITHUB_OUTPUT"
+              echo "enable-lto=true" >> "$GITHUB_OUTPUT"
+              ;;
+            "Fedora 43")
+              echo "distro=fedora" >> "$GITHUB_OUTPUT"
+              echo "version=43" >> "$GITHUB_OUTPUT"
+              echo "toolchain=cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake" >> "$GITHUB_OUTPUT"
+              echo "enable-lto=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  build-dispatch:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: parse-platform
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      distro: ${{ needs.parse-platform.outputs.distro }}
+      version: ${{ needs.parse-platform.outputs.version }}
+      toolchain: ${{ needs.parse-platform.outputs.toolchain }}
+      build-type: "Release"
+      enable-lto: ${{ needs.parse-platform.outputs.enable-lto == 'true' }}
+      publish-artifact: false
+      publish-package: false
+      skip-tt-train: true
+      tracy: false
+
   build:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -33,7 +94,13 @@ jobs:
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-gcc-14-toolchain.cmake"
             build-type: "Release"
+          - distro: "fedora"
+            version: "43"
+            toolchain: "cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake"
+            build-type: "Release"
+            enable-lto: true
     with:
+      distro: ${{ matrix.config.distro || 'ubuntu' }}
       version: ${{ matrix.config.version }}
       toolchain: ${{ matrix.config.toolchain }}
       build-type: ${{ matrix.config.build-type }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -19,20 +19,45 @@ on:
         default: "amd64"
   workflow_dispatch:
     inputs:
-      distro:
+      platform:
         required: false
-        type: string
-        default: "ubuntu"
-      version:
-        required: false
-        type: string
-        default: "24.04"
+        type: choice
+        default: "Ubuntu 24.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+          - "Fedora 43"
+        description: "Platform to analyze"
       architecture:
         required: false
         type: string
         default: "amd64"
 
 jobs:
+  parse-platform:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs:
+      distro: ${{ steps.parse.outputs.distro }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - id: parse
+        run: |
+          case "${{ inputs.platform }}" in
+            "Ubuntu 22.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=22.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Ubuntu 24.04")
+              echo "distro=ubuntu" >> "$GITHUB_OUTPUT"
+              echo "version=24.04" >> "$GITHUB_OUTPUT"
+              ;;
+            "Fedora 43")
+              echo "distro=fedora" >> "$GITHUB_OUTPUT"
+              echo "version=43" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
   determine-scan-type:
     runs-on: ubuntu-latest
     outputs:
@@ -53,13 +78,15 @@ jobs:
           echo "do-scan=$do_scan" >> "$GITHUB_OUTPUT"
 
   build-docker-image:
+    needs: [parse-platform]
+    if: ${{ !cancelled() && (needs.parse-platform.result == 'success' || needs.parse-platform.result == 'skipped') }}
     uses: ./.github/workflows/build-docker-artifact.yaml
     permissions:
       packages: write
     secrets: inherit
     with:
-      distro: ${{ inputs.distro || 'ubuntu' }}
-      version: ${{ inputs.version || '24.04' }}
+      distro: ${{ github.event_name == 'workflow_dispatch' && needs.parse-platform.outputs.distro || inputs.distro || 'ubuntu' }}
+      version: ${{ github.event_name == 'workflow_dispatch' && needs.parse-platform.outputs.version || inputs.version || '24.04' }}
       architecture: ${{ inputs.architecture || 'amd64' }}
 
   clang-tidy:

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -96,9 +96,6 @@ else
     toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 fi
 
-
-# Requested handling for 20.04 -> 22.04 migration
-
 configure_only="OFF"
 enable_distributed="ON"
 with_python_bindings="ON"

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -86,13 +86,18 @@ cxx_compiler_path=""
 cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
-toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 
-# Requested handling for 20.04 -> 22.04 migration
-if [[ "$FLAVOR" == "ubuntu" && "$VERSION" == "20.04" ]]; then
+if [[ "$ID" == "fedora" ]]; then
+    toolchain_path="cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake"
+elif [[ "$FLAVOR" == "ubuntu" && "$VERSION" == "20.04" ]]; then
     echo "WARNING: You are using Ubuntu 20.04 which is end of life. Default toolchain is set to libcpp, which is an unsupported configuration. This default behavior will be removed by June 2025."
     toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+else
+    toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 fi
+
+
+# Requested handling for 20.04 -> 22.04 migration
 
 configure_only="OFF"
 enable_distributed="ON"

--- a/cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake
@@ -5,10 +5,10 @@ set(CMAKE_C_COMPILER clang-21 CACHE INTERNAL "C compiler")
 set(CMAKE_CXX_COMPILER clang++-21 CACHE INTERNAL "C++ compiler")
 
 # Use for configure time
-set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Not using clang's libc++")
 
 # Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
-# We really need to fix out code, though.
+# We really need to fix our code, though.
 find_program(MOLD ld.mold)
 if(MOLD)
     set(CMAKE_LINKER_TYPE MOLD)

--- a/cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-21-libstdcpp-toolchain.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang-21 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-21 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-21)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -15,8 +15,7 @@ if ! command -v $PYTHON_CMD &>/dev/null; then
 fi
 
 echo "Getting uv and python 3.12"
-python3 -m pip install uv
-uv python install 3.12
+${PYTHON_CMD} -m pip install uv
 
 # Set Python environment directory
 if [ -z "$PYTHON_ENV_DIR" ]; then
@@ -35,7 +34,6 @@ detect_os
 
 if [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" = "22.04" ]; then
     echo "Ubuntu 22.04 detected: force pip/setuptools/wheel versions"
-    #pip install --force-reinstall pip==25.1.1
     uv pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
     uv pip install setuptools wheel==0.45.1
 else
@@ -44,6 +42,7 @@ else
 fi
 
 echo "Installing dev dependencies"
+# need the index strategy to fallback to specified torch version buried in reqs
 uv pip install --index-strategy unsafe-best-match -r $(pwd)/tt_metal/python_env/requirements-dev.txt
 
 echo "Installing tt-metal"

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -14,6 +14,10 @@ if ! command -v $PYTHON_CMD &>/dev/null; then
     exit 1
 fi
 
+echo "Getting uv and python 3.12"
+python3 -m pip install uv
+uv python install 3.12
+
 # Set Python environment directory
 if [ -z "$PYTHON_ENV_DIR" ]; then
     PYTHON_ENV_DIR=$(pwd)/python_env
@@ -21,7 +25,7 @@ fi
 echo "Creating virtual env in: $PYTHON_ENV_DIR"
 
 # Create and activate virtual environment
-$PYTHON_CMD -m venv $PYTHON_ENV_DIR
+uv venv $PYTHON_ENV_DIR --python 3.12
 source $PYTHON_ENV_DIR/bin/activate
 
 # Import functions for detecting OS
@@ -31,19 +35,19 @@ detect_os
 
 if [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" = "22.04" ]; then
     echo "Ubuntu 22.04 detected: force pip/setuptools/wheel versions"
-    pip install --force-reinstall pip==25.1.1
-    python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-    python3 -m pip install setuptools wheel==0.45.1
+    #pip install --force-reinstall pip==25.1.1
+    uv pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
+    uv pip install setuptools wheel==0.45.1
 else
     echo "$OS_ID $OS_VERSION detected: updating wheel and setuptools to latest"
-    python3 -m pip install --upgrade wheel setuptools
+    uv pip install --upgrade wheel setuptools
 fi
 
 echo "Installing dev dependencies"
-python3 -m pip install -r $(pwd)/tt_metal/python_env/requirements-dev.txt
+uv pip install --index-strategy unsafe-best-match -r $(pwd)/tt_metal/python_env/requirements-dev.txt
 
 echo "Installing tt-metal"
-pip install -e .
+uv pip install -e .
 
 # Do not install hooks when this is a worktree
 if [ $(git rev-parse --git-dir) = $(git rev-parse --git-common-dir) ]; then

--- a/dockerfile/Dockerfile.fedora
+++ b/dockerfile/Dockerfile.fedora
@@ -21,6 +21,7 @@ RUN dnf update -y && dnf install -y \
     openmpi{,devel} \
     libxml2{,-devel} \
     libxslt{,-devel} \
+    patch \
     && dnf clean all
 
 #############################################################

--- a/dockerfile/Dockerfile.fedora
+++ b/dockerfile/Dockerfile.fedora
@@ -1,6 +1,6 @@
 ARG FEDORA_VERSION=43
 FROM mirror.gcr.io/fedora:${FEDORA_VERSION} AS base
-# Re-declare ARG make it available in the build stage
+# Re-declare ARG to make it available in the build stage
 ARG FEDORA_VERSION
 
 # Install basic tools to build
@@ -17,10 +17,14 @@ RUN dnf update -y && dnf install -y \
     xz \
     zstd \
     ccache \
-    wget{,2} \
-    openmpi{,devel} \
-    libxml2{,-devel} \
-    libxslt{,-devel} \
+    wget, \
+    wget2 \
+    openmpi \
+    openmpi-devel \
+    libxml2 \
+    libxml2-devel \
+    libxslt \
+    libxslt-devel \
     patch \
     && dnf clean all
 

--- a/dockerfile/Dockerfile.fedora
+++ b/dockerfile/Dockerfile.fedora
@@ -1,0 +1,115 @@
+ARG FEDORA_VERSION=43
+FROM mirror.gcr.io/fedora:${FEDORA_VERSION} AS base
+# Re-declare ARG make it available in the build stage
+ARG FEDORA_VERSION
+
+# Install basic tools to build
+RUN dnf update -y && dnf install -y \
+    cmake \
+    ninja-build \
+    clang \
+    gcc \
+    gcc-c++ \
+    make \
+    mold \
+    wget \
+    tar \
+    xz \
+    zstd \
+    ccache \
+    wget{,2} \
+    openmpi{,devel} \
+    libxml2{,-devel} \
+    libxslt{,-devel} \
+    && dnf clean all
+
+#############################################################
+
+FROM base AS basic-ttnn-runtime
+
+# Install basic runtime dependencies
+RUN dnf install -y \
+    git \
+    python3-devel \
+    python3-pip \
+    uv \
+    && dnf clean all
+
+# Install the SFPI compiler
+COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
+COPY /tt_metal/sfpi-info.sh /opt/tt_metal_infra/scripts/docker/sfpi-info.sh
+COPY /tt_metal/sfpi-version /opt/tt_metal_infra/scripts/docker/sfpi-version
+RUN chmod +x /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
+RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
+
+# Set up virtual environment
+ENV PYTHON_ENV_DIR=/opt/venv
+RUN uv venv $PYTHON_ENV_DIR --python 3.12
+
+# Ensure the virtual environment is used for all Python-related commands
+ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
+ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
+
+# Ensure the virtual environment is activated on shell startup
+RUN echo "source $PYTHON_ENV_DIR/bin/activate" >> /etc/bashrc
+
+# Add PyTorch CPU wheels to pip config
+RUN mkdir -p /etc && \
+    echo "[global]\nextra-index-url = https://download.pytorch.org/whl/cpu" > /etc/pip.conf
+
+#############################################################
+
+FROM base AS evaluation
+
+RUN mkdir /tt-metal
+WORKDIR /tt-metal
+
+# Install additional runtime dependencies
+RUN dnf install -y \
+    python3 \
+    python3-pip \
+    git \
+    uv \
+    ccache \
+    slurm-slurmd \
+    && dnf clean all
+
+# Install Python deps (skip venv)
+COPY tt_metal/python_env/requirements-dev.txt tt_metal/python_env/
+COPY docs/requirements-docs.txt docs/
+COPY tests/sweep_framework/requirements-sweeps.txt tests/sweep_framework/
+COPY tools/triage/requirements.txt tools/triage/
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip3 install --upgrade setuptools
+RUN pip3 install --ignore-installed -r tt_metal/python_env/requirements-dev.txt
+
+## Install Metal dependencies
+COPY install_dependencies.sh .
+COPY tt_metal/sfpi-info.sh tt_metal/
+COPY tt_metal/sfpi-version tt_metal/
+COPY scripts/ttexalens_ref.txt scripts/
+RUN ./install_dependencies.sh --docker
+
+# Build & install Metal
+COPY . .
+
+ARG BUILD_METAL_ARGS=""
+
+# Configure with CPM cache shared LOCKED mount
+RUN --mount=type=cache,target=/tt-metal/.cpmcache,sharing=locked,id=cpm \
+    ./build_metal.sh $BUILD_METAL_ARGS --configure-only --cpm-source-cache /tt-metal/.cpmcache --build-dir /usr --enable-ccache
+
+# Build & install with CCACHE_REMOTE_STORAGE secret and CPM non-locking mount
+RUN --mount=type=secret,id=CCACHE_REMOTE_STORAGE \
+    --mount=type=cache,target=/tt-metal/.cpmcache,sharing=shared,id=cpm \
+    export CCACHE_REMOTE_STORAGE=$(cat /run/secrets/CCACHE_REMOTE_STORAGE) && \
+    export CCACHE_REMOTE_ONLY=1 && \
+    cmake --build /usr --target install
+
+# Build & install Python package
+RUN uv pip install -e .
+
+# Add permissions for all users (MPI uses non-root users and some tests write here)
+RUN chmod -R 777 /usr/libexec/tt-metalium
+
+WORKDIR /root

--- a/tests/sweep_framework/requirements-sweeps.txt
+++ b/tests/sweep_framework/requirements-sweeps.txt
@@ -2,5 +2,5 @@ termcolor
 beautifultable
 faster-fifo
 # For PostgreSQL database connectivity
-psycopg-binary == 3.2.9
+psycopg-binary == 3.2.12
 ijson


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Fedora isn't in CI yet.

### What's changed

* Fedora support. 
* This PR refactors platform handling, so rather than selecting an ubuntu version, you select an item that is distro+version. 
* Fedora uses python 3.14, which is incompatible with our current deps. Introduce `uv` to create a venv with python 3.12 and use as a proving ground for uv instead of pip

### Checklist
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nsexton/0-fedora-ci)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-fedora-ci)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fedora-ci)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fedora-ci)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fedora-ci)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-fedora-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fedora-ci)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs