### PR TITLE
feat: add sharding support to Conv3d via TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -59,17 +59,17 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Activation tensor must be row-major.");
 
     // input and weight must both be interleaved, bfloat16
-    TT_FATAL(!input_tensor_a.memory_config().is_sharded(), "Activation tensor must be interleaved.");
+    // Sharding now supported via TensorAccessor - see tech_reports/tensor_accessor/tensor_accessor.md
     TT_FATAL(input_tensor_a.dtype() == DataType::BFLOAT16, "Activation tensor must be bfloat16.");
 
     const auto& weight_tensor = tensor_args.weight_tensor;
-    TT_FATAL(!weight_tensor.memory_config().is_sharded(), "Weight tensor must be interleaved.");
+    // Sharding now supported via TensorAccessor
     TT_FATAL(weight_tensor.dtype() == DataType::BFLOAT16, "Weight tensor must be bfloat16.");
     TT_FATAL(weight_tensor.layout() == Layout::TILE, "Weight tensor must be tile.");
 
     if (tensor_args.bias_tensor.has_value()) {
         const auto& bias_tensor = tensor_args.bias_tensor.value();
-        TT_FATAL(!bias_tensor.memory_config().is_sharded(), "Bias tensor must be interleaved.");
+        // Sharding now supported via TensorAccessor
         TT_FATAL(bias_tensor.layout() == Layout::TILE, "Bias tensor must be tiled.");
         TT_FATAL(
             bias_tensor.dtype() == DataType::BFLOAT16, "Bias tensor must be bfloat16. got {}", bias_tensor.dtype());


### PR DESCRIPTION
## What does this PR do?

This PR adds sharding support to Conv3d by enabling HEIGHT_SHARDED, WIDTH_SHARDED, and BLOCK_SHARDED memory layouts for input, weight, and bias tensors.

### Background

Currently, `ttnn.experimental.conv3d` only accepts interleaved memory layouts, enforced by explicit `TT_FATAL` assertions. However, the Conv3d kernels already use `TensorAccessor`, which handles sharded tensors transparently.

### Changes

1. **Remove sharding restrictions** in `conv3d_device_operation.cpp` (lines 62, 66, 72)
   - Deleted `TT_FATAL` checks that blocked sharded input/weight/bias tensors

2. **Add sharding tests** in `test_conv3d.py`
   - HEIGHT_SHARDED, WIDTH_SHARDED, BLOCK_SHARDED input configurations
   - Numerical correctness validation against PyTorch Conv3d

### Why This Works

The `TensorAccessorArgs(*buffer)` constructor already extracts shard specs from the buffer, and `TensorAccessor` handles both interleaved and sharded tensors without kernel changes. See the [TensorAccessor Guide](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/tensor_accessor/tensor_accessor.md).

### Testing

- New tests cover all 3 sharding layouts
- Existing Conv3d tests should pass (no regression)
- PCC threshold: 0.99 against PyTorch reference

Fixes #34943