### PR TITLE
Fix ring sdpa missing compile arg `broadcast_provided_mask_heads` passed to reader kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -213,6 +213,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         Sq_chunk_t, q_num_chunks, Sk_chunk_t, k_num_chunks, num_cores,
         true,   //(std::uint32_t)is_causal,
         false,  //(std::uint32_t)use_provided_mask,
+        false,  //(std::uint32_t)broadcast_provided_mask_heads,
         false,  //(std::uint32_t)use_padded_mask,
         false,  //(uint32_t)is_chunked,
         0,      // block_size_t,


### PR DESCRIPTION
### Ticket
L2 nightly sdpa tests were failing when this [commit](https://github.com/tenstorrent/tt-metal/commit/fe3a7199710d10621dc52a5f5b2a4903b611733f#diff-f4c6fae8d84e154aa08e04ea0fa2555a8b4798d0fb572bd8709dad105f662afc) added this argument

First failing run: https://github.com/tenstorrent/tt-metal/actions/runs/20688579878/job/59393475225#step:6:33342
Last successful run: https://github.com/tenstorrent/tt-metal/actions/runs/20673251275 

### Problem description
The reader_interleaved.cpp kernel expects 22 scalar compile-time arguments (indices 0-21), followed by TensorAccessorArgs starting at index 22. However, ring_distributed_sdpa_program_factory.cpp only provides 21 scalar arguments, missing the broadcast_provided_mask_heads argument.

### What's changed
Add the missing broadcast_provided_mask_heads argument (set to false since ring mode doesn't use provided masks)

### Checklist
- [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/20707497477) All SDPA tests passing, failures are irrelevant to this PR


- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aling/fix-ring-sdpa)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aling/fix-ring-sdpa)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aling/fix-ring-sdpa)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aling/fix-ring-sdpa)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aling/fix-ring-sdpa)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aling/fix-ring-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aling/fix-ring-sdpa)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs