### PR TITLE
feat: Add Microsoft Phi-4 Support & Harden Model Config

### DIFF
--- a/models/tt_transformers/model_params/phi-4/accuracy_decoder_config.json
+++ b/models/tt_transformers/model_params/phi-4/accuracy_decoder_config.json
@@ -1,0 +1,14 @@
+{
+    "decoders": {
+        "0": {
+            "precision_cfg": {
+                "WQKV": "BFP8"
+            }
+        },
+        "39": {
+            "precision_cfg": {
+                "WQKV": "BFP8"
+            }
+        }
+    }
+}

--- a/models/tt_transformers/model_params/phi-4/config.json
+++ b/models/tt_transformers/model_params/phi-4/config.json
@@ -1,0 +1,31 @@
+{
+    "architectures": [
+        "Phi3ForCausalLM"
+    ],
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "bos_token_id": 100257,
+    "embd_pdrop": 0.0,
+    "eos_token_id": 100265,
+    "hidden_act": "silu",
+    "hidden_size": 5120,
+    "initializer_range": 0.02,
+    "intermediate_size": 17920,
+    "max_position_embeddings": 16384,
+    "model_type": "phi3",
+    "num_attention_heads": 40,
+    "num_hidden_layers": 40,
+    "num_key_value_heads": 10,
+    "original_max_position_embeddings": 16384,
+    "pad_token_id": 100349,
+    "resid_pdrop": 0.0,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": null,
+    "rope_theta": 250000.0,
+    "sliding_window": null,
+    "tie_word_embeddings": false,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.47.0",
+    "use_cache": true,
+    "vocab_size": 100352
+}

--- a/models/tt_transformers/model_params/phi-4/params.json
+++ b/models/tt_transformers/model_params/phi-4/params.json
@@ -1,0 +1,10 @@
+{
+    "dim": 5120,
+    "n_layers": 40,
+    "n_heads": 40,
+    "n_kv_heads": 10,
+    "vocab_size": 100352,
+    "intermediate_size": 17920,
+    "norm_eps": 1e-05,
+    "rope_theta": 250000.0
+}

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -762,6 +762,9 @@ def pad_to_size(x: torch.Tensor, dim: int, size: int) -> torch.Tensor:
 
 
 def get_base_model_name(model_name: str) -> str:
+    # Explicitly handle phi-4 which doesn't follow the <Size>B format
+    if "phi-4" in model_name.lower():
+        return "Phi-4"
     # Remove the suffix after B- (case insensitive), e.g. "Llama-3.1-70B-Instruct" -> "Llama-3.1-70B"
     match = re.search(r"(.*?\d+[bB])-", model_name)
     return match.group(1) if match else model_name

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -449,6 +449,7 @@ class ModelArgs:
         "Mistral-7B-Instruct-v0.3": "models/tt_transformers/model_params/Mistral-7B-Instruct-v0.3",
         "Qwen2.5-VL-3B-Instruct": "models/tt_transformers/model_params/Qwen2.5-VL-3B-Instruct",
         "Qwen2.5-VL-32B-Instruct": "models/tt_transformers/model_params/Qwen2.5-VL-32B-Instruct",
+        "Phi-4": "models/tt_transformers/model_params/phi-4",
         "Qwen2.5-VL-72B-Instruct": "models/tt_transformers/model_params/Qwen2.5-VL-72B-Instruct",
         "Qwen3-VL-32B-Instruct": "models/tt_transformers/model_params/Qwen3-VL-32B-Instruct",
     }
@@ -521,8 +522,10 @@ class ModelArgs:
             self.model_name = HF_MODEL.strip("/").split("/")[
                 -1
             ]  # HF model names use / even on windows. May be overridden by config.
+            if "phi-4" in self.model_name.lower():
+                self.model_name = "Phi-4"
         else:
-            assert False, "Please set HF_MODEL to a HuggingFace name e.g. meta-llama/Llama-3.1-8B-Instruct"
+            raise ValueError("Please set HF_MODEL to a HuggingFace name e.g. meta-llama/Llama-3.1-8B-Instruct")
 
         logger.info(f"Checkpoint directory: {self.CKPT_DIR}")
         logger.info(f"Tokenizer file: {self.TOKENIZER_PATH + '/tokenizer.model'}")
@@ -556,9 +559,10 @@ class ModelArgs:
         self.max_prefill_chunk_size = self.get_max_prefill_chunk_size()
 
         if (
-            self.base_model_name in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B", "gemma-3-27b", "gemma-3-4b"]
+            self.base_model_name
+            in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B", "gemma-3-27b", "gemma-3-4b", "Phi-4"]
             and self.device_name == "N150"
-        ) or (self.base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B"] and self.device_name == "N300"):
+        ) or (self.base_model_name in ["Qwen2.5-7B", "Qwen2.5-VL-7B", "Phi-4"] and self.device_name == "N300"):
             logger.info(f"Reducing prefill_len_cutoff to 512 for {self.model_name} on {self.device_name}")
             self.prefill_len_cutoff = 512
         elif self.base_model_name in ["Mixtral-8x7B"] and self.device_name == "T3K":
@@ -2269,6 +2273,7 @@ class ModelArgs:
                 "QwQ-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128, "P150x4": 128},
                 "Qwen3-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128, "P150x4": 128},
                 "Qwen3-Embedding-8B": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
+                "Phi-4": {"N150": 4, "N300": 64, "T3K": 128, "TG": 128, "P150x4": 128},
                 "Mistral-Small-3.1-24B": {
                     "N150": 32,
                     "N300": 64,


### PR DESCRIPTION
## feat: Add Microsoft Phi-4 Support

### Summary
This PR enables support for the Microsoft Phi-4 (14B) model on Tenstorrent Wormhole hardware.

### Changes

#### 1. Phi-4 Support (Feature)
- **Model Recognition**: Updated common.py and model_config.py to correctly identify and load microsoft/phi-4.
- **Optimization Strategy**: Added specific configurations for Phi-4 — defaults to BFP8 for WQKV weights to fit within DRAM on N150/N300 devices.
- **Memory Safety**: Set appropriate MAX_PREFILL_CHUNK_SIZE (4 for N150) to prevent OOM errors, reduced prefill_len_cutoff to 512 for N150/N300.
- **Config Overrides**: Added model_params/phi-4/ with config.json (250k RoPE), params.json, and accuracy_decoder_config.json (decoders 0 and 39 for 40-layer coverage).

#### 2. Safety Improvement
- Replaced assert False with 
aise ValueError for missing HF_MODEL environment variable, ensuring the error is enforced even when Python runs with -O optimization flag.

### Verification
- Phi-4: Validated config loading and parameter ingestion (RoPE theta: 250000.0).
- Existing models: Verified that existing configurations (Llama-3, Phi-3, etc.) are unaffected.

### Files Changed (5)
- \models/tt_transformers/model_params/phi-4/config.json\ (new)
- \models/tt_transformers/model_params/phi-4/params.json\ (new)
- \models/tt_transformers/model_params/phi-4/accuracy_decoder_config.json\ (new)
- \models/tt_transformers/tt/model_config.py\ (modified)
- \models/tt_transformers/tt/common.py\ (modified)