### PR TITLE
1136 bug: tensor to torch workflow implementation through host conversion

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn import ShardTensorToMesh
 
 pytestmark = pytest.mark.use_module_device
 
@@ -136,3 +137,33 @@ def test_to_for_01_rank_on_device(device, shape, layout, dtype, pad_value):
     torch_output_tensor = ttnn.to_torch(tensor)
     assert torch_input_tensor.shape == torch_output_tensor.shape
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
+
+
+# Regression test for issue #31136: to_torch with mesh_composer=None on device-sharded tensor
+# Issue: https://github.com/tenstorrent/tt-metal/issues/31136
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 3, 3),
+        (1, 1, 32, 32),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+def test_to_torch_with_mesh_composer_none(shape, layout):
+    """Regression test for issue #31136: to_torch with mesh_composer=None on device-sharded tensor"""
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+
+    mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape((1, 1)))
+
+    ttnn_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=layout,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+    torch_output_tensor = ttnn_tensor.to_torch(mesh_composer=None)
+
+    assert torch.allclose(torch_input_tensor, torch_output_tensor)
+    ttnn.close_mesh_device(mesh_device)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -149,21 +149,17 @@ def test_to_for_01_rank_on_device(device, shape, layout, dtype, pad_value):
     ],
 )
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
-def test_to_torch_with_mesh_composer_none(shape, layout):
+def test_to_torch_with_mesh_composer_none(device, shape, layout):
     """Regression test for issue #31136: to_torch with mesh_composer=None on device-sharded tensor"""
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
 
-    mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape((1, 1)))
-
     ttnn_tensor = ttnn.from_torch(
         torch_input_tensor,
-        device=mesh_device,
+        device=device,
         dtype=ttnn.bfloat16,
         layout=layout,
-        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
 
     torch_output_tensor = ttnn_tensor.to_torch(mesh_composer=None)
 
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
-    ttnn.close_mesh_device(mesh_device)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_and_from_torch.py
@@ -8,7 +8,6 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from ttnn import ShardTensorToMesh
 
 pytestmark = pytest.mark.use_module_device
 

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -395,7 +395,7 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
         TT_THROW("Unreachable");
     };
 
-    auto extract_single_buffer = [](const HostStorage& storage) -> HostBuffer {
+    auto extract_buffer_from_host_storage = [](const HostStorage& storage) -> HostBuffer {
         std::vector<HostBuffer> buffers;
         storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
         TT_FATAL(
@@ -409,13 +409,13 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
 
     return convert_to_logical(std::visit(
         tt::stl::overloaded{
-            [&extract_single_buffer](const HostStorage& storage) -> HostBuffer {
-                return extract_single_buffer(storage);
+            [&extract_buffer_from_host_storage](const HostStorage& storage) -> HostBuffer {
+                return extract_buffer_from_host_storage(storage);
             },
-            [&tt_tensor, &extract_single_buffer](const DeviceStorage&) -> HostBuffer {
+            [&tt_tensor, &extract_buffer_from_host_storage](const DeviceStorage&) -> HostBuffer {
                 auto host_tensor = tt_tensor.cpu();
                 const auto& host_storage = std::get<HostStorage>(host_tensor.storage());
-                return extract_single_buffer(host_storage);
+                return extract_buffer_from_host_storage(host_storage);
             },
             [&tt_tensor](auto&&) -> HostBuffer {
                 TT_THROW(


### PR DESCRIPTION
### Ticket
[Link to Github Issue 31136](https://github.com/tenstorrent/tt-metal/issues/31136)

### Problem description
tt_tensor.to_torch(mesh_composer=None) gives unexpected error on mesh_device_1x1
Actually, it throws, with "Tensor with Devise storage cannot be converted to torch".

### What's changed
Added implementation of the logic via moving tensor from device to host and reuse of already implemented functionality to convert host based tensor to_torch.
Bug gone.
Unit tests, based on the initial bug description, for functionality have been provided

### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/20859756921
- [x] New tests provide coverage for changes
