### PR TITLE
[skip ci] Fix ops test timeout

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -12,7 +12,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 40
+        default: 5
       docker-image:
         required: true
         type: string


### PR DESCRIPTION
### Problem description
We don't want to have a silent blowup of ops test. So we need set lower timeout number for test

### What's changed
Set timeout to 5