### PR TITLE
Implement simplified compute kernel syntax

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -242,7 +242,7 @@ void Kernel::process_named_compile_time_args(
     callback(this->named_compile_time_args());
 }
 
-void Kernel::process_include_paths(const std::function<void(const std::string& path)> callback) const {
+void Kernel::process_include_paths(const std::function<void(const std::string& path)>& callback) const {
     // For FILE_PATH kernels, add the kernel source directory to the include path.
     // This enables relative includes (e.g., #include "foo.inc") to work when the kernel
     // source is transformed and inlined (as with simplified compute kernel syntax).

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -242,6 +242,15 @@ void Kernel::process_named_compile_time_args(
     callback(this->named_compile_time_args());
 }
 
+void Kernel::process_include_paths(const std::function<void(const std::string& path)> callback) const {
+    // For FILE_PATH kernels, add the kernel source directory to the include path.
+    // This enables relative includes (e.g., #include "foo.inc") to work when the kernel
+    // source is transformed and inlined (as with simplified compute kernel syntax).
+    if (kernel_src_.source_type_ == KernelSource::FILE_PATH) {
+        callback(kernel_src_.path_.parent_path().string());
+    }
+}
+
 bool Kernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -5,7 +5,10 @@
 #pragma once
 
 #include <umd/device/types/core_coordinates.hpp>
+#include <fstream>
+#include <sstream>
 #include <string>
+#include <tt_stl/unreachable.hpp>
 
 #include "api/tt-metalium/data_types.hpp"
 #include "api/tt-metalium/kernel_types.hpp"
@@ -41,6 +44,26 @@ struct KernelSource {
             name = "Kernel_Source_Code";
         }
         return name;
+    }
+
+    // Returns the actual source code (file content or source string)
+    std::string get_content() const {
+        switch (source_type_) {
+            case SourceType::FILE_PATH: {
+                std::ifstream file(path_);
+                if (!file.is_open()) {
+                    throw std::runtime_error("Cannot open kernel source file: " + path_.string());
+                }
+                std::stringstream buffer;
+                buffer << file.rdbuf();
+                if (file.fail() && !file.eof()) {
+                    throw std::runtime_error("Failed to read kernel source file: " + path_.string());
+                }
+                return buffer.str();
+            }
+            case SourceType::SOURCE_CODE: return source_;
+        }
+        ttsl::unreachable();
     }
 };
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -115,6 +115,7 @@ public:
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
+    void process_include_paths(std::function<void(const std::string& path)>) const override;
 
     void validate_runtime_args_size(
         size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -115,7 +115,7 @@ public:
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
-    void process_include_paths(std::function<void(const std::string& path)>) const override;
+    void process_include_paths(const std::function<void(const std::string& path)>&) const override;
 
     void validate_runtime_args_size(
         size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) const;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -459,6 +459,10 @@ void JitBuildState::compile_one(
     // Append common args provided by the build state
     cmd += this->cflags_;
     cmd += this->includes_;
+    // Add kernel-specific include paths (e.g., kernel source directory for relative includes)
+    if (settings) {
+        settings->process_include_paths([&cmd](const std::string& path) { cmd += fmt::format("-I{} ", path); });
+    }
     cmd += fmt::format("-c -o {} {} ", obj, src);
     cmd += defines;
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -9,11 +9,13 @@
 #include <cstdint>
 #include <tt_backend_api_types.hpp>
 #include <cstddef>
+#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <iostream>
 #include <ostream>
 #include <fstream>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -41,19 +43,6 @@ namespace tt::tt_metal {
 
 namespace {
 
-void gen_kernel_cpp(const string& src, const string& dst_name, const vector<string>& prolog) {
-    std::ofstream out(dst_name);
-    for (const string& s : prolog) {
-        out << s;
-    }
-    out << src;
-}
-
-void gen_kernel_cpp(const string& src, const string& dst_name) {
-    vector<string> empty_prolog;
-    gen_kernel_cpp(src, dst_name, empty_prolog);
-}
-
 string get_kernel_source_to_include(const KernelSource& kernel_src) {
     switch (kernel_src.source_type_) {
         case KernelSource::FILE_PATH: {
@@ -62,6 +51,102 @@ string get_kernel_source_to_include(const KernelSource& kernel_src) {
         case KernelSource::SOURCE_CODE: return kernel_src.source_;
     }
     ttsl::unreachable();
+}
+
+// Simple kernel syntax refers to declaring kernel entry point as just "void kernel_main()"
+// This is in contrast to legacy syntax: "namespace NAMESPACE { void MAIN() { ... } }"
+// Eventually we may want to deprecate legacy syntax, but for now we support both.
+// This namespace isolates the logic related to simple kernel syntax.
+namespace simple_kernel_syntax {
+
+const std::regex kernel_main_pattern(R"(\bvoid\s+kernel_main\s*\(\s*\)\s*\{)");
+
+size_t find_kernel_main_definition(const string& source) {
+    std::smatch match;
+    if (std::regex_search(source, match, kernel_main_pattern)) {
+        return static_cast<size_t>(match.position());
+    }
+    return string::npos;
+}
+
+bool has_legacy_syntax_markers(const string& source) {
+    // Check for legacy syntax markers: "namespace NAMESPACE" or "void MAIN"
+    // If found, the file uses legacy syntax (possibly mixed with kernel_main for data movement)
+    return source.find("namespace NAMESPACE") != string::npos || source.find("void MAIN") != string::npos;
+}
+
+size_t count_kernel_main_definitions(const string& source) {
+    auto begin = std::sregex_iterator(source.begin(), source.end(), kernel_main_pattern);
+    auto end = std::sregex_iterator();
+    return std::distance(begin, end);
+}
+
+bool is_used_in_source(const string& source) {
+    // Use simplified syntax only if kernel_main is found AND no legacy markers present.
+    // This handles kernels with multiple entrypoints that have kernel_main() for data movement
+    // but legacy syntax for compute - we must not transform those.
+    if (find_kernel_main_definition(source) == string::npos) {
+        return false;
+    }
+    if (has_legacy_syntax_markers(source)) {
+        return false;
+    }
+    // Multiple kernel_main() with simplified syntax for compute is not supported.
+    // We cannot determine which kernel_main belongs to compute. Use legacy syntax for compute.
+    if (count_kernel_main_definitions(source) > 1) {
+        throw std::runtime_error(
+            "Multiple kernel_main() definitions found. Kernels with multiple entrypoints must use "
+            "legacy syntax (namespace NAMESPACE { void MAIN { } }) for the compute path.");
+    }
+    return true;
+}
+
+// Transforms simplified kernel to legacy format:
+//   - Splits at "void kernel_main()"
+//   - Preamble (#includes) stays outside namespace
+//   - Function body wrapped in namespace, renamed to func_name
+string transform_to_legacy_syntax(const string& source, const char* ns_name, const char* func_name) {
+    size_t func_pos = find_kernel_main_definition(source);
+    if (func_pos == string::npos) {
+        throw std::runtime_error("Could not find 'void kernel_main() {' in source");
+    }
+
+    string preamble = source.substr(0, func_pos);
+    string function_part = source.substr(func_pos);
+
+    // Rename kernel_main -> func_name
+    size_t name_pos = function_part.find("kernel_main");
+    if (name_pos != string::npos) {
+        function_part.replace(name_pos, strlen("kernel_main"), func_name);
+    }
+
+    ostringstream result;
+    result << preamble;
+    result << "namespace " << ns_name << " {\n";
+    result << function_part;
+    result << "\n}  // namespace " << ns_name << "\n";
+    return result.str();
+}
+}  // namespace simple_kernel_syntax
+
+// Generates TRISC prolog: #define + #include for defines_generated.h
+string build_trisc_prolog(const char* trisc_define) {
+    ostringstream prolog;
+    prolog << "#define " << trisc_define << "\n";
+    prolog << "#include \"defines_generated.h\"\n";
+    return prolog.str();
+}
+
+// Writes content to a file, throwing on failure
+void write_file(const string& path, const string& content) {
+    std::ofstream f(path);
+    if (!f) {
+        throw std::runtime_error("Cannot create file: " + path);
+    }
+    f << content;
+    if (!f) {
+        throw std::runtime_error("Failed to write file: " + path);
+    }
 }
 
 }  // namespace
@@ -75,8 +160,7 @@ void jit_build_genfiles_kernel_include(
     string kernel_header = out_dir + "kernel_includes.hpp";
 
     const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
-
-    gen_kernel_cpp(kernel_src_to_include, kernel_header);
+    write_file(kernel_header, kernel_src_to_include);
 }
 
 void jit_build_genfiles_triscs_src(
@@ -84,43 +168,67 @@ void jit_build_genfiles_triscs_src(
     // Note: assumes dirs (and descriptors) already created
     log_trace(tt::LogBuildKernels, "Generating defines for TRISCs");
 
-    string out_dir = env.get_out_kernel_root_path() + settings.get_full_kernel_name() + "/";
-    string unpack_base = out_dir + "chlkc_unpack";
-    string math_base = out_dir + "chlkc_math";
-    string pack_base = out_dir + "chlkc_pack";
-    string unpack_cpp = unpack_base + ".cpp";
-    string math_cpp = math_base + ".cpp";
-    string pack_cpp = pack_base + ".cpp";
+    const string out_dir = env.get_out_kernel_root_path() + settings.get_full_kernel_name() + "/";
+    const string unpack_cpp = out_dir + "chlkc_unpack.cpp";
+    const string math_cpp = out_dir + "chlkc_math.cpp";
+    const string pack_cpp = out_dir + "chlkc_pack.cpp";
 
-    const string& kernel_src_to_include = get_kernel_source_to_include(kernel_src);
+    // Read content for syntax detection (needed for both paths)
+    const string kernel_content = kernel_src.get_content();
+    const bool simplified = simple_kernel_syntax::is_used_in_source(kernel_content);
 
-    vector<string> unpack_prolog;
-    unpack_prolog.push_back("#define TRISC_UNPACK\n");
-    unpack_prolog.push_back("#include \"defines_generated.h\"\n");
-    vector<string> math_prolog;
-    math_prolog.push_back("#define TRISC_MATH\n");
-    math_prolog.push_back("#include \"defines_generated.h\"\n");
-    vector<string> pack_prolog;
-    pack_prolog.push_back("#define TRISC_PACK\n");
-    pack_prolog.push_back("#include \"defines_generated.h\"\n");
+    if (simplified) {
+        log_trace(tt::LogBuildKernels, "Detected simplified compute kernel syntax (kernel_main)");
+    } else {
+        log_warning(
+            tt::LogBuildKernels,
+            "Compute kernel '{}' uses deprecated 'namespace NAMESPACE {{ void MAIN {{ }} }}' syntax. "
+            "Please migrate to simplified 'void kernel_main() {{ }}' syntax.",
+            settings.get_full_kernel_name());
+    }
 
-    // TODO(pgk) - is this really worth it?
-    std::thread t0([&]() { gen_kernel_cpp(kernel_src_to_include, unpack_cpp, unpack_prolog); });
-    std::thread t1([&]() { gen_kernel_cpp(kernel_src_to_include, math_cpp, math_prolog); });
-    std::thread t2([&]() { gen_kernel_cpp(kernel_src_to_include, pack_cpp, pack_prolog); });
-    t0.join();
-    t1.join();
-    t2.join();
+    // Build prologs (same for both syntaxes)
+    const string unpack_prolog = build_trisc_prolog("TRISC_UNPACK");
+    const string math_prolog = build_trisc_prolog("TRISC_MATH");
+    const string pack_prolog = build_trisc_prolog("TRISC_PACK");
+
+    // Determine kernel source for each TRISC.
+    //
+    // Why the if-else structure is necessary:
+    // - Simplified syntax: MUST transform source, so we inline the transformed content
+    // - Legacy syntax: use existing get_kernel_source_to_include() which returns:
+    //   - FILE_PATH: #include directive (preserves file refs in compiler errors)
+    //   - SOURCE_CODE: the source directly
+    string unpack_src, math_src, pack_src;
+    if (simplified) {
+        unpack_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_unpack", "unpack_main");
+        math_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_math", "math_main");
+        pack_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_pack", "pack_main");
+    } else {
+        // Legacy: use existing helper that handles FILE_PATH vs SOURCE_CODE appropriately
+        const string src = get_kernel_source_to_include(kernel_src);
+        unpack_src = math_src = pack_src = src;
+    }
+
+    // Generate the three TRISC source files
+    write_file(unpack_cpp, unpack_prolog + unpack_src);
+    write_file(math_cpp, math_prolog + math_src);
+    write_file(pack_cpp, pack_prolog + pack_src);
 
     // Here we generate an auxiliary header with defines added via add_define() call
     // this header is then included from the kernel
     // We also append the include path to generated dir to hlkc cmldline.
-    std::ofstream gen_defines_file;
-    string generated_defines_fname = out_dir + "/defines_generated.h";
-    gen_defines_file.open(generated_defines_fname, std::ios_base::out);
+    const string generated_defines_fname = out_dir + "defines_generated.h";
+    std::ofstream gen_defines_file(generated_defines_fname);
+    if (!gen_defines_file) {
+        throw std::runtime_error("Cannot create file: " + generated_defines_fname);
+    }
     settings.process_defines([&gen_defines_file](const string& define, const string& value) {
         gen_defines_file << "#define " << define << " " << value << endl;
     });
+    if (!gen_defines_file) {
+        throw std::runtime_error("Failed to write file: " + generated_defines_fname);
+    }
 }
 
 namespace {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -201,9 +201,16 @@ void jit_build_genfiles_triscs_src(
     //   - SOURCE_CODE: the source directly
     string unpack_src, math_src, pack_src;
     if (simplified) {
-        unpack_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_unpack", "unpack_main");
-        math_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_math", "math_main");
-        pack_src = simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_pack", "pack_main");
+        // For FILE_PATH sources, add #line directive to preserve original file's line numbers
+        // in compiler diagnostics and __LINE__ macro. This ensures error messages reference
+        // the original kernel file, not the generated file.
+        string line_directive;
+        if (kernel_src.source_type_ == KernelSource::FILE_PATH) {
+            line_directive = "#line 1 \"" + kernel_src.path_.string() + "\"\n";
+        }
+        unpack_src = line_directive + simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_unpack", "unpack_main");
+        math_src = line_directive + simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_math", "math_main");
+        pack_src = line_directive + simple_kernel_syntax::transform_to_legacy_syntax(kernel_content, "chlkc_pack", "pack_main");
     } else {
         // Legacy: use existing helper that handles FILE_PATH vs SOURCE_CODE appropriately
         const string src = get_kernel_source_to_include(kernel_src);

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -32,7 +32,7 @@ public:
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
     // Called to process additional include paths (e.g., kernel source directory for relative includes)
-    virtual void process_include_paths(std::function<void(const std::string& path)>) const {}
+    virtual void process_include_paths(const std::function<void(const std::string& path)>&) const {}
 
     virtual ~JitBuildSettings() = default;
 };

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -31,6 +31,8 @@ public:
     // Called to process the user named compile time args
     virtual void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
+    // Called to process additional include paths (e.g., kernel source directory for relative includes)
+    virtual void process_include_paths(std::function<void(const std::string& path)>) const {}
 
     virtual ~JitBuildSettings() = default;
 };


### PR DESCRIPTION
### Ticket
#10426

### Problem description
Compute kernel requires cumbersome entrypoint declaration:
```cpp
namespace NAMESPACE { void MAIN(...) {...} }
```

### What's changed
Allow define compute kernel entrypoint the same way as it is done for e.g. data movement kernels:
```cpp
void kernel_main(...) {...}
```

Implemented as thin layer that detects novel syntax and transforms it to the old one. This backward-compatible way allows us to start start deprecation period for the old syntax, and once its done, backend can be refactored to remove handling of the old syntax.

Refactoring of existing kernels will be delivered in separate PRs.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=prybicki/simplify-compute-kernel-syntax)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:prybicki/simplify-compute-kernel-syntax)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=prybicki/simplify-compute-kernel-syntax)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:prybicki/simplify-compute-kernel-syntax)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=prybicki/simplify-compute-kernel-syntax)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:prybicki/simplify-compute-kernel-syntax)
- [ ] New/Existing tests provide coverage for changes

