### PR TITLE
[skip ci] Fix wheel tag checkout

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: ${{ startsWith(inputs.ref, 'refs/tags/') || startsWith(github.ref, 'refs/tags/') && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -67,7 +67,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 500
+          ref: ${{ inputs.ref || github.sha }}
+          fetch-depth: ${{ startsWith(inputs.ref, 'refs/tags/') || startsWith(github.ref, 'refs/tags/') && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 
       # Python for driving the build; not the version the wheel targets

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: ${{ startsWith(inputs.ref, 'refs/tags/') || startsWith(github.ref, 'refs/tags/') && 1 || 500 }}
+          fetch-depth: ${{ (startsWith(inputs.ref || github.ref, 'refs/tags/')) && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 
       # Python for driving the build; not the version the wheel targets


### PR DESCRIPTION
### Problem description
Currently when we want to build a wheel on tag ref it will fail with 
```
Error: fatal: Cannot fetch both 5491d3c8f20e3247efbf21d7441566ac01327fda and refs/tags/v0.65.1-rc12 to refs/tags/v0.65.1-rc12
```
https://github.com/tenstorrent/tt-metal/actions/runs/20631812521/job/59449278241

### What's changed
Add checkout reference and set fetch depth to 1  when building on tag