### PR TITLE
Modify unary_bcast API in metal to add new data formats

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -49,3 +49,8 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
     _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, tilize, is_int_fpu_en>(
         num_faces, dst_format);
 }
+
+template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
+inline void llk_math_eltwise_unary_datacopy_uninit() {
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>();
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -91,3 +91,11 @@ inline void llk_unpack_A_block(
         WAYPOINT("UPAD");
     }
 }
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_A_uninit(const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+
+    _llk_unpack_A_uninit_<BType>(face_r_dim);
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -50,6 +50,11 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
         num_faces, dst_format);
 }
 
+template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
+inline void llk_math_eltwise_unary_datacopy_uninit() {
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>();
+}
+
 /*************************************************************************
  * LLK FAST ELTWISE UNARY DATACOPY
  *************************************************************************/

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -91,3 +91,11 @@ inline void llk_unpack_A_block(
         WAYPOINT("UPAD");
     }
 }
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_A_uninit(const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+
+    _llk_unpack_A_uninit_<BType>(face_r_dim);
+}

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -6,12 +6,14 @@
 
 #include "compute_kernel_api/common.h"
 #ifdef TRISC_MATH
+#include "llk_math_common_api.h"
 #include "llk_math_binary_api.h"
 #include "llk_math_matmul_api.h"
 #include "llk_math_common.h"
 #include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
+#include "llk_unpack_common_api.h"
 #include "llk_unpack_AB_api.h"
 #include "llk_unpack_A_api.h"
 #include "llk_unpack_common_api.h"
@@ -25,18 +27,28 @@ namespace ckernel {
 
 template <BroadcastType bcast_type>
 ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
-    // Pass through uses A2D and potentially direct unpack to dest.
-    const auto data_copy_type = (bcast_type == BroadcastType::NONE) ? A2D : B2D;
-    const bool enable_unpack_to_dest = data_copy_type == A2D;
+    // 32bit formats are implemented using unpack to dest, since SrcB/FPU cannot handle these formats
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
 
     // Will configure A & B in similar way
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
-    UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(
-        false, false /*transpose within 16x16 face*/, icb)));
 
-    MATH((llk_math_eltwise_unary_datacopy_init<data_copy_type, DST_ACCUM_MODE, bcast_type>(icb)));
+    if (enable_unpack_to_dest) {
+        UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, true>(
+            false, false /*transpose within 16x16 face*/, icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, bcast_type>(icb)));
+    } else {
+        UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(
+            false, false /*transpose within 16x16 face*/, icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<B2D, DST_ACCUM_MODE, bcast_type>(icb)));
+    }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure(icb, icb)));
+#endif
 
     PACK((llk_pack_hw_configure_disaggregated<DST_ACCUM_MODE, false>(ocb)));
     PACK((llk_pack_init<false>(ocb)));
@@ -45,14 +57,40 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb) {
 
 template <BroadcastType bcast_type>
 ALWI void unary_bcast(uint32_t icb, uint32_t in_tile_index, uint32_t dst_tile_index) {
-    // Pass through uses A2D and potentially direct unpack to dest.
-    const auto data_copy_type = (bcast_type == BroadcastType::NONE) ? A2D : B2D;
-    const bool enable_unpack_to_dest = data_copy_type == A2D;
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    // 32bit and uint16 are implemented using upk to dest, since SrcB/FPU cannot handle these formats
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
 
-    UNPACK(
-        (llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, enable_unpack_to_dest>(icb, in_tile_index)));
-    MATH((llk_math_eltwise_unary_datacopy<data_copy_type, DST_ACCUM_MODE, bcast_type, enable_unpack_to_dest>(
-        dst_tile_index, icb)));
+    if (enable_unpack_to_dest) {
+        UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, true>(icb, in_tile_index)));
+        // UNPACK((llk_unpack_set_srcb_dummy_valid()));
+        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, bcast_type, true>(dst_tile_index, icb)));
+    } else {
+        UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(icb, in_tile_index)));
+        MATH((llk_math_eltwise_unary_datacopy<B2D, DST_ACCUM_MODE, bcast_type, false>(dst_tile_index, icb)));
+    }
+#endif
+}
+
+template <BroadcastType bcast_type>
+ALWI void unary_bcast_uninit(uint32_t icb) {
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    const std::uint32_t dst_format = get_operand_dst_format(icb);
+    const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+                                       (dst_format == (std::uint32_t)DataFormat::Int32);
+
+    if (enable_unpack_to_dest) {
+        UNPACK((llk_unpack_A_uninit<bcast_type>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, true>()));
+    } else {
+        UNPACK((llk_unpack_A_uninit<bcast_type>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, false>()));
+    }
+#endif
 }
 
 template <BroadcastType old_bcast_type, BroadcastType new_bcast_type>


### PR DESCRIPTION
Modify unary_bcast API in metal to add new data formats Float32, Int32, UInt32, UInt16

### Ticket
https://github.com/tenstorrent/tt-metal/issues/23354

### Problem description
unary_bcast did not support datatypes listed above

### What's changed
Add LLK implementations for ROW, COL, SCALAR unary_bcast for Float32, Int32, UInt32, UInt16
Modify compute kernel API to expose new functionality to metal

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pgardner/unary_bcast2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pgardner/unary_bcast2)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pgardner/unary_bcast2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pgardner/unary_bcast2)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/unary_bcast2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/unary_bcast2)
- [ ] https://github.com/tenstorrent/tt-metal/actions/runs/20883742533 device perf regressions
- [ ] New/Existing tests provide coverage for changes