### PR TITLE
[skip ci] Re-gen Docker containers

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -281,7 +281,14 @@ prep_ubuntu_system() {
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
     # Add Kitware repository for latest CMake
+    # Ensure keyring directory exists and download the latest key
+    mkdir -p /usr/share/keyrings
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # Verify the key was created successfully
+    if [ ! -f /usr/share/keyrings/kitware-archive-keyring.gpg ]; then
+        echo "[ERROR] Failed to create Kitware GPG keyring"
+        exit 1
+    fi
     echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
 
     # Add GCC toolchain repository for specific g++ versions if needed

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -281,15 +281,18 @@ prep_ubuntu_system() {
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
     # Add Kitware repository for latest CMake
-    # Ensure keyring directory exists and download the latest key
-    mkdir -p /usr/share/keyrings
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    # Verify the key was created successfully
-    if [ ! -f /usr/share/keyrings/kitware-archive-keyring.gpg ]; then
-        echo "[ERROR] Failed to create Kitware GPG keyring"
-        exit 1
-    fi
+    # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
+    test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+
+    # Add the repository to sources list and update
     echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+    apt-get update
+
+    # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
+    test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
+
+    # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
+    apt-get install -y --no-install-recommends kitware-archive-keyring
 
     # Add GCC toolchain repository for specific g++ versions if needed
     if [[ "$OS_ID" == "ubuntu" ]]; then


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Kitware rotated their signing key, it looks like.
Our old Docker containers don't even install the package meant to keep the signing key up-to-date.
We have an obsolete signing key in our image :(

### What's changed
Install the package to keep the signing key up-to-date
Re-gen the Docker images

NOTE: this may still be a problem on next rotation because our image is effectively stale for long periods if we don't make changes; so a key rotation (Kitware's or anybody's) could still bite us if the overlap time is shorter than our sporadic make-a-change-to-the-image time.