### PR TITLE
[skip ci] Add ClangStaticAnalyzer to code analysis

### DIFF
--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,6 +1,7 @@
 {
   "analyzer": [
     "--analyzers", "clangsa",
-    "--skip", "/work/.codechecker.skiplist"
+    "--skip", "/work/.codechecker.skiplist",
+    "--jobs", "32"
   ]
 }

--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,0 +1,6 @@
+{
+  "analyzer": [
+    "--analyzers", "clangsa",
+    "--skip", ".codechecker.skiplist"
+  ]
+}

--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,5 +1,5 @@
 {
-  "analyzer": [
+  "analyze": [
     "--analyzers", "clangsa",
     "--skip", "/work/.codechecker.skiplist",
     "--drop-reports-from-skipped-files"

--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,7 +1,6 @@
 {
   "analyzer": [
     "--analyzers", "clangsa",
-    "--skip", "/work/.codechecker.skiplist",
-    "--jobs", "32"
+    "--skip", "/work/.codechecker.skiplist"
   ]
 }

--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,6 +1,7 @@
 {
   "analyzer": [
     "--analyzers", "clangsa",
-    "--skip", "/work/.codechecker.skiplist"
+    "--skip", "/work/.codechecker.skiplist",
+    "--drop-reports-from-skipped-files"
   ]
 }

--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,6 +1,6 @@
 {
   "analyzer": [
     "--analyzers", "clangsa",
-    "--skip", ".codechecker.skiplist"
+    "--skip", "/work/.codechecker.skiplist"
   ]
 }

--- a/.codechecker.skiplist
+++ b/.codechecker.skiplist
@@ -1,0 +1,22 @@
+# CodeChecker skip list - exclude third-party and generated code
+# See: https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip
+
+# External third-party dependencies (not Tenstorrent code)
+-*/.cpmcache/*
+
+# NOTE: tt_metal/third_party/umd IS scanned - it's Tenstorrent code
+# UMD simulation is disabled via TT_UMD_BUILD_SIMULATION=FALSE in the preset
+
+# Build directories
+-*/.build/*
+-*/build/*
+-*/build-*/*
+
+# System headers
+-/usr/*
+
+# Generated files
+-*_generated.h
+-*_generated.cpp
+-*.pb.h
+-*.pb.cc

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -214,6 +214,7 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - ${{ github.workspace }}/../../_actions:${{ github.workspace }}/../../_actions # HACK: make actions available inside container
       options: --tmpfs /tmp
     defaults:
       run:

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -207,8 +207,8 @@ jobs:
 
   clang-static-analyzer:
     name: 🔬 Clang Static Analyzer
-    needs: [ build-docker-image, determine-scan-type ]
-    if: ${{ (inputs.enable-static-analysis == true || github.event_name == 'schedule') && needs.determine-scan-type.outputs.do-scan == 'true' }}
+    needs: [ build-docker-image ]
+    if: ${{ inputs.enable-static-analysis == true || github.event_name == 'schedule' }}
     runs-on: tt-ubuntu-2204-xlarge-stable
     container:
       image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -249,6 +249,7 @@ jobs:
 
       - name: Upload CodeChecker reports
         uses: actions/upload-artifact@v4
+        if: always()
         timeout-minutes: 10
         with:
           name: CodeChecker-Static-Analysis-Reports

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -231,6 +231,11 @@ jobs:
       - name: 🔧 CMake configure
         run: cmake --preset clang-static-analyzer
 
+      - name: Setup clang symlinks for CodeChecker
+        run: |
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+
       - name: 🔬 Analyze with CodeChecker
         uses: whisperity/codechecker-analysis-action@v1.0.4
         id: codechecker

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -231,6 +231,9 @@ jobs:
       - name: 🔧 CMake configure
         run: cmake --preset clang-static-analyzer
 
+      - name: 🛠️ Generate files
+        run: cmake --build .build/clang-static-analyzer --target all_generated_files --config RelWithDebInfo
+
       - name: Setup clang symlinks for CodeChecker
         run: |
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -2,7 +2,7 @@ name: "Code analysis"
 
 on:
   schedule:
-    - cron: "0 */3 * * *" # This cron schedule runs the workflow every 3 hours
+    - cron: "0 2 * * 1,3,5" # Static analysis: 2 AM UTC on Mon/Wed/Fri
   workflow_call:
     inputs:
       distro:
@@ -208,7 +208,7 @@ jobs:
   clang-static-analyzer:
     name: 🔬 Clang Static Analyzer
     needs: [ build-docker-image, determine-scan-type ]
-    if: ${{ inputs.enable-static-analysis == true && needs.determine-scan-type.outputs.do-scan == 'true' }}
+    if: ${{ (inputs.enable-static-analysis == true || github.event_name == 'schedule') && needs.determine-scan-type.outputs.do-scan == 'true' }}
     runs-on: tt-ubuntu-2204-xlarge-stable
     container:
       image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
@@ -232,7 +232,7 @@ jobs:
         run: cmake --preset clang-static-analyzer
 
       - name: 🛠️ Generate files
-        run: cmake --build .build/clang-static-analyzer --target all_generated_files --config RelWithDebInfo
+        run: cmake --build .build/clang-static-analyzer --target all_generated_files
 
       - name: Setup clang symlinks for CodeChecker
         run: |

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -231,7 +231,7 @@ jobs:
         run: cmake --preset clang-static-analyzer
 
       - name: 🔬 Analyze with CodeChecker
-        uses: whisperity/codechecker-analysis-action@v1
+        uses: whisperity/codechecker-analysis-action@v1.0.4
         id: codechecker
         with:
           logfile: /work/.build/clang-static-analyzer/compile_commands.json

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: "amd64"
+      enable-static-analysis:
+        description: "Enable Clang Static Analyzer (CSA) via CodeChecker"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       distro:
@@ -31,6 +36,11 @@ on:
         required: false
         type: string
         default: "amd64"
+      enable-static-analysis:
+        description: "Enable Clang Static Analyzer (CSA) via CodeChecker"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   determine-scan-type:
@@ -194,3 +204,42 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           ccache -s >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+  clang-static-analyzer:
+    name: 🔬 Clang Static Analyzer
+    needs: [ build-docker-image, determine-scan-type ]
+    if: ${{ inputs.enable-static-analysis == true && needs.determine-scan-type.outputs.do-scan == 'true' }}
+    runs-on: tt-ubuntu-2204-xlarge-stable
+    container:
+      image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+      options: --tmpfs /tmp
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
+
+      - name: 🔧 CMake configure
+        run: cmake --preset clang-static-analyzer
+
+      - name: 🔬 Analyze with CodeChecker
+        uses: whisperity/codechecker-analysis-action@v1
+        id: codechecker
+        with:
+          logfile: /work/.build/clang-static-analyzer/compile_commands.json
+          llvm-version: ignore # Already installed in our Docker container
+
+      - name: Upload CodeChecker reports
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: CodeChecker-Static-Analysis-Reports
+          path: ${{ steps.codechecker.outputs.result-html-dir }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -254,3 +254,29 @@ jobs:
         with:
           name: CodeChecker-Static-Analysis-Reports
           path: ${{ steps.codechecker.outputs.result-html-dir }}
+
+  publish-clangsa-pages:
+    name: 📄 Publish CSA HTML to GitHub Pages
+    needs: [ clang-static-analyzer ]
+    if: ${{ always() && needs.clang-static-analyzer.result != 'skipped' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download CodeChecker reports artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: CodeChecker-Static-Analysis-Reports
+          path: site
+
+      - name: Add .nojekyll
+        run: touch site/.nojekyll
+
+      - name: Publish to blozano-tt/clangsa-results (gh-pages)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.WILDER_PAT }}
+          external_repository: blozano-tt/clangsa-results
+          publish_branch: gh-pages
+          publish_dir: site
+          force_orphan: true
+          commit_message: "Update CSA reports from tt-metal @ ${{ github.sha }}"

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -245,6 +245,7 @@ jobs:
         with:
           logfile: /work/.build/clang-static-analyzer/compile_commands.json
           llvm-version: ignore # Already installed in our Docker container
+          config: /work/.codechecker.json
 
       - name: Upload CodeChecker reports
         uses: actions/upload-artifact@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,17 @@
         }
       },
       {
+        "name": "clang-static-analyzer",
+        "inherits": "default",
+        "description": "Run Clang Static Analyzer",
+        "binaryDir": "${sourceDir}/.build/clang-static-analyzer",
+        "cacheVariables": {
+          "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {"value": "TRUE"},
+          "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"},
+          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"}
+        }
+      },
+      {
         "name": "clang-tidy-fix",
         "inherits": "clang-tidy",
         "description": "Run Clang Tidy and apply fixes",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,8 @@
         "cacheVariables": {
           "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {"value": "TRUE"},
           "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"},
-          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"}
+          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"},
+          "TT_UMD_BUILD_SIMULATION": {"value": "FALSE"}
         }
       },
       {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,8 +34,10 @@
         "name": "clang-static-analyzer",
         "inherits": "default",
         "description": "Run Clang Static Analyzer",
+        "generator": "Ninja",
         "binaryDir": "${sourceDir}/.build/clang-static-analyzer",
         "cacheVariables": {
+          "CMAKE_BUILD_TYPE": {"value": "Debug"},
           "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {"value": "TRUE"},
           "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"},
           "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"},

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <tuple>  // for getter
+#include <tuple>  // for get
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <tuple>  // for get
+#include <tuple>  // for getter
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
### Summary

Integrates the Clang Static Analyzer (CSA) into the `code-analysis.yaml` workflow using [CodeChecker](https://codechecker.readthedocs.io/). CSA performs deep path-sensitive analysis to find bugs like null dereferences, memory leaks, use-after-free, and other security issues that clang-tidy doesn't catch.

### Changes

**New files:**
- `.codechecker.json` - CodeChecker configuration (uses `clangsa` analyzer with skiplist)
- `.codechecker.skiplist` - Excludes external dependencies, build directories, system headers, and generated files from analysis

**Modified files:**
- `CMakePresets.json` - Added `clang-static-analyzer` preset with:
  - `CMAKE_EXPORT_COMPILE_COMMANDS=TRUE` for compilation database
  - `CMAKE_DISABLE_PRECOMPILE_HEADERS=TRUE` (required for accurate analysis)
  - `TT_UMD_BUILD_SIMULATION=FALSE` to exclude simulation code
- `.github/workflows/code-analysis.yaml` - Added `clang-static-analyzer` job

### How to use

The job is **opt-in** via the `enable-static-analysis` input parameter:

```yaml
# From workflow_dispatch or workflow_call
enable-static-analysis: true
```

Results are uploaded as an artifact containing HTML reports.

### What gets scanned

- All Tenstorrent C++ code including `tt_metal/third_party/umd`
- Excludes: CPM dependencies, build artifacts, system headers, generated files (protobuf, flatbuffers)

### Notes

- Uses `whisperity/codechecker-analysis-action@v1.0.4`
- Requires the `_actions` volume mount hack to work inside the container
- Reports upload even if analysis finds issues (`if: always()`)

---

### Checklist

- [x] [ClangStaticAnalyzer](https://github.com/tenstorrent/tt-metal/actions/runs/20742615423/job/59552513000)