### PR TITLE
feat: refactor import_tracy_op_logs

### DIFF
--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -335,8 +335,10 @@ def import_tracy_op_logs(
     for opData in opsData:
         ops[opData["global_call_count"]] = opData
 
-    tracyOpTimesData = []
-    df = pd.read_csv(tracyOpTimesLog, engine="pyarrow")
+    try:
+        df = pd.read_csv(tracyOpTimesLog, engine="pyarrow")
+    except (ImportError, ValueError):
+        df = pd.read_csv(tracyOpTimesLog)
 
     # Filter and update host_time for TT_DNN/TT_METAL ops
     tt_mask = df["name"].str.contains("TT_DNN|TT_METAL", regex=True, na=False)

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -336,27 +336,35 @@ def import_tracy_op_logs(
         ops[opData["global_call_count"]] = opData
 
     tracyOpTimesData = []
-    with open(tracyOpTimesLog, "r") as csvFile:
-        csvReader = csv.DictReader(csvFile)
-        tracyOpTimesData = list(csvReader)
+    df = pd.read_csv(tracyOpTimesLog, engine="pyarrow")
 
-    for op in tracyOpTimesData:
-        if "TT_DNN" in op["name"] or "TT_METAL" in op["name"]:
+    # Filter and update host_time for TT_DNN/TT_METAL ops
+    tt_mask = df["name"].str.contains("TT_DNN|TT_METAL", regex=True, na=False)
+    if tt_mask.any():
+        tt_df = df[tt_mask]
+        for op in tt_df.to_dict(orient="records"):
             opID = int(op["zone_text"].split(":")[-1])
-            assert opID in ops, f"Op time for op {opID} must present"
+            assert opID in ops, f"Op time for op {opID} must present. OpID: {opID}, Name: {op['name']}"
             ops[opID]["host_time"] = op
 
-    for op in tracyOpTimesData:
-        if op["special_parent_text"] and "id:" in op["special_parent_text"]:
-            parentOpID = int(op["special_parent_text"].split(":")[-1])
+    parent_mask = df["special_parent_text"].str.contains("id:", na=False)
+    if parent_mask.any():
+        child_df = df[parent_mask].copy()
+        child_df["parentOpID"] = child_df["special_parent_text"].str.rsplit(":", n=1).str[-1].astype(int)
 
-            if "child_calls" in ops[parentOpID]:
-                if op["name"] in ops[parentOpID]["child_calls"]:
-                    ops[parentOpID]["child_calls"][op["name"]] += int(op["exec_time_ns"])
-                else:
-                    ops[parentOpID]["child_calls"][op["name"]] = int(op["exec_time_ns"])
-            else:
-                ops[parentOpID]["child_calls"] = {op["name"]: int(op["exec_time_ns"])}
+        # Only process children of ops we know about
+        child_df = child_df[child_df["parentOpID"].isin(ops)]
+
+        if not child_df.empty:
+            # Aggregate durations by (parentOpID, name)
+            summary = child_df.groupby(["parentOpID", "name"])["exec_time_ns"].sum()
+            for (pID, name), total_ns in summary.items():
+                opData = ops[pID]
+                if "child_calls" not in opData:
+                    opData["child_calls"] = {}
+                cc = opData["child_calls"]
+                # Use name as key, add up total execution time
+                cc[name] = cc.get(name, 0) + int(total_ns)
 
     return ops, signposts, traceReplays
 


### PR DESCRIPTION
### Ticket
None (yet)

### Problem description
This pull request refactors the `import_tracy_op_logs` function in `tools/tracy/process_ops_logs.py` to improve performance and readability by leveraging pandas for log file processing instead of manual CSV iteration.

### What's changed
* Switched from manual CSV reading with `csv.DictReader` to using pandas `read_csv` with the `pyarrow` engine for more efficient data manipulation.
* Replaced manual filtering and iteration for TT_DNN/TT_METAL ops with a pandas mask and vectorized operations to update `host_time` for relevant ops.
* Improved handling of parent-child operation relationships by using pandas masks and groupby aggregation to efficiently sum execution times and update `child_calls` for parent ops.

Test: `python -m cProfile -o /tmp/profile -m tracy -r --no-op-info-cache --tracy-tools-folder=.build/default/tools/profiler/bin/ -m pytest 'tests/ttnn/unit_tests/operations/matmul/test_matmul.py’`

Before: 
<img width="1299" height="788" alt="image" src="https://github.com/user-attachments/assets/daf8294f-8b3b-4f97-8fb2-96f6320e1251" />

After:
<img width="1264" height="860" alt="image" src="https://github.com/user-attachments/assets/b6be7100-1601-49fa-8140-d891d994a28c" />


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=o2buzzle/feat/optimize-tracy-analyze)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:o2buzzle/feat/optimize-tracy-analyze)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs