### PR TITLE
Skip conv3d qwen test on Blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv3d.py
@@ -8,6 +8,7 @@ import pytest
 import ttnn
 import torch.nn as nn
 from tests.ttnn.utils_for_testing import check_with_pcc
+from models.common.utility_functions import skip_for_blackhole
 
 
 def _out_size(in_size, pad, stride, k):
@@ -220,6 +221,7 @@ def test_conv3d_cache_hash(device, input_shape, out_channels, kernel_size, strid
     assert device.num_program_cache_entries() == 2
 
 
+@skip_for_blackhole("C_in blocking not supported on Blackhole - reduction path produces incorrect results")
 @pytest.mark.parametrize(
     "input_shape, out_channels, kernel_size, stride, padding, padding_mode, blocking",
     [


### PR DESCRIPTION
C_in blocking with multiple blocks triggers a reduction path that
produces incorrect results on Blackhole. Test passes on Wormhole.