### PR TITLE
[skip ci] Remove old ls command from t3k unit tests

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -249,7 +249,6 @@ jobs:
       - name: Run unit regression tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          ls -lart /mnt/MLPerf/tt_dnn-models/tt/Falcon/tiiuae/falcon-40b-instruct/
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           ${{ matrix.test-group.cmd }}


### PR DESCRIPTION
### Problem description
All t3k unit tests are running the command `ls -lart /mnt/MLPerf/tt_dnn-models/tt/Falcon/tiiuae/falcon-40b-instruct/`. This just adds noise to the test logs and I believe is an artifact from containerization efforts ~10months ago.

### What's changed
Remove the command from the workflow to tidy up the logs.

E.g https://github.com/tenstorrent/tt-metal/actions/runs/20750101058/job/59577538415#step:6:1