### PR TITLE
Use default timeout for vLLM nightly tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -361,7 +361,6 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-          slow-dispatch-timeout: 40 # Increased above default to account for vLLM's longer-running dispatch operations and avoid false-positive hang detection when auto-triage is enabled.
 
       - name: Ensure BH Eth links online
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}


### PR DESCRIPTION
### What's changed
Removed the override in `.github/workflows/vllm-nightly-tests-impl.yaml` for the `slow-dispatch-timeout` so it uses the default one that is set inside the `.github/actions/setup-job/action.yml` - currently set to 60 seconds

60sec timeout - https://github.com/tenstorrent/tt-metal/actions/runs/20752617160/job/59586436543#step:5:14

### Checklist
- [ ] vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/20752617160