### PR TITLE
Add trace region override for select models on QB2

### DIFF
--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -125,6 +125,9 @@ def get_supported_trace_region_size(request, mesh_device):
             "T3K": 70000000,
             "TG": 70000000,
         },
+        "DeepSeek-R1-Distill-Llama-70B": {
+            "P150x4": 90000000,
+        },
     }
 
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))


### PR DESCRIPTION
### Ticket
Close https://github.com/tenstorrent/tt-metal/issues/35295

### Problem description
Copied from the issue:
> `2026-01-05 20:48:16.135 | critical |          Always | TT_FATAL: Creating trace buffers of size 52330496B on MeshDevice 0, but only 50000000B is allocated for trace region. (assert.hpp:103)`

This is on QB2 system. I checked this model on WH loudbox and it was running fine there. So, there must be difference in compiled kernel sizes between BH (what QB2 contains) and WH devices, which is not surprising. 

### What's changed
Added override for the models under test if they require a different trace region size than the default value -- `50000000B`. 

### Checklist

We do not have a CI pipeline for QB2 yet. @gsarabandoTT is building on for us [per this comment](https://github.com/tenstorrent/tt-metal/issues/35295#issuecomment-3715007832). Before that, we can still perform local testing:
- Local testing showed all models passing through the scenarios in the issue. Thanks, @aczajkowskiTT for running the local tests!