### PR TITLE
Expose Hyperparams to Standard Namespace AG & RS

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_all_gather_async.py
@@ -229,6 +229,9 @@ def run_all_gather_impl(
                 num_links=num_links,
                 memory_config=mem_config_ag,
                 topology=all_gather_topology,
+                chunks_per_sync=chunks_per_sync,
+                num_workers_per_link=num_workers_per_link,
+                num_buffers_per_channel=num_buffers_per_channel,
                 subdevice_id=worker_sub_device_id,
                 sub_core_grids=sub_core_grids,
             )
@@ -483,15 +486,15 @@ def test_all_gather_async(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "ag_output_shape, dim, layout, ag_input_dtype, enable_trace, num_iters",
+    "ag_output_shape, dim, layout, ag_input_dtype, enable_trace, num_iters, chunks_per_sync, num_workers_per_link, num_buffers_per_channel,",
     [
-        ([1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, 10),  # perf
-        ([1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1),  # check
-        ([1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, 10),  # perf
-        ([1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1),  # check
+        ([1, 1, 3072, 8192], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, 10, None, None, None),  # perf
+        ([1, 1, 352, 5120], 3, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1, 2, 2, 8),  # check
+        ([1, 8, 512, 512], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, 10, None, None, None),  # perf
+        ([1, 1, 512, 48], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1, 2, 2, 8),  # check
         # Composite-AG tests
-        ([1, 1, 17, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True, 10),  # perf
-        ([1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1),  # check
+        ([1, 1, 17, 64], 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, True, 10, None, None, None),  # perf
+        ([1, 1, 64, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, 1, None, None, None),  # check
     ],
     ids=[
         "dit_shape-perf",  # this one triggers the default chunks_per_sync
@@ -529,6 +532,9 @@ def test_ttnn_all_gather(
     ag_input_dtype,
     enable_trace,
     num_iters,
+    chunks_per_sync,
+    num_workers_per_link,
+    num_buffers_per_channel,
     mem_config_input,
     mem_config_ag,
     all_gather_topology,
@@ -546,6 +552,9 @@ def test_ttnn_all_gather(
         all_gather_topology=all_gather_topology,
         enable_trace=enable_trace,
         num_iters=num_iters,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
         use_semaphore_free_all_gather_impl=True,
     )
 

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -252,7 +252,7 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "rs_input_shape, dim, layout, rs_input_dtype, use_new, enable_trace, num_iters, use_barrier, use_persistent_buffers",
+    "rs_input_shape, dim, layout, rs_input_dtype, use_new, enable_trace, num_iters, use_barrier, use_persistent_buffers, chunks_per_sync, num_workers_per_link, num_buffers_per_channel,",
     [
         # Dim 0 tests
         (
@@ -265,6 +265,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # perf, barrier_with_persistent
         (
             [8, 2, 128, 128],
@@ -276,6 +279,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # check, barrier_without_persistent
         # Dim 1 tests
         (
@@ -288,6 +294,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # perf, barrier_with_persistent
         (
             [2, 16, 56, 56],
@@ -299,6 +308,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # check, barrier_without_persistent
         (
             [2, 8, 512, 512],
@@ -310,6 +322,9 @@ def run_reduce_scatter_impl(
             10,
             False,
             True,
+            None,
+            None,
+            None,
         ),  # perf, no_barrier_with_persistent
         # Dim 2 tests
         (
@@ -322,6 +337,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # check, barrier_with_persistent
         (
             [4, 1, 1024, 340],
@@ -333,6 +351,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # perf, barrier_without_persistent
         (
             [1, 1, 512, 512],
@@ -344,6 +365,9 @@ def run_reduce_scatter_impl(
             1,
             False,
             True,
+            None,
+            None,
+            None,
         ),  # check, no_barrier_with_persistent
         # Dim 3 tests
         (
@@ -356,6 +380,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # perf, barrier_with_persistent
         (
             [1, 1, 13, 512],
@@ -367,6 +394,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # check, barrier_without_persistent
         (
             [3, 1, 41, 512],
@@ -378,6 +408,9 @@ def run_reduce_scatter_impl(
             10,
             False,
             True,
+            None,
+            None,
+            None,
         ),  # perf, no_barrier_with_persistent
         (
             [8, 1, 512, 2560],
@@ -389,6 +422,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # check, barrier_with_persistent
         (
             [4, 1, 1024, 2560],
@@ -400,6 +436,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # perf, barrier_without_persistent
         (
             [1, 1, 1024, 2560],
@@ -411,6 +450,9 @@ def run_reduce_scatter_impl(
             1,
             False,
             True,
+            None,
+            None,
+            None,
         ),  # check, no_barrier_with_persistent
         (
             [1, 1, 352, 2560],
@@ -422,6 +464,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # perf, barrier_with_persistent
         (
             [2, 1, 2048, 2560],
@@ -433,7 +478,10 @@ def run_reduce_scatter_impl(
             1,
             True,
             False,
-        ),  # check, barrier_without_persistent
+            2,
+            2,
+            8,
+        ),  # check, barrier_without_persistent_with_hyperparams
         (
             [1, 1, 4096, 2560],
             3,
@@ -444,7 +492,10 @@ def run_reduce_scatter_impl(
             10,
             False,
             True,
-        ),  # perf, no_barrier_with_persistent
+            2,
+            2,
+            8,
+        ),  # perf, no_barrier_with_persistent_with_hyperparams
         # Composite-RS tests
         (
             [1, 1, 1, 8],
@@ -456,6 +507,9 @@ def run_reduce_scatter_impl(
             1,
             True,
             True,
+            None,
+            None,
+            None,
         ),  # check, barrier_with_persistent
         (
             [2, 32, 2048, 64],
@@ -467,6 +521,9 @@ def run_reduce_scatter_impl(
             10,
             True,
             False,
+            None,
+            None,
+            None,
         ),  # perf, barrier_without_persistent
         (
             [1, 1, 1, 16],
@@ -478,7 +535,10 @@ def run_reduce_scatter_impl(
             1,
             False,
             True,
-        ),  # check, no_barrier_with_persistent
+            2,
+            2,
+            8,
+        ),  # check, no_barrier_with_persistent_with_hyperparams
         (
             [1, 1, 29, 32],
             3,
@@ -489,7 +549,10 @@ def run_reduce_scatter_impl(
             10,
             True,
             True,
-        ),  # perf, barrier_with_persistent
+            2,
+            2,
+            8,
+        ),  # perf, barrier_with_persistent_with_hyperparams
     ],
     ids=[
         "scatter_dim_0_test_one-perf-barrier_with_persistent",
@@ -507,12 +570,12 @@ def run_reduce_scatter_impl(
         "batch_4-perf-barrier_without_persistent",
         "batch_1_sd35_spatial-check-no_barrier_with_persistent",
         "batch_1_sd35_prompt-perf-barrier_with_persistent",
-        "batch_2-check-barrier_without_persistent",
-        "batch_1-perf-no_barrier_with_persistent",
+        "batch_2-check-barrier_without_persistent_with_hyperparams",
+        "batch_1-perf-no_barrier_with_persistent_with_hyperparams",
         "composite_rs_test_one-check-barrier_with_persistent",
         "composite_rs_test_two-perf-barrier_without_persistent",
-        "composite_rs_test_three-check-no_barrier_with_persistent",
-        "composite_rs_test_four-perf-barrier_with_persistent",
+        "composite_rs_test_three-check-no_barrier_with_persistent_with_hyperparams",
+        "composite_rs_test_four-perf-barrier_with_persistent_with_hyperparams",
     ],
 )
 @pytest.mark.parametrize(
@@ -552,6 +615,9 @@ def test_reduce_scatter_async(
     num_iters,
     use_barrier,
     use_persistent_buffers,
+    chunks_per_sync,
+    num_workers_per_link,
+    num_buffers_per_channel,
     mem_config_input,
     mem_config_rs,
     ones_tensor,
@@ -573,6 +639,9 @@ def test_reduce_scatter_async(
         ones_tensor=ones_tensor,
         use_barrier=use_barrier,
         use_persistent_buffers=use_persistent_buffers,
+        chunks_per_sync=chunks_per_sync,
+        num_workers_per_link=num_workers_per_link,
+        num_buffers_per_channel=num_buffers_per_channel,
         use_new=use_new,
     )
 

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -769,7 +769,7 @@ def test_reduce_scatter_async_training_shapes(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.BufferType.DRAM,
-            True,
+            False,
             True,
             10,  # perf
         ),
@@ -786,7 +786,7 @@ def test_reduce_scatter_async_training_shapes(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.DRAM,
-            False,
+            True,
             False,
             1,  # check
         ),
@@ -821,7 +821,7 @@ def test_reduce_scatter_async_training_shapes(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            False,
+            True,
             False,
             1,  # check
         ),
@@ -938,7 +938,7 @@ def test_reduce_scatter_async_sharded_to_sharded(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.DRAM,
-            False,
+            True,
             True,
             10,  # perf
         ),
@@ -953,7 +953,7 @@ def test_reduce_scatter_async_sharded_to_sharded(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            True,
+            False,
             False,
             1,  # check
         ),

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -161,9 +161,13 @@ def run_reduce_scatter_impl(
                 dim=dim,
                 num_links=num_links,
                 memory_config=mem_config_rs,
+                intermediate_memory_config=mem_config_intermediate,
                 topology=rs_topology,
                 subdevice_id=worker_sub_device_id,
                 cluster_axis=cluster_axis,
+                chunks_per_sync=chunks_per_sync,
+                num_workers_per_link=num_workers_per_link,
+                num_buffers_per_channel=num_buffers_per_channel,
             )
         else:
             logger.info(f"Using experimental reduce scatter")

--- a/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_multi_tensor_ccl.cpp
@@ -153,6 +153,7 @@ TEST_F(MeshDevice1x4Fixture, ReduceScatter) {
         std::nullopt,
         std::nullopt,
         std::nullopt,
+        std::nullopt,
         aggregated_output_tensor);
     // Quiesce parent mesh after reduce scatter
     mesh_device_->quiesce_devices();

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -26,6 +26,9 @@ ttnn::Tensor ExecuteAllGather::invoke(
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     std::optional<uint32_t> num_links,
     std::optional<tt::tt_fabric::Topology> topology,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     // If cluster_axis is None, but mesh shape is not 1xM or Mx1, then we call all-gather on cluster_axis=1, then
     // all-gather on cluster_axis=0
@@ -48,6 +51,9 @@ ttnn::Tensor ExecuteAllGather::invoke(
                     optional_output_tensor,
                     num_links,
                     topology,
+                    chunks_per_sync,
+                    num_workers_per_link,
+                    num_buffers_per_channel,
                     sub_core_grid);
             }
             return tensor;
@@ -74,6 +80,9 @@ ttnn::Tensor ExecuteAllGather::invoke(
         optional_output_tensor,
         num_links_,
         topology_,
+        chunks_per_sync,
+        num_workers_per_link,
+        num_buffers_per_channel,
         sub_core_grid);
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
@@ -21,6 +21,9 @@ struct ExecuteAllGather {
         const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
         std::optional<uint32_t> num_links = std::nullopt,
         std::optional<tt::tt_fabric::Topology> topology = std::nullopt,
+        std::optional<uint32_t> chunks_per_sync = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
         const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_nanobind.cpp
@@ -68,6 +68,9 @@ void bind_all_gather(nb::module_& mod) {
                std::optional<ttnn::Tensor>& optional_output_tensor,
                const std::optional<uint32_t> num_links,
                const std::optional<tt::tt_fabric::Topology> topology,
+               const std::optional<uint32_t> chunks_per_sync,
+               const std::optional<uint32_t> num_workers_per_link,
+               const std::optional<uint32_t> num_buffers_per_channel,
                const std::optional<CoreRangeSet>& sub_core_grids) {
                 return self(
                     input_tensor,
@@ -78,6 +81,9 @@ void bind_all_gather(nb::module_& mod) {
                     optional_output_tensor,
                     num_links,
                     topology,
+                    chunks_per_sync,
+                    num_workers_per_link,
+                    num_buffers_per_channel,
                     sub_core_grids);
             },
             nb::arg("input_tensor").noconvert(),
@@ -89,6 +95,9 @@ void bind_all_gather(nb::module_& mod) {
             nb::arg("output_tensor") = nb::none(),
             nb::arg("num_links") = nb::none(),
             nb::arg("topology") = nb::none(),
+            nb::arg("chunks_per_sync") = nb::none(),
+            nb::arg("num_workers_per_link") = nb::none(),
+            nb::arg("num_buffers_per_channel") = nb::none(),
             nb::arg("sub_core_grids") = nb::none()});
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_nanobind.cpp
@@ -33,6 +33,9 @@ void bind_all_gather(nb::module_& mod) {
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
             num_links (int, optional): The number of links to use for the all-gather operation. Defaults to `None`, for which the number of links is determined automatically.
             topology (ttnn.Topology, optional): Fabric topology. Defaults to `None`.
+            chunks_per_sync (int, optional): Hyperparameter.
+            num_workers_per_link (int, optional): Hyperparameter.
+            num_buffers_per_channel (int, optional): Hyperparameter.
             sub_core_grids (CoreRangeSet, optional): Specifies sub-core grid ranges for advanced core selection control. Default uses all the cores in the device.
 
         Returns:

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -161,6 +161,9 @@ ttsl::hash::hash_t AllGatherDeviceOperation::compute_program_hash(
         operation_attributes.memory_config,
         subdevice_core_range_set,
         operation_attributes.topology,
+        operation_attributes.chunks_per_sync,
+        operation_attributes.num_workers_per_link,
+        operation_attributes.num_buffers_per_channel,
         input_tensor);
 }
 
@@ -176,6 +179,9 @@ ttnn::Tensor all_gather(
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel,
     const std::optional<CoreRangeSet>& sub_core_grid) {
     using OperationType = ttnn::operations::ccl::AllGatherDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
@@ -186,6 +192,9 @@ ttnn::Tensor all_gather(
             .subdevice_id = subdevice_id,
             .topology = topology,
             .num_links = num_links,
+            .chunks_per_sync = chunks_per_sync,
+            .num_workers_per_link = num_workers_per_link,
+            .num_buffers_per_channel = num_buffers_per_channel,
             .sub_core_grid = sub_core_grid},
         OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor});
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
@@ -30,6 +30,9 @@ struct AllGatherDeviceOperation {
         const std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
         const tt::tt_fabric::Topology topology;
         const uint32_t num_links;
+        const std::optional<uint32_t> chunks_per_sync;
+        const std::optional<uint32_t> num_workers_per_link;
+        const std::optional<uint32_t> num_buffers_per_channel;
         const std::optional<CoreRangeSet> sub_core_grid;
     };
 
@@ -97,5 +100,8 @@ ttnn::Tensor all_gather(
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     uint32_t num_links,
     tt::tt_fabric::Topology topology,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel,
     const std::optional<CoreRangeSet>& sub_core_grid);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_program_factory.cpp
@@ -122,12 +122,12 @@ AllGatherDeviceOperation::AllGatherProgram::create_at(
         barrier_semaphore,
         false,  // using_persistent_buffers - false since we always barrier in this version
         operation_attributes.subdevice_id,
-        no_fuse,       // never fusing with this
-        std::nullopt,  // use chunks per sync decision making tree
-        std::nullopt,  // use num workers per link decision making tree
-        std::nullopt,  // use num buffers per channel decision making tree
-        first_coord,   // first core in the subdevice is our offset as we don't use this version for fusions
-        false,         // reverse_order = false
+        no_fuse,  // never fusing with this
+        operation_attributes.chunks_per_sync,
+        operation_attributes.num_workers_per_link,
+        operation_attributes.num_buffers_per_channel,
+        first_coord,  // first core in the subdevice is our offset as we don't use this version for fusions
+        false,        // reverse_order = false
         operation_attributes.sub_core_grid);
 
     return {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
@@ -50,27 +50,42 @@ ReduceScatterDeviceOperation::spec_return_value_t ReduceScatterDeviceOperation::
     const auto& input_tensor = tensor_args.input_tensor;
     auto inter_shape = input_tensor.tensor_spec().logical_shape();
 
-    if (operation_attributes.topology == ::ttnn::ccl::Topology::Linear) {
+    // For now default to tt::tt_metal::BufferType::DRAM to prevent CB overflows.
+    // TODO: add L1 estimation similar to the one in all_to_all_dispatch and choose to use L1 as an intermediate buffer
+    // if enough space is available #30043. L1 estimation has to be done outside the program cache
+    MemoryConfig adjusted_intermediate_mem_config,
+        intermediate_mem_config = operation_attributes.optional_intermediate_mem_config.value_or(
+            MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM));
+
+    if (operation_attributes.topology == ttnn::ccl::Topology::Linear) {
         inter_shape[0] *= 2;
+
+        // Adjust memory config for sharded tensors
+        if (intermediate_mem_config.is_sharded() &&
+            !operation_attributes.optional_intermediate_mem_config.has_value()) {
+            auto intermediate_shard_spec = intermediate_mem_config.shard_spec().value();
+            intermediate_shard_spec.shape[0] *= 2;
+            adjusted_intermediate_mem_config = intermediate_mem_config.with_shard_spec(intermediate_shard_spec);
+        } else {
+            adjusted_intermediate_mem_config = intermediate_mem_config;
+        }
+    } else {
+        adjusted_intermediate_mem_config = intermediate_mem_config;
     }
 
     auto output_shape = input_tensor.logical_shape();
     uint32_t target_ring_size = ::ttnn::ccl::get_topological_dimension(input_tensor, operation_attributes.cluster_axis);
     output_shape[operation_attributes.dim] /= target_ring_size;
-    // For now default to tt::tt_metal::BufferType::DRAM to prevent CB overflows.
-    // TODO: add L1 estimation similar to the one in all_to_all_dispatch and choose to use L1 as an intermediate buffer
-    // if enough space is available #30043. L1 estimation has to be done outside the program cache
-    auto mem_config = operation_attributes.memory_config;
-    auto intermediate_mem_config =
-        MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM);
+
     return {
         TensorSpec(
             inter_shape,
             tt::tt_metal::TensorLayout(
-                input_tensor.dtype(), input_tensor.tensor_spec().page_config(), intermediate_mem_config)),
+                input_tensor.dtype(), input_tensor.tensor_spec().page_config(), adjusted_intermediate_mem_config)),
         TensorSpec(
             output_shape,
-            tt::tt_metal::TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), mem_config)),
+            tt::tt_metal::TensorLayout(
+                input_tensor.dtype(), input_tensor.tensor_spec().page_config(), operation_attributes.memory_config)),
     };
 }
 
@@ -95,8 +110,12 @@ ttsl::hash::hash_t ReduceScatterDeviceOperation::compute_program_hash(
         operation_attributes.num_links,
         operation_attributes.cluster_axis,
         operation_attributes.memory_config,
+        operation_attributes.optional_intermediate_mem_config,
         subdevice_core_range_set,
         operation_attributes.topology,
+        operation_attributes.chunks_per_sync,
+        operation_attributes.num_workers_per_link,
+        operation_attributes.num_buffers_per_channel,
         input_tensor);
 }
 
@@ -109,9 +128,13 @@ ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduc
     std::optional<uint32_t> cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::MemoryConfig>& optional_intermediate_mem_config,
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     uint32_t num_links,
-    tt::tt_fabric::Topology topology) {
+    tt::tt_fabric::Topology topology,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     using OperationType = ttnn::operations::ccl::ReduceScatterDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
@@ -139,11 +139,15 @@ ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduc
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .memory_config = memory_config,
+            .optional_intermediate_mem_config = optional_intermediate_mem_config,
             .dim = dim,
             .cluster_axis = cluster_axis,
             .subdevice_id = subdevice_id,
             .topology = topology,
-            .num_links = num_links},
+            .num_links = num_links,
+            .chunks_per_sync = chunks_per_sync,
+            .num_workers_per_link = num_workers_per_link,
+            .num_buffers_per_channel = num_buffers_per_channel},
         OperationType::tensor_args_t{.input_tensor = input_tensor, .optional_output_tensor = optional_output_tensor});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
@@ -26,11 +26,15 @@ using ReduceScatterProgramArtifacts =
 struct ReduceScatterDeviceOperation {
     struct operation_attributes_t {
         const MemoryConfig memory_config;
+        const std::optional<MemoryConfig> optional_intermediate_mem_config;
         uint32_t dim;
         const std::optional<uint32_t> cluster_axis;
         const std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
         const tt::tt_fabric::Topology topology;
         const uint32_t num_links;
+        const std::optional<uint32_t> chunks_per_sync;
+        const std::optional<uint32_t> num_workers_per_link;
+        const std::optional<uint32_t> num_buffers_per_channel;
     };
 
     struct tensor_args_t {
@@ -91,7 +95,11 @@ ttnn::operations::ccl::ReduceScatterDeviceOperation::tensor_return_value_t reduc
     std::optional<uint32_t> cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
     const ttnn::MemoryConfig& memory_config,
+    const std::optional<ttnn::MemoryConfig>& optional_intermediate_mem_config,
     const std::optional<ttnn::Tensor>& optional_output_tensor,
     uint32_t num_links,
-    tt::tt_fabric::Topology topology);
+    tt::tt_fabric::Topology topology,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_program_factory.cpp
@@ -131,10 +131,10 @@ ReduceScatterDeviceOperation::ReduceScatterProgram::create_at(
         barrier_semaphore,
         false,  // since we don't have a persistent intermediate buffer option, this must be false
         operation_attributes.subdevice_id,
-        no_fuse,       // never fusing with this
-        std::nullopt,  // use chunks per sync decision making tree
-        std::nullopt,  // use num workers per link decision making tree
-        std::nullopt,  // use num buffers per channel decision making tree
+        no_fuse,  // never fusing with this
+        operation_attributes.chunks_per_sync,
+        operation_attributes.num_workers_per_link,
+        operation_attributes.num_buffers_per_channel,
         first_coord);  // first core in the subdevice is our offset as we don't use this version for fusions
 
     shared_variables_t shared_vars{

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp
@@ -18,9 +18,13 @@ struct ExecuteReduceScatter {
         std::optional<uint32_t> cluster_axis = std::nullopt,
         const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<ttnn::MemoryConfig>& intermediate_memory_config = std::nullopt,
         const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
         std::optional<uint32_t> num_links = std::nullopt,
-        std::optional<tt::tt_fabric::Topology> topology = std::nullopt);
+        std::optional<tt::tt_fabric::Topology> topology = std::nullopt,
+        std::optional<uint32_t> chunks_per_sync = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
 };
 
 }  // namespace operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_nanobind.cpp
@@ -57,18 +57,26 @@ void bind_reduce_scatter(nb::module_& mod) {
                const std::optional<uint32_t> cluster_axis,
                const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
                const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::MemoryConfig>& intermediate_memory_config,
                std::optional<ttnn::Tensor>& optional_output_tensor,
                const std::optional<uint32_t> num_links,
-               const std::optional<tt::tt_fabric::Topology> topology) {
+               const std::optional<tt::tt_fabric::Topology> topology,
+               const std::optional<uint32_t> chunks_per_sync,
+               const std::optional<uint32_t> num_workers_per_link,
+               const std::optional<uint32_t> num_buffers_per_channel) {
                 return self(
                     input_tensor,
                     dim,
                     cluster_axis,
                     subdevice_id,
                     memory_config,
+                    intermediate_memory_config,
                     optional_output_tensor,
                     num_links,
-                    topology);
+                    topology,
+                    chunks_per_sync,
+                    num_workers_per_link,
+                    num_buffers_per_channel);
             },
             nb::arg("input_tensor").noconvert(),
             nb::arg("dim"),
@@ -76,9 +84,13 @@ void bind_reduce_scatter(nb::module_& mod) {
             nb::arg("cluster_axis") = nb::none(),
             nb::arg("subdevice_id") = nb::none(),
             nb::arg("memory_config") = nb::none(),
+            nb::arg("intermediate_memory_config") = nb::none(),
             nb::arg("output_tensor") = nb::none(),
             nb::arg("num_links") = nb::none(),
             nb::arg("topology").noconvert() = nb::none(),
+            nb::arg("chunks_per_sync") = nb::none(),
+            nb::arg("num_workers_per_link") = nb::none(),
+            nb::arg("num_buffers_per_channel") = nb::none(),
         });
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_nanobind.cpp
@@ -30,9 +30,13 @@ void bind_reduce_scatter(nb::module_& mod) {
             cluster_axis (int, optional): The cluster axis to reduce across. Defaults to `None`.
             subdevice_id (ttnn.SubDeviceId, optional): Subdevice id for worker cores.
             memory_config (ttnn.MemoryConfig, optional): Output memory configuration.
+            intermediate_memory_config (ttnn.MemoryConfig, optional): Memory configuration for intermediate buffer used within the operation.
             output_tensor (ttnn.Tensor, optional): Preallocated output tensor.
             num_links (int, optional): The number of links to use for the reduce-scatter operation. Defaults to `None`, for which the number of links is determined automatically.
             topology (ttnn.Topology, optional): Fabric topology. Defaults to `None`.
+            chunks_per_sync (int, optional): Hyperparameter.
+            num_workers_per_link (int, optional): Hyperparameter.
+            num_buffers_per_channel (int, optional): Hyperparameter.
 
         Returns:
             ttnn.Tensor: The reduced and scattered tensor, with output_shape = input_shape for all the unspecified dimensions, and output_shape[dim] = input_shape[dim] / num_devices, where num_devices is the number of devices along the `cluster_axis` if specified, else the total number of devices along the mesh.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -341,8 +341,12 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
             worker_subdevice_id_opt,
             out_memory_config,
             std::nullopt,
+            std::nullopt,
             num_preferred_links,
-            topology_);
+            topology_,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt);
     }
     interleaved_tensor.deallocate();
     ttnn::Tensor gathered;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.cpp
@@ -66,7 +66,10 @@ ttnn::Tensor composite_reduce_scatter(
     tt::tt_fabric::Topology topology,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-    std::optional<uint32_t> cluster_axis) {
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     bool is_row_major = input_tensor.layout() == ttnn::Layout::ROW_MAJOR;
 
     uint32_t num_devices = ::ttnn::ccl::get_topological_dimension(input_tensor, cluster_axis);
@@ -137,9 +140,13 @@ ttnn::Tensor composite_reduce_scatter(
                                                       cluster_axis,
                                                       subdevice_id,
                                                       native_rs_output_memory_config,
+                                                      std::nullopt,  // optional intermediate memory config
                                                       std::nullopt,  // optional output tensor
                                                       num_links,
-                                                      topology_)
+                                                      topology_,
+                                                      chunks_per_sync,
+                                                      num_workers_per_link,
+                                                      num_buffers_per_channel)
                                                       .at(1);  // first is the intermediate tensor
     // remove the padding we previously inserted
     ttnn::Tensor rs_output_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/composite_common.hpp
@@ -42,7 +42,10 @@ ttnn::Tensor composite_reduce_scatter(
     tt::tt_fabric::Topology topology,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-    std::optional<uint32_t> cluster_axis);
+    std::optional<uint32_t> cluster_axis,
+    std::optional<uint32_t> chunks_per_sync,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel);
 
 ttnn::Tensor composite_all_gather(
     ttnn::Tensor input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/reduce_scatter_minimal_async.cpp
@@ -45,7 +45,16 @@ ttnn::Tensor ExecuteReduceScatterMinimalAsync::invoke(
     if (composite_common::use_composite_reduce_scatter(input_tensor, dim, cluster_axis)) {
         log_debug(tt::LogOp, "reduce_scatter_minimal_async: using composite_reduce_scatter");
         return composite_common::composite_reduce_scatter(
-            input_tensor, dim, num_links, usable_topology, memory_config, sub_device_id, cluster_axis);
+            input_tensor,
+            dim,
+            num_links,
+            usable_topology,
+            memory_config,
+            sub_device_id,
+            cluster_axis,
+            chunks_per_sync,
+            num_workers_per_link,
+            num_buffers_per_channel);
     }
 
     bool using_persistent_buffers = persistent_output_buffers.has_value();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/33591)

### Problem description
The AG and RS backends utilize hyperparams, that are auto calculated when values are not specified by the user. The experimental namespace implementations expose these hyperparams to the user allowing custom values, however they are not exposed in the standard namespace implementations.

### What's changed
Expose the hyperparams for the standard namespace implementations and update tests appropriately.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
  - [x] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
  - [x] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [x] T3K Nightly https://github.com/tenstorrent/tt-metal/actions/runs/20793737504

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/ag-rs-expose-hyper-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/ag-rs-expose-hyper-params)
  - [x] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs