### PR TITLE
Enable MeshWorkload in ttnn.generic op

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -580,6 +580,7 @@ run_t3000_ccl_tests() {
   # p2p: 1 test should be enough
   # trace test with device delay
   pytest -n auto tests/nightly/t3000/ccl/test_point_to_point.py::test_point_to_point_with_device_delay -k tile
+  pytest -n auto tests/ttnn/unit_tests/operations/debug/test_generic_op.py::test_point_to_point
 
   # all broadcast: row major + tile test
   # both rm and tile test are called here

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1016,333 +1016,6 @@ TEST_F(TTNNFixtureWithDevice, TestGenericOpSemaphoreDescriptorSameIdNonOverlappi
     EXPECT_NO_THROW({ tt::tt_metal::Program program(program_descriptor); });
 }
 
-TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
-    log_info(tt::LogTest, "Running {}: sending data from device (0,0) to device (0,1)", __func__);
-    auto mesh_device = get_mesh_device();
-    auto mesh_shape = mesh_device->shape();
-    const size_t num_devices = mesh_shape[0] * mesh_shape[1];  // 2x4 = 8
-
-    auto sender_coord = tt::tt_metal::distributed::MeshCoordinate(0, 0);
-    auto receiver_coord = tt::tt_metal::distributed::MeshCoordinate(0, 1);
-
-    auto full_shape = ttnn::Shape({1, static_cast<uint32_t>(num_devices), 32, 64});
-    auto dtype = tt::tt_metal::DataType::BFLOAT16;
-    auto layout = tt::tt_metal::Layout::TILE;
-    auto memory_config =
-        tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM);
-
-    Tensor input_full = ttnn::random::random(full_shape, dtype).to_layout(layout);
-    auto mapper = ttnn::distributed::shard_tensor_to_mesh_mapper(*mesh_device, 1);
-    Tensor input_sharded = ttnn::distributed::distribute_tensor(input_full, *mapper);
-    Tensor input_tensor = input_sharded.to_device(mesh_device.get(), memory_config);
-    tt::tt_metal::distributed::Synchronize(mesh_device.get(), std::nullopt, {});
-
-    // Get sender's data for verification - this is device 0's unique shard
-    auto input_shards = ttnn::distributed::get_device_tensors(input_tensor);
-    auto sender_data = input_shards[0].cpu();
-    auto original_receiver_data = input_shards[1].cpu();
-
-    // Create output tensor (same spec as input, allocated on mesh)
-    Tensor output_tensor = tt::tt_metal::allocate_tensor_on_device(input_tensor.tensor_spec(), mesh_device.get());
-
-    const uint32_t input_num_pages = ttnn::operations::data_movement::get_num_pages(input_tensor);
-    const uint32_t input_page_size_bytes = input_tensor.tensor_spec().compute_page_size_bytes();
-    const uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
-    const uint32_t aligned_input_page_size_bytes = tt::round_up(input_page_size_bytes, l1_alignment);
-
-    // Figure out packets - single packet
-    const uint32_t fabric_max_packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    const uint32_t max_packet_size_bytes = std::bit_floor(fabric_max_packet_size_bytes);
-    const uint32_t num_pages_per_packet =
-        std::min(max_packet_size_bytes / aligned_input_page_size_bytes, input_num_pages);
-    const uint32_t packet_size_bytes = aligned_input_page_size_bytes * num_pages_per_packet;
-    const uint32_t num_page_segments = 1;  // pages fit in single packet
-
-    // Create intermediate tensor using the same logic as point_to_point operation
-    TensorSpec intermediate_spec = ttnn::operations::point_to_point::p2p_compute_intermediate_tensor_spec(
-        input_tensor, receiver_coord, sender_coord, ttnn::ccl::Topology::Linear);
-    Tensor intermediate_tensor = tt::tt_metal::allocate_tensor_on_device(intermediate_spec, mesh_device.get());
-
-    // Use single core for simplicity
-    CoreCoord sender_core = {0, 0};
-    CoreCoord receiver_core = {0, 0};
-    CoreRangeSet sender_core_set(std::set<CoreRange>{CoreRange(sender_core)});
-    CoreRangeSet receiver_core_set(std::set<CoreRange>{CoreRange(receiver_core)});
-
-    tt::DataFormat input_dataformat = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
-
-    auto sd_id = mesh_device->get_sub_device_ids().at(0);
-    auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    auto semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device.get(), available_cores, 0);
-    tt::tt_metal::distributed::Synchronize(mesh_device.get(), std::nullopt, {});
-
-    // Determine routing direction and next fabric node ID (same logic as point_to_point operations)
-    const auto sender_fabric_id = mesh_device->get_fabric_node_id(sender_coord);
-    const auto receiver_fabric_id = mesh_device->get_fabric_node_id(receiver_coord);
-    const auto [num_hops_sender, dst_is_forward, next_fabric_id_sender] =
-        ttnn::operations::point_to_point::detail::fabric_1d_routing(
-            mesh_device.get(), sender_coord, receiver_coord, ttnn::ccl::Topology::Linear);
-    const auto [num_hops_receiver, sender_is_forward, next_fabric_id_receiver] =
-        ttnn::operations::point_to_point::detail::fabric_1d_routing(
-            mesh_device.get(), receiver_coord, sender_coord, ttnn::ccl::Topology::Linear);
-
-    constexpr uint32_t link_idx = 0;  // for single link implementation
-
-    // =========================================================================
-    // Build MeshProgramDescriptor
-    // =========================================================================
-    tt::tt_metal::experimental::MeshProgramDescriptor mesh_program_descriptor;
-
-    // ----- SENDER PROGRAM -----
-    {
-        constexpr auto sender_cb_id = tt::CBIndex::c_0;
-        constexpr auto packet_header_cb_id = tt::CBIndex::c_1;
-        constexpr auto packet_cb_id = tt::CBIndex::c_2;
-        constexpr auto cb_num_pages = 2;
-
-        CBFormatDescriptor sender_cb_format = {
-            .buffer_index = sender_cb_id,
-            .data_format = input_dataformat,
-            .page_size = aligned_input_page_size_bytes,
-        };
-        CBDescriptor sender_cb_desc = {
-            .total_size = cb_num_pages * aligned_input_page_size_bytes,
-            .core_ranges = sender_core_set,
-            .format_descriptors = {sender_cb_format},
-        };
-
-        CBFormatDescriptor packet_header_cb_format = {
-            .buffer_index = packet_header_cb_id,
-            .data_format = tt::DataFormat::RawUInt32,
-            .page_size = packet_header_size_bytes,
-        };
-        CBDescriptor packet_header_cb_desc = {
-            .total_size = 2 * 2 * packet_header_size_bytes,  // 2 headers * 2 buffering
-            .core_ranges = sender_core_set,
-            .format_descriptors = {packet_header_cb_format},
-        };
-
-        CBFormatDescriptor packet_cb_format = {
-            .buffer_index = packet_cb_id,
-            .data_format = input_dataformat,
-            .page_size = packet_size_bytes,
-        };
-        CBDescriptor packet_cb_desc = {
-            .total_size = packet_size_bytes,
-            .core_ranges = sender_core_set,
-            .format_descriptors = {packet_cb_format},
-        };
-
-        std::vector<uint32_t> reader_ct_args;
-        tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_ct_args);
-
-        std::vector<uint32_t> reader_rt_args = {
-            input_tensor.buffer()->address(),
-            input_num_pages,
-            0,  // page_idx_start
-            input_page_size_bytes,
-        };
-
-        std::vector<uint32_t> writer_ct_args = {
-            sender_cb_id,
-            packet_header_cb_id,
-            packet_cb_id,
-            l1_alignment,
-        };
-        tt::tt_metal::TensorAccessorArgs(*intermediate_tensor.buffer()).append_to(writer_ct_args);
-
-        std::vector<uint32_t> writer_rt_args = {
-            intermediate_tensor.buffer()->address(),
-            0,                // page_idx_start
-            input_num_pages,  // page_idx_end
-            num_hops_sender,
-            input_page_size_bytes,
-            packet_size_bytes,
-            num_pages_per_packet,
-            num_page_segments,
-            semaphore.address(),
-            (uint32_t)dst_is_forward,
-        };
-
-        KernelDescriptor reader_kernel = {
-            .kernel_source =
-                "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/"
-                "reader_unary_interleaved_start_id_gen.cpp",
-            .core_ranges = sender_core_set,
-            .compile_time_args = reader_ct_args,
-            .runtime_args = {{sender_core, reader_rt_args}},
-            .config = tt::tt_metal::ReaderConfigDescriptor{},
-        };
-
-        KernelDescriptor writer_kernel = {
-            .kernel_source = "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp",
-            .core_ranges = sender_core_set,
-            .compile_time_args = writer_ct_args,
-            .runtime_args = {{sender_core, writer_rt_args}},
-            .config = tt::tt_metal::WriterConfigDescriptor{},
-        };
-
-        ProgramDescriptor sender_program = {
-            .kernels = {reader_kernel, writer_kernel},
-            .cbs = {sender_cb_desc, packet_header_cb_desc, packet_cb_desc},
-        };
-
-        // Manually append fabric connection args (same pattern as send_program_factory.cpp)
-        // Modify the writer kernel's runtime args in the descriptor
-        auto& writer_kernel_desc = sender_program.kernels[1];                  // writer is index 1
-        auto& writer_rt_args_ref = writer_kernel_desc.runtime_args[0].second;  // first (and only) core's args
-
-        if (dst_is_forward) {
-            tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
-                sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core, writer_rt_args_ref);
-        }
-        writer_rt_args_ref.push_back(!dst_is_forward);
-        if (!dst_is_forward) {
-            tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
-                sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core, writer_rt_args_ref);
-        }
-
-        mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(sender_coord), sender_program);
-    }
-
-    // ----- RECEIVER PROGRAM -----
-    {
-        constexpr auto packet_header_cb_id = tt::CBIndex::c_0;
-        constexpr auto packet_cb_id = tt::CBIndex::c_1;
-        constexpr auto receiver_cb_id = tt::CBIndex::c_2;
-
-        CBFormatDescriptor packet_header_cb_format = {
-            .buffer_index = packet_header_cb_id,
-            .data_format = tt::DataFormat::RawUInt32,
-            .page_size = packet_header_size_bytes,
-        };
-        CBDescriptor packet_header_cb_desc = {
-            .total_size = 2 * 2 * packet_header_size_bytes,
-            .core_ranges = receiver_core_set,
-            .format_descriptors = {packet_header_cb_format},
-        };
-
-        CBFormatDescriptor packet_cb_format = {
-            .buffer_index = packet_cb_id,
-            .data_format = input_dataformat,
-            .page_size = packet_size_bytes,
-        };
-        CBDescriptor packet_cb_desc = {
-            .total_size = packet_size_bytes,
-            .core_ranges = receiver_core_set,
-            .format_descriptors = {packet_cb_format},
-        };
-
-        const uint32_t receiver_cb_num_pages = 3 * num_pages_per_packet;
-        CBFormatDescriptor receiver_cb_format = {
-            .buffer_index = receiver_cb_id,
-            .data_format = input_dataformat,
-            .page_size = input_page_size_bytes,
-        };
-        CBDescriptor receiver_cb_desc = {
-            .total_size = receiver_cb_num_pages * input_page_size_bytes,
-            .core_ranges = receiver_core_set,
-            .format_descriptors = {receiver_cb_format},
-        };
-
-        std::vector<uint32_t> reader_ct_args = {
-            (uint32_t)packet_header_cb_id,
-            (uint32_t)packet_cb_id,
-            (uint32_t)receiver_cb_id,
-            l1_alignment,
-        };
-        tt::tt_metal::TensorAccessorArgs(*intermediate_tensor.buffer()).append_to(reader_ct_args);
-
-        std::vector<uint32_t> reader_rt_args = {
-            0,                // page_idx_start
-            input_num_pages,  // page_idx_end
-            num_pages_per_packet,
-            intermediate_tensor.buffer()->address(),
-            packet_size_bytes,
-            input_page_size_bytes,
-            num_page_segments,
-            semaphore.address(),
-            num_hops_receiver,
-            (uint32_t)sender_is_forward,
-        };
-
-        std::vector<uint32_t> writer_ct_args = {(uint32_t)receiver_cb_id};
-        tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_ct_args);
-
-        std::vector<uint32_t> writer_rt_args = {
-            output_tensor.buffer()->address(),
-            input_num_pages,
-            0,  // page_idx_start
-            input_page_size_bytes,
-        };
-
-        KernelDescriptor reader_kernel = {
-            .kernel_source = "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp",
-            .core_ranges = receiver_core_set,
-            .compile_time_args = reader_ct_args,
-            .runtime_args = {{receiver_core, reader_rt_args}},
-            .config = tt::tt_metal::ReaderConfigDescriptor{},
-        };
-
-        KernelDescriptor writer_kernel = {
-            .kernel_source =
-                "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/"
-                "writer_unary_interleaved_start_id_gen.cpp",
-            .core_ranges = receiver_core_set,
-            .compile_time_args = writer_ct_args,
-            .runtime_args = {{receiver_core, writer_rt_args}},
-            .config = tt::tt_metal::WriterConfigDescriptor{},
-        };
-
-        ProgramDescriptor receiver_program = {
-            .kernels = {reader_kernel, writer_kernel},
-            .cbs = {packet_header_cb_desc, packet_cb_desc, receiver_cb_desc},
-        };
-
-        // Manually append fabric connection args (same pattern as receive_program_factory.cpp)
-        // Modify the reader kernel's runtime args in the descriptor
-        auto& reader_kernel_desc = receiver_program.kernels[0];                // reader is index 0
-        auto& reader_rt_args_ref = reader_kernel_desc.runtime_args[0].second;  // first (and only) core's args
-
-        if (sender_is_forward) {
-            tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
-                receiver_fabric_id,
-                next_fabric_id_receiver,
-                link_idx,
-                receiver_program,
-                receiver_core,
-                reader_rt_args_ref);
-        }
-        reader_rt_args_ref.push_back(!sender_is_forward);
-        if (!sender_is_forward) {
-            tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
-                receiver_fabric_id,
-                next_fabric_id_receiver,
-                link_idx,
-                receiver_program,
-                receiver_core,
-                reader_rt_args_ref);
-        }
-
-        mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(receiver_coord), receiver_program);
-    }
-
-    ttnn::generic_op(std::vector<Tensor>{input_tensor, intermediate_tensor, output_tensor}, mesh_program_descriptor);
-    tt::tt_metal::distributed::Synchronize(mesh_device.get(), std::nullopt, {});
-
-    size_t output_receiver_idx = 1;
-    auto output_data = ttnn::distributed::get_device_tensors(output_tensor);
-    auto output_tensor_cpu = output_data[output_receiver_idx].cpu();
-
-    log_info(tt::LogTest, "Sender data: {}", ttnn::to_string(sender_data));
-    log_info(tt::LogTest, "Output at receiver: {}", ttnn::to_string(output_tensor_cpu));
-
-    EXPECT_EQ(output_tensor_cpu.to_vector<bfloat16>(), sender_data.to_vector<bfloat16>())
-        << "Receiver should have sender's data after transfer";
-}
-
-// Fixture for 1x4 mesh with fabric - matches MeshDevice1x4Fixture from test_multi_tensor_ccl.cpp
 class MeshDevice1x4FabricFixture : public MeshDeviceFixtureBase {
 protected:
     MeshDevice1x4FabricFixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 4}}) {
@@ -1352,34 +1025,15 @@ protected:
         MeshDeviceFixtureBase::TearDown();
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
     }
-
-    std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> get_line_devices() {
-        return {
-            mesh_device_->create_submesh(MeshShape(1, 1), tt::tt_metal::distributed::MeshCoordinate(0, 0)),
-            mesh_device_->create_submesh(MeshShape(1, 1), tt::tt_metal::distributed::MeshCoordinate(0, 1)),
-            mesh_device_->create_submesh(MeshShape(1, 1), tt::tt_metal::distributed::MeshCoordinate(0, 2)),
-            mesh_device_->create_submesh(MeshShape(1, 1), tt::tt_metal::distributed::MeshCoordinate(0, 3)),
-        };
-    }
-
-    std::vector<tt::tt_metal::distributed::MeshCoordinate> get_ring_coords() {
-        return {
-            tt::tt_metal::distributed::MeshCoordinate(0, 0),
-            tt::tt_metal::distributed::MeshCoordinate(0, 1),
-            tt::tt_metal::distributed::MeshCoordinate(0, 2),
-            tt::tt_metal::distributed::MeshCoordinate(0, 3),
-        };
-    }
 };
 
 TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
-    log_info(tt::LogTest, "Running {}: all_gather via generic_op with MUX mode", __func__);
+    // This test replicates AllGatherReturnedTensor test in test_multi_tensor_ccl.cpp but with the generic op.
+    // Hardcoded for 1x4 linear topology with 1 worker per direction and 1 link.
+    log_info(tt::LogTest, "Running {}: all_gather via generic_op with MUX", __func__);
 
-    auto mesh_devices = get_line_devices();
-    auto ring_coords = get_ring_coords();
-    const uint32_t ring_size = static_cast<uint32_t>(ring_coords.size());
+    constexpr uint32_t ring_size = 4;
 
-    // Same tensor spec as AllGatherReturnedTensor test in test_multi_tensor_ccl.cpp
     TensorSpec tensor_spec(
         ttnn::Shape({1, 8, 1024, 768}),
         TensorLayout(tt::tt_metal::DataType::BFLOAT16, PageConfig(tt::tt_metal::Layout::TILE), MemoryConfig{}));
@@ -1387,15 +1041,17 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         ttnn::Shape({ring_size, 8, 1024, 768}),
         TensorLayout(tt::tt_metal::DataType::BFLOAT16, PageConfig(tt::tt_metal::Layout::TILE), MemoryConfig{}));
 
-    // Create per-device tensors with unique data (same pattern as test_multi_tensor_ccl.cpp)
+    // Create per-device tensors with unique data
+    // Note: submeshes must be kept alive until after aggregate() is called
+    std::vector<std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> submeshes;
     std::vector<ttnn::Tensor> input_tensors, output_tensors;
-    for (size_t dev_idx = 0; dev_idx < mesh_devices.size(); dev_idx++) {
+    for (uint32_t dev_idx = 0; dev_idx < ring_size; dev_idx++) {
+        submeshes.push_back(mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, dev_idx)));
         std::vector<bfloat16> data(tensor_spec.logical_shape().volume(), bfloat16(static_cast<float>(dev_idx)));
-        input_tensors.push_back(
-            Tensor::from_vector(std::move(data), tensor_spec).to_device(mesh_devices[dev_idx].get()));
+        input_tensors.push_back(Tensor::from_vector(std::move(data), tensor_spec).to_device(submeshes.back().get()));
         std::vector<bfloat16> out_data(output_tensor_spec.logical_shape().volume(), bfloat16(-1));
         output_tensors.push_back(
-            Tensor::from_vector(std::move(out_data), output_tensor_spec).to_device(mesh_devices[dev_idx].get()));
+            Tensor::from_vector(std::move(out_data), output_tensor_spec).to_device(submeshes.back().get()));
     }
 
     auto input_tensor = tt::tt_metal::experimental::unit_mesh::aggregate(input_tensors);
@@ -1404,15 +1060,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
     mesh_device_->quiesce_devices();
 
     // =========================================================================
-    // Configuration matching build_all_gather_async_minimal_default_program_artifacts
+    // Configuration - hardcoded for this test case
     // =========================================================================
-    const uint32_t num_links = 1;
-    // num_directions_per_link = 2 (forward and backward)
-    // num_mux_cores_per_direction_per_link = 1
-    const uint32_t num_workers_per_direction = 1;
-    const uint32_t num_buffers_per_channel = 1;
-    const uint32_t gather_dim = 0;
-
     tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(tt::tt_metal::DataType::BFLOAT16);
     const size_t packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     const uint32_t page_size = tensor_spec.compute_page_size_bytes();
@@ -1420,89 +1069,78 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
     const uint32_t num_tiles_to_write_per_packet = std::min(4u, num_pages_per_packet);
     const uint32_t cb_num_pages = 3 * num_tiles_to_write_per_packet;
 
-    // 4D tensor shape normalization
-    // For 4D tensor {1, 8, 1024, 768} with gather_dim=0:
-    // batch_head_size = accumulate(cbegin, cend-2) = shape[0] * shape[1] = 1 * 8 = 8
-    // c_includes_dim = 1 (since rank_diff=0 and dim=0)
-    // input_tensor_C = accumulate(rbegin+2, rend-1) = shape[1] = 8
+    // Shape info for {1, 8, 1024, 768} with gather_dim=0
     const auto& input_shape = input_tensor.padded_shape();
     const auto& output_shape = output_tensor.padded_shape();
     const uint32_t input_tensor_Wt = input_shape[-1] / tt::constants::TILE_WIDTH;
     const uint32_t input_tensor_Ht = input_shape[-2] / tt::constants::TILE_HEIGHT;
     const uint32_t output_tensor_Wt = output_shape[-1] / tt::constants::TILE_WIDTH;
     const uint32_t output_tensor_Ht = output_shape[-2] / tt::constants::TILE_HEIGHT;
-    // Match production code's map_nd_to_4d calculation for shape {1, 8, 1024, 768} with dim=0
     const uint32_t batch_head_size = input_shape[0] * input_shape[1];  // 1 * 8 = 8
     const uint32_t input_tensor_C = input_shape[1];                    // 8
     const uint32_t output_tensor_C = output_shape[1];                  // 8
     const uint32_t input_tensor_num_pages = input_tensor.physical_volume() / tt::constants::TILE_HW;
     const uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
 
-    // MUX configuration
+    // Tile range - single worker handles all pages
+    const uint32_t tile_start = 0;
+    const uint32_t tile_end = single_batch_head_num_pages;
+    constexpr uint32_t HEURISTIC_MAX_CHUNKS_PER_SYNC = 160;
+    const uint32_t chunks_per_sync =
+        std::min(std::max(tile_end / num_tiles_to_write_per_packet, 1u), HEURISTIC_MAX_CHUNKS_PER_SYNC);
+
     const uint32_t l1_unreserved_base =
         mesh_device_->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     tt::tt_fabric::FabricMuxConfig mux_config(
-        num_workers_per_direction,
+        1,  // num_workers_per_direction
         0,  // num_header_only_channels
-        num_buffers_per_channel,
+        1,  // num_buffers_per_channel
         0,  // num_buffers_header_only_channel
         packet_size_bytes,
         l1_unreserved_base);
 
-    // Global semaphores for inter-device synchronization
     auto sd_id = mesh_device_->get_sub_device_ids().at(0);
     auto available_cores = mesh_device_->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    // semaphore[0] for forward direction (dir=0), semaphore[1] for backward direction (dir=1)
     std::vector<ttnn::GlobalSemaphore> global_semaphores = {
         ttnn::global_semaphore::create_global_semaphore(mesh_device_.get(), available_cores, 0),
         ttnn::global_semaphore::create_global_semaphore(mesh_device_.get(), available_cores, 0),
     };
     tt::tt_metal::distributed::Synchronize(mesh_device_.get(), std::nullopt, {});
 
+    // Fixed core layout for all devices
+    CoreCoord mux_fwd_core = {0, 0};
+    CoreCoord worker_fwd_core = {1, 0};
+    CoreCoord mux_bwd_core = {2, 0};
+    CoreCoord worker_bwd_core = {3, 0};
+
+    CoreRangeSet worker_cores(std::set<CoreRange>{CoreRange(worker_fwd_core), CoreRange(worker_bwd_core)});
+    CoreRangeSet mux_fwd_core_set(std::set<CoreRange>{CoreRange(mux_fwd_core)});
+    CoreRangeSet mux_bwd_core_set(std::set<CoreRange>{CoreRange(mux_bwd_core)});
+
+    auto mux_fwd_virtual = mesh_device_->worker_core_from_logical_core(mux_fwd_core);
+    auto mux_bwd_virtual = mesh_device_->worker_core_from_logical_core(mux_bwd_core);
+    auto worker_fwd_virtual = mesh_device_->worker_core_from_logical_core(worker_fwd_core);
+    auto worker_bwd_virtual = mesh_device_->worker_core_from_logical_core(worker_bwd_core);
+
+    auto mux_ct_args = mux_config.get_fabric_mux_compile_time_args();
+
     // =========================================================================
-    // Build MeshProgramDescriptor (MUX mode - user handles all fabric setup)
+    // Build MeshProgramDescriptor for each device in the 1x4 line
     // =========================================================================
     tt::tt_metal::experimental::MeshProgramDescriptor mesh_program_descriptor;
 
     for (uint32_t ring_index = 0; ring_index < ring_size; ring_index++) {
-        const auto& device_coord = ring_coords[ring_index];
+        MeshCoordinate device_coord(0, ring_index);
 
-        // Topology info
-        // forward_coord exists if not last chip, backward_coord exists if not first chip
-        std::optional<tt::tt_metal::distributed::MeshCoordinate> forward_coord =
-            (ring_index < ring_size - 1) ? std::optional{ring_coords[ring_index + 1]} : std::nullopt;
-        std::optional<tt::tt_metal::distributed::MeshCoordinate> backward_coord =
-            (ring_index > 0) ? std::optional{ring_coords[ring_index - 1]} : std::nullopt;
-
-        auto [num_targets_forward, num_targets_backward] = ttnn::ccl::get_forward_backward_line_mcast_distance(
-            ring_size, ring_index, ttnn::ccl::Topology::Linear, false);
-
-        // mux_connection_valid(dir)
-        // dir=0: forward direction, valid if forward_coord exists
-        // dir=1: backward direction, valid if backward_coord exists
-        auto mux_connection_valid = [&](uint32_t dir) {
-            return (dir == 1 && backward_coord.has_value()) || (dir == 0 && forward_coord.has_value());
-        };
-
-        // Core layout: [mux_dir0, workers_dir0..., mux_dir1, workers_dir1...]
-        // For simplicity with 1 worker per direction:
-        // Core 0: mux for dir=0 (forward)
-        // Core 1: worker for dir=0 (forward)
-        // Core 2: mux for dir=1 (backward)
-        // Core 3: worker for dir=1 (backward)
-        CoreCoord mux_fwd_core = {0, 0};
-        CoreCoord worker_fwd_core = {1, 0};
-        CoreCoord mux_bwd_core = {2, 0};
-        CoreCoord worker_bwd_core = {3, 0};
-
-        CoreRangeSet worker_cores(std::set<CoreRange>{CoreRange(worker_fwd_core), CoreRange(worker_bwd_core)});
-        CoreRangeSet mux_fwd_core_set(std::set<CoreRange>{CoreRange(mux_fwd_core)});
-        CoreRangeSet mux_bwd_core_set(std::set<CoreRange>{CoreRange(mux_bwd_core)});
-
-        auto mux_fwd_virtual = mesh_device_->worker_core_from_logical_core(mux_fwd_core);
-        auto mux_bwd_virtual = mesh_device_->worker_core_from_logical_core(mux_bwd_core);
-        auto worker_fwd_virtual = mesh_device_->worker_core_from_logical_core(worker_fwd_core);
-        auto worker_bwd_virtual = mesh_device_->worker_core_from_logical_core(worker_bwd_core);
+        // For 1x4 linear topology:
+        // - has_forward: all except last device (index 3)
+        // - has_backward: all except first device (index 0)
+        // - num_targets_forward: devices after this one = ring_size - 1 - ring_index
+        // - num_targets_backward: devices before this one = ring_index
+        const bool has_forward = ring_index < ring_size - 1;
+        const bool has_backward = ring_index > 0;
+        const uint32_t num_targets_forward = ring_size - 1 - ring_index;
+        const uint32_t num_targets_backward = ring_index;
 
         // Circular Buffer
         tt::CBIndex sender_cb_index = tt::CBIndex::c_0;
@@ -1512,8 +1150,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             .format_descriptors = {{sender_cb_index, df, page_size}},
         };
 
-        // Reader CT args
-        std::vector<uint32_t> reader_ct_args = {
+        // Common CT args for reader/writer
+        std::vector<uint32_t> common_ct_args = {
             ring_size,
             ring_index,
             static_cast<uint32_t>(sender_cb_index),
@@ -1522,7 +1160,7 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             num_targets_forward,
             num_targets_backward,
             static_cast<uint32_t>(ttnn::ccl::Topology::Linear),
-            gather_dim,
+            0,  // gather_dim
             batch_head_size,
             input_tensor_Wt,
             input_tensor_Ht,
@@ -1533,64 +1171,40 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             0,  // fuse_op
             0,  // reverse_order
         };
+
+        // Reader CT args
+        std::vector<uint32_t> reader_ct_args = common_ct_args;
         tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_ct_args);
         tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(reader_ct_args);
 
         // Writer CT args
-        std::vector<uint32_t> writer_ct_args = {
-            ring_size,
-            ring_index,
-            static_cast<uint32_t>(sender_cb_index),
-            num_tiles_to_write_per_packet,
-            page_size,
-            num_targets_forward,
-            num_targets_backward,
-            static_cast<uint32_t>(ttnn::ccl::Topology::Linear),
-            gather_dim,
-            batch_head_size,
-            input_tensor_Wt,
-            input_tensor_Ht,
-            input_tensor_C,
-            output_tensor_Wt,
-            output_tensor_Ht,
-            output_tensor_C,
-            0,  // fuse_op
-            0,  // reverse_order
-        };
+        std::vector<uint32_t> writer_ct_args = common_ct_args;
         // fabric_mux_connection_ct_args
         writer_ct_args.push_back(mux_config.get_num_buffers(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL));
         writer_ct_args.push_back(
             mux_config.get_buffer_size_bytes(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL));
         writer_ct_args.push_back(mux_config.get_status_address());
         writer_ct_args.push_back(mux_config.get_termination_signal_address());
-        writer_ct_args.push_back(num_workers_per_direction);
+        writer_ct_args.push_back(1);  // num_workers_per_direction
 
-        // Unicast/mcast routing args
-        // For 1D fabric:
-        // unicast_args: {dst_mesh_id=0, distance_in_hops=1} if coord exists, else {0, 0} (2 elements)
-        // mcast_args: {start_distance=1, range_hops=num_targets, 0, 0, 0, 0} if coord exists, else zeros (6 elements)
-        if (forward_coord.has_value()) {
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 1u});  // unicast_forward: {dst_mesh_id, distance}
-            writer_ct_args.insert(writer_ct_args.end(), {1u, num_targets_forward, 0u, 0u, 0u, 0u});  // mcast_forward
+        // Routing args: unicast (2 args) + mcast (6 args) per direction
+        // Forward direction
+        if (has_forward) {
+            writer_ct_args.insert(writer_ct_args.end(), {0u, 1u});  // unicast: {dst_mesh_id=0, distance=1}
+            writer_ct_args.insert(writer_ct_args.end(), {1u, num_targets_forward, 0u, 0u, 0u, 0u});  // mcast
         } else {
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u});                  // unicast_forward (no target)
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u, 0u, 0u, 0u, 0u});  // mcast_forward (no target)
+            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u});  // no target
         }
-        if (backward_coord.has_value()) {
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 1u});  // unicast_backward: {dst_mesh_id, distance}
-            writer_ct_args.insert(writer_ct_args.end(), {1u, num_targets_backward, 0u, 0u, 0u, 0u});  // mcast_backward
+        // Backward direction
+        if (has_backward) {
+            writer_ct_args.insert(writer_ct_args.end(), {0u, 1u});  // unicast: {dst_mesh_id=0, distance=1}
+            writer_ct_args.insert(writer_ct_args.end(), {1u, num_targets_backward, 0u, 0u, 0u, 0u});  // mcast
         } else {
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u});                  // unicast_backward (no target)
-            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u, 0u, 0u, 0u, 0u});  // mcast_backward (no target)
+            writer_ct_args.insert(writer_ct_args.end(), {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u});  // no target
         }
         tt::tt_metal::TensorAccessorArgs(*output_tensor.buffer()).append_to(writer_ct_args);
 
-        // MUX CT args
-        auto mux_ct_args = mux_config.get_fabric_mux_compile_time_args();
-
-        // Local semaphores for MUX connection
-        // 5 semaphores per worker: termination_sync, local_fabric_mux_status, local_flow_control, local_teardown,
-        // local_buffer_index
+        // Semaphores - 5 per worker core
         ProgramDescriptor::SemaphoreDescriptors semaphores;
         for (uint32_t i = 0; i < 5; i++) {
             semaphores.push_back(
@@ -1607,29 +1221,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
                  .initial_value = 0});
         }
 
-        // Worker RT args builder
+        // Build worker RT args helper
         auto build_worker_rt_args = [&](uint32_t dir,
-                                        CoreCoord worker_logical,
                                         CoreCoord worker_virtual,
                                         CoreCoord mux_virtual,
                                         CoreCoord opposite_virtual,
-                                        CoreCoord termination_master_virtual,
-                                        bool mux_valid,
-                                        uint32_t sem_base) {
-            // Tile range calculation
-            uint32_t worker_id = 0;
-            uint32_t global_worker_id = worker_id;
-            uint32_t global_worker_count = num_links * num_workers_per_direction;
-            uint32_t base_pages = single_batch_head_num_pages / global_worker_count;
-            uint32_t remainder = single_batch_head_num_pages % global_worker_count;
-            uint32_t tile_start = global_worker_id * base_pages + std::min(global_worker_id, remainder);
-            uint32_t tile_end = (global_worker_id + 1) * base_pages + std::min(global_worker_id + 1, remainder);
-            constexpr uint32_t HEURISTIC_MAX_CHUNKS_PER_SYNC = 160;
-            uint32_t chunks_per_sync = std::min(
-                std::max((tile_end - tile_start) / num_tiles_to_write_per_packet, 1u), HEURISTIC_MAX_CHUNKS_PER_SYNC);
-            uint32_t start_pages_in_row = tile_start % input_tensor_Wt;
-            uint32_t start_row_offset = tile_start / input_tensor_Wt * output_tensor_Wt;
-
+                                        bool mux_valid) {
             std::vector<uint32_t> reader_rt = {
                 input_tensor.buffer()->address(),
                 output_tensor.buffer()->address(),
@@ -1637,8 +1234,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
                 dir,
                 tile_start,
                 tile_end,
-                start_pages_in_row,
-                start_row_offset,
+                0,  // start_pages_in_row (tile_start % input_tensor_Wt = 0)
+                0,  // start_row_offset (tile_start / input_tensor_Wt * output_tensor_Wt = 0)
                 chunks_per_sync,
             };
 
@@ -1654,106 +1251,81 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
                 dir,
                 tile_start,
                 tile_end,
-                start_pages_in_row,
-                start_row_offset,
+                0,  // start_pages_in_row
+                0,  // start_row_offset
                 chunks_per_sync,
             };
 
             // fabric_mux_connection_rt_args
-            writer_rt.push_back(mux_valid ? 1 : 0);  // mux_connection_valid
-            writer_rt.push_back(1);                  // is_termination_master (worker 0 is master)
+            writer_rt.push_back(mux_valid ? 1 : 0);
+            writer_rt.push_back(1);  // is_termination_master
             writer_rt.push_back(mux_virtual.x);
             writer_rt.push_back(mux_virtual.y);
             writer_rt.push_back(
-                mux_config.get_channel_base_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
-            writer_rt.push_back(mux_config.get_connection_info_address(
-                tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
-            writer_rt.push_back(mux_config.get_connection_handshake_address(
-                tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
+                mux_config.get_channel_base_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
             writer_rt.push_back(
-                mux_config.get_flow_control_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
+                mux_config.get_connection_info_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
             writer_rt.push_back(
-                mux_config.get_buffer_index_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
-            writer_rt.push_back(mux_config.get_channel_credits_stream_id(
-                tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, worker_id));
-            // Local semaphore IDs (kernel uses get_semaphore(id) to get L1 address)
-            writer_rt.push_back(sem_base + 0);  // termination_sync_address
-            writer_rt.push_back(sem_base + 1);  // local_fabric_mux_status_address
-            writer_rt.push_back(sem_base + 2);  // local_flow_control_address
-            writer_rt.push_back(sem_base + 3);  // local_teardown_address
-            writer_rt.push_back(sem_base + 4);  // local_buffer_index_address
-            writer_rt.push_back(termination_master_virtual.x);
-            writer_rt.push_back(termination_master_virtual.y);
+                mux_config.get_connection_handshake_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
+            writer_rt.push_back(
+                mux_config.get_flow_control_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
+            writer_rt.push_back(
+                mux_config.get_buffer_index_address(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
+            writer_rt.push_back(
+                mux_config.get_channel_credits_stream_id(tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, 0));
+            // Semaphore IDs 0-4
+            for (uint32_t i = 0; i < 5; i++) {
+                writer_rt.push_back(i);
+            }
+            writer_rt.push_back(worker_virtual.x);  // termination_master coords = self
+            writer_rt.push_back(worker_virtual.y);
 
             return std::make_pair(reader_rt, writer_rt);
         };
 
-        // Build RT args for forward (dir=0) and backward (dir=1) workers
-        auto [fwd_reader_rt, fwd_writer_rt] = build_worker_rt_args(
-            0,
-            worker_fwd_core,
-            worker_fwd_virtual,
-            mux_fwd_virtual,
-            worker_bwd_virtual,
-            worker_fwd_virtual,
-            mux_connection_valid(0),
-            0);
-        auto [bwd_reader_rt, bwd_writer_rt] = build_worker_rt_args(
-            1,
-            worker_bwd_core,
-            worker_bwd_virtual,
-            mux_bwd_virtual,
-            worker_fwd_virtual,
-            worker_bwd_virtual,
-            mux_connection_valid(1),
-            0);
+        auto [fwd_reader_rt, fwd_writer_rt] =
+            build_worker_rt_args(0, worker_fwd_virtual, mux_fwd_virtual, worker_bwd_virtual, has_forward);
+        auto [bwd_reader_rt, bwd_writer_rt] =
+            build_worker_rt_args(1, worker_bwd_virtual, mux_bwd_virtual, worker_fwd_virtual, has_backward);
 
         // Build ProgramDescriptor
         ProgramDescriptor program_desc = {.kernels = {}, .semaphores = semaphores, .cbs = {cb_desc}};
 
         // MUX RT args
-        std::vector<uint32_t> fwd_mux_rt;
-        std::vector<uint32_t> bwd_mux_rt;
-        const uint32_t link = 0;  // num_links = 1
         const auto src_node_id = mesh_device_->get_fabric_node_id(device_coord);
 
-        if (mux_connection_valid(0)) {
-            const auto dst_node_id = mesh_device_->get_fabric_node_id(forward_coord.value());
+        std::vector<uint32_t> fwd_mux_rt, bwd_mux_rt;
+        if (has_forward) {
+            const auto dst_node_id = mesh_device_->get_fabric_node_id(MeshCoordinate(0, ring_index + 1));
             fwd_mux_rt = mux_config.get_fabric_mux_run_time_args<ProgramDescriptor>(
-                src_node_id, dst_node_id, link, program_desc, mux_fwd_core);
+                src_node_id, dst_node_id, 0, program_desc, mux_fwd_core);
         }
-
-        if (mux_connection_valid(1)) {
-            const auto dst_node_id = mesh_device_->get_fabric_node_id(backward_coord.value());
+        if (has_backward) {
+            const auto dst_node_id = mesh_device_->get_fabric_node_id(MeshCoordinate(0, ring_index - 1));
             bwd_mux_rt = mux_config.get_fabric_mux_run_time_args<ProgramDescriptor>(
-                src_node_id, dst_node_id, link, program_desc, mux_bwd_core);
+                src_node_id, dst_node_id, 0, program_desc, mux_bwd_core);
         }
 
-        // Create Kernel Descriptors
-        KernelDescriptor reader_kernel = {
+        // Kernel Descriptors
+        program_desc.kernels.push_back({
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = reader_ct_args,
             .runtime_args = {{worker_fwd_core, fwd_reader_rt}, {worker_bwd_core, bwd_reader_rt}},
             .config = tt::tt_metal::ReaderConfigDescriptor{},
-        };
+        });
 
-        KernelDescriptor writer_kernel = {
+        program_desc.kernels.push_back({
             .kernel_source =
                 "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp",
             .core_ranges = worker_cores,
             .compile_time_args = writer_ct_args,
             .runtime_args = {{worker_fwd_core, fwd_writer_rt}, {worker_bwd_core, bwd_writer_rt}},
             .config = tt::tt_metal::WriterConfigDescriptor{},
-        };
+        });
 
-        // Add kernels to program descriptor
-        program_desc.kernels.push_back(reader_kernel);
-        program_desc.kernels.push_back(writer_kernel);
-
-        // Add MUX kernels only if connection is valid
-        if (mux_connection_valid(0)) {
+        if (has_forward) {
             program_desc.kernels.push_back({
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_fwd_core_set,
@@ -1765,7 +1337,7 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
                         .noc = tt::tt_metal::NOC::RISCV_0_default},
             });
         }
-        if (mux_connection_valid(1)) {
+        if (has_backward) {
             program_desc.kernels.push_back({
                 .kernel_source = "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
                 .core_ranges = mux_bwd_core_set,
@@ -1781,14 +1353,12 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(device_coord), std::move(program_desc));
     }
 
-    // Execute
-    log_info(tt::LogTest, "Executing all_gather via generic_op with MUX mode...");
+    log_info(tt::LogTest, "Executing all_gather via generic_op with MUX...");
     ttnn::generic_op(std::vector<Tensor>{input_tensor, output_tensor}, mesh_program_descriptor);
     mesh_device_->quiesce_devices();
 
-    // Verify (same verification as AllGatherReturnedTensor in test_multi_tensor_ccl.cpp)
     auto disaggregated_output = tt::tt_metal::experimental::unit_mesh::disaggregate(output_tensor);
-    for (size_t dev_idx = 0; dev_idx < ring_size; dev_idx++) {
+    for (uint32_t dev_idx = 0; dev_idx < ring_size; dev_idx++) {
         auto data = disaggregated_output[dev_idx].to_vector<bfloat16>();
         for (size_t i = 0; i < data.size(); i++) {
             // NOLINTNEXTLINE(bugprone-integer-division)

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1037,6 +1037,8 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
     // Get sender's data for verification - this is device 0's unique shard
     auto input_shards = ttnn::distributed::get_device_tensors(input_tensor);
     auto sender_data = input_shards[0].cpu();
+    auto original_receiver_data = input_shards[1].cpu();
+    log_info(tt::LogTest, "Original shard data at receiver: {}", ttnn::to_string(original_receiver_data));
 
     // Create output tensor (same spec as input, allocated on mesh)
     Tensor output_tensor = tt::tt_metal::allocate_tensor_on_device(input_tensor.tensor_spec(), mesh_device.get());

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1714,23 +1714,19 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
         // MUX RT args
         std::vector<uint32_t> fwd_mux_rt;
         std::vector<uint32_t> bwd_mux_rt;
+        const uint32_t link = 0;  // num_links = 1
+        const auto src_node_id = mesh_device_->get_fabric_node_id(device_coord);
 
         if (mux_connection_valid(0)) {
-            auto src_node = mesh_device_->get_fabric_node_id(device_coord);
-            auto dst_node = mesh_device_->get_fabric_node_id(forward_coord.value());
-            auto links = tt::tt_fabric::get_forwarding_link_indices(src_node, dst_node);
-            uint32_t link_idx = links.empty() ? 0 : links[0];
+            const auto dst_node_id = mesh_device_->get_fabric_node_id(forward_coord.value());
             fwd_mux_rt = mux_config.get_fabric_mux_run_time_args<ProgramDescriptor>(
-                src_node, dst_node, link_idx, program_desc, mux_fwd_core);
+                src_node_id, dst_node_id, link, program_desc, mux_fwd_core);
         }
 
         if (mux_connection_valid(1)) {
-            auto src_node = mesh_device_->get_fabric_node_id(device_coord);
-            auto dst_node = mesh_device_->get_fabric_node_id(backward_coord.value());
-            auto links = tt::tt_fabric::get_forwarding_link_indices(src_node, dst_node);
-            uint32_t link_idx = links.empty() ? 0 : links[0];
+            const auto dst_node_id = mesh_device_->get_fabric_node_id(backward_coord.value());
             bwd_mux_rt = mux_config.get_fabric_mux_run_time_args<ProgramDescriptor>(
-                src_node, dst_node, link_idx, program_desc, mux_bwd_core);
+                src_node_id, dst_node_id, link, program_desc, mux_bwd_core);
         }
 
         // Create Kernel Descriptors

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1350,7 +1350,8 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             });
         }
 
-        mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(device_coord), std::move(program_desc));
+        mesh_program_descriptor.mesh_programs.emplace_back(
+            ttnn::MeshCoordinateRange(device_coord), std::move(program_desc));
     }
 
     log_info(tt::LogTest, "Executing all_gather via generic_op with MUX...");

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -1051,6 +1051,11 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
     const uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     const uint32_t aligned_input_page_size_bytes = tt::round_up(input_page_size_bytes, l1_alignment);
 
+    log_info(tt::LogTest, "input_num_pages: {}", input_num_pages);
+    log_info(tt::LogTest, "input_page_size_bytes: {}", input_page_size_bytes);
+    log_info(tt::LogTest, "l1_alignment: {}", l1_alignment);
+    log_info(tt::LogTest, "aligned_input_page_size_bytes: {}", aligned_input_page_size_bytes);
+
     // Figure out packets - single packet
     const uint32_t fabric_max_packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     const uint32_t max_packet_size_bytes = std::bit_floor(fabric_max_packet_size_bytes);
@@ -1058,6 +1063,11 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
         std::min(max_packet_size_bytes / aligned_input_page_size_bytes, input_num_pages);
     const uint32_t packet_size_bytes = aligned_input_page_size_bytes * num_pages_per_packet;
     const uint32_t num_page_segments = 1;  // pages fit in single packet
+
+    log_info(tt::LogTest, "fabric_max_packet_size_bytes: {}", fabric_max_packet_size_bytes);
+    log_info(tt::LogTest, "max_packet_size_bytes: {}", max_packet_size_bytes);
+    log_info(tt::LogTest, "num_pages_per_packet: {}", num_pages_per_packet);
+    log_info(tt::LogTest, "packet_size_bytes: {}", packet_size_bytes);
 
     // Create intermediate tensor using the same logic as point_to_point operation
     TensorSpec intermediate_spec = ttnn::operations::point_to_point::p2p_compute_intermediate_tensor_spec(
@@ -1072,11 +1082,13 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
 
     tt::DataFormat input_dataformat = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     const auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+    log_info(tt::LogTest, "packet_header_size_bytes: {}", packet_header_size_bytes);
 
     auto sd_id = mesh_device->get_sub_device_ids().at(0);
     auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
     auto semaphore = ttnn::global_semaphore::create_global_semaphore(mesh_device.get(), available_cores, 0);
     tt::tt_metal::distributed::Synchronize(mesh_device.get(), std::nullopt, {});
+    log_info(tt::LogTest, "available_cores: {}", available_cores);
 
     // Determine routing direction and next fabric node ID (same logic as point_to_point operations)
     const auto sender_fabric_id = mesh_device->get_fabric_node_id(sender_coord);
@@ -1087,6 +1099,13 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
     const auto [num_hops_receiver, sender_is_forward, next_fabric_id_receiver] =
         ttnn::operations::point_to_point::detail::fabric_1d_routing(
             mesh_device.get(), receiver_coord, sender_coord, ttnn::ccl::Topology::Linear);
+
+    log_info(tt::LogTest, "num_hops_sender: {}", num_hops_sender);
+    log_info(tt::LogTest, "dst_is_forward: {}", dst_is_forward);
+    log_info(tt::LogTest, "next_fabric_id_sender: {}", next_fabric_id_sender);
+    log_info(tt::LogTest, "num_hops_receiver: {}", num_hops_receiver);
+    log_info(tt::LogTest, "sender_is_forward: {}", sender_is_forward);
+    log_info(tt::LogTest, "next_fabric_id_receiver: {}", next_fabric_id_receiver);
 
     constexpr uint32_t link_idx = 0;  // for single link implementation
 
@@ -1203,6 +1222,7 @@ TEST_F(MeshDevice2x4Fabric1DFixture, TestGenericOpPointToPoint) {
             tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
                 sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core, writer_rt_args_ref);
         }
+        log_info(tt::LogTest, "writer_rt_args_ref: {}", writer_rt_args_ref);
 
         mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(sender_coord), sender_program);
     }

--- a/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 import numpy as np
+from math import prod
 from loguru import logger
 
 from models.common.utility_functions import skip_for_blackhole
@@ -131,3 +132,324 @@ def test_eltwise_exp(device, num_tiles):
     matching = torch.allclose(torch_golden, torch_output)
     logger.info(f"Tensors are matching: {matching}")
     assert matching
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_point_to_point(mesh_device):
+    logger.info("Running test_point_to_point: sending data from device (0,0) to device (0,1)")
+    mesh_shape = mesh_device.shape
+    num_devices = prod(mesh_shape)
+
+    sender_coord = ttnn.MeshCoordinate(0, 0)
+    receiver_coord = ttnn.MeshCoordinate(0, 1)
+
+    full_shape = (1, num_devices, 32, 64)
+    dtype = ttnn.bfloat16
+
+    input_torch = torch.rand(full_shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        input_torch,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Get sender's data for verification
+    input_shards = ttnn.get_device_tensors(input_tensor)
+    sender_data = ttnn.to_torch(input_shards[0])
+    original_receiver_data = ttnn.to_torch(input_shards[1])
+    logger.info(f"Original shard data at receiver: {original_receiver_data}")
+
+    # Create output tensor
+    output_tensor = ttnn.allocate_tensor_on_device(input_tensor.spec, mesh_device)
+
+    input_num_pages = (prod(input_tensor.padded_shape) + 1024 - 1) // 1024  # = 2
+    input_page_size_bytes = input_num_pages * 1024
+    l1_alignment = 16
+    aligned_input_page_size_bytes = ((input_page_size_bytes + l1_alignment - 1) // l1_alignment) * l1_alignment
+
+    fabric_max_packet_size_bytes = 4416
+
+    max_packet_size_bytes = 1 << (fabric_max_packet_size_bytes.bit_length() - 1)  # bit_floor equivalent.. = 4096
+    num_pages_per_packet = min(max_packet_size_bytes // aligned_input_page_size_bytes, input_num_pages)  # = 2
+    packet_size_bytes = aligned_input_page_size_bytes * num_pages_per_packet  # = 4096
+    num_page_segments = 1
+
+    # Create intermediate tensor
+    intermediate_spec = ttnn._ttnn.operations.point_to_point.p2p_compute_intermediate_tensor_spec(
+        input_tensor, receiver_coord, sender_coord, ttnn.Topology.Linear
+    )
+    intermediate_tensor = ttnn.allocate_tensor_on_device(intermediate_spec, mesh_device)
+
+    # Use single core for simplicity
+    sender_core = ttnn.CoreCoord(0, 0)
+    receiver_core = ttnn.CoreCoord(0, 0)
+    sender_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+    receiver_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(receiver_core, receiver_core)])
+
+    input_dataformat = dtype
+    packet_header_size_bytes = 64
+
+    # FIX THIS
+    grid = mesh_device.compute_with_storage_grid_size()
+    num_cores = grid.x * grid.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, grid, row_wise=True)
+    global_semaphore = ttnn.create_global_semaphore(mesh_device, available_cores, 0)
+    global_semaphore_address = ttnn.get_global_semaphore_address(global_semaphore)
+    ttnn.synchronize_device(mesh_device)
+
+    # Determine routing direction and next fabric node ID (hardcoded for FABRIC_1D + Linear)
+    sender_fabric_id = mesh_device.get_fabric_node_id(sender_coord)
+    receiver_fabric_id = mesh_device.get_fabric_node_id(receiver_coord)
+    num_hops_sender = 1
+    dst_is_forward = False
+    next_fabric_id_sender = mesh_device.get_fabric_node_id(receiver_coord)
+    num_hops_receiver = 1
+    sender_is_forward = True
+    next_fabric_id_receiver = mesh_device.get_fabric_node_id(sender_coord)
+
+    link_idx = 0  # for single link implementation
+
+    # Build MeshProgramDescriptor
+    mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+
+    # ----- SENDER PROGRAM -----
+    sender_cb_id = 0
+    packet_header_cb_id = 1
+    packet_cb_id = 2
+    cb_num_pages = 2
+
+    sender_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=sender_cb_id,
+        data_format=input_dataformat,
+        page_size=aligned_input_page_size_bytes,
+    )
+    sender_cb_desc = ttnn.CBDescriptor(
+        total_size=cb_num_pages * aligned_input_page_size_bytes,
+        core_ranges=sender_core_set,
+        format_descriptors=[sender_cb_format],
+    )
+
+    packet_header_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=packet_header_cb_id,
+        data_format=ttnn.uint32,
+        page_size=packet_header_size_bytes,
+    )
+    packet_header_cb_desc = ttnn.CBDescriptor(
+        total_size=2 * 2 * packet_header_size_bytes,  # 2 headers * 2 buffering
+        core_ranges=sender_core_set,
+        format_descriptors=[packet_header_cb_format],
+    )
+
+    packet_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=packet_cb_id,
+        data_format=input_dataformat,
+        page_size=packet_size_bytes,
+    )
+    packet_cb_desc = ttnn.CBDescriptor(
+        total_size=packet_size_bytes,
+        core_ranges=sender_core_set,
+        format_descriptors=[packet_cb_format],
+    )
+
+    reader_ct_args = ttnn.TensorAccessorArgs(input_tensor).get_compile_time_args()
+
+    reader_rt_args = ttnn.RuntimeArgs()
+    reader_rt_args[sender_core.x][sender_core.y] = [
+        input_tensor.buffer_address(),
+        input_num_pages,
+        0,  # page_idx_start
+        input_page_size_bytes,
+    ]
+
+    writer_ct_args = [
+        sender_cb_id,
+        packet_header_cb_id,
+        packet_cb_id,
+        l1_alignment,
+    ]
+    writer_ct_args.extend(ttnn.TensorAccessorArgs(intermediate_tensor).get_compile_time_args())
+
+    writer_rt_args = ttnn.RuntimeArgs()
+    writer_rt_args[sender_core.x][sender_core.y] = [
+        intermediate_tensor.buffer_address(),
+        0,  # page_idx_start
+        input_num_pages,  # page_idx_end
+        num_hops_sender,
+        input_page_size_bytes,
+        packet_size_bytes,
+        num_pages_per_packet,
+        num_page_segments,
+        global_semaphore_address,
+        int(dst_is_forward),
+    ]
+
+    reader_kernel = ttnn.KernelDescriptor(
+        kernel_source="ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp",
+        core_ranges=sender_core_set,
+        compile_time_args=reader_ct_args,
+        runtime_args=reader_rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source="ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp",
+        core_ranges=sender_core_set,
+        compile_time_args=writer_ct_args,
+        runtime_args=writer_rt_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    sender_program = ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel],
+        semaphores=[],
+        cbs=[sender_cb_desc, packet_header_cb_desc, packet_cb_desc],
+    )
+
+    # Append fabric connection args to writer kernel
+    writer_kernel_idx = 1
+    writer_rt_args_ref = sender_program.kernels[writer_kernel_idx].runtime_args[sender_core.x]
+
+    if dst_is_forward:
+        fabric_args = ttnn.get_fabric_connection_rt_args(
+            sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core
+        )
+        writer_rt_args_ref.extend(sender_core.y, fabric_args)
+    writer_rt_args_ref.append(sender_core.y, int(not dst_is_forward))
+    if not dst_is_forward:
+        fabric_args = ttnn.get_fabric_connection_rt_args(
+            sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core
+        )
+        writer_rt_args_ref.extend(sender_core.y, fabric_args)
+
+    mesh_program_descriptor[ttnn.MeshCoordinateRange(sender_coord, sender_coord)] = sender_program
+
+    # ----- RECEIVER PROGRAM -----
+    packet_header_cb_id = 0
+    packet_cb_id = 1
+    receiver_cb_id = 2
+
+    packet_header_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=packet_header_cb_id,
+        data_format=ttnn.uint32,
+        page_size=packet_header_size_bytes,
+    )
+    packet_header_cb_desc = ttnn.CBDescriptor(
+        total_size=2 * 2 * packet_header_size_bytes,
+        core_ranges=receiver_core_set,
+        format_descriptors=[packet_header_cb_format],
+    )
+
+    packet_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=packet_cb_id,
+        data_format=input_dataformat,
+        page_size=packet_size_bytes,
+    )
+    packet_cb_desc = ttnn.CBDescriptor(
+        total_size=packet_size_bytes,
+        core_ranges=receiver_core_set,
+        format_descriptors=[packet_cb_format],
+    )
+
+    receiver_cb_num_pages = 3 * num_pages_per_packet
+    receiver_cb_format = ttnn.CBFormatDescriptor(
+        buffer_index=receiver_cb_id,
+        data_format=input_dataformat,
+        page_size=input_page_size_bytes,
+    )
+    receiver_cb_desc = ttnn.CBDescriptor(
+        total_size=receiver_cb_num_pages * input_page_size_bytes,
+        core_ranges=receiver_core_set,
+        format_descriptors=[receiver_cb_format],
+    )
+
+    reader_ct_args = [
+        packet_header_cb_id,
+        packet_cb_id,
+        receiver_cb_id,
+        l1_alignment,
+    ]
+    reader_ct_args.extend(ttnn.TensorAccessorArgs(intermediate_tensor).get_compile_time_args())
+
+    reader_rt_args = ttnn.RuntimeArgs()
+    reader_rt_args[receiver_core.x][receiver_core.y] = [
+        0,  # page_idx_start
+        input_num_pages,  # page_idx_end
+        num_pages_per_packet,
+        intermediate_tensor.buffer_address(),
+        packet_size_bytes,
+        input_page_size_bytes,
+        num_page_segments,
+        global_semaphore_address,
+        num_hops_receiver,
+        int(sender_is_forward),
+    ]
+
+    writer_ct_args = [receiver_cb_id]
+    writer_ct_args.extend(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args())
+
+    writer_rt_args = ttnn.RuntimeArgs()
+    writer_rt_args[receiver_core.x][receiver_core.y] = [
+        output_tensor.buffer_address(),
+        input_num_pages,
+        0,  # page_idx_start
+        input_page_size_bytes,
+    ]
+
+    reader_kernel = ttnn.KernelDescriptor(
+        kernel_source="ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp",
+        core_ranges=receiver_core_set,
+        compile_time_args=reader_ct_args,
+        runtime_args=reader_rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source="ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp",
+        core_ranges=receiver_core_set,
+        compile_time_args=writer_ct_args,
+        runtime_args=writer_rt_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    receiver_program = ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel],
+        semaphores=[],
+        cbs=[packet_header_cb_desc, packet_cb_desc, receiver_cb_desc],
+    )
+
+    # Append fabric connection args to reader kernel
+    reader_kernel_idx = 0
+    reader_rt_args_ref = receiver_program.kernels[reader_kernel_idx].runtime_args[receiver_core.x]
+
+    if sender_is_forward:
+        fabric_args = ttnn.get_fabric_connection_rt_args(
+            receiver_fabric_id, next_fabric_id_receiver, link_idx, receiver_program, receiver_core
+        )
+        reader_rt_args_ref.extend(receiver_core.y, fabric_args)
+    reader_rt_args_ref.append(receiver_core.y, int(not sender_is_forward))
+    if not sender_is_forward:
+        fabric_args = ttnn.get_fabric_connection_rt_args(
+            receiver_fabric_id, next_fabric_id_receiver, link_idx, receiver_program, receiver_core
+        )
+        reader_rt_args_ref.extend(receiver_core.y, fabric_args)
+
+    mesh_program_descriptor[ttnn.MeshCoordinateRange(receiver_coord, receiver_coord)] = receiver_program
+
+    # Execute generic_op
+    ttnn.generic_op([input_tensor, intermediate_tensor, output_tensor], mesh_program_descriptor)
+    ttnn.synchronize_device(mesh_device)
+
+    # Verify output
+    output_data = ttnn.get_device_tensors(output_tensor)
+    output_receiver_idx = 1
+    output_tensor_cpu = ttnn.to_torch(output_data[output_receiver_idx])
+
+    logger.info(f"Sender data: {sender_data}")
+    logger.info(f"Output at receiver: {output_tensor_cpu}")
+
+    assert torch.allclose(output_tensor_cpu, sender_data), "Receiver should have sender's data after transfer"

--- a/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
+++ b/tests/ttnn/unit_tests/operations/debug/test_generic_op.py
@@ -308,17 +308,12 @@ def test_point_to_point(mesh_device):
     # Append fabric connection args to writer kernel
     writer_rt_args_ref = sender_program.kernels[1].runtime_args[sender_core.x][sender_core.y]
 
-    if dst_is_forward:
-        fabric_args = ttnn.setup_fabric_connection(
-            sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core
-        )
-        writer_rt_args_ref.extend(fabric_args)
+    # dst_is_forward = False
     writer_rt_args_ref.append(int(not dst_is_forward))
-    if not dst_is_forward:
-        fabric_args = ttnn.setup_fabric_connection(
-            sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core
-        )
-        writer_rt_args_ref.extend(fabric_args)
+    fabric_args = ttnn.setup_fabric_connection(
+        sender_fabric_id, next_fabric_id_sender, link_idx, sender_program, sender_core
+    )
+    writer_rt_args_ref.extend(fabric_args)
 
     mesh_program_descriptor[ttnn.MeshCoordinateRange(sender_coord, sender_coord)] = sender_program
 
@@ -419,17 +414,12 @@ def test_point_to_point(mesh_device):
     # Append fabric connection args to reader kernel
     reader_rt_args_ref = receiver_program.kernels[0].runtime_args[receiver_core.x][receiver_core.y]
 
-    if sender_is_forward:
-        fabric_args = ttnn.setup_fabric_connection(
-            receiver_fabric_id, next_fabric_id_receiver, link_idx, receiver_program, receiver_core
-        )
-        reader_rt_args_ref.extend(fabric_args)
+    # sender_is_forward = True
+    fabric_args = ttnn.setup_fabric_connection(
+        receiver_fabric_id, next_fabric_id_receiver, link_idx, receiver_program, receiver_core
+    )
+    reader_rt_args_ref.extend(fabric_args)
     reader_rt_args_ref.append(int(not sender_is_forward))
-    if not sender_is_forward:
-        fabric_args = ttnn.setup_fabric_connection(
-            receiver_fabric_id, next_fabric_id_receiver, link_idx, receiver_program, receiver_core
-        )
-        reader_rt_args_ref.extend(fabric_args)
 
     mesh_program_descriptor[ttnn.MeshCoordinateRange(receiver_coord, receiver_coord)] = receiver_program
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -18,6 +18,7 @@
 
 namespace tt::tt_metal {
 class Program;
+struct ProgramDescriptor;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
@@ -40,15 +41,18 @@ size_t get_tt_fabric_max_payload_size_bytes();
 // It is advised to call the API once all the other run-time args for the prgram are
 // determined/pushed to keep things clean and avoid any extra arg management.
 //
+// Template parameter ProgramOrDescriptor defaults to Program. When ProgramDescriptor is passed,
+// it adds SemaphoreDescriptors instead of creating semaphores (only WORKER core_type supported).
+//
 // Inputs:
 // src_chip_id: physical chip id/device id of the sender chip
 // dst_chip_id: physical chip id/device id of the receiver chip
 // link_idx: the link (0..n) to use b/w the src_chip_id and dst_chip_id. On WH for
 //                instance we can have upto 4 active links b/w two chips
-// worker_program: program handle
+// worker_program_or_desc: program handle or program descriptor
 // worker_core: worker core logical coordinates
 // worker_args: list of existing run-time args to which the connection args will be appended
-// core_type: core type which the worker will be running on
+// core_type: core type which the worker will be running on (defaults to WORKER)
 //
 // Constraints:
 // 1. Currently the sender and receiver chip should be physically adjacent (for 1D)
@@ -56,11 +60,12 @@ size_t get_tt_fabric_max_payload_size_bytes();
 // 3. When connecting with 1D fabric routers, users are responsible for setting up the
 // connection appropriately. The API will not perform any checks to ensure that the
 // connection is indeed a 1D connection b/w all the workers.
+template <typename ProgramOrDescriptor = tt::tt_metal::Program>
 void append_fabric_connection_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
-    tt::tt_metal::Program& worker_program,
+    ProgramOrDescriptor& worker_program_or_desc,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type = CoreType::WORKER);

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -177,11 +177,13 @@ public:
         const tt::tt_fabric::FabricEriscDatamoverConfig& fabric_router_config) const;
 
     // Returns the run-time arguments for the mux kernel depending on the connection setup with fabric router
+    // Template parameter ProgramOrDescriptor defaults to Program. When ProgramDescriptor is passed,
+    template <typename ProgramOrDescriptor = tt::tt_metal::Program>
     std::vector<uint32_t> get_fabric_mux_run_time_args(
         const FabricNodeId& src_fabric_node_id,
         const FabricNodeId& dst_fabric_node_id,
         uint32_t link_idx,
-        tt::tt_metal::Program& mux_program,
+        ProgramOrDescriptor& mux_program_or_desc,
         const CoreCoord& mux_logical_core) const;
 
     uint8_t get_num_channels(FabricMuxChannelType channel_type) const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -42,7 +42,7 @@ size_t get_tt_fabric_max_payload_size_bytes();
 // determined/pushed to keep things clean and avoid any extra arg management.
 //
 // Template parameter ProgramOrDescriptor defaults to Program. When ProgramDescriptor is passed,
-// it adds SemaphoreDescriptors instead of creating semaphores (only WORKER core_type supported).
+// it adds SemaphoreDescriptors instead of creating semaphores.
 //
 // Inputs:
 // src_chip_id: physical chip id/device id of the sender chip
@@ -177,7 +177,6 @@ public:
         const tt::tt_fabric::FabricEriscDatamoverConfig& fabric_router_config) const;
 
     // Returns the run-time arguments for the mux kernel depending on the connection setup with fabric router
-    // Template parameter ProgramOrDescriptor defaults to Program. When ProgramDescriptor is passed,
     template <typename ProgramOrDescriptor = tt::tt_metal::Program>
     std::vector<uint32_t> get_fabric_mux_run_time_args(
         const FabricNodeId& src_fabric_node_id,

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -79,11 +79,12 @@ enum class FabricApiType : uint8_t {
 // next_hop_nodes: vector of next-hop nodes, one per route.
 // connection_link_indices: optional per-route link indices; if empty, a valid link is auto-selected.
 // api_type: set envvar for the kernel to indicate which fabric API type being used. Linear or Mesh.
+template <typename ProgramOrDescriptor>
 void append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<FabricNodeId>& dst_nodes,
     const std::vector<uint32_t>& connection_link_indices,
-    tt::tt_metal::Program& worker_program,
+    ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -36,10 +36,8 @@ struct MeshRuntimeArgsDescriptor {
 
     // Per-coordinate runtime args: maps mesh coordinate → per-core runtime args
     // If a coordinate is not present, uses the base ProgramDescriptor's runtime_args
-    using CoordinateRuntimeArgs = std::unordered_map<
-        distributed::MeshCoordinate,
-        KernelDescriptor::RuntimeArgs  // [core_x][core_y] -> args
-        >;
+    // RuntimeArgs is a vector of pairs: (CoreCoord, CoreRuntimeArgs)
+    using CoordinateRuntimeArgs = std::unordered_map<distributed::MeshCoordinate, KernelDescriptor::RuntimeArgs>;
     CoordinateRuntimeArgs coordinate_args;
 };
 
@@ -49,7 +47,7 @@ struct MeshProgramDescriptor {
 
     // GlobalSemaphores to allocate at mesh level
     // Referenced via GlobalSemRef{index} in RuntimeArgsBuilder
-    ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores;
+    // ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores;
 
     //------------------------------------------------------------------
     // Topology/Configuration
@@ -58,10 +56,9 @@ struct MeshProgramDescriptor {
 
     // Custom reflection attributes
     static constexpr auto attribute_names =
-        std::forward_as_tuple("num_mesh_programs", "num_runtime_args", "num_global_semaphores", "sub_device_id");
+        std::forward_as_tuple("num_mesh_programs", "num_runtime_args", "sub_device_id");
     auto attribute_values() const {
-        return std::forward_as_tuple(
-            mesh_programs.size(), mesh_runtime_args.size(), global_semaphores.size(), sub_device_id);
+        return std::forward_as_tuple(mesh_programs.size(), mesh_runtime_args.size(), sub_device_id);
     }
 };
 

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -18,7 +18,7 @@ struct MeshProgramDescriptor {
 
     // ProgramDescriptor too large for reflection inline storage.
     static constexpr auto attribute_names = std::forward_as_tuple("num_mesh_programs");
-    auto attribute_values() const { return std::forward_as_tuple(mesh_programs.size()); }
+    auto attribute_values() const { return std::make_tuple(mesh_programs.size()); }
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt_stl/small_vector.hpp>
+
+#include <umd/device/types/core_coordinates.hpp>
+
+#include <optional>
+#include <unordered_map>
+
+namespace tt::tt_metal::experimental {
+
+struct GlobalSemaphoreDescriptor {
+    CoreRangeSet cores;
+    uint32_t initial_value;
+    tt::tt_metal::BufferType buffer_type = tt::tt_metal::BufferType::L1;
+};
+
+// Per-device runtime arg override
+struct MeshRuntimeArgsDescriptor {
+    // Which kernel this applies to (index into ProgramDescriptor::kernels)
+    uint32_t kernel_index;
+
+    // Per-coordinate runtime args: maps mesh coordinate → per-core runtime args
+    // If a coordinate is not present, uses the base ProgramDescriptor's runtime_args
+    using CoordinateRuntimeArgs = std::unordered_map<
+        distributed::MeshCoordinate,
+        KernelDescriptor::RuntimeArgs  // [core_x][core_y] -> args
+        >;
+    CoordinateRuntimeArgs coordinate_args;
+};
+
+struct MeshProgramDescriptor {
+    std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
+    std::vector<MeshRuntimeArgsDescriptor> mesh_runtime_args = {{}};
+
+    ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores = {{}};
+
+    //------------------------------------------------------------------
+    // Topology/Configuration
+    //------------------------------------------------------------------
+    // std::optional<tt::tt_fabric::Topology> topology;
+    // std::optional<uint32_t> cluster_axis;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+
+    // Custom reflection attributes to avoid serializing the large mesh_programs map
+    // which exceeds the Attribute storage size limit
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("num_mesh_programs", "num_runtime_args", "num_global_semaphores", "sub_device_id");
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            mesh_programs.size(), mesh_runtime_args.size(), global_semaphores.size(), sub_device_id);
+    }
+};
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -7,25 +7,39 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/core_coord.hpp>
 
 #include <optional>
 #include <unordered_map>
 #include <vector>
-
 namespace tt::tt_metal::experimental {
+
+enum class FabricConnectionMode : uint8_t {
+    Direct,
+    RoutingPlane,
+    MUX,
+};
 
 // Describes a single fabric connection from one mesh coordinate to another.
 // Used for explicit point-to-point connections when user knows exact src->dst pairs.
 struct FabricConnectionDescriptor {
     distributed::MeshCoordinate src_coord;
     distributed::MeshCoordinate dst_coord;
+    std::vector<distributed::MeshCoordinate> dst_coords;
+
     size_t kernel_index = 0;
     CoreCoord worker_core;
 
     // Link index for multi-link scenarios (0 for single link)
     uint32_t link_idx = 0;
     CoreType core_type = CoreType::WORKER;
+
+    // In case we want different fabric config for different devices
+    FabricConnectionMode mode = FabricConnectionMode::Direct;
+
+    // Only needed for RoutingPlane mode
+    tt::tt_fabric::FabricApiType api_type = tt::tt_fabric::FabricApiType::Linear;
 };
 
 // Describes a fabric topology to auto-generate connections.
@@ -46,6 +60,7 @@ struct MeshProgramDescriptor {
     // Option B: Explicit fabric connections specified by the user
     std::optional<FabricTopologyDescriptor> fabric_topology = std::nullopt;
     std::vector<FabricConnectionDescriptor> fabric_connections;
+    FabricConnectionMode mode = FabricConnectionMode::Direct;
 
     static constexpr auto attribute_names =
         std::forward_as_tuple("num_mesh_programs", "has_fabric_topology", "num_fabric_connections");

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -6,67 +6,15 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
-#include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt-metalium/core_coord.hpp>
 
-#include <optional>
 #include <unordered_map>
-#include <vector>
 namespace tt::tt_metal::experimental {
-
-enum class FabricConnectionMode : uint8_t {
-    Direct,
-    RoutingPlane,
-    MUX,
-};
-
-// Describes a single fabric connection from one mesh coordinate to another.
-// Used for explicit point-to-point connections when user knows exact src->dst pairs.
-struct FabricConnectionDescriptor {
-    distributed::MeshCoordinate src_coord;
-    distributed::MeshCoordinate dst_coord;
-    std::vector<distributed::MeshCoordinate> dst_coords;
-
-    size_t kernel_index = 0;
-    CoreCoord worker_core;
-
-    // Link index for multi-link scenarios (0 for single link)
-    uint32_t link_idx = 0;
-    CoreType core_type = CoreType::WORKER;
-
-    // In case we want different fabric config for different devices
-    FabricConnectionMode mode = FabricConnectionMode::Direct;
-
-    // Only needed for RoutingPlane mode
-    tt::tt_fabric::FabricApiType api_type = tt::tt_fabric::FabricApiType::Linear;
-};
-
-// Describes a fabric topology to auto-generate connections.
-// Use this when you want standard patterns (ring, linear, mesh) without
-// specifying each connection explicitly.
-struct FabricTopologyDescriptor {
-    tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear;
-    std::optional<uint32_t> cluster_axis;
-    size_t kernel_index = 0;
-    CoreCoord worker_core;
-    CoreType core_type = CoreType::WORKER;
-};
 
 struct MeshProgramDescriptor {
     std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
 
-    // Option A: Auto-generate fabric connections from topology
-    // Option B: Explicit fabric connections specified by the user
-    std::optional<FabricTopologyDescriptor> fabric_topology = std::nullopt;
-    std::vector<FabricConnectionDescriptor> fabric_connections;
-    FabricConnectionMode mode = FabricConnectionMode::Direct;
-
-    static constexpr auto attribute_names =
-        std::forward_as_tuple("num_mesh_programs", "has_fabric_topology", "num_fabric_connections");
-    auto attribute_values() const {
-        return std::forward_as_tuple(mesh_programs.size(), fabric_topology.has_value(), fabric_connections.size());
-    }
+    static constexpr auto attribute_names = std::forward_as_tuple("num_mesh_programs");
+    auto attribute_values() const { return std::forward_as_tuple(mesh_programs.size()); }
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -7,12 +7,16 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 
-#include <unordered_map>
+#include <vector>
+#include <utility>
+
 namespace tt::tt_metal::experimental {
 
 struct MeshProgramDescriptor {
-    std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
+    using MeshPrograms = std::vector<std::pair<distributed::MeshCoordinateRange, ProgramDescriptor>>;
+    MeshPrograms mesh_programs;
 
+    // ProgramDescriptor too large for reflection inline storage.
     static constexpr auto attribute_names = std::forward_as_tuple("num_mesh_programs");
     auto attribute_values() const { return std::forward_as_tuple(mesh_programs.size()); }
 };

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -6,16 +6,52 @@
 
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 
+#include <optional>
 #include <unordered_map>
+#include <vector>
 
 namespace tt::tt_metal::experimental {
+
+// Describes a single fabric connection from one mesh coordinate to another.
+// Used for explicit point-to-point connections when user knows exact src->dst pairs.
+struct FabricConnectionDescriptor {
+    distributed::MeshCoordinate src_coord;
+    distributed::MeshCoordinate dst_coord;
+    size_t kernel_index = 0;
+    CoreCoord worker_core;
+
+    // Link index for multi-link scenarios (0 for single link)
+    uint32_t link_idx = 0;
+    CoreType core_type = CoreType::WORKER;
+};
+
+// Describes a fabric topology to auto-generate connections.
+// Use this when you want standard patterns (ring, linear, mesh) without
+// specifying each connection explicitly.
+struct FabricTopologyDescriptor {
+    tt::tt_fabric::Topology topology = tt::tt_fabric::Topology::Linear;
+    std::optional<uint32_t> cluster_axis;
+    size_t kernel_index = 0;
+    CoreCoord worker_core;
+    CoreType core_type = CoreType::WORKER;
+};
 
 struct MeshProgramDescriptor {
     std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("num_mesh_programs");
-    auto attribute_values() const { return std::forward_as_tuple(mesh_programs.size()); }
+    // Option A: Auto-generate fabric connections from topology
+    // Option B: Explicit fabric connections specified by the user
+    std::optional<FabricTopologyDescriptor> fabric_topology = std::nullopt;
+    std::vector<FabricConnectionDescriptor> fabric_connections;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("num_mesh_programs", "has_fabric_topology", "num_fabric_connections");
+    auto attribute_values() const {
+        return std::forward_as_tuple(mesh_programs.size(), fabric_topology.has_value(), fabric_connections.size());
+    }
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -4,62 +4,18 @@
 
 #pragma once
 
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer_constants.h>
-#include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/sub_device_types.hpp>
-#include <tt-metalium/buffer_types.hpp>
-#include <tt_stl/small_vector.hpp>
 
-#include <umd/device/types/core_coordinates.hpp>
-
-#include <optional>
 #include <unordered_map>
 
 namespace tt::tt_metal::experimental {
 
-// Describes a GlobalSemaphore to be allocated at mesh level
-struct GlobalSemaphoreDescriptor {
-    CoreRangeSet cores;
-    uint32_t initial_value = 0;
-    tt::tt_metal::BufferType buffer_type = tt::tt_metal::BufferType::L1;
-};
-
-// Per-device runtime arg override
-struct MeshRuntimeArgsDescriptor {
-    // Which kernel this applies to (index into ProgramDescriptor::kernels)
-    uint32_t kernel_index;
-
-    // Per-coordinate runtime args: maps mesh coordinate → per-core runtime args
-    // If a coordinate is not present, uses the base ProgramDescriptor's runtime_args
-    // RuntimeArgs is a vector of pairs: (CoreCoord, CoreRuntimeArgs)
-    using CoordinateRuntimeArgs = std::unordered_map<distributed::MeshCoordinate, KernelDescriptor::RuntimeArgs>;
-    CoordinateRuntimeArgs coordinate_args;
-};
-
 struct MeshProgramDescriptor {
     std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
-    std::vector<MeshRuntimeArgsDescriptor> mesh_runtime_args = {{}};
 
-    // GlobalSemaphores to allocate at mesh level
-    // Referenced via GlobalSemRef{index} in RuntimeArgsBuilder
-    // ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores;
-
-    //------------------------------------------------------------------
-    // Topology/Configuration
-    //------------------------------------------------------------------
-    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
-
-    // Custom reflection attributes
-    static constexpr auto attribute_names =
-        std::forward_as_tuple("num_mesh_programs", "num_runtime_args", "sub_device_id");
-    auto attribute_values() const {
-        return std::forward_as_tuple(mesh_programs.size(), mesh_runtime_args.size(), sub_device_id);
-    }
+    static constexpr auto attribute_names = std::forward_as_tuple("num_mesh_programs");
+    auto attribute_values() const { return std::forward_as_tuple(mesh_programs.size()); }
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_program_descriptor.hpp
@@ -22,9 +22,10 @@
 
 namespace tt::tt_metal::experimental {
 
+// Describes a GlobalSemaphore to be allocated at mesh level
 struct GlobalSemaphoreDescriptor {
     CoreRangeSet cores;
-    uint32_t initial_value;
+    uint32_t initial_value = 0;
     tt::tt_metal::BufferType buffer_type = tt::tt_metal::BufferType::L1;
 };
 
@@ -46,17 +47,16 @@ struct MeshProgramDescriptor {
     std::unordered_map<distributed::MeshCoordinateRange, ProgramDescriptor> mesh_programs;
     std::vector<MeshRuntimeArgsDescriptor> mesh_runtime_args = {{}};
 
-    ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores = {{}};
+    // GlobalSemaphores to allocate at mesh level
+    // Referenced via GlobalSemRef{index} in RuntimeArgsBuilder
+    ttsl::SmallVector<GlobalSemaphoreDescriptor, 3> global_semaphores;
 
     //------------------------------------------------------------------
     // Topology/Configuration
     //------------------------------------------------------------------
-    // std::optional<tt::tt_fabric::Topology> topology;
-    // std::optional<uint32_t> cluster_axis;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
 
-    // Custom reflection attributes to avoid serializing the large mesh_programs map
-    // which exceeds the Attribute storage size limit
+    // Custom reflection attributes
     static constexpr auto attribute_names =
         std::forward_as_tuple("num_mesh_programs", "num_runtime_args", "num_global_semaphores", "sub_device_id");
     auto attribute_values() const {

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -205,6 +205,7 @@ private:
 
 bool operator==(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
 bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
+bool operator<(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
 std::ostream& operator<<(std::ostream& os, const MeshCoordinateRange& range);
 
 // Represents a set of non-overlapping MeshCoordinateRanges.

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -142,25 +142,7 @@ struct ProgramDescriptor {
     CBDescriptors cbs;
     std::optional<ttsl::hash::hash_t> custom_program_hash;
 
-    std::optional<uint32_t> find_available_semaphore_id(const CoreCoord& core, CoreType core_type) const {
-        constexpr uint32_t NUM_SEMAPHORES = 16;  // same as impl/buffers/semaphore.hpp
-        std::bitset<NUM_SEMAPHORES> used_semaphores;
-
-        // check existing semaphores
-        for (const auto& sem_desc : semaphores) {
-            if (sem_desc.core_type == core_type && sem_desc.core_ranges.contains(core)) {
-                used_semaphores.set(sem_desc.id);
-            }
-        }
-
-        // find first available semaphore ID
-        for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
-            if (!used_semaphores.test(i)) {
-                return i;
-            }
-        }
-        return std::nullopt;
-    }
+    std::optional<uint32_t> find_available_semaphore_id(const CoreCoord& core, CoreType core_type) const;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -73,79 +73,6 @@ struct SemaphoreDescriptor {
     uint32_t initial_value = 0;
 };
 
-struct GlobalSemRef {
-    uint32_t index;
-    constexpr operator uint32_t() const { return index; }
-};
-
-// Type trait to detect GlobalSemRef at compile-time
-template <typename T>
-struct is_global_sem_ref : std::false_type {};
-template <>
-struct is_global_sem_ref<GlobalSemRef> : std::true_type {};
-template <typename T>
-inline constexpr bool is_global_sem_ref_v = is_global_sem_ref<std::decay_t<T>>::value;
-
-//==============================================================================
-// CoreRuntimeArgs - Runtime args with automatic GlobalSemaphore resolution
-//
-// Usage:
-//   CoreRuntimeArgs args{buf_addr, size, GlobalSemRef{0}, data, GlobalSemRef{1}};
-//   // Later, infra calls:
-//   args.resolve(semaphores);  // Resolves only positions 2 and 4
-//
-// How it works:
-//   - Variadic constructor captures which positions are GlobalSemRef at compile-time
-//   - Stores ref positions in a small vector (typically 0-3 refs per kernel)
-//   - resolve() only touches ref positions - O(num_refs) not O(num_args)
-//==============================================================================
-// struct CoreRuntimeArgs {
-//     std::vector<uint32_t> args;
-//     ttsl::SmallVector<uint8_t, 4> ref_positions;  // Indices where GlobalSemRef was used
-
-//     CoreRuntimeArgs() = default;
-
-//     // Variadic constructor - detects GlobalSemRef positions at compile-time
-//     template <typename... ArgTypes>
-//     explicit CoreRuntimeArgs(ArgTypes... values) : args{static_cast<uint32_t>(values)...} {
-//         capture_ref_positions<ArgTypes...>(std::make_index_sequence<sizeof...(ArgTypes)>{});
-//     }
-
-//     // Resolve GlobalSemRef positions to actual addresses
-//     template <typename SemaphoreContainer>
-//     void resolve(const SemaphoreContainer& semaphores) {
-//         for (auto pos : ref_positions) {
-//             args[pos] = semaphores[args[pos]].address();
-//         }
-//     }
-
-//     // Check if resolution is needed
-//     bool needs_resolution() const { return !ref_positions.empty(); }
-
-//     // Access underlying args
-//     std::vector<uint32_t>& get() { return args; }
-//     const std::vector<uint32_t>& get() const { return args; }
-
-//     // Vector-like interface for compatibility with Program constructor
-//     auto begin() { return args.begin(); }
-//     auto end() { return args.end(); }
-//     auto begin() const { return args.begin(); }
-//     auto end() const { return args.end(); }
-//     size_t size() const { return args.size(); }
-//     bool empty() const { return args.empty(); }
-//     uint32_t& operator[](size_t i) { return args[i]; }
-//     uint32_t operator[](size_t i) const { return args[i]; }
-//     uint32_t* data() { return args.data(); }
-//     const uint32_t* data() const { return args.data(); }
-
-// private:
-//     template <typename... ArgTypes, size_t... Is>
-//     void capture_ref_positions(std::index_sequence<Is...>) {
-//         // Fold expression: for each type, if it's GlobalSemRef, record its position
-//         ((is_global_sem_ref_v<ArgTypes> ? (ref_positions.push_back(static_cast<uint8_t>(Is)), 0) : 0), ...);
-//     }
-// };
-
 struct ReaderConfigDescriptor {};
 struct WriterConfigDescriptor {};
 struct DataMovementConfigDescriptor {
@@ -175,7 +102,6 @@ struct KernelDescriptor {
     using CompileTimeArgs = std::vector<uint32_t>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
     using Defines = std::vector<std::pair<std::string, std::string>>;
-    // Runtime args: CoreRuntimeArgs auto-detects GlobalSemRef positions
     using CoreRuntimeArgs = std::vector<uint32_t>;
     using RuntimeArgs = std::vector<std::pair<CoreCoord, CoreRuntimeArgs>>;
     using CommonRuntimeArgs = CoreRuntimeArgs;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -14,6 +14,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 
+#include <bitset>
 #include <optional>
 
 /**
@@ -141,6 +142,32 @@ struct ProgramDescriptor {
     CBDescriptors cbs;
     std::optional<ttsl::hash::hash_t> custom_program_hash;
 };
+
+inline std::optional<uint32_t> find_available_semaphore_id(
+    const ProgramDescriptor& desc, const CoreCoord& core, CoreType core_type) {
+    constexpr uint32_t NUM_SEMAPHORES = 16;  // from tt_metal/impl/buffers/semaphore.hpp
+    std::bitset<NUM_SEMAPHORES> used_semaphores;
+
+    // check existing semaphores
+    for (const auto& sem_desc : desc.semaphores) {
+        if (sem_desc.core_type == core_type) {
+            for (const auto& core_range : sem_desc.core_ranges.ranges()) {
+                if (core_range.contains(core)) {
+                    used_semaphores.set(sem_desc.id);
+                    break;
+                }
+            }
+        }
+    }
+
+    // find first available semaphore ID
+    for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
+        if (!used_semaphores.test(i)) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -73,6 +73,79 @@ struct SemaphoreDescriptor {
     uint32_t initial_value = 0;
 };
 
+struct GlobalSemRef {
+    uint32_t index;
+    constexpr operator uint32_t() const { return index; }
+};
+
+// Type trait to detect GlobalSemRef at compile-time
+template <typename T>
+struct is_global_sem_ref : std::false_type {};
+template <>
+struct is_global_sem_ref<GlobalSemRef> : std::true_type {};
+template <typename T>
+inline constexpr bool is_global_sem_ref_v = is_global_sem_ref<std::decay_t<T>>::value;
+
+//==============================================================================
+// CoreRuntimeArgs - Runtime args with automatic GlobalSemaphore resolution
+//
+// Usage:
+//   CoreRuntimeArgs args{buf_addr, size, GlobalSemRef{0}, data, GlobalSemRef{1}};
+//   // Later, infra calls:
+//   args.resolve(semaphores);  // Resolves only positions 2 and 4
+//
+// How it works:
+//   - Variadic constructor captures which positions are GlobalSemRef at compile-time
+//   - Stores ref positions in a small vector (typically 0-3 refs per kernel)
+//   - resolve() only touches ref positions - O(num_refs) not O(num_args)
+//==============================================================================
+struct CoreRuntimeArgs {
+    std::vector<uint32_t> args;
+    ttsl::SmallVector<uint8_t, 4> ref_positions;  // Indices where GlobalSemRef was used
+
+    CoreRuntimeArgs() = default;
+
+    // Variadic constructor - detects GlobalSemRef positions at compile-time
+    template <typename... ArgTypes>
+    explicit CoreRuntimeArgs(ArgTypes... values) : args{static_cast<uint32_t>(values)...} {
+        capture_ref_positions<ArgTypes...>(std::make_index_sequence<sizeof...(ArgTypes)>{});
+    }
+
+    // Resolve GlobalSemRef positions to actual addresses
+    template <typename SemaphoreContainer>
+    void resolve(const SemaphoreContainer& semaphores) {
+        for (auto pos : ref_positions) {
+            args[pos] = semaphores[args[pos]].address();
+        }
+    }
+
+    // Check if resolution is needed
+    bool needs_resolution() const { return !ref_positions.empty(); }
+
+    // Access underlying args
+    std::vector<uint32_t>& get() { return args; }
+    const std::vector<uint32_t>& get() const { return args; }
+
+    // Vector-like interface for compatibility with Program constructor
+    auto begin() { return args.begin(); }
+    auto end() { return args.end(); }
+    auto begin() const { return args.begin(); }
+    auto end() const { return args.end(); }
+    size_t size() const { return args.size(); }
+    bool empty() const { return args.empty(); }
+    uint32_t& operator[](size_t i) { return args[i]; }
+    uint32_t operator[](size_t i) const { return args[i]; }
+    uint32_t* data() { return args.data(); }
+    const uint32_t* data() const { return args.data(); }
+
+private:
+    template <typename... ArgTypes, size_t... Is>
+    void capture_ref_positions(std::index_sequence<Is...>) {
+        // Fold expression: for each type, if it's GlobalSemRef, record its position
+        ((is_global_sem_ref_v<ArgTypes> ? (ref_positions.push_back(static_cast<uint8_t>(Is)), 0) : 0), ...);
+    }
+};
+
 struct ReaderConfigDescriptor {};
 struct WriterConfigDescriptor {};
 struct DataMovementConfigDescriptor {
@@ -102,9 +175,9 @@ struct KernelDescriptor {
     using CompileTimeArgs = std::vector<uint32_t>;
     using NamedCompileTimeArgs = std::vector<std::pair<std::string, uint32_t>>;
     using Defines = std::vector<std::pair<std::string, std::string>>;
-    using CoreRuntimeArgs = std::vector<uint32_t>;
-    using RuntimeArgs = std::vector<std::pair<CoreCoord, CoreRuntimeArgs>>;
-    using CommonRuntimeArgs = std::vector<uint32_t>;
+    // Runtime args: CoreRuntimeArgs auto-detects GlobalSemRef positions
+    using RuntimeArgs = std::vector<std::vector<CoreRuntimeArgs>>;
+    using CommonRuntimeArgs = CoreRuntimeArgs;
     using ConfigDescriptor = std::variant<
         ReaderConfigDescriptor,
         WriterConfigDescriptor,
@@ -121,8 +194,13 @@ struct KernelDescriptor {
     NamedCompileTimeArgs named_compile_time_args;
     Defines defines;
 
+<<<<<<< HEAD
     // vector of pairs, where runtime_args[i].first is the core coord and runtime_args[i].second is the vector of
     // runtime args for that core
+=======
+    // runtime_args[i][j] = CoreRuntimeArgs for core(i, j)
+    // Use GlobalSemRef{index} for semaphore addresses - infra resolves automatically
+>>>>>>> ae806b43487 (wip templated kernel arg to resolve globalsemaphore address)
     RuntimeArgs runtime_args;
     CommonRuntimeArgs common_runtime_args;
 

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -141,33 +141,27 @@ struct ProgramDescriptor {
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
     std::optional<ttsl::hash::hash_t> custom_program_hash;
-};
 
-inline std::optional<uint32_t> find_available_semaphore_id(
-    const ProgramDescriptor& desc, const CoreCoord& core, CoreType core_type) {
-    constexpr uint32_t NUM_SEMAPHORES = 16;  // from tt_metal/impl/buffers/semaphore.hpp
-    std::bitset<NUM_SEMAPHORES> used_semaphores;
+    std::optional<uint32_t> find_available_semaphore_id(const CoreCoord& core, CoreType core_type) const {
+        constexpr uint32_t NUM_SEMAPHORES = 16;  // same as impl/buffers/semaphore.hpp
+        std::bitset<NUM_SEMAPHORES> used_semaphores;
 
-    // check existing semaphores
-    for (const auto& sem_desc : desc.semaphores) {
-        if (sem_desc.core_type == core_type) {
-            for (const auto& core_range : sem_desc.core_ranges.ranges()) {
-                if (core_range.contains(core)) {
-                    used_semaphores.set(sem_desc.id);
-                    break;
-                }
+        // check existing semaphores
+        for (const auto& sem_desc : semaphores) {
+            if (sem_desc.core_type == core_type && sem_desc.core_ranges.contains(core)) {
+                used_semaphores.set(sem_desc.id);
             }
         }
-    }
 
-    // find first available semaphore ID
-    for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
-        if (!used_semaphores.test(i)) {
-            return i;
+        // find first available semaphore ID
+        for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
+            if (!used_semaphores.test(i)) {
+                return i;
+            }
         }
+        return std::nullopt;
     }
-    return std::nullopt;
-}
+};
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -454,6 +454,12 @@ bool operator==(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs) 
     return lhs.start_coord() == rhs.start_coord() && lhs.end_coord() == rhs.end_coord();
 }
 bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs) { return !(lhs == rhs); }
+bool operator<(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs) {
+    if (lhs.start_coord() != rhs.start_coord()) {
+        return lhs.start_coord() < rhs.start_coord();
+    }
+    return lhs.end_coord() < rhs.end_coord();
+}
 
 std::ostream& operator<<(std::ostream& os, const MeshCoordinateRange& range) {
     os << "MeshCoordinateRange(start=" << range.start_coord() << ", end=" << range.end_coord() << ")";

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -184,8 +184,7 @@ void append_fabric_connection_rt_args(
     uint32_t worker_flow_control_semaphore_id;
 
     if constexpr (std::is_same_v<ProgramOrDescriptor, tt::tt_metal::ProgramDescriptor>) {
-        auto teardown_sem_id_opt =
-            tt::tt_metal::find_available_semaphore_id(worker_program_or_desc, worker_core, core_type);
+        auto teardown_sem_id_opt = worker_program_or_desc.find_available_semaphore_id(worker_core, core_type);
         TT_FATAL(teardown_sem_id_opt.has_value(), "No available semaphore ID for teardown semaphore");
         worker_teardown_semaphore_id = teardown_sem_id_opt.value();
         worker_program_or_desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
@@ -194,8 +193,7 @@ void append_fabric_connection_rt_args(
             .core_ranges = CoreRangeSet(CoreRange(worker_core, worker_core)),
             .initial_value = 0});
 
-        auto buffer_index_sem_id_opt =
-            tt::tt_metal::find_available_semaphore_id(worker_program_or_desc, worker_core, core_type);
+        auto buffer_index_sem_id_opt = worker_program_or_desc.find_available_semaphore_id(worker_core, core_type);
         TT_FATAL(buffer_index_sem_id_opt.has_value(), "No available semaphore ID for buffer index semaphore");
         worker_buffer_index_semaphore_id = buffer_index_sem_id_opt.value();
         worker_program_or_desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
@@ -245,8 +243,7 @@ void append_fabric_connection_rt_args(
             .edm_direction = router_direction};
 
         if constexpr (std::is_same_v<ProgramOrDescriptor, tt::tt_metal::ProgramDescriptor>) {
-            auto flow_control_sem_id_opt =
-                tt::tt_metal::find_available_semaphore_id(worker_program_or_desc, worker_core, core_type);
+            auto flow_control_sem_id_opt = worker_program_or_desc.find_available_semaphore_id(worker_core, core_type);
             TT_FATAL(flow_control_sem_id_opt.has_value(), "No available semaphore ID for flow control semaphore");
             worker_flow_control_semaphore_id = flow_control_sem_id_opt.value();
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -8,23 +8,20 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "fabric/fabric_edm_packet_header.hpp"
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include <optional>
-#include <set>
 #include <vector>
 
 #include "impl/context/metal_context.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/xy_pair.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include "impl/buffers/semaphore.hpp"
 
 #include "fabric_host_utils.hpp"
 #include "fabric_context.hpp"
@@ -103,10 +100,6 @@ void append_fabric_connection_rt_args(
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type) {
-    static_assert(
-        std::is_same_v<ProgramOrDescriptor, tt::tt_metal::Program> ||
-            std::is_same_v<ProgramOrDescriptor, tt::tt_metal::ProgramDescriptor>,
-        "ProgramOrDescriptor must be either Program or ProgramDescriptor");
     TT_FATAL(
         src_fabric_node_id != dst_fabric_node_id,
         "Expected different src and dst chip ids but got same, Src: {}, Dst: {}",
@@ -459,7 +452,6 @@ size_t get_number_of_available_routing_planes(
 
 }  // namespace experimental
 
-// Explicit template instantiations
 template void append_fabric_connection_rt_args<tt::tt_metal::Program>(
     const FabricNodeId&,
     const FabricNodeId&,

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
-#include <type_traits>
 #include <vector>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -262,11 +261,6 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args(
     uint32_t link_idx,
     ProgramOrDescriptor& mux_program_or_desc,
     const CoreCoord& mux_logical_core) const {
-    static_assert(
-        std::is_same_v<ProgramOrDescriptor, tt::tt_metal::Program> ||
-            std::is_same_v<ProgramOrDescriptor, tt::tt_metal::ProgramDescriptor>,
-        "ProgramOrDescriptor must be either Program or ProgramDescriptor");
-
     std::vector<uint32_t> args;
 
     auto regions_to_clear = get_memory_regions_to_clear();
@@ -284,7 +278,6 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args(
     return args;
 }
 
-// Explicit template instantiations
 template std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args<tt::tt_metal::Program>(
     const FabricNodeId&, const FabricNodeId&, uint32_t, tt::tt_metal::Program&, const CoreCoord&) const;
 

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -272,7 +272,7 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args(
         args.push_back(static_cast<uint32_t>(size));
     }
 
-    tt::tt_fabric::append_fabric_connection_rt_args(
+    tt::tt_fabric::append_fabric_connection_rt_args<ProgramOrDescriptor>(
         src_fabric_node_id, dst_fabric_node_id, link_idx, mux_program_or_desc, mux_logical_core, args, core_type_);
 
     return args;

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -5,11 +5,32 @@
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tile.hpp>
 
+#include "impl/buffers/semaphore.hpp"
 #include "tt_stl/overloaded.hpp"
 
 namespace tt::tt_metal {
 
 TileDescriptor::TileDescriptor(const Tile& tile) :
     height(tile.get_height()), width(tile.get_width()), transpose(tile.get_transpose_of_faces()) {}
+
+std::optional<uint32_t> ProgramDescriptor::find_available_semaphore_id(
+    const CoreCoord& core, CoreType core_type) const {
+    std::bitset<NUM_SEMAPHORES> used_semaphores;
+
+    // check existing semaphores
+    for (const auto& sem_desc : semaphores) {
+        if (sem_desc.core_type == core_type && sem_desc.core_ranges.contains(core)) {
+            used_semaphores.set(sem_desc.id);
+        }
+    }
+
+    // find first available semaphore ID
+    for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
+        if (!used_semaphores.test(i)) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -258,6 +258,7 @@ void py_module(nb::module_& mod) {
                 TT_FATAL(device, "Device ID requested for MeshCoord {} not found.", coord);
                 return device->id();
             })
+        .def("get_fabric_node_id", &MeshDevice::get_fabric_node_id, nb::arg("coord"))
         .def(
             "create_submesh",
             &MeshDevice::create_submesh,

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -4,16 +4,51 @@
 
 #include "fabric.hpp"
 
-#include <optional>
-
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/vector.h>
 
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 
 namespace ttnn::fabric {
 
 void bind_fabric_api(nb::module_& mod) {
+    nb::class_<tt::tt_fabric::MeshId>(mod, "MeshId", R"(
+        Mesh identifier wrapping a uint32_t value.
+        Used to identify different meshes in a multi-mesh fabric topology.
+    )")
+        .def(nb::init<uint32_t>(), nb::arg("value"), "Create a MeshId from an integer value.")
+        .def(
+            "__int__", [](const tt::tt_fabric::MeshId& id) { return *id; }, "Convert MeshId to integer.")
+        .def(
+            "__eq__",
+            [](const tt::tt_fabric::MeshId& lhs, const tt::tt_fabric::MeshId& rhs) { return lhs == rhs; },
+            nb::arg("other"))
+        .def("__repr__", [](const tt::tt_fabric::MeshId& id) { return fmt::format("MeshId({})", *id); });
+
+    nb::class_<tt::tt_fabric::FabricNodeId>(mod, "FabricNodeId", R"(
+        Identifies a node (chip) in the fabric topology.
+        Combines a mesh_id and chip_id to uniquely identify a device.
+    )")
+        .def(
+            nb::init<tt::tt_fabric::MeshId, uint32_t>(),
+            nb::arg("mesh_id"),
+            nb::arg("chip_id"),
+            "Create a FabricNodeId from mesh_id and chip_id.")
+        .def_ro("mesh_id", &tt::tt_fabric::FabricNodeId::mesh_id, "The mesh identifier.")
+        .def_ro("chip_id", &tt::tt_fabric::FabricNodeId::chip_id, "The chip identifier within the mesh.")
+        .def(
+            "__eq__",
+            [](const tt::tt_fabric::FabricNodeId& lhs, const tt::tt_fabric::FabricNodeId& rhs) { return lhs == rhs; },
+            nb::arg("other"))
+        .def("__repr__", [](const tt::tt_fabric::FabricNodeId& id) {
+            return fmt::format("FabricNodeId(M{}, D{})", *id.mesh_id, id.chip_id);
+        });
+
     // custom mapping here for interface stability
     nb::enum_<tt::tt_fabric::FabricConfig>(mod, "FabricConfig")
         .value("DISABLED", tt::tt_fabric::FabricConfig::DISABLED)
@@ -90,6 +125,56 @@ void bind_fabric_api(nb::module_& mod) {
         nb::arg("fabric_udm_mode") = nb::cast(tt::tt_fabric::FabricUDMMode::DISABLED),
         nb::arg("fabric_manager_mode") = nb::cast(tt::tt_fabric::FabricManagerMode::DEFAULT),
         nb::arg("router_config") = nb::cast(tt::tt_fabric::FabricRouterConfig{}));
+
+    // Returns fabric connection runtime args (also adds semaphores to program_descriptor)
+    mod.def(
+        "get_fabric_connection_rt_args",
+        [](const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
+           const tt::tt_fabric::FabricNodeId& dst_fabric_node_id,
+           uint32_t link_idx,
+           tt::tt_metal::ProgramDescriptor& program_descriptor,
+           tt::tt_metal::CoreCoord worker_core,
+           tt::CoreType core_type) {
+            std::vector<uint32_t> fabric_args;
+
+            tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
+                src_fabric_node_id,
+                dst_fabric_node_id,
+                link_idx,
+                program_descriptor,
+                worker_core,
+                fabric_args,
+                core_type);
+
+            return fabric_args;
+        },
+        nb::arg("src_fabric_node_id"),
+        nb::arg("dst_fabric_node_id"),
+        nb::arg("link_idx"),
+        nb::arg("program_descriptor"),
+        nb::arg("worker_core"),
+        nb::arg("core_type") = nb::cast(tt::CoreType::WORKER),
+        R"(
+            Returns fabric connection runtime arguments and adds semaphores to program.
+
+            This function computes the runtime args needed to connect a worker to the
+            fabric router, and also adds necessary semaphores to the program descriptor.
+
+            Args:
+                src_fabric_node_id: FabricNodeId of the source chip
+                dst_fabric_node_id: FabricNodeId of the destination chip
+                link_idx: Link index (0..n) to use between src and dst chips
+                program_descriptor: ProgramDescriptor to add semaphores to (mutated)
+                worker_core: Logical core coordinate of the worker
+                core_type: Core type (WORKER or ETH), defaults to WORKER
+
+            Returns:
+                List of runtime args to extend the kernel's runtime args with
+
+            Note:
+                - Source and destination chips should be physically adjacent (for 1D fabric)
+                - Source and destination chips should be on the same mesh (for 1D fabric)
+        )");
 }
 
 }  // namespace ttnn::fabric

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -126,9 +126,8 @@ void bind_fabric_api(nb::module_& mod) {
         nb::arg("fabric_manager_mode") = nb::cast(tt::tt_fabric::FabricManagerMode::DEFAULT),
         nb::arg("router_config") = nb::cast(tt::tt_fabric::FabricRouterConfig{}));
 
-    // Returns fabric connection runtime args (also adds semaphores to program_descriptor)
     mod.def(
-        "get_fabric_connection_rt_args",
+        "setup_fabric_connection",
         [](const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
            const tt::tt_fabric::FabricNodeId& dst_fabric_node_id,
            uint32_t link_idx,
@@ -155,11 +154,8 @@ void bind_fabric_api(nb::module_& mod) {
         nb::arg("worker_core"),
         nb::arg("core_type") = nb::cast(tt::CoreType::WORKER),
         R"(
-            Returns fabric connection runtime arguments and adds semaphores to program.
-
-            This function computes the runtime args needed to connect a worker to the
-            fabric router, and also adds necessary semaphores to the program descriptor.
-
+            Sets up fabric connection: returns necessary runtime args and appends SemaphoreDescriptors to
+            the given ProgramDescriptor
             Args:
                 src_fabric_node_id: FabricNodeId of the source chip
                 dst_fabric_node_id: FabricNodeId of the destination chip
@@ -167,13 +163,6 @@ void bind_fabric_api(nb::module_& mod) {
                 program_descriptor: ProgramDescriptor to add semaphores to (mutated)
                 worker_core: Logical core coordinate of the worker
                 core_type: Core type (WORKER or ETH), defaults to WORKER
-
-            Returns:
-                List of runtime args to extend the kernel's runtime args with
-
-            Note:
-                - Source and destination chips should be physically adjacent (for 1D fabric)
-                - Source and destination chips should be on the same mesh (for 1D fabric)
         )");
 }
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -24,17 +24,17 @@ void verify_no_duplicate_mesh_coord_ranges(
 }
 
 GenericOpDeviceOperation::program_factory_t GenericOpDeviceOperation::select_program_factory(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
     return program::GenericMeshProgramFactory{};
 }
 
 void GenericOpDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& attributes, const tensor_args_t& /*tensor_args*/) {
     verify_no_duplicate_mesh_coord_ranges(attributes.mesh_programs);
 }
 
 void GenericOpDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& attributes, const tensor_args_t& /*tensor_args*/) {
     verify_no_duplicate_mesh_coord_ranges(attributes.mesh_programs);
 }
 
@@ -45,7 +45,7 @@ spec_return_value_t GenericOpDeviceOperation::compute_output_specs(
 }
 
 tensor_return_value_t GenericOpDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
     // Don't create anything, user is passing output tensor.
     return tensor_args.output_tensor;
 }
@@ -113,7 +113,7 @@ tt::stl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::Progra
 }
 
 tt::stl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
     size_t hash = 0;
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
         ttsl::hash::hash_combine(hash, mesh_coord_range);

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -95,18 +95,14 @@ tt::stl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::Progra
     return hash;
 }
 
-tt::stl::hash::hash_t compute_mesh_program_descriptor_hash(
-    const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor) {
-    size_t hash = 0;
-    // for (const auto& mesh_program : mesh_program_descriptor.mesh_programs) {
-    //     ttsl::hash::hash_combine(hash, compute_program_descriptor_hash(mesh_program.second));
-    // }
-    return hash;
-}
-
 tt::stl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return compute_mesh_program_descriptor_hash(operation_attributes);
+    size_t hash = 0;
+    for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
+        ttsl::hash::hash_combine(hash, mesh_coord_range);
+        ttsl::hash::hash_combine(hash, compute_program_descriptor_hash(program_descriptor));
+    }
+    return hash;
 }
 
 }  // namespace ttnn::operations::generic

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "generic_op_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include "generic_op_device_operation.hpp"
+#include "generic_op_device_operation_types.hpp"
 
 #include <tt_stl/reflection.hpp>
 #include <unordered_set>
@@ -23,8 +24,8 @@ void verify_no_duplicate_mesh_coord_ranges(
 }
 
 GenericOpDeviceOperation::program_factory_t GenericOpDeviceOperation::select_program_factory(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
-    return GenericMeshProgram{};
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return program::GenericMeshProgramFactory{};
 }
 
 void GenericOpDeviceOperation::validate_on_program_cache_miss(
@@ -37,14 +38,14 @@ void GenericOpDeviceOperation::validate_on_program_cache_hit(
     verify_no_duplicate_mesh_coord_ranges(attributes.mesh_programs);
 }
 
-GenericOpDeviceOperation::spec_return_value_t GenericOpDeviceOperation::compute_output_specs(
+spec_return_value_t GenericOpDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     // User has to do this. Just referencing last element (preallocated output tensor).
     return tensor_args.output_tensor.tensor_spec();
 }
 
-GenericOpDeviceOperation::tensor_return_value_t GenericOpDeviceOperation::create_output_tensors(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+tensor_return_value_t GenericOpDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     // Don't create anything, user is passing output tensor.
     return tensor_args.output_tensor;
 }
@@ -124,9 +125,9 @@ tt::stl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
 }  // namespace ttnn::operations::generic
 
 namespace ttnn::prim {
-ttnn::operations::generic::GenericOpDeviceOperation::tensor_return_value_t generic_op(
+ttnn::operations::generic::tensor_return_value_t generic_op(
     const std::vector<Tensor>& io_tensors,
-    const ttnn::operations::generic::GenericOpDeviceOperation::operation_attributes_t& operation_attributes) {
+    const ttnn::operations::generic::operation_attributes_t& operation_attributes) {
     using OperationType = ttnn::operations::generic::GenericOpDeviceOperation;
     TT_FATAL(
         io_tensors.size() >= 2,

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/mesh_program_descriptor.hpp>
+#include <tt-metalium/global_semaphore.hpp>
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -35,6 +36,7 @@ struct GenericOpDeviceOperation {
 
         struct mesh_shared_variables_t {
             shared_variables_t program_shared_variables;
+            std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -48,6 +50,7 @@ struct GenericOpDeviceOperation {
 
         static cached_program_t create_at(
             const tt::tt_metal::ProgramDescriptor& program_descriptor,
+            const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -36,7 +36,7 @@ struct GenericOpDeviceOperation {
 
         struct mesh_shared_variables_t {
             shared_variables_t program_shared_variables;
-            std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
+            // std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -50,7 +50,7 @@ struct GenericOpDeviceOperation {
 
         static cached_program_t create_at(
             const tt::tt_metal::ProgramDescriptor& program_descriptor,
-            const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
+            // const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -59,17 +59,11 @@ struct GenericOpDeviceOperation {
 
     using program_factory_t = std::variant<GenericMeshProgram>;
 
-    // Mandatory methods
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
-
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Select the program factory based on the operation attributes and tensor args
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
-
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
-
-    // Validate the operation when it creates a program. Usually will have more checks
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -37,7 +37,6 @@ struct GenericOpDeviceOperation {
             shared_variables_t program_shared_variables;
         };
 
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
         using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<mesh_shared_variables_t>;
 
         static cached_mesh_workload_t create_mesh_workload(
@@ -46,7 +45,7 @@ struct GenericOpDeviceOperation {
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 
-        static cached_program_t create_at(
+        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
             const tt::tt_metal::ProgramDescriptor& program_descriptor,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -10,54 +10,17 @@
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include "ttnn/device_operation.hpp"
+#include "generic_op_program_factory.hpp"
+#include "generic_op_device_operation_types.hpp"
 
 namespace ttnn::operations::generic {
 
 struct GenericOpDeviceOperation {
-    using operation_attributes_t = tt::tt_metal::experimental::MeshProgramDescriptor;
-
-    using tensor_return_value_t = Tensor;
-
-    using spec_return_value_t = TensorSpec;
-
-    // NOTE: output tensor is the last element in the vector io_tensors
-    struct tensor_args_t {
-        const std::vector<Tensor>& io_tensors;
-        const Tensor& output_tensor;
-    };
-
-    struct GenericMeshProgram {
-        struct shared_variables_t {
-            uint32_t num_kernel_handles{};
-            std::vector<tt::tt_metal::CBHandle> cb_handles;
-        };
-
-        struct mesh_shared_variables_t {
-            shared_variables_t program_shared_variables;
-        };
-
-        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<mesh_shared_variables_t>;
-
-        static cached_mesh_workload_t create_mesh_workload(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
-            const tt::tt_metal::ProgramDescriptor& program_descriptor,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-
-        static void override_runtime_arguments(
-            cached_mesh_workload_t& cached_mesh_workload,
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
-    };
-
-    using program_factory_t = std::variant<GenericMeshProgram>;
+    using operation_attributes_t = generic::operation_attributes_t;
+    using tensor_args_t = generic::tensor_args_t;
+    using spec_return_value_t = generic::spec_return_value_t;
+    using tensor_return_value_t = generic::tensor_return_value_t;
+    using program_factory_t = std::variant<program::GenericMeshProgramFactory>;
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
@@ -75,7 +38,7 @@ struct GenericOpDeviceOperation {
 }  // namespace ttnn::operations::generic
 
 namespace ttnn::prim {
-ttnn::operations::generic::GenericOpDeviceOperation::tensor_return_value_t generic_op(
+ttnn::operations::generic::tensor_return_value_t generic_op(
     const std::vector<Tensor>& io_tensors,
-    const ttnn::operations::generic::GenericOpDeviceOperation::operation_attributes_t& operation_attributes);
+    const ttnn::operations::generic::operation_attributes_t& operation_attributes);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -7,7 +7,6 @@
 #include <variant>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/mesh_program_descriptor.hpp>
-#include <tt-metalium/global_semaphore.hpp>
 
 #include "ttnn/decorators.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -36,7 +35,6 @@ struct GenericOpDeviceOperation {
 
         struct mesh_shared_variables_t {
             shared_variables_t program_shared_variables;
-            // std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -50,7 +48,6 @@ struct GenericOpDeviceOperation {
 
         static cached_program_t create_at(
             const tt::tt_metal::ProgramDescriptor& program_descriptor,
-            // const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation_types.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/experimental/mesh_program_descriptor.hpp>
+
+namespace ttnn::operations::generic {
+
+using operation_attributes_t = tt::tt_metal::experimental::MeshProgramDescriptor;
+using tensor_return_value_t = Tensor;
+using spec_return_value_t = TensorSpec;
+
+// NOTE: output tensor is the last element in the vector io_tensors
+struct tensor_args_t {
+    const std::vector<Tensor>& io_tensors;
+    const Tensor& output_tensor;
+};
+
+}  // namespace ttnn::operations::generic

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/global_circular_buffer.hpp>
 
 #include "generic_op_device_operation.hpp"
-// #include "ttnn/global_semaphore.hpp"
 
 namespace ttnn::operations::generic {
 using namespace tt::tt_metal;
@@ -23,20 +22,7 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, mesh_shared_variables_t> mesh_shared_variables;
 
-    distributed::MeshDevice* mesh_device = tensor_args.io_tensors.front().device();
-    auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-
-    // std::vector<GlobalSemaphore> global_semaphores;
-    // global_semaphores.reserve(operation_attributes.global_semaphores.size());
-    // for (const auto& sem_desc : operation_attributes.global_semaphores) {
-    //     global_semaphores.push_back(ttnn::global_semaphore::create_global_semaphore(
-    //         mesh_device, sem_desc.cores, sem_desc.initial_value, sem_desc.buffer_type));
-    // }
-    // if (!global_semaphores.empty()) {
-    //     ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {subdevice_id};
-    //     tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevice_ids);
-    // }
+    // distributed::MeshDevice* mesh_device = tensor_args.io_tensors.front().device();
 
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
         auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
@@ -48,24 +34,8 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
 
 GenericOpDeviceOperation::GenericMeshProgram::cached_program_t GenericOpDeviceOperation::GenericMeshProgram::create_at(
     const tt::tt_metal::ProgramDescriptor& program_descriptor,
-    // const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
-    // Make a copy and resolve GlobalSemaphore refs in-place
-    // ProgramDescriptor resolved_descriptor = program_descriptor;
-    // for (auto& kernel : resolved_descriptor.kernels) {
-    //     for (auto& row : kernel.runtime_args) {
-    //         for (auto& core_args : row) {
-    //             if (core_args.needs_resolution()) {
-    //                 core_args.resolve(global_semaphores);
-    //             }
-    //         }
-    //     }
-    //     if (kernel.common_runtime_args.needs_resolution()) {
-    //         kernel.common_runtime_args.resolve(global_semaphores);
-    //     }
-    // }
-
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
     Program program{program_descriptor};
     shared_variables_t shared_vars;
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -34,7 +34,8 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
 }
 
-GenericOpDeviceOperation::GenericMeshProgram::cached_program_t GenericOpDeviceOperation::GenericMeshProgram::create_at(
+ttnn::device_operation::CachedProgram<GenericOpDeviceOperation::GenericMeshProgram::shared_variables_t>
+GenericOpDeviceOperation::GenericMeshProgram::create_at(
     const tt::tt_metal::ProgramDescriptor& program_descriptor,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -35,8 +35,8 @@ GenericMeshProgramFactory::cached_mesh_workload_t GenericMeshProgramFactory::cre
 
 GenericMeshProgramFactory::cached_program_t GenericMeshProgramFactory::create_at(
     const tt::tt_metal::ProgramDescriptor& program_descriptor,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
     Program program{program_descriptor};
     shared_variables_t shared_vars;
 
@@ -116,8 +116,8 @@ void override_program_runtime_arguments(
 void GenericMeshProgramFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_mesh_workload,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
     auto& workload_programs = cached_mesh_workload.workload.get_programs();
     const auto& mesh_programs = operation_attributes.mesh_programs;
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -11,50 +11,10 @@
 #include <tt-metalium/mesh_device.hpp>
 
 #include "generic_op_device_operation.hpp"
-#include "ttnn/operations/ccl/ccl_common.hpp"
 
 namespace ttnn::operations::generic {
 using namespace tt::tt_metal;
 using namespace tt::tt_metal::experimental;
-
-std::vector<FabricConnectionDescriptor> generate_fabric_connections_from_topology(
-    const FabricTopologyDescriptor& topo_desc,
-    const Tensor& reference_tensor,
-    const std::vector<ttnn::MeshCoordinate>& all_coords) {
-    std::vector<FabricConnectionDescriptor> connections;
-
-    for (const auto& coord : all_coords) {
-        auto forward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-            reference_tensor, coord, 1, topo_desc.topology, topo_desc.cluster_axis);
-
-        if (forward_coord.has_value()) {
-            connections.push_back(FabricConnectionDescriptor{
-                .src_coord = coord,
-                .dst_coord = forward_coord.value(),
-                .kernel_index = topo_desc.kernel_index,
-                .worker_core = topo_desc.worker_core,
-                .link_idx = 0,
-                .core_type = topo_desc.core_type});
-        }
-
-        if (topo_desc.topology != tt::tt_fabric::Topology::NeighborExchange) {
-            auto backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
-                reference_tensor, coord, -1, topo_desc.topology, topo_desc.cluster_axis);
-
-            if (backward_coord.has_value()) {
-                connections.push_back(FabricConnectionDescriptor{
-                    .src_coord = coord,
-                    .dst_coord = backward_coord.value(),
-                    .kernel_index = topo_desc.kernel_index,
-                    .worker_core = topo_desc.worker_core,
-                    .link_idx = 0,
-                    .core_type = topo_desc.core_type});
-            }
-        }
-    }
-
-    return connections;
-}
 
 GenericOpDeviceOperation::GenericMeshProgram::cached_mesh_workload_t
 GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
@@ -65,124 +25,10 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, mesh_shared_variables_t> mesh_shared_variables;
 
-    const bool has_fabric_topology = operation_attributes.fabric_topology.has_value();
-    const bool has_fabric_connections = !operation_attributes.fabric_connections.empty();
-    const bool needs_fabric_setup = (has_fabric_topology || has_fabric_connections);
-
-    // MUX mode means user handles all fabric setup - framework should not set up fabric connections
-    TT_FATAL(
-        !(operation_attributes.mode == FabricConnectionMode::MUX && needs_fabric_setup),
-        "MUX mode should not specify fabric_topology or fabric_connections - user handles all fabric setup");
-
-    if (!needs_fabric_setup) {
-        for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-            auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
-            mesh_workload.add_program(mesh_coord_range, std::move(cached_program.program));
-            mesh_shared_variables[mesh_coord_range] =
-                mesh_shared_variables_t{std::move(cached_program.shared_variables)};
-        }
-        return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
-    }
-
-    distributed::MeshDevice* mesh_device = tensor_args.io_tensors.front().device();
-    std::vector<ttnn::MeshCoordinate> all_coords = tensor_coords.coords();
-
-    std::vector<FabricConnectionDescriptor> fabric_connections;
-    if (has_fabric_topology) {
-        const auto& reference_tensor = tensor_args.io_tensors.front();
-        fabric_connections = generate_fabric_connections_from_topology(
-            operation_attributes.fabric_topology.value(), reference_tensor, all_coords);
-    } else {
-        fabric_connections = operation_attributes.fabric_connections;
-    }
-
-    // Process each coord and create programs directly
-    std::unordered_map<ttnn::MeshCoordinate, Program> programs_by_coord;
-    std::unordered_map<ttnn::MeshCoordinate, shared_variables_t> shared_vars_by_coord;
-
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        for (const auto& coord : mesh_coord_range) {
-            // Filter connections for this coord
-            std::vector<const FabricConnectionDescriptor*> coord_connections;
-            for (const auto& connection : fabric_connections) {
-                if (connection.src_coord == coord) {
-                    coord_connections.push_back(&connection);
-                }
-            }
-
-            if (coord_connections.empty()) {
-                // No fabric connections - use original descriptor directly
-                auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
-                programs_by_coord[coord] = std::move(cached_program.program);
-                shared_vars_by_coord[coord] = std::move(cached_program.shared_variables);
-                continue;
-            }
-
-            // Has fabric connections - create modified descriptor
-            ProgramDescriptor modified_desc = program_descriptor;
-            auto src_fabric_node_id = mesh_device->get_fabric_node_id(coord);
-
-            for (const auto* connection : coord_connections) {
-                TT_FATAL(
-                    connection->mode != FabricConnectionMode::MUX, "Fabric connections are not supported for MUX mode");
-                if (connection->kernel_index >= modified_desc.kernels.size()) {
-                    continue;
-                }
-
-                // TODO (vtangTT): need to handle routing plane setup here for 1:N connections (all_broadcast, etc.)
-                auto& kernel_desc = modified_desc.kernels[connection->kernel_index];
-
-                // Find runtime args for this core
-                auto args_it = std::find_if(
-                    kernel_desc.runtime_args.begin(), kernel_desc.runtime_args.end(), [&connection](const auto& pair) {
-                        return pair.first == connection->worker_core;
-                    });
-
-                TT_FATAL(
-                    args_it != kernel_desc.runtime_args.end(),
-                    "Core {} has fabric connections but no base runtime args for kernel {}",
-                    connection->worker_core.str(),
-                    connection->kernel_index);
-
-                auto& args_vec = args_it->second;
-                auto dst_fabric_node_id = mesh_device->get_fabric_node_id(connection->dst_coord);
-
-                auto link_indices = tt::tt_fabric::get_forwarding_link_indices(src_fabric_node_id, dst_fabric_node_id);
-                uint32_t selected_link =
-                    link_indices.empty()
-                        ? 0
-                        : (connection->link_idx >= link_indices.size() ? link_indices[0] : connection->link_idx);
-
-                bool is_forward = !args_vec.empty() && args_vec.back() != 0;
-                if (!is_forward) {
-                    args_vec.push_back(1);  // backward_flag = 1
-                }
-
-                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
-                    src_fabric_node_id,
-                    dst_fabric_node_id,
-                    selected_link,
-                    modified_desc,
-                    connection->worker_core,
-                    args_vec);
-
-                if (is_forward) {
-                    args_vec.push_back(0);  // backward_flag = 0
-                }
-            }
-
-            // Create program with modified descriptor
-            auto cached_program = create_at(modified_desc, tensor_args, tensor_return_value);
-            programs_by_coord[coord] = std::move(cached_program.program);
-            shared_vars_by_coord[coord] = std::move(cached_program.shared_variables);
-        }
-    }
-
-    // Add programs to workload (stored by individual coordinate instead of ranges when fabric is used)
-    for (auto& [coord, program] : programs_by_coord) {
-        ttnn::MeshCoordinateRange single_coord_range(coord);
-        mesh_workload.add_program(single_coord_range, std::move(program));
-        mesh_shared_variables[single_coord_range] = mesh_shared_variables_t{std::move(shared_vars_by_coord[coord])};
+        auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
+        mesh_workload.add_program(mesh_coord_range, std::move(cached_program.program));
+        mesh_shared_variables[mesh_coord_range] = mesh_shared_variables_t{std::move(cached_program.shared_variables)};
     }
 
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
@@ -282,31 +128,15 @@ void override_program_runtime_arguments(
 void GenericOpDeviceOperation::GenericMeshProgram::override_runtime_arguments(
     cached_mesh_workload_t& cached_mesh_workload,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*tensor_return_value*/) {
-    const bool use_fabric =
-        operation_attributes.fabric_topology.has_value() || !operation_attributes.fabric_connections.empty();
-
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
     for (auto& [mesh_coord_range, program] : cached_mesh_workload.workload.get_programs()) {
         auto& shared_vars = cached_mesh_workload.shared_variables.at(mesh_coord_range);
         auto& program_shared_vars = shared_vars.program_shared_variables;
 
-        const ProgramDescriptor* program_desc = nullptr;
-        if (!use_fabric) {
-            auto it = operation_attributes.mesh_programs.find(mesh_coord_range);
-            if (it != operation_attributes.mesh_programs.end()) {
-                program_desc = &it->second;
-            }
-        } else {
-            // Fabric used - programs stored by single coordinate (not ranges), find matching descriptor
-            for (const auto& coord : mesh_coord_range) {
-                program_desc = find_program_descriptor_for_coord(operation_attributes.mesh_programs, coord);
-                break;
-            }
-        }
-
-        if (program_desc) {
-            override_program_runtime_arguments(program, program_shared_vars, *program_desc);
+        auto it = operation_attributes.mesh_programs.find(mesh_coord_range);
+        if (it != operation_attributes.mesh_programs.end()) {
+            override_program_runtime_arguments(program, program_shared_vars, it->second);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -58,9 +58,11 @@ std::vector<FabricConnectionDescriptor> generate_fabric_connections_from_topolog
     return connections;
 }
 
-// Apply a single fabric connection to a program
 void apply_fabric_connection(
-    Program& program, const FabricConnectionDescriptor& connection, distributed::MeshDevice* mesh_device) {
+    Program& program,
+    const FabricConnectionDescriptor& connection,
+    distributed::MeshDevice* mesh_device,
+    std::vector<uint32_t>& args_vec) {
     auto src_fabric_node_id = mesh_device->get_fabric_node_id(connection.src_coord);
     auto dst_fabric_node_id = mesh_device->get_fabric_node_id(connection.dst_coord);
 
@@ -68,10 +70,22 @@ void apply_fabric_connection(
     uint32_t selected_link =
         (link_indices.empty() || connection.link_idx < link_indices.size()) ? connection.link_idx : link_indices[0];
 
-    // Copy existing runtime args and append fabric connection args
-    auto& kernel_rt_args = GetRuntimeArgs(program, connection.kernel_index, connection.worker_core);
-    std::vector<uint32_t> args_vec(kernel_rt_args.data(), kernel_rt_args.data() + kernel_rt_args.size());
+    // The last arg is expected to be the direction flag (is_forward / forward_flag).
+    // FabricConnectionManager::build_from_args expects: forward_flag, [forward_args], backward_flag, [backward_args]
+    // Since we're only setting up one direction (src -> dst), we add:
+    // - forward_fabric_args (if the direction flag was forward/true)
+    // - backward_flag = 0 (or 1 if direction was backward, then no forward args were added)
 
+    // Determine if this is a forward or backward connection by checking the direction flag
+    // (assumed to be the last element before we append fabric args)
+    bool is_forward = !args_vec.empty() && args_vec.back() != 0;
+
+    // For backward direction, we need to add backward_flag=1 before fabric args
+    if (!is_forward) {
+        args_vec.push_back(1);  // backward_flag = 1
+    }
+
+    // Append fabric connection args
     tt::tt_fabric::append_fabric_connection_rt_args(
         src_fabric_node_id,
         dst_fabric_node_id,
@@ -80,6 +94,11 @@ void apply_fabric_connection(
         connection.worker_core,
         args_vec,
         connection.core_type);
+
+    // For forward direction, we need to add backward_flag=0 after fabric args
+    if (is_forward) {
+        args_vec.push_back(0);  // backward_flag = 0
+    }
 
     SetRuntimeArgs(program, connection.kernel_index, connection.worker_core, args_vec);
 }
@@ -133,21 +152,67 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
         fabric_connections = operation_attributes.fabric_connections;
     }
 
+    // Build a map of which kernels on which coords have fabric connections
+    // These kernels should NOT have their runtime args set during Program construction
+    // because we need to append fabric connection args first
+    std::unordered_map<ttnn::MeshCoordinate, std::unordered_set<size_t>> kernels_with_fabric;
+    for (const auto& connection : fabric_connections) {
+        kernels_with_fabric[connection.src_coord].insert(connection.kernel_index);
+    }
+
     std::unordered_map<ttnn::MeshCoordinate, Program> programs_by_coord;
     std::unordered_map<ttnn::MeshCoordinate, shared_variables_t> shared_vars_by_coord;
+    // Store original runtime args for kernels with fabric connections
+    std::unordered_map<ttnn::MeshCoordinate, std::unordered_map<size_t, KernelDescriptor::RuntimeArgs>>
+        original_runtime_args;
+
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
         for (const auto& coord : mesh_coord_range) {
-            auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
-            programs_by_coord[coord] = std::move(cached_program.program);
-            shared_vars_by_coord[coord] = std::move(cached_program.shared_variables);
+            // Check if this coord has any fabric connections
+            auto fabric_it = kernels_with_fabric.find(coord);
+            if (fabric_it != kernels_with_fabric.end()) {
+                // Create a modified descriptor without runtime args for fabric kernels
+                ProgramDescriptor modified_desc = program_descriptor;
+                for (size_t kernel_idx : fabric_it->second) {
+                    if (kernel_idx < modified_desc.kernels.size()) {
+                        // Save original runtime args
+                        original_runtime_args[coord][kernel_idx] = modified_desc.kernels[kernel_idx].runtime_args;
+                        // Clear runtime args so Program constructor doesn't set them
+                        modified_desc.kernels[kernel_idx].runtime_args.clear();
+                    }
+                }
+                auto cached_program = create_at(modified_desc, tensor_args, tensor_return_value);
+                programs_by_coord[coord] = std::move(cached_program.program);
+                shared_vars_by_coord[coord] = std::move(cached_program.shared_variables);
+            } else {
+                auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
+                programs_by_coord[coord] = std::move(cached_program.program);
+                shared_vars_by_coord[coord] = std::move(cached_program.shared_variables);
+            }
         }
     }
 
     // Apply fabric connections to programs
+    // This builds the full runtime args (original + fabric args) and sets them
     for (const auto& connection : fabric_connections) {
         auto it = programs_by_coord.find(connection.src_coord);
         if (it != programs_by_coord.end()) {
-            apply_fabric_connection(it->second, connection, mesh_device);
+            // Get original runtime args for this kernel
+            std::vector<uint32_t> args_vec;
+            auto orig_it = original_runtime_args.find(connection.src_coord);
+            if (orig_it != original_runtime_args.end()) {
+                auto kernel_it = orig_it->second.find(connection.kernel_index);
+                if (kernel_it != orig_it->second.end()) {
+                    // Find the runtime args for the specific worker core
+                    for (const auto& [core, args] : kernel_it->second) {
+                        if (core == connection.worker_core) {
+                            args_vec = args;
+                            break;
+                        }
+                    }
+                }
+            }
+            apply_fabric_connection(it->second, connection, mesh_device, args_vec);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -25,29 +25,49 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
 
     distributed::MeshDevice* mesh_device = tensor_args.io_tensors.front().device();
     auto subdevice_id = operation_attributes.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto available_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
-    std::vector<GlobalSemaphore> global_semaphores(operation_attributes.global_semaphores.size());
-    for (size_t i = 0; i < operation_attributes.global_semaphores.size(); i++) {
-        const auto& semaphore = operation_attributes.global_semaphores[i];
-        global_semaphores[i] = ttnn::global_semaphore::create_global_semaphore(
-            mesh_device, semaphore.cores, semaphore.initial_value, semaphore.buffer_type);
+    auto subdevice_cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+
+    std::vector<GlobalSemaphore> global_semaphores;
+    global_semaphores.reserve(operation_attributes.global_semaphores.size());
+    for (const auto& sem_desc : operation_attributes.global_semaphores) {
+        global_semaphores.push_back(ttnn::global_semaphore::create_global_semaphore(
+            mesh_device, sem_desc.cores, sem_desc.initial_value, sem_desc.buffer_type));
     }
-    ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {subdevice_id};
-    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevice_ids);
+    if (!global_semaphores.empty()) {
+        ttnn::SmallVector<tt::tt_metal::SubDeviceId> subdevice_ids = {subdevice_id};
+        tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, subdevice_ids);
+    }
 
     for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        auto cached_program = create_at(program_descriptor, tensor_args, tensor_return_value);
+        auto cached_program = create_at(program_descriptor, global_semaphores, tensor_args, tensor_return_value);
         mesh_workload.add_program(mesh_coord_range, std::move(cached_program.program));
-        mesh_shared_variables[mesh_coord_range] = mesh_shared_variables_t{std::move(cached_program.shared_variables)};
+        mesh_shared_variables[mesh_coord_range] =
+            mesh_shared_variables_t{std::move(cached_program.shared_variables), global_semaphores};
     }
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
 }
 
 GenericOpDeviceOperation::GenericMeshProgram::cached_program_t GenericOpDeviceOperation::GenericMeshProgram::create_at(
     const tt::tt_metal::ProgramDescriptor& program_descriptor,
+    const std::vector<tt::tt_metal::GlobalSemaphore>& global_semaphores,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& /*tensor_return_value*/) {
-    Program program{program_descriptor};
+    // Make a copy and resolve GlobalSemaphore refs in-place
+    ProgramDescriptor resolved_descriptor = program_descriptor;
+    for (auto& kernel : resolved_descriptor.kernels) {
+        for (auto& row : kernel.runtime_args) {
+            for (auto& core_args : row) {
+                if (core_args.needs_resolution()) {
+                    core_args.resolve(global_semaphores);
+                }
+            }
+        }
+        if (kernel.common_runtime_args.needs_resolution()) {
+            kernel.common_runtime_args.resolve(global_semaphores);
+        }
+    }
+
+    Program program{resolved_descriptor};
     shared_variables_t shared_vars;
 
     auto cbs = program.circular_buffers();
@@ -73,28 +93,29 @@ void override_program_runtime_arguments(
     for (size_t kernel_handle = 0; kernel_handle < shared_vars.num_kernel_handles; ++kernel_handle) {
         const auto& kernel_desc = program_descriptor.kernels[kernel_handle];
 
-        for (const auto& [core_coord, runtime_arg] : kernel_desc.runtime_args) {
-            if (!runtime_arg.empty()) {
-                auto& cached_runtime_args = GetRuntimeArgs(program, kernel_handle, core_coord);
-                TT_FATAL(
-                    cached_runtime_args.size() == runtime_arg.size(),
-                    "Runtime args size mismatch: cached {} vs new {}",
-                    cached_runtime_args.size(),
-                    runtime_arg.size());
-                std::copy(runtime_arg.begin(), runtime_arg.end(), cached_runtime_args.data());
+        for (size_t i = 0; i < kernel_desc.runtime_args.size(); i++) {
+            for (size_t j = 0; j < kernel_desc.runtime_args[i].size(); j++) {
+                const auto& core_rt_args = kernel_desc.runtime_args[i][j];
+                if (!core_rt_args.empty()) {
+                    auto& cached_runtime_args = GetRuntimeArgs(program, kernel_handle, CoreCoord(i, j));
+                    TT_FATAL(
+                        cached_runtime_args.size() == core_rt_args.size(),
+                        "Runtime args size mismatch: cached {} vs new {}",
+                        cached_runtime_args.size(),
+                        core_rt_args.size());
+                    std::copy(core_rt_args.begin(), core_rt_args.end(), cached_runtime_args.data());
+                }
             }
         }
-        if (!kernel_desc.common_runtime_args.empty()) {
+        const auto& common_args = kernel_desc.common_runtime_args;
+        if (!common_args.empty()) {
             auto& cached_common_runtime_args = GetCommonRuntimeArgs(program, kernel_handle);
             TT_FATAL(
-                cached_common_runtime_args.size() == kernel_desc.common_runtime_args.size(),
+                cached_common_runtime_args.size() == common_args.size(),
                 "Common runtime args size mismatch: cached {} vs new {}",
                 cached_common_runtime_args.size(),
-                kernel_desc.common_runtime_args.size());
-            std::copy(
-                kernel_desc.common_runtime_args.begin(),
-                kernel_desc.common_runtime_args.end(),
-                cached_common_runtime_args.data());
+                common_args.size());
+            std::copy(common_args.begin(), common_args.end(), cached_common_runtime_args.data());
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -10,14 +10,13 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/mesh_device.hpp>
 
-#include "generic_op_device_operation.hpp"
+#include "generic_op_program_factory.hpp"
 
-namespace ttnn::operations::generic {
+namespace ttnn::operations::generic::program {
 using namespace tt::tt_metal;
 using namespace tt::tt_metal::experimental;
 
-GenericOpDeviceOperation::GenericMeshProgram::cached_mesh_workload_t
-GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
+GenericMeshProgramFactory::cached_mesh_workload_t GenericMeshProgramFactory::create_mesh_workload(
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& /*tensor_coords*/,
     const tensor_args_t& tensor_args,
@@ -34,8 +33,7 @@ GenericOpDeviceOperation::GenericMeshProgram::create_mesh_workload(
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(mesh_shared_variables)};
 }
 
-ttnn::device_operation::CachedProgram<GenericOpDeviceOperation::GenericMeshProgram::shared_variables_t>
-GenericOpDeviceOperation::GenericMeshProgram::create_at(
+GenericMeshProgramFactory::cached_program_t GenericMeshProgramFactory::create_at(
     const tt::tt_metal::ProgramDescriptor& program_descriptor,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -54,7 +52,7 @@ GenericOpDeviceOperation::GenericMeshProgram::create_at(
 
 void override_program_runtime_arguments(
     Program& program,
-    GenericOpDeviceOperation::GenericMeshProgram::shared_variables_t& shared_vars,
+    GenericMeshProgramFactory::shared_variables_t& shared_vars,
     const ProgramDescriptor& program_descriptor) {
     // Update kernel runtime args.
     TT_ASSERT(
@@ -115,7 +113,7 @@ void override_program_runtime_arguments(
     }
 }
 
-void GenericOpDeviceOperation::GenericMeshProgram::override_runtime_arguments(
+void GenericMeshProgramFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_mesh_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -141,4 +139,4 @@ void GenericOpDeviceOperation::GenericMeshProgram::override_runtime_arguments(
             program_it->second, shared_vars.program_shared_variables, program_descriptor);
     }
 }
-}  // namespace ttnn::operations::generic
+}  // namespace ttnn::operations::generic::program

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -51,17 +51,6 @@ GenericOpDeviceOperation::GenericMeshProgram::cached_program_t GenericOpDeviceOp
     return {std::move(program), std::move(shared_vars)};
 }
 
-const ProgramDescriptor* find_program_descriptor_for_coord(
-    const std::unordered_map<ttnn::MeshCoordinateRange, ProgramDescriptor>& mesh_programs,
-    const ttnn::MeshCoordinate& coord) {
-    for (const auto& [range, desc] : mesh_programs) {
-        if (range.contains(coord)) {
-            return &desc;
-        }
-    }
-    return nullptr;
-}
-
 void override_program_runtime_arguments(
     Program& program,
     GenericOpDeviceOperation::GenericMeshProgram::shared_variables_t& shared_vars,

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "generic_op_device_operation_types.hpp"
+
+namespace ttnn::operations::generic::program {
+
+struct GenericMeshProgramFactory {
+    struct shared_variables_t {
+        uint32_t num_kernel_handles{};
+        std::vector<tt::tt_metal::CBHandle> cb_handles;
+    };
+
+    struct mesh_shared_variables_t {
+        shared_variables_t program_shared_variables;
+    };
+
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<mesh_shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const operation_attributes_t& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_mesh_workload,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const tt::tt_metal::ProgramDescriptor& program_descriptor,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::generic::program

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
@@ -8,8 +8,23 @@
 namespace ttnn::operations::generic {
 
 Tensor GenericOp::invoke(
+    const std::vector<Tensor>& io_tensors,
+    const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor) {
+    return ttnn::prim::generic_op(io_tensors, mesh_program_descriptor);
+}
+
+Tensor GenericOp::invoke(
     const std::vector<Tensor>& io_tensors, const tt::tt_metal::ProgramDescriptor& program_descriptor) {
-    return ttnn::prim::generic_op(io_tensors, program_descriptor);
+    // Get mesh shape from the first tensor's device
+    TT_FATAL(!io_tensors.empty(), "io_tensors must not be empty");
+    auto* mesh_device = io_tensors.front().device();
+    TT_FATAL(mesh_device != nullptr, "Tensor must be on a device");
+
+    // Create SPMD MeshProgramDescriptor that broadcasts the program to the entire mesh
+    tt::tt_metal::experimental::MeshProgramDescriptor mesh_program_descriptor;
+    mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(mesh_device->shape()), program_descriptor);
+
+    return invoke(io_tensors, mesh_program_descriptor);
 }
 
 }  // namespace ttnn::operations::generic

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
@@ -15,12 +15,11 @@ Tensor GenericOp::invoke(
 
 Tensor GenericOp::invoke(
     const std::vector<Tensor>& io_tensors, const tt::tt_metal::ProgramDescriptor& program_descriptor) {
-    // Get mesh shape from the first tensor's device
     TT_FATAL(!io_tensors.empty(), "io_tensors must not be empty");
     auto* mesh_device = io_tensors.front().device();
     TT_FATAL(mesh_device != nullptr, "Tensor must be on a device");
 
-    // Create SPMD MeshProgramDescriptor that broadcasts the program to the entire mesh
+    // Create SPMD MeshProgramDescriptor; same program for the entire mesh
     tt::tt_metal::experimental::MeshProgramDescriptor mesh_program_descriptor;
     mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(mesh_device->shape()), program_descriptor);
 

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
@@ -21,7 +21,8 @@ Tensor GenericOp::invoke(
 
     // Create SPMD MeshProgramDescriptor; same program for the entire mesh
     tt::tt_metal::experimental::MeshProgramDescriptor mesh_program_descriptor;
-    mesh_program_descriptor.mesh_programs.emplace(ttnn::MeshCoordinateRange(mesh_device->shape()), program_descriptor);
+    mesh_program_descriptor.mesh_programs.emplace_back(
+        ttnn::MeshCoordinateRange(mesh_device->shape()), program_descriptor);
 
     return invoke(io_tensors, mesh_program_descriptor);
 }

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.hpp
@@ -25,7 +25,6 @@ struct GenericOp {
         const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor);
 
     // Convenience entry point for single ProgramDescriptor (SPMD mode)
-    // Creates a MeshProgramDescriptor that broadcasts the program to the entire mesh
     static Tensor invoke(
         const std::vector<Tensor>& io_tensors, const tt::tt_metal::ProgramDescriptor& program_descriptor);
 };  // struct GenericOp

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/mesh_program_descriptor.hpp>
 #include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::generic {
@@ -17,6 +18,14 @@ namespace ttnn::operations::generic {
 
 struct GenericOp {
     // TODO: #20830 - Split io_tensors into input_tensors and output_tensor properly.
+
+    // Primary entry point for mesh programs
+    static Tensor invoke(
+        const std::vector<Tensor>& io_tensors,
+        const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor);
+
+    // Convenience entry point for single ProgramDescriptor (SPMD mode)
+    // Creates a MeshProgramDescriptor that broadcasts the program to the entire mesh
     static Tensor invoke(
         const std::vector<Tensor>& io_tensors, const tt::tt_metal::ProgramDescriptor& program_descriptor);
 };  // struct GenericOp

--- a/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
@@ -37,10 +37,9 @@ void bind_generic_operation(nb::module_& mod) {
             Refer to tests/ttnn/unit_tests/operations/debug/test_generic_op.py for usage examples
         )doc";
 
-    // Use concrete type for self (required by function_traits - generic lambdas don't work)
+    // Use concrete type for self
     using registered_operation_t = std::decay_t<decltype(ttnn::generic_op)>;
 
-    // Lambdas for each overload with concrete self type
     auto mesh_program_invoke = [](const registered_operation_t& self,
                                   const std::vector<Tensor>& io_tensors,
                                   const tt::tt_metal::experimental::MeshProgramDescriptor& desc) {

--- a/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
@@ -25,8 +25,10 @@ void bind_generic_operation(nb::module_& mod) {
         Args:
             io_tensors (List[ttnn.Tensor]): List of input tensors and output tensor(s). Output tensor(s) must be
                 pre-allocated and included as the last element(s) in the list.
-            program_descriptor (ttnn.ProgramDescriptor): Descriptor containing kernel specifications,
-                computational buffer configurations, semaphores, and other execution parameters.
+            program_descriptor (ttnn.ProgramDescriptor or ttnn.MeshProgramDescriptor): Descriptor containing
+                kernel specifications, computational buffer configurations, semaphores, and other execution
+                parameters. Use ProgramDescriptor for SPMD mode (same program on all devices) or
+                MeshProgramDescriptor for explicit per-device control.
 
         Returns:
             ttnn.Tensor: Handle to the output tensor.
@@ -35,8 +37,28 @@ void bind_generic_operation(nb::module_& mod) {
             Refer to tests/ttnn/unit_tests/operations/debug/test_generic_op.py for usage examples
         )doc";
 
+    // Use concrete type for self (required by function_traits - generic lambdas don't work)
+    using registered_operation_t = std::decay_t<decltype(ttnn::generic_op)>;
+
+    // Lambdas for each overload with concrete self type
+    auto mesh_program_invoke = [](const registered_operation_t& self,
+                                  const std::vector<Tensor>& io_tensors,
+                                  const tt::tt_metal::experimental::MeshProgramDescriptor& desc) {
+        return self(io_tensors, desc);
+    };
+
+    auto program_invoke = [](const registered_operation_t& self,
+                             const std::vector<Tensor>& io_tensors,
+                             const tt::tt_metal::ProgramDescriptor& desc) { return self(io_tensors, desc); };
+
     bind_registered_operation(
-        mod, ttnn::generic_op, doc, ttnn::nanobind_arguments_t{nb::arg("io_tensors"), nb::arg("program_descriptors")});
+        mod,
+        ttnn::generic_op,
+        doc,
+        // Overload for MeshProgramDescriptor (explicit mesh control)
+        ttnn::nanobind_overload_t{mesh_program_invoke, nb::arg("io_tensors"), nb::arg("mesh_program_descriptor")},
+        // Overload for ProgramDescriptor (SPMD mode - broadcasts to all devices)
+        ttnn::nanobind_overload_t{program_invoke, nb::arg("io_tensors"), nb::arg("program_descriptor")});
 }
 
 }  // namespace ttnn::operations::generic

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -161,7 +161,7 @@ from ttnn._ttnn.fabric import (
     set_fabric_config,
     MeshId,
     FabricNodeId,
-    get_fabric_connection_rt_args,
+    setup_fabric_connection,
 )
 
 # Import cluster functions and types

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -159,6 +159,9 @@ from ttnn._ttnn.fabric import (
     FabricUDMMode,
     FabricManagerMode,
     set_fabric_config,
+    MeshId,
+    FabricNodeId,
+    get_fabric_connection_rt_args,
 )
 
 # Import cluster functions and types
@@ -250,6 +253,7 @@ from ttnn.types import (
     RuntimeArgsColProxy,
     SemaphoreDescriptor,
     ProgramDescriptor,
+    MeshProgramDescriptor,
     cb_descriptor_from_sharded_tensor,
     TensorAccessorArgs,
 )

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -107,6 +107,7 @@ RuntimeArgs = ttnn._ttnn.program_descriptor.RuntimeArgs
 RuntimeArgsColProxy = ttnn._ttnn.program_descriptor.RuntimeArgsColProxy
 SemaphoreDescriptor = ttnn._ttnn.program_descriptor.SemaphoreDescriptor
 ProgramDescriptor = ttnn._ttnn.program_descriptor.ProgramDescriptor
+MeshProgramDescriptor = ttnn._ttnn.program_descriptor.MeshProgramDescriptor
 cb_descriptor_from_sharded_tensor = ttnn._ttnn.program_descriptor.cb_descriptor_from_sharded_tensor
 
 TensorAccessorArgs = ttnn._ttnn.tensor_accessor_args.TensorAccessorArgs


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35386

### Problem description
As described in issue

### What's changed
- new `MeshProgramDescriptor` in experimental namespace
    - vector of MeshCoordRange + ProgramDescriptor pairs to describe a MeshWorkload
- generic op support for new descriptor, allowing user to pass either a `MeshProgramDescriptor` or just a `ProgramDescriptor`, which will default to SPMD
- nanobinds for new descriptor + `RuntimeArgsView` to allow for mutable python 2D indexing 

Fabric changes:
- templated helpers that append rt args to accept `ProgramDescriptor`; defaults to just a metal Program (old behaviour)
- nanobinded `append_fabric_connection_rt_args` for use in python land

No strong opinion on whether to change fabric helpers to accept `ProgramDescriptors` and expose them to python or just replicate the logic where needed. Consumers from tt-mlir will not be using these helpers, so it's rly a convenience thing for users who want to prototype with the generic op + descriptor.

Tests added (which is >50% of this PR):
- cpp allgather test w/ MeshProgramDescriptor + generic op
- pytest point to point

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vtangTT/mesh-program-descriptor)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vtangTT/mesh-program-descriptor)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vtangTT/mesh-program-descriptor)
- [x] New/Existing tests provide coverage for changes
  - cpp test: https://github.com/tenstorrent/tt-metal/actions/runs/21006400616/job/60391228242
  - pytest: https://github.com/tenstorrent/tt-metal/actions/runs/21009276464/job/60400993650


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vtangTT/mesh-program-descriptor)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vtangTT/mesh-program-descriptor)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vtangTT/mesh-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vtangTT/mesh-program-descriptor)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs