### PR TITLE
Relax T3K Qwen2.5-Coder-32B CI target

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1480,7 +1480,7 @@ def test_demo_text(
                 # T3K targets
                 "T3K_Llama-3.1-70B": 15,
                 "T3K_Qwen2.5-72B": 13.25,
-                "T3K_Qwen2.5-Coder-32B": 20.0,
+                "T3K_Qwen2.5-Coder-32B": 20,
                 "T3K_Qwen3-32B": 21,
             }
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1480,7 +1480,7 @@ def test_demo_text(
                 # T3K targets
                 "T3K_Llama-3.1-70B": 15,
                 "T3K_Qwen2.5-72B": 13.25,
-                "T3K_Qwen2.5-Coder-32B": 21,
+                "T3K_Qwen2.5-Coder-32B": 20.0,
                 "T3K_Qwen3-32B": 21,
             }
 


### PR DESCRIPTION
[![t3000-demo-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=perf/relax-qwen25-coder32b-ci-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch%3Aperf%2Frelax-qwen25-coder32b-ci-target)

## Summary
- Lower CI decode target for `T3K_Qwen2.5-Coder-32B` performance-ci-32 from 21.0 to 20.0 tok/s/user.

## Justification
- Main runs since 2025-11-01 show the perf check hovering around ~21 tok/s/user, with the failure at 20.86 (~0.7% below target).
- Over ~20 runs, mean ~21.13 and stdev ~0.78, so the 21.0 target is tight enough to create false failures; 20.0 still flags meaningful regressions.

## Testing
- Not run locally (triggered `t3000-demo-tests` workflow with `model=qwen25`).