### PR TITLE
Re-introduce galaxy CCL testing

### DIFF
--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar #issue #35151
+          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           # {

--- a/tests/nightly/tg/ccl/test_all_to_all_combine_6U.py
+++ b/tests/nightly/tg/ccl/test_all_to_all_combine_6U.py
@@ -31,25 +31,25 @@ from tests.nightly.t3000.ccl.test_all_to_all_combine import (
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
         },
-        {
-            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
-        },
-        {
-            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
-        },
+        # {
+        #    "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        #    "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        #    "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+        #    "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        # },# test removed due to issue 35320
+        # {
+        #    "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        #    "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        #    "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        #    "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        # },# test removed due to issue 35320
     ],
     ids=[
         "fabric_2d",
         "fabric_1d_line",
         "fabric_1d_ring",
-        "fabric_manager_enabled_2d",
-        "fabric_manager_enabled_1d_line",
+        # "fabric_manager_enabled_2d",# test removed due to issue 35320
+        # "fabric_manager_enabled_1d_line",# test removed due to issue 35320
     ],
     indirect=True,
 )

--- a/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
@@ -41,14 +41,19 @@ from tracy import signpost
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
         },
-        {
-            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_manager": ttnn.FabricManagerMode.ENABLED,
-        },
+        # {
+        #    "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        #    "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        #    "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        #    "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        # },# test removed due to issue 35320
     ],
-    ids=["fabric_1d_line", "fabric_1d_ring", "fabric_2d", "fabric_manager_enabled_1d_line"],
+    ids=[
+        "fabric_1d_line",
+        "fabric_1d_ring",
+        "fabric_2d",
+        # "fabric_manager_enabled_1d_line"# test removed due to issue 35320
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize("trace_mode", [False])

--- a/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
+++ b/tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py
@@ -52,7 +52,7 @@ from tracy import signpost
         "fabric_1d_line",
         "fabric_1d_ring",
         "fabric_2d",
-        # "fabric_manager_enabled_1d_line"# test removed due to issue 35320
+        # "fabric_manager_enabled_1d_line"  # test removed due to issue 35320
     ],
     indirect=True,
 )

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -53,7 +53,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
         #        "trace_region_size": 90112,
         #    },
         #    ttnn.Topology.Linear,
-        # ),# test removed due to issue 35320
+        # ),  # test removed due to issue 35320
     ],
     indirect=["device_params"],
     ids=[

--- a/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_all_gather_async.py
@@ -46,17 +46,20 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
             },
             ttnn.Topology.Linear,
         ),
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_manager": ttnn.FabricManagerMode.ENABLED,
-                "trace_region_size": 90112,
-            },
-            ttnn.Topology.Linear,
-        ),
+        # (
+        #    {
+        #        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        #        "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        #        "trace_region_size": 90112,
+        #    },
+        #    ttnn.Topology.Linear,
+        # ),# test removed due to issue 35320
     ],
     indirect=["device_params"],
-    ids=["fabric_linear", "fabric_manager_enabled_linear"],
+    ids=[
+        "fabric_linear",
+        # "fabric_manager_enabled_linear" # test removed due to issue 35320
+    ],
 )
 @pytest.mark.parametrize("chunks_per_sync", [20])
 @pytest.mark.parametrize("num_workers_per_link", [2])

--- a/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
@@ -54,17 +54,20 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
             },
             ttnn.Topology.Linear,
         ),
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_manager": ttnn.FabricManagerMode.ENABLED,
-                "trace_region_size": 90112,
-            },
-            ttnn.Topology.Linear,
-        ),
+        # (
+        #    {
+        #        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        #        "fabric_manager": ttnn.FabricManagerMode.ENABLED,
+        #        "trace_region_size": 90112,
+        #    },
+        #    ttnn.Topology.Linear,
+        # ),
     ],
     indirect=["device_params"],
-    ids=["fabric_linear", "fabric_manager_enabled_linear"],
+    ids=[
+        "fabric_linear",
+        # "fabric_manager_enabled_linear"# test removed due to issue 35320
+    ],
 )
 @pytest.mark.parametrize("chunks_per_sync", [2])
 @pytest.mark.parametrize("num_workers_per_link", [2])

--- a/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/tg/ccl/test_minimal_reduce_scatter_async.py
@@ -66,7 +66,7 @@ from models.common.utility_functions import skip_for_blackhole, skip_for_wormhol
     indirect=["device_params"],
     ids=[
         "fabric_linear",
-        # "fabric_manager_enabled_linear"# test removed due to issue 35320
+        # "fabric_manager_enabled_linear" # test removed due to issue 35320
     ],
 )
 @pytest.mark.parametrize("chunks_per_sync", [2])


### PR DESCRIPTION
### Ticket
#35151 

### Problem description
A fabric configuration that requires a wrapper not available in CI was added to the test causing those tests to stall, as a result all CCL testing on galaxy was removed, in this PR we remove the invalid tests and re-introduce CCL testing to galaxy nightly

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jvega/fix_35151)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jvega/fix_35151) https://github.com/tenstorrent/tt-metal/actions/runs/20756403493
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jvega/fix_35151)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/fix_35151)
- [x] Galaxy Nightly https://github.com/tenstorrent/tt-metal/actions/runs/20756504969
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs