### PR TITLE
Adjust host channel sizing and CQ offsets

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -257,7 +257,7 @@ TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
             cq_zeros.data(),
             (cq_size - cq_start),
-            get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
+            get_absolute_cq_offset(local_device->id(), channel, 0, cq_size) + cq_start,
             mmio_device_id,
             channel);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -314,7 +314,7 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
     tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
         cq_zeros.data(),
         (cq_size - cq_start),
-        get_absolute_cq_offset(channel, 0, cq_size) + cq_start,
+        get_absolute_cq_offset(device->id(), channel, 0, cq_size) + cq_start,
         mmio_device_id,
         channel);
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -227,22 +227,22 @@ void Device::configure_command_queue_programs() {
                 this->sysmem_manager_->reset(cq_id);
 
                 pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] =
-                    (cq_start + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
+                    (cq_start + get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size)) >> 4;
                 pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] =
-                    (cq_start + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
+                    (cq_start + get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size)) >> 4;
                 pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) +
-                     get_absolute_cq_offset(channel, cq_id, cq_size)) >>
+                     get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size)) >>
                     4;
                 pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) +
-                     get_absolute_cq_offset(channel, cq_id, cq_size)) >>
+                     get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size)) >>
                     4;
 
                 tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
                     pointers.data(),
                     pointers.size() * sizeof(uint32_t),
-                    get_absolute_cq_offset(channel, cq_id, cq_size),
+                    get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size),
                     mmio_device_id,
                     get_umd_channel(channel));
             }

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -15,9 +15,13 @@ uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id 
 
 uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
 
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size) {
-    return (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
-           ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
+uint32_t get_absolute_cq_offset(ChipId chip_id, uint16_t channel, uint8_t cq_id, uint32_t cq_size) {
+    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+    uint32_t host_channel_stride = static_cast<uint32_t>(
+        tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_stride(mmio_device_id, channel));
+    uint32_t channel_offset =
+        host_channel_stride * get_umd_channel(channel) + ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE);
+    return channel_offset + get_relative_cq_offset(cq_id, cq_size);
 }
 
 template <bool addr_16B>

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -55,7 +55,7 @@ uint16_t get_umd_channel(uint16_t channel);
 /// @param cq_id uint8_t ID the command queue
 /// @param cq_size uint32_t size of the command queue
 /// @return uint32_t absolute offset
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_absolute_cq_offset(ChipId chip_id, uint16_t channel, uint8_t cq_id, uint32_t cq_size);
 
 // mostly used in debug_tools
 template <bool addr_16B>

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -132,9 +132,7 @@ public:
     // page size is padded appropriately.
     static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE_DISPATCH = 4096;
 
-    static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30;                                         // 1GB
-    static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                      // 256 MB;
-    static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE;  // 256 MB;
+    static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 26;  // 64 MB;
 
     // Number of entries in the fabric header ring buffer
     static constexpr uint32_t FABRIC_HEADER_RB_ENTRIES = 1;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -88,7 +88,7 @@ void DispatchKernel::GenerateStaticConfigs() {
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = get_absolute_cq_offset(device_->id(), channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;
@@ -139,7 +139,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = get_absolute_cq_offset(device_->id(), channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
         uint32_t completion_queue_start_addr = issue_queue_start_addr + issue_queue_size;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -82,7 +82,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = get_absolute_cq_offset(device_->id(), channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -139,7 +139,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
             tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
-        uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
+        uint32_t command_queue_start_addr = get_absolute_cq_offset(device_->id(), channel, cq_id_, cq_size);
         uint32_t issue_queue_start_addr = command_queue_start_addr + cq_start;
         uint32_t issue_queue_size = device_->sysmem_manager().get_issue_queue_size(cq_id_);
 
@@ -548,7 +548,7 @@ void PrefetchKernel::ConfigureCore() {
         uint32_t prefetch_q_pcie_rd_ptr =
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_PCIE_RD);
         std::vector<uint32_t> prefetch_q_pcie_rd_ptr_addr_data = {
-            get_absolute_cq_offset(channel, cq_id_, cq_size) + cq_start};
+            get_absolute_cq_offset(device_->id(), channel, cq_id_, cq_size) + cq_start};
         detail::WriteToDeviceL1(device_, logical_core_, prefetch_q_rd_ptr, prefetch_q_rd_ptr_addr_data, GetCoreType());
         detail::WriteToDeviceL1(
             device_, logical_core_, prefetch_q_pcie_rd_ptr, prefetch_q_pcie_rd_ptr_addr_data, GetCoreType());

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -11,7 +11,8 @@
 
 namespace tt::tt_metal {
 
-SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start) :
+SystemMemoryCQInterface::SystemMemoryCQInterface(
+    ChipId device_id, uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start) :
     cq_start(cq_start),
     command_completion_region_size(
         (((cq_size - cq_start) / DispatchSettings::TRANSFER_PAGE_SIZE) / 4) * DispatchSettings::TRANSFER_PAGE_SIZE),
@@ -19,8 +20,9 @@ SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id
     id(cq_id),
     issue_fifo_size(command_issue_region_size >> 4),
     issue_fifo_limit(
-        ((cq_start + this->command_issue_region_size) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4),
-    offset(get_absolute_cq_offset(channel, cq_id, cq_size)),
+        ((cq_start + this->command_issue_region_size) + get_absolute_cq_offset(device_id, channel, cq_id, cq_size)) >>
+        4),
+    offset(get_absolute_cq_offset(device_id, channel, cq_id, cq_size)),
     completion_fifo_size(command_completion_region_size >> 4),
     completion_fifo_limit(issue_fifo_limit + completion_fifo_size) {
     TT_ASSERT(

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal {
 
@@ -14,7 +15,7 @@ struct SystemMemoryCQInterface {
     // Device signals completion and writes data for D2H transfers in the completion region, host reads from the
     // completion region Equation for issue fifo size is | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
-    SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start);
+    SystemMemoryCQInterface(ChipId device_id, uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t cq_start);
 
     // Percentage of the command queue that is dedicated for issuing commands. Issue queue size is rounded to be 32B
     // aligned and remaining space is dedicated for completion queue Smaller issue queues can lead to more stalls for

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -775,7 +775,7 @@ void configure_dispatch_cores(IDevice* device) {
                 // Initialize completion queue write pointer and read pointer copy
                 uint32_t issue_queue_size = device->sysmem_manager().get_issue_queue_size(cq_id);
                 uint32_t completion_queue_start_addr =
-                    cq_start + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);
+                    cq_start + issue_queue_size + get_absolute_cq_offset(serviced_device_id, channel, cq_id, cq_size);
                 uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
                 std::vector<uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
                 detail::WriteToDeviceL1(

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -26,83 +26,16 @@ namespace ll_api {
 
 namespace wormhole {
 
-static constexpr uint32_t TENSIX_STATIC_TLB_START = 16;
-static constexpr uint32_t ETH_STATIC_TLB_START = 0;
-
-int32_t get_static_tlb_index_logical_eth(CoreCoord target) {
-    if (target.y >= tt::umd::wormhole::ETH_LOCATIONS.size()) {
-        TT_THROW("Invalid ETH core coordinate for generating static TLB index");
-    }
-    int32_t tlb_index = ETH_STATIC_TLB_START + target.y;
-    return tlb_index;
-}
-
-int32_t get_static_tlb_index_logical_tensix(CoreCoord target) {
-    if ((target.x >= tt::umd::wormhole::T6_X_LOCATIONS.size()) ||
-        (target.y >= tt::umd::wormhole::T6_Y_LOCATIONS.size())) {
-        TT_THROW("Invalid TENSIX core coordinate for generating static TLB index");
-    }
-    return TENSIX_STATIC_TLB_START + (target.y * 8) + target.x;
-}
-
-int32_t get_static_tlb_index(tt::umd::CoreCoord target) {
-    if (target.coord_system != tt::CoordSystem::LOGICAL) {
-        TT_THROW("Invalid TENSIX core coordinate for generating static TLB index");
-    }
-    switch (target.core_type) {
-        case tt::CoreType::ETH: return get_static_tlb_index_logical_eth({target.x, target.y});
-        case tt::CoreType::TENSIX: return get_static_tlb_index_logical_tensix({target.x, target.y});
-        default: TT_THROW("Invalid core type for generating static TLB index");
-    }
-}
+int32_t get_static_tlb_size() { return 1 << 20; }
 
 }  // namespace wormhole
 
 namespace blackhole {
 
 static constexpr uint32_t NUM_PORTS_PER_DRAM_CHANNEL = 3;
-static constexpr uint32_t NUM_DRAM_CHANNELS = 8;
-// Values taken from blackhole.py in `src/t6ifc/t6py/packages/tenstorrent/chip/blackhole.py`
-static constexpr uint32_t ETH_STATIC_TLB_START = 0;
-static constexpr uint32_t TENSIX_STATIC_TLB_START = 38;
+// static constexpr uint32_t NUM_DRAM_CHANNELS = 8;
 
-int32_t get_static_tlb_index_logical_eth(CoreCoord target) {
-    if (target.y >= tt::umd::blackhole::ETH_LOCATIONS.size()) {
-        TT_THROW("Invalid ETH core coordinate for generating static TLB index");
-    }
-    int tlb_index = ETH_STATIC_TLB_START + target.y;
-    return tlb_index;
-}
-
-int32_t get_static_tlb_index_logical_tensix(CoreCoord target) {
-    if ((target.x >= tt::umd::blackhole::T6_X_LOCATIONS.size()) ||
-        (target.y >= tt::umd::blackhole::T6_Y_LOCATIONS.size())) {
-        TT_THROW("Invalid TENSIX core coordinate for generating static TLB index");
-    }
-    return TENSIX_STATIC_TLB_START + (target.y * 14) + target.x;
-}
-
-int32_t get_static_tlb_index_logical_dram(CoreCoord target) {
-    auto dram_tlb_index = target.x;
-    if (dram_tlb_index > 7) {
-        TT_THROW("Invalid DRAM core coordinate for generating static TLB index");
-    }
-    // Each DRAM channel has 3 ports, and the logical x coordinate directly corresponds to the channel.
-    // Therefore, the x coordinate alone is sufficient for determining the TLB mapping.
-    return tt::umd::blackhole::TLB_BASE_INDEX_4G + (dram_tlb_index);
-}
-
-int32_t get_static_tlb_index(tt::umd::CoreCoord target) {
-    if (target.coord_system != tt::CoordSystem::LOGICAL) {
-        TT_THROW("Invalid TENSIX core coordinate for generating static TLB index");
-    }
-    switch (target.core_type) {
-        case tt::CoreType::ETH: return get_static_tlb_index_logical_eth({target.x, target.y});
-        case tt::CoreType::TENSIX: return get_static_tlb_index_logical_tensix({target.x, target.y});
-        case tt::CoreType::DRAM: return get_static_tlb_index_logical_dram({target.x, target.y});
-        default: TT_THROW("Invalid core type for generating static TLB index");
-    }
-}
+int32_t get_static_tlb_size() { return 2 * (1 << 20); }
 
 // Returns last port of dram channel passed as the argument to align with dram_preferred_worker_endpoint
 // This core will be used for configuring 4GB TLB.
@@ -114,75 +47,42 @@ tt_xy_pair ddr_to_noc0(unsigned i) {
 
 void configure_static_tlbs(
     tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
-    using get_static_tlb_index_ptr = std::int32_t (*)(tt::umd::CoreCoord);
-    get_static_tlb_index_ptr get_static_tlb_index;
-
-    const uint32_t dynamic_tlb_count = 16;
-    uint32_t dynamic_tlb_base_index, dynamic_tlb_16m_size, dram_channel_0_peer2peer_region_start, dram_channel_0_x,
-        dram_channel_0_y;
+    using get_static_tlb_size_ptr = std::int32_t (*)();
+    get_static_tlb_size_ptr get_static_tlb_size;
 
     // Need to set these values based on arch because UMD does not expose architecture_implementation
     switch (arch) {
-        case tt::ARCH::WORMHOLE_B0:
-            get_static_tlb_index = wormhole::get_static_tlb_index;
-            dynamic_tlb_base_index = tt::umd::wormhole::DYNAMIC_TLB_BASE_INDEX;
-            dynamic_tlb_16m_size = tt::umd::wormhole::DYNAMIC_TLB_16M_SIZE;
-            dram_channel_0_peer2peer_region_start = tt::umd::wormhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-            dram_channel_0_x = tt::umd::wormhole::DRAM_CHANNEL_0_X;
-            dram_channel_0_y = tt::umd::wormhole::DRAM_CHANNEL_0_Y;
-            break;
-        case tt::ARCH::BLACKHOLE:
-            get_static_tlb_index = blackhole::get_static_tlb_index;
-            dynamic_tlb_base_index = tt::umd::blackhole::DYNAMIC_TLB_BASE_INDEX;
-            dynamic_tlb_16m_size = 0;
-            dram_channel_0_peer2peer_region_start = tt::umd::blackhole::DRAM_CHANNEL_0_PEER2PEER_REGION_START;
-            dram_channel_0_x = tt::umd::blackhole::DRAM_CHANNEL_0_X;
-            dram_channel_0_y = tt::umd::blackhole::DRAM_CHANNEL_0_Y;
-            break;
+        case tt::ARCH::WORMHOLE_B0: get_static_tlb_size = wormhole::get_static_tlb_size; break;
+        case tt::ARCH::BLACKHOLE: get_static_tlb_size = blackhole::get_static_tlb_size; break;
         default: TT_THROW("Configuring static TLBs is not supported for {}", tt::get_string(arch));
     }
 
     std::int32_t address = 0;
-    // Setup static TLBs for all worker cores
-    for (const tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::TENSIX, tt::CoordSystem::LOGICAL)) {
-        auto tlb_index = get_static_tlb_index(core);
+    // Setup static TLBs for all worker cores.
+    for (const tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::TENSIX, tt::CoordSystem::TRANSLATED)) {
         // TODO
         // Note: see issue #10107
         // Strict is less performant than Posted, however, metal doesn't presently
         // use this on a perf path and the launch_msg "kernel config" needs to
         // arrive prior to the "go" message during device init and slow dispatch
         // Revisit this when we have a more flexible UMD api
-        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address, tt::umd::tlb_data::Strict);
+        device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
     // Setup static TLBs for all eth cores
-    for (const tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::ETH, tt::CoordSystem::LOGICAL)) {
-        auto tlb_index = get_static_tlb_index(core);
-        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address, tt::umd::tlb_data::Strict);
+    for (const tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::ETH, tt::CoordSystem::TRANSLATED)) {
+        device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
 
-    // TODO (#9932): Remove workaround for BH
-    if (arch != tt::ARCH::BLACKHOLE) {
-        // Setup static TLBs for MMIO mapped data space
-        uint64_t peer_dram_offset = dram_channel_0_peer2peer_region_start;
-        for (uint32_t tlb_id = dynamic_tlb_base_index; tlb_id < dynamic_tlb_base_index + dynamic_tlb_count; tlb_id++) {
-            device_driver.configure_tlb(
-                mmio_device_id,
-                tt::umd::CoreCoord(dram_channel_0_x, dram_channel_0_y, tt::CoreType::DRAM, tt::CoordSystem::NOC0),
-                tlb_id,
-                peer_dram_offset);
-            // Align address space of 16MB TLB to 16MB boundary
-            peer_dram_offset += dynamic_tlb_16m_size;
-        }
-    } else {
-        // Setup static 4GB tlbs for DRAM cores
-        uint32_t dram_addr = 0;
-        for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
-            tt::umd::CoreCoord dram_core =
-                tt::umd::CoreCoord(blackhole::ddr_to_noc0(dram_channel), tt::CoreType::DRAM, tt::CoordSystem::NOC0);
-            auto tlb_index = tt::umd::blackhole::TLB_COUNT_2M + dram_channel;
-            device_driver.configure_tlb(mmio_device_id, dram_core, tlb_index, dram_addr, tt::umd::tlb_data::Posted);
-        }
-    }
+    // if (arch == tt::ARCH::BLACKHOLE) {
+    //     // Setup static 4GB tlbs for DRAM cores.
+    //     uint32_t dram_addr = 0;
+    //     for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
+    //         tt::umd::CoreCoord dram_core =
+    //             tt::umd::CoreCoord(blackhole::ddr_to_noc0(dram_channel), tt::CoreType::DRAM, tt::CoordSystem::NOC0);
+    //         device_driver.configure_tlb(mmio_device_id, dram_core, 4ULL * (1ULL << 30), dram_addr,
+    //         tt::umd::tlb_data::Posted);
+    //     }
+    // }
 }
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -220,6 +220,7 @@ public:
 
     uint32_t get_num_host_channels(ChipId device_id) const;
     uint32_t get_host_channel_size(ChipId device_id, uint32_t channel) const;
+    uint64_t get_host_channel_stride(ChipId device_id, uint32_t channel) const;
     // Returns address in host space
     void* host_dma_address(uint64_t offset, ChipId src_device_id, uint16_t channel) const;
     uint64_t get_pcie_base_addr_from_device(ChipId chip_id) const;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35333)

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs