### PR TITLE
Fix static analysis warnings in profiler_paths.hpp

### DIFF
--- a/tt_metal/impl/profiler/profiler_paths.hpp
+++ b/tt_metal/impl/profiler/profiler_paths.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
 #define HOST_SIDE_LOG "profile_log_host.csv"
 #define DEVICE_SIDE_LOG "profile_log_device.csv"
 
@@ -13,14 +17,17 @@ constexpr std::string_view PROFILER_RUNTIME_ROOT_DIR = "generated/profiler/";
 constexpr std::string_view PROFILER_LOGS_DIR_NAME = ".logs/";
 constexpr std::string_view PROFILER_DEVICE_PERF_REPORT_NAME = "cpp_device_perf_report.csv";
 
+// TODO: This function should not be reading environment variables directly, it should use rtoptions.
 inline std::string get_profiler_artifacts_dir() {
     std::string artifacts_dir;
-    if (std::getenv("TT_METAL_PROFILER_DIR")) {
-        artifacts_dir = std::string(std::getenv("TT_METAL_PROFILER_DIR")) + "/";
+    const char* profiler_dir = std::getenv("TT_METAL_PROFILER_DIR");
+    if (profiler_dir) {
+        artifacts_dir = std::string(profiler_dir) + "/";
     } else {
         std::string prefix;
-        if (std::getenv("TT_METAL_HOME")) {
-            prefix = std::string(std::getenv("TT_METAL_HOME")) + "/";
+        const char* metal_home = std::getenv("TT_METAL_HOME");
+        if (metal_home) {
+            prefix = std::string(metal_home) + "/";
         }
         artifacts_dir = prefix + std::string(PROFILER_RUNTIME_ROOT_DIR);
     }


### PR DESCRIPTION
### Ticket
N/A - Code quality fix

### Problem description
Static analysis flagged `profiler_paths.hpp` for reading environment variables multiple times without null-checking the second read. This is a TOCTOU (time-of-check to time-of-use) issue where the environment variable could theoretically change between reads.

Additionally, the file was missing required standard library includes.

### What's changed
- Refactored `get_profiler_artifacts_dir()` to read each environment variable (`TT_METAL_PROFILER_DIR`, `TT_METAL_HOME`) only once into a local `const char*` variable
- Added missing standard library headers: `<cstdlib>`, `<string>`, `<string_view>`
- Added TODO comment noting this function should use rtoptions instead of reading environment variables directly

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-cleanup-profiler-paths)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-cleanup-profiler-paths)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-cleanup-profiler-paths)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-cleanup-profiler-paths)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-cleanup-profiler-paths)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-cleanup-profiler-paths)
- [x] New/Existing tests provide coverage for changes