### PR TITLE
Remove falcon7b perplexity tests from CI since they're no longer useful

### DIFF
--- a/.github/workflows/t3000-perplexity-tests-impl.yaml
+++ b/.github/workflows/t3000-perplexity-tests-impl.yaml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k_falcon7b_tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_perplexity_tests, timeout: 300, owner_id: U05RWH3QUPM}, # Salar Hosseini
           { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_perplexity_tests, timeout: 300, owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k_llama_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama70b_perplexity_tests, timeout: 300, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral8x7b_perplexity_tests, timeout: 300, owner_id: U03PUAKE719}, # Miguel Tairum

--- a/tests/scripts/t3000/run_t3000_perplexity_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perplexity_tests.sh
@@ -2,25 +2,6 @@
 
 TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
 
-run_t3000_falcon7b_perplexity_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_falcon7b_perplexity_tests"
-
-  # Falcon7B perplexity tests
-  pytest -n auto models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py --timeout=1500 ; fail+=$?
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_falcon7b_perplexity_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 run_t3000_falcon40b_perplexity_tests() {
   # Record the start time
   fail=0

--- a/tests/scripts/t3000/run_t3000_perplexity_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perplexity_tests.sh
@@ -222,9 +222,6 @@ run_t3000_tests() {
   # Run Qwen3 perplexity tests
   run_t3000_qwen3_perplexity_tests
 
-  # Run Falcon-7B perplexity tests
-  run_t3000_falcon7b_perplexity_tests
-
   # Run Falcon-40B perplexity tests
   run_t3000_falcon40b_perplexity_tests
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- We no longer monitor perplexity scores for Falcon7b and they're redundant with the output checks in the demo tests / the pcc checks in the perf tests for monitoring accuracy regressions. 

### What's changed
- Removed the falcon7b perplexity tests from CI

### Checklist

- T3K perplexity tests - https://github.com/tenstorrent/tt-metal/actions/runs/20761384144