### PR TITLE
Fix resource leaks in WatcherServer::read_kernel_ids_from_file

### DIFF
--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <condition_variable>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <map>
 #include <mutex>
@@ -237,17 +238,14 @@ void WatcherServer::Impl::register_kernel_elf_paths(int id, std::vector<std::str
 void WatcherServer::Impl::read_kernel_ids_from_file() {
     std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + LOG_FILE_PATH);
     std::string fname = output_dir.string() + KERNEL_FILE_NAME;
-    FILE* f = fopen(fname.c_str(), "r");
+    std::ifstream f(fname);
     if (!f) {
         TT_THROW("Watcher failed to open kernel name file: {}\n", fname);
     }
 
-    char* line = nullptr;
-    size_t len;
-    while (getline(&line, &len, f) != -1) {
-        std::string s(line);
-        s = s.substr(0, s.length() - 1);  // Strip newline
-        kernel_names_.push_back(s.substr(s.find(':') + 2));
+    std::string line;
+    while (std::getline(f, line)) {
+        kernel_names_.push_back(line.substr(line.find(':') + 2));
     }
 }
 


### PR DESCRIPTION
### Ticket
N/A - Static analysis finding

### Problem description
Clang static analyzer detected resource leaks in `WatcherServer::Impl::read_kernel_ids_from_file()`:
1. **File handle leak**: The file opened with `fopen()` was never closed with `fclose()`
2. **Memory leak**: The `line` buffer allocated by `getline()` was never freed with `free()`

### What's changed
Replaced C-style file I/O with modern C++ `std::ifstream`:
- `FILE* f = fopen(...)` → `std::ifstream f(fname)`
- C-style `getline(&line, &len, f)` → `std::getline(f, line)`

Benefits:
- **RAII**: `std::ifstream` automatically closes the file when it goes out of scope
- **Automatic memory management**: `std::getline()` uses `std::string` which manages its own memory
- **Cleaner code**: Removed manual newline stripping since `std::getline()` doesn't include trailing newlines

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/watcher-server-resource-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/watcher-server-resource-leak)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/watcher-server-resource-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/watcher-server-resource-leak)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/watcher-server-resource-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/watcher-server-resource-leak)
- [x] New/Existing tests provide coverage for changes