### PR TITLE
Avoid including dataflow_api.h in firmware builds.

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc
@@ -18,7 +18,6 @@
 #include "hostdev/dev_msgs.h"
 #include "internal/risc_attribs.h"
 #include "internal/circular_buffer_interface.h"
-#include "api/dataflow/dataflow_api.h"
 #include "internal/ethernet/dataflow_api.h"
 #include "internal/ethernet/tunneling.h"
 #include "dev_mem_map.h"

--- a/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/erisc.cc
@@ -7,7 +7,6 @@
 #include "internal/firmware_common.h"
 #include "noc_parameters.h"
 #include "internal/risc_attribs.h"
-#include "api/dataflow/dataflow_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "internal/debug/watcher_common.h"
 

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -10,7 +10,6 @@
 #include "hostdev/dev_msgs.h"
 #include "stream_io_map.h"
 #include "internal/firmware_common.h"
-#include "api/dataflow/dataflow_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "internal/risc_attribs.h"
 #include "internal/circular_buffer_interface.h"

--- a/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/subordinate_erisc.cc
@@ -9,7 +9,6 @@
 #include "hostdev/dev_msgs.h"
 #include "stream_io_map.h"
 #include "internal/firmware_common.h"
-#include "api/dataflow/dataflow_api.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "internal/risc_attribs.h"
 #include "internal/circular_buffer_interface.h"

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -30,6 +30,11 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include "internal/debug/sanitize.h"
 
+#if !defined(KERNEL_BUILD)
+// This file uses noc_mode, which isn't defined in the firmware build.
+#error "dataflow_api.h is only supported in kernel build. Firmware build should use low-level APIs instead."
+#endif
+
 // clang-format off
 /**
  * Returns the absolute logical X coordinate value that this kernel is running on. The absolute coordinate

--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -7,7 +7,7 @@
 #include "internal/circular_buffer_interface.h"
 #include "api/debug/assert.h"
 #include "api/alignment.h"
-#ifndef COMPILE_FOR_TRISC
+#if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/noc.h"
 #include "experimental/lock.h"
@@ -18,7 +18,11 @@ namespace experimental {
 namespace detail {
 
 #ifndef COMPILE_FOR_TRISC
+#if defined(KERNEL_BUILD)
 static constexpr uint8_t default_noc_mode = noc_mode;
+#else
+static constexpr uint8_t default_noc_mode = 0;
+#endif
 static constexpr uint8_t default_cmd_buf = write_at_cmd_buf;
 template <uint8_t nm = default_noc_mode>
 FORCE_INLINE void update_pages_sent(
@@ -204,7 +208,7 @@ FORCE_INLINE void resize_remote_receiver_cb_interface(
 }
 
 #ifndef COMPILE_FOR_TRISC
-
+#if defined(KERNEL_BUILD)
 FORCE_INLINE void remote_cb_wait_front(uint32_t cb_id, uint32_t num_pages) {
     WAYPOINT("RCWF");
     RemoteReceiverCBInterface& remote_cb = get_remote_receiver_cb_interface(cb_id);
@@ -376,7 +380,7 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
     }
     remote_cb.fifo_wr_ptr = dest_addr;
 }
-
+#endif
 #endif
 
 template <uint32_t num_local_cbs>
@@ -409,7 +413,7 @@ FORCE_INLINE void update_remote_cb_config_in_l1(uint32_t remote_cb_index) {
         remote_cb_interface.fifo_rd_ptr;
 }
 
-#ifndef COMPILE_FOR_TRISC
+#if !defined(COMPILE_FOR_TRISC) && defined(KERNEL_BUILD)
 
 class Noc;
 class CircularBuffer;

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
@@ -12,7 +12,7 @@ constexpr uint8_t noc_mode = NOC_MODE;
 #else
 
 extern uint8_t noc_index;
-constexpr uint8_t noc_mode = DM_DEDICATED_NOC;
+// noc_mode may switch dynamically while in the firwmare, so we can't define it here.
 #endif
 extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
 extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_common.h
@@ -12,7 +12,7 @@ constexpr uint8_t noc_mode = NOC_MODE;
 #else
 
 extern uint8_t noc_index;
-// noc_mode may switch dynamically while in the firwmare, so we can't define it here.
+// noc_mode may switch dynamically while in the firmware, so we can't define it here.
 #endif
 extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];
 extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];

--- a/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/internal/ethernet/dataflow_api.h
@@ -12,8 +12,12 @@
 #include "internal/ethernet/erisc.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "noc_nonblocking_api.h"
-#include "api/dataflow/dataflow_api.h"
 #include "internal/ethernet/tunneling.h"
+#if defined(KERNEL_BUILD)
+#include "api/dataflow/dataflow_api.h"
+#else
+#include "internal/dataflow/dataflow_api_common.h"
+#endif
 /**
  * Indicates if the ethernet transaction queue is busy ingesting a command at this moment,
  *

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -17,7 +17,11 @@
 #include "api/debug/dprint.h"
 #include "risc_common.h"
 #if !defined(COMPILE_FOR_TRISC)
+#if defined(KERNEL_BUILD)
 #include "api/dataflow/dataflow_api.h"
+#else
+#include "internal/dataflow/dataflow_api_common.h"
+#endif
 #endif
 
 constexpr size_t round_up_to_mult_of_4(size_t value) { return ((value + 3) / 4) * 4; }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -292,7 +292,7 @@ inline void __attribute__((always_inline)) profiler_noc_async_write_posted(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
     WAYPOINT("NAWW");
 #if !defined(KERNEL_BUILD)
-    constexpr uint32_t noc_mode = DM_DEDICATED_NOC;
+    constexpr uint8_t noc_mode = DM_DEDICATED_NOC;
 #endif
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len<noc_mode>(

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -291,6 +291,9 @@ struct NocRegisterStateSave {
 inline void __attribute__((always_inline)) profiler_noc_async_write_posted(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
     WAYPOINT("NAWW");
+#if !defined(KERNEL_BUILD)
+    constexpr uint32_t noc_mode = DM_DEDICATED_NOC;
+#endif
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len<noc_mode>(
         noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true, true);


### PR DESCRIPTION
### Ticket
#18562 

### Problem description
Firmware builds don't have statically-defined noc_mode, so the API functions in dataflow_api.h don't make sense to use and can cause problems. For example, noc_async_atomic_barrier in brisc.cc could hang if remote CBs are used with a kernel with dynamic NOC mode.

### What's changed
Prohibit including dataflow_api.h from the firmware. The only function usage that needs to be changed is that a definition of RISC_POST_HEARTBEAT needs to be included in the erisc firmware, and noc_async_atomic_barrier has to be removed from brisc.cc and replaced with a custom version.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/removedataflowfirmware)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/removedataflowfirmware)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/removedataflowfirmware)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/removedataflowfirmware)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/removedataflowfirmware)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/removedataflowfirmware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/removedataflowfirmware)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs