### PR TITLE
[skip ci] Fix memory leak in backtrace() when backtrace_symbols fails

### DIFF
--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -40,6 +40,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     char** strings = backtrace_symbols(array, s);
     if (strings == nullptr) {
         std::cout << "backtrace_symbols error." << std::endl;
+        free(array);
         return bt;
     }
     for (size_t i = skip; i < s; ++i) {

--- a/tt_stl/tt_stl/assert.hpp
+++ b/tt_stl/tt_stl/assert.hpp
@@ -40,7 +40,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
     char** strings = backtrace_symbols(array, s);
     if (strings == nullptr) {
         std::cout << "backtrace_symbols error." << std::endl;
-        free(array);
+        free(array);  // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
         return bt;
     }
     for (size_t i = skip; i < s; ++i) {


### PR DESCRIPTION
### Ticket
N/A - Found via clang static analyzer

### Problem description
The clang static analyzer was reporting a potential memory leak in the `backtrace()` function in `tt_stl/tt_stl/assert.hpp`:

> potential leak of memory pointed to by array

When `backtrace_symbols()` returns `nullptr` (e.g., due to memory allocation failure), the function was returning early without freeing the `array` that was previously allocated via `malloc()`.

### What's changed
Added `free(array)` before the early return when `backtrace_symbols()` fails, ensuring memory is properly cleaned up in the error path.

```diff
     if (strings == nullptr) {
         std::cout << "backtrace_symbols error." << std::endl;
+        free(array);
         return bt;
     }
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/backtrace-memory-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/backtrace-memory-leak)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/backtrace-memory-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/backtrace-memory-leak)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/backtrace-memory-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/backtrace-memory-leak)
- [x] New/Existing tests provide coverage for changes (N/A - trivial bug fix)