### PR TITLE
Haibo sun/issue#29156

### DIFF
--- a/tt_metal/hw/inc/api/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/api/debug/dprint_pages.h
@@ -6,6 +6,17 @@
 #pragma once
 #include "api/debug/dprint.h"
 
+inline void print_cb_details(uint32_t cb_id) {
+    DPRINT << "cb_id " << cb_id << ": { "
+           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
+           << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
+           << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
+           << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
+           << "rd_ptr: " << get_local_cb_interface(cb_id).fifo_rd_ptr << ", "
+           << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
+           << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
+}
+
 #if (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)) && defined(DEBUG_PRINT_ENABLED) && \
     !defined(FORCE_DPRINT_OFF)
 
@@ -56,6 +67,7 @@ inline void print_u16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t n
     }
 }
 
+inline void print_cb_details(uint32_t cb_id);
 }  // namespace tt::data_movement::common
 
 #endif
@@ -114,6 +126,7 @@ inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize 
     DPRINT << "++++++" << ENDL();
 }
 
+inline void print_cb_details(uint32_t cb_id);
 }  // namespace tt::compute::common
 
 #endif

--- a/tt_metal/hw/inc/api/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/api/debug/dprint_pages.h
@@ -6,9 +6,12 @@
 #pragma once
 #include "api/debug/dprint.h"
 
+#if (                                                            \
+    defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || \
+    (defined(COMPILE_FOR_TRISC) && (COMPILE_FOR_TRISC != 1)))
 inline void print_cb_details(uint32_t cb_id) {
     DPRINT << "cb_id " << cb_id << ": { "
-           << "size:  " << get_local_cb_interface(cb_id).fifo_size << ", "
+           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
            << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
            << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
            << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "
@@ -16,6 +19,7 @@ inline void print_cb_details(uint32_t cb_id) {
            << "wr_ptr: " << get_local_cb_interface(cb_id).fifo_wr_ptr << ", "
            << "wr_tile_ptr: " << get_local_cb_interface(cb_id).fifo_wr_tile_ptr << " }" << ENDL();
 }
+#endif
 
 #if (defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)) && defined(DEBUG_PRINT_ENABLED) && \
     !defined(FORCE_DPRINT_OFF)
@@ -67,7 +71,6 @@ inline void print_u16_pages(uint32_t l1_addr, uint32_t elts_per_page, uint32_t n
     }
 }
 
-inline void print_cb_details(uint32_t cb_id);
 }  // namespace tt::data_movement::common
 
 #endif
@@ -126,7 +129,6 @@ inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize 
     DPRINT << "++++++" << ENDL();
 }
 
-inline void print_cb_details(uint32_t cb_id);
 }  // namespace tt::compute::common
 
 #endif

--- a/tt_metal/hw/inc/api/debug/dprint_pages.h
+++ b/tt_metal/hw/inc/api/debug/dprint_pages.h
@@ -8,7 +8,7 @@
 
 inline void print_cb_details(uint32_t cb_id) {
     DPRINT << "cb_id " << cb_id << ": { "
-           << "size: " << get_local_cb_interface(cb_id).fifo_size << ", "
+           << "size:  " << get_local_cb_interface(cb_id).fifo_size << ", "
            << "limit: " << get_local_cb_interface(cb_id).fifo_limit << ", "
            << "page_size: " << get_local_cb_interface(cb_id).fifo_page_size << ", "
            << "num_pages: " << get_local_cb_interface(cb_id).fifo_num_pages << ", "


### PR DESCRIPTION
### Ticket
Link to Github Issue
#29156
### Problem description
cb helper function in only one file

### What's changed
added debug cb text function to dprint_pages.h

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Haibo_Sun/issue#29156)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Haibo_Sun/issue#29156)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Haibo_Sun/issue#29156)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Haibo_Sun/issue#29156)
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Haibo_Sun/issue#29156)
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Haibo_Sun/issue#29156)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Haibo_Sun/issue#29156)
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs