### PR TITLE
[skip ci] Fix potential null pointer dereference in SubDeviceManagerTracker

### DIFF
--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -38,6 +38,7 @@ namespace tt::tt_metal {
 SubDeviceManagerTracker::SubDeviceManagerTracker(
     IDevice* device, std::unique_ptr<AllocatorImpl>&& global_allocator, tt::stl::Span<const SubDevice> sub_devices) :
     device_(device) {
+    TT_FATAL(device_ != nullptr, "SubDeviceManagerTracker requires a valid device");
     auto sub_device_manager = std::make_unique<SubDeviceManager>(device, std::move(global_allocator), sub_devices);
     default_sub_device_manager_ = sub_device_manager.get();
     active_sub_device_manager_ = default_sub_device_manager_;


### PR DESCRIPTION
### Ticket
N/A - Static analysis finding

### Problem description
Clang static analyzer flagged a potential null pointer dereference in `SubDeviceManagerTracker::reset_sub_device_state()`. If `device_` is `nullptr`, the `dynamic_cast<distributed::MeshDevice*>(device_)` returns `nullptr`, causing the condition to be false and execution to fall through to the `else` branch where `device_` would be dereferenced.

### What's changed
Added a `TT_FATAL` check in the `SubDeviceManagerTracker` constructor to ensure `device_` is never `nullptr`. This:
- Fails fast with a clear error message at object creation time
- Protects all member functions that use `device_`
- Makes the invariant explicit: `device_` must be valid for the lifetime of the tracker

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/null-check-sub-device-manager-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/null-check-sub-device-manager-tracker)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/null-check-sub-device-manager-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/null-check-sub-device-manager-tracker)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/null-check-sub-device-manager-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/null-check-sub-device-manager-tracker)
- [x] New/Existing tests provide coverage for changes