### PR TITLE
Fix potential divide-by-zero in get_max_cores_divisible_by_tiles_per_core_tiles

### DIFF
--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -39,7 +39,7 @@ std::tuple<uint32_t, uint32_t> get_max_cores_divisible_by_tiles_per_core_tiles(
             num_cores = i;
         }
     }
-    if (request_even) {
+    if (request_even && num_cores > 1) {
         num_cores = num_cores - num_cores % 2;
     }
     uint32_t per_core_tiles_dim = num_tiles / num_cores;


### PR DESCRIPTION
### Ticket
N/A - Static analyzer finding

### Problem description
Clang Static Analyzer identified a potential divide-by-zero in `get_max_cores_divisible_by_tiles_per_core_tiles`.

When `num_cores` is 1 (no divisor found in the loop) and `request_even` is true, the expression:
```cpp
num_cores = num_cores - num_cores % 2;
```
evaluates to `1 - 1 = 0`, causing a divide-by-zero on the subsequent division:
```cpp
uint32_t per_core_tiles_dim = num_tiles / num_cores;
```

### What's changed
Guard the even adjustment to only apply when `num_cores > 1`:
```cpp
if (request_even && num_cores > 1) {
    num_cores = num_cores - num_cores % 2;
}
```

This is the minimal fix that preserves the original behavior. When `num_cores` is 1, there's no meaningful way to make it even without producing 0, so we skip the adjustment and use the single core as a fallback.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/work-split-divide-by-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/work-split-divide-by-zero)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/work-split-divide-by-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/work-split-divide-by-zero)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/work-split-divide-by-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/work-split-divide-by-zero)
- [x] New/Existing tests provide coverage for changes