### PR TITLE
Increase benchmark timeout for Qwen2.5-VL-72B in vLLM [v1] nightly

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -207,7 +207,7 @@ jobs:
               "name": "[WH-T3K][v1] Qwen2.5-VL-72B-Instruct",
               "model": "Qwen/Qwen2.5-VL-72B-Instruct",
               "server-timeout": 10,
-              "benchmark-timeout": 5,
+              "benchmark-timeout": 10,
               "runner-label": "config-t3000",
               "arch": "arch-wormhole_b0",
               "mesh-device": "T3K",


### PR DESCRIPTION
### Ticket
Close #35339

### Problem description
Qwen2.5-VL-72B started failing due to a timeout violation during multimodal benchmarking. More details are in the linked issue.

### What's changed
Increasing the `benchmark-timeout` value for the test in vLLM [v1] fixed the failing multimodal test. However, the root cause may be worth investigating as we observe that vLLM [v0] test of the same model did not require such a increase in timeout.

### Checklist

- [x] vLLM nightly pass in CI (confirmed in two runs)
  - https://github.com/tenstorrent/tt-metal/actions/runs/20761493295
  - https://github.com/tenstorrent/tt-metal/actions/runs/20767227771