### PR TITLE
Add INT32 support for Remainder, FMOD in LLK

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1142,7 +1142,10 @@ def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-def test_binary_remainder_fmod_int32_full_range(input_shapes, ttnn_op, device):
+def test_binary_remainder_fmod_int32_range_1e15(input_shapes, ttnn_op, device):
+    """
+    Sampled pairwise INT32 remainder/fmod test for range [-1e15, 1e15].
+    """
     value_ranges_a = [
         (-300, 300),
         (-500, 500),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1090,3 +1090,137 @@ def test_binary_scalar_div_int32(device):
     assert torch.allclose(z_torch, tt_out, atol=1e-10, rtol=1e-5, equal_nan=True)
     assert torch.equal(z_torch_floor, tt_out_floor)
     assert torch.equal(z_torch_trunc, tt_out_trunc)
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [
+        ttnn.remainder,
+        ttnn.fmod,
+    ],
+)
+def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
+    torch_input_tensor_a = torch.tensor(
+        [0, 1, 0, 3, 7, -3, -7, 3, 7, -3, -7, 1, -1, 2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896]
+    )
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    torch_input_tensor_b = torch.tensor(
+        [
+            2,
+            1,
+            -1,
+            2,
+            5,
+            2,
+            5,
+            -2,
+            -5,
+            -2,
+            -5,
+            1,
+            -1,
+            2147483647,
+            -2147483645,
+            65535,
+            -2147483647,
+            1073872895,
+            -1073872899,
+        ]
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [
+        ttnn.remainder,
+        ttnn.fmod,
+    ],
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 2, 32, 128])),),
+)
+def test_binary_remainder_fmod_int32_full_range(input_shapes, ttnn_op, device):
+    value_ranges_a = [
+        (-300, 300),
+        (-500, 500),
+        (-1000, 1000),
+        (-1e4, 1e4),
+        (-1e5, 1e5),
+        (-1e7, 1e7),
+        (2e9, 2077000000),  # large positive input
+        (-2147483647, -2e9),  # large negative input
+        (-2147483647, 2147483647),  # full range
+        (-2147483647, 2147483647),  # large numerator
+        (-10, 10),  # small numerator
+    ]
+
+    value_ranges_b = [
+        (-250, 250),
+        (-750, 750),
+        (-500, 1000),
+        (-5e3, 5e3),
+        (-5e4, 5e4),
+        (-1e6, 1e6),
+        (2e9, 2147483647),  # large positive input
+        (-2077000000, -2e9),  # large negative input
+        (-2147483647, 2147483647),  # full range
+        (-10, 10),  # small denominator
+        (-2147483647, 2147483647),  # large denominator
+    ]
+
+    torch_input_tensor_a = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_a
+    )
+    torch_input_tensor_b = create_full_range_tensor(
+        input_shape=input_shapes, dtype=torch.int32, value_ranges=value_ranges_b
+    )
+
+    torch_input_tensor_b[
+        torch_input_tensor_b == 0
+    ] = 1  # avoid division by zero since nan and inf are not representable in int32
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b, device=device)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.equal(output_tensor, torch_output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1096,7 +1096,7 @@ def test_binary_scalar_div_int32(device):
     "ttnn_op",
     [
         ttnn.remainder,
-        # ttnn.fmod,
+        ttnn.fmod,
     ],
 )
 def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
@@ -1127,9 +1127,6 @@ def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
 
     output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
-
-    print(output_tensor)
-    print(torch_output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1091,16 +1091,17 @@ def test_binary_scalar_div_int32(device):
     assert torch.equal(z_torch_floor, tt_out_floor)
     assert torch.equal(z_torch_trunc, tt_out_trunc)
 
+
 @pytest.mark.parametrize(
     "ttnn_op",
     [
         ttnn.remainder,
-        ttnn.fmod,
+        # ttnn.fmod,
     ],
 )
 def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
     torch_input_tensor_a = torch.tensor(
-        [0, 1, 0, 3, 7, -3, -7, 3, 7, -3, -7, 1, -1, 2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896]
+        [0, 0, 1, 1, -1, -1, 2147483647, -2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896, -2147483647]
     )
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
@@ -1111,27 +1112,7 @@ def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
     )
 
     torch_input_tensor_b = torch.tensor(
-        [
-            2,
-            1,
-            -1,
-            2,
-            5,
-            2,
-            5,
-            -2,
-            -5,
-            -2,
-            -5,
-            1,
-            -1,
-            2147483647,
-            -2147483645,
-            65535,
-            -2147483647,
-            1073872895,
-            -1073872899,
-        ]
+        [1, -1, 1, -1, 1, -1, 1, 1000, 2147483647, -2147483647, -2147483645, 65535, -2147483647, -1]
     )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
@@ -1146,6 +1127,9 @@ def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
 
     output_tensor = ttnn_op(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
+
+    print(output_tensor)
+    print(torch_output_tensor)
 
     assert torch.equal(output_tensor, torch_output_tensor)
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -34,7 +34,7 @@ sfpi_inline void calculate_fmod_int32_body(
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_fmod_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-#pragma GCC unroll 0
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         calculate_fmod_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -18,11 +18,12 @@ sfpi_inline void calculate_fmod_int32_body(
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
-    // Compute unsigned remainder
-    sfpi::vInt r;
-    sfpi::vInt a_signed;
-    sfpi::vInt b_signed;
-    compute_unsigned_remainder_int32(dst_index_in0, dst_index_in1, r, a_signed, b_signed);
+    // Read inputs
+    sfpi::vInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt b_signed = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // Compute unsigned remainder (b_signed only used for computation, not sign)
+    sfpi::vInt r = compute_unsigned_remainder_int32(a_signed, b_signed);
 
     // FMOD sign handling (result has the same sign as a)
     v_if(a_signed < 0) { r = -r; }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_div_int32_floor.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// FMOD = a - trunc(a / b) * b
+// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
+sfpi_inline void calculate_fmod_int32_body(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
+    sfpi::vInt b_orig = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // When converting to float, integers are treated as sign-magnitude.
+    // Convert inputs to positive values to avoid conversion problems.
+    sfpi::vInt b = sfpi::abs(b_orig);
+
+    // Convert to float for reciprocal computation
+    // Handle edge case: if conversion results in negative
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
+    v_endif;
+
+    // Compute reciprocal of b
+    sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
+    sfpi::vFloat e = -inv_b_f * b_f + sfpi::vConst1;
+    sfpi::vInt a_orig = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    e = e * e + e;
+    sfpi::vInt a = sfpi::abs(a_orig);
+    inv_b_f = e * inv_b_f + inv_b_f;
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
+    v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
+    v_endif;
+
+    // Initial quotient approximation : q = a * 1/b
+    sfpi::vFloat q_f = a_f * inv_b_f + vConstFloatPrgm0;
+    sfpi::vInt sign = a_orig ^ b_orig;
+    sfpi::vUInt q = sfpi::exman9(q_f);
+
+    // Compute q * b
+    // SFPMUL24 multiplies two 23-bit integers
+    sfpi::vInt qb;
+
+    qb.get() = __builtin_rvtt_bh_sfpmul24(q.get(), b.get(), 0);
+
+    q <<= 10;
+    qb <<= 10;
+
+    /// Compute remainder
+    sfpi::vInt r = a - qb;
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
+
+    // Compute correction: r / b in float32
+    sfpi::vFloat correction_f = r_f * inv_b_f;
+    sfpi::vInt b1 = b >> 23;
+    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
+
+    // Compute tmp = correction * b
+    sfpi::vInt tmp_hi;
+    sfpi::vInt tmp_lo;
+    b1.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b1.get(), 0);
+    tmp_hi.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b.get(), 1);
+    tmp_lo.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b.get(), 0);
+    tmp_hi += b1;
+    tmp_hi <<= 23;
+    sfpi::vInt tmp = tmp_lo + tmp_hi;
+
+    // Adjust FMOD based on its sign
+    v_if(r < 0) { r += tmp; }
+    v_else { r -= tmp; }
+    v_endif;
+
+    // Since the correction might have been rounded, we may need to correct one
+    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
+    v_if(r < 0 && (r - 1) < 0) { r += b; }
+    v_elseif(r >= b) { r -= b; }
+    v_endif;
+
+    v_if(a_orig < 0) { r = -r; }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_fmod_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_fmod_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void fmod_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -22,7 +22,7 @@ sfpi_inline void calculate_fmod_int32_body(
     sfpi::vInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vInt b_signed = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-    // Compute unsigned remainder (b_signed only used for computation, not sign)
+    // Compute unsigned remainder
     sfpi::vInt r = compute_unsigned_remainder_int32(a_signed, b_signed);
 
     // FMOD sign handling (result has the same sign as a)
@@ -34,7 +34,7 @@ sfpi_inline void calculate_fmod_int32_body(
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_fmod_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-#pragma GCC unroll 8
+#pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         calculate_fmod_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -112,7 +112,7 @@ sfpi_inline void calculate_remainder_int32_body(
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-#pragma GCC unroll 0
+#pragma GCC unroll 2
     for (int d = 0; d < ITERATIONS; d++) {
         calculate_remainder_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -11,6 +11,9 @@
 
 namespace ckernel::sfpu {
 
+// 2^31 as float (used for INT32 sign-magnitude conversion edge cases)
+constexpr float TWO_POW_31 = 2147483648.0f;
+
 // Computes the unsigned remainder: |a| - floor(|a| / |b|) * |b|
 // Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 // Returns: r (unsigned remainder), a_signed, b_signed (original signed values)
@@ -28,7 +31,7 @@ sfpi_inline void compute_unsigned_remainder_int32(
     // Convert to float for reciprocal computation
     // Handle edge case: if conversion results in negative
     sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
-    v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
+    v_if(b_f < 0.0f) { b_f = TWO_POW_31; }
     v_endif;
 
     // Compute reciprocal of b
@@ -39,7 +42,7 @@ sfpi_inline void compute_unsigned_remainder_int32(
     sfpi::vInt a = sfpi::abs(a_signed);
     inv_b_f = e * inv_b_f + inv_b_f;
     sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
-    v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
+    v_if(a_f < 0.0f) { a_f = TWO_POW_31; }
     v_endif;
 
     // Initial quotient approximation : q = a * 1/b
@@ -87,7 +90,6 @@ sfpi_inline void compute_unsigned_remainder_int32(
 }
 
 // Remainder = a - floor(a / b) * b
-// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 sfpi_inline void calculate_remainder_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_div_int32_floor.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// Remainder = a - floor(a / b) * b
+// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
+sfpi_inline void calculate_remainder_int32_body(
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+
+    sfpi::vInt b_orig = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // When converting to float, integers are treated as sign-magnitude.
+    // Convert inputs to positive values to avoid conversion problems.
+    sfpi::vInt b = sfpi::abs(b_orig);
+
+    // Convert to float for reciprocal computation
+    // Handle edge case: if conversion results in negative
+    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
+    v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
+    v_endif;
+
+    // Compute reciprocal of b
+    sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
+    sfpi::vFloat e = -inv_b_f * b_f + sfpi::vConst1;
+    sfpi::vInt a_orig = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    e = e * e + e;
+    sfpi::vInt a = sfpi::abs(a_orig);
+    inv_b_f = e * inv_b_f + inv_b_f;
+    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
+    v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
+    v_endif;
+
+    // Initial quotient approximation : q = a * 1/b
+    sfpi::vFloat q_f = a_f * inv_b_f + vConstFloatPrgm0;
+    sfpi::vInt sign = a_orig ^ b_orig;
+    sfpi::vUInt q = sfpi::exman9(q_f);
+
+    // Compute q * b
+    // SFPMUL24 multiplies two 23-bit integers
+    sfpi::vInt qb;
+
+    qb.get() = __builtin_rvtt_bh_sfpmul24(q.get(), b.get(), 0);
+
+    q <<= 10;
+    qb <<= 10;
+
+    // Compute remainder
+    sfpi::vInt r = a - qb;
+    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
+
+    // Compute correction: r / b in float32
+    sfpi::vFloat correction_f = r_f * inv_b_f;
+    sfpi::vInt b1 = b >> 23;
+    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
+
+    // Compute tmp = correction * b
+    sfpi::vInt tmp_hi;
+    sfpi::vInt tmp_lo;
+    b1.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b1.get(), 0);
+    tmp_hi.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b.get(), 1);
+    tmp_lo.get() = __builtin_rvtt_bh_sfpmul24(correction.get(), b.get(), 0);
+    tmp_hi += b1;
+    tmp_hi <<= 23;
+    sfpi::vInt tmp = tmp_lo + tmp_hi;
+
+    // Adjust remainder based on its sign
+    v_if(r < 0) { r += tmp; }
+    v_else { r -= tmp; }
+    v_endif;
+
+    // Since the correction might have been rounded, we may need to correct one
+    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
+    v_if(r < 0 && (r - 1) < 0) { r += b; }
+    v_elseif(r >= b) { r -= b; }
+    v_endif;
+
+    v_if(r != 0) {
+        v_if(sign < 0) {  // signs differ: need to adjust for floor division
+            // When signs differ, floor(a/b) = trunc(a/b) - 1, so remainder needs adjustment
+            v_if(a_orig < 0) { r = b_orig - r; }
+            v_else { r += b_orig; }
+            v_endif;
+        }
+        v_elseif(a_orig < 0 && b_orig < 0) { r = -r; }
+        v_endif;
+    }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_remainder_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_fmod_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_fmod_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32, APPROXIMATE>(sfpu::fmod_int32_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_fmod_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_remainder_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_remainder_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32, APPROXIMATE>(sfpu::remainder_int32_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_remainder_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -84,6 +84,8 @@ enum class SfpuType {
     div_int32,
     div_int32_floor,
     div_int32_trunc,
+    remainder_int32,
+    fmod_int32,
     lt,
     gt,
     ge,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -18,11 +18,14 @@ sfpi_inline void calculate_fmod_int32_body(
     // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
+    // Load signed inputs
+    sfpi::vInt a_signed = __builtin_rvtt_sfpload(
+        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
+    sfpi::vInt b_signed = __builtin_rvtt_sfpload(
+        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
+
     // Compute unsigned remainder
-    sfpi::vInt r;
-    sfpi::vInt a_signed;
-    sfpi::vInt b_signed;
-    compute_unsigned_remainder_int32(dst_index_in0, dst_index_in1, r, a_signed, b_signed);
+    sfpi::vInt r = compute_unsigned_remainder_int32(a_signed, b_signed);
 
     // FMOD sign handling (result has the same sign as a)
     v_if(a_signed < 0) { r = -r; }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,63 +11,76 @@
 
 namespace ckernel::sfpu {
 
+// FMOD = a - trunc(a / b) * b
+// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 sfpi_inline void calculate_fmod_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
-    // ---- Load |b| ----
+    // Equivalent to: sfpi::vUInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
     sfpi::vUInt b = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
 
+    // When converting to float, integers are treated as sign-magnitude.
+    // Convert inputs to positive values to avoid conversion problems
     b = sfpi::abs(b);
 
+    // Convert to float for reciprocal computation
+    // Handle edge case: if conversion results in negative
     sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
     v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
     v_endif;
 
-    // ---- Compute reciprocal of b ----
+    // Compute reciprocal of b
     sfpi::vFloat neg_b_f = sfpi::setman(sfpi::vConstNeg1, sfpi::reinterpret<sfpi::vInt>(b_f));
 
     sfpi::vFloat inv_b_f = sfpi::vConstFloatPrgm2 + sfpi::vConstFloatPrgm1 * neg_b_f;
 
     sfpi::vFloat scale = sfpi::setman(b_f, 0);
 
+    // First Newton-Raphson iteration: inv_b_f = inv_b_f * (2 - inv_b_f * b_f)
     sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
     scale = sfpi::reinterpret<sfpi::vFloat>((254 << 23) - sfpi::reinterpret<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
+    // Halley's Method
     sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
 
-    // ---- Load |a| ----
+    // Equivalent to: sfpi::vUInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vUInt a = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
 
     a = sfpi::abs(a);
 
+    // Continue Halley's Method
     e = e * e + e;
     inv_b_f = e * inv_b_f + inv_b_f;
 
+    // Apply scaling factor to finalize reciprocal
     sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
     v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
     v_endif;
 
     inv_b_f = inv_b_f * scale;
 
-    // ---- Initial quotient approximation ----
+    // Initial quotient approximation : q = a * 1/b
     sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
     sfpi::vUInt q = sfpi::exman9(q_f);
 
     sfpi::vUInt MASK_11 = 0x7ff;
 
-    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);
-    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);
-    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);
-    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);
-
+    // Split q and b into 11-bit chunks to compute q * b
+    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);          // Lower 11 bits of q
+    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);              // Upper bits of q
+    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);  // Middle 11 bits of b
+    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);          // Lower 11 bits of b
     q = q << 11;
 
     sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
 
+    // hi = q2 * b0 + q1 * b1 (high part)
+    // lo = q1 * b0 (low part)
     sfpi::vFloat hi = q2 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat lo = q1 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     hi = q1 * b1 + hi;
@@ -75,7 +88,7 @@ sfpi_inline void calculate_fmod_int32_body(
     sfpi::vInt qb = sfpi::exman9(lo) << 11;
     qb += sfpi::exman9(hi) << 22;
 
-    // ---- Compute truncating remainder ----
+    // Compute FMOD
     a = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
     a = sfpi::abs(a);
@@ -84,12 +97,13 @@ sfpi_inline void calculate_fmod_int32_body(
 
     sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
 
+    // Compute correction: r / b in float32
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, 0);
-
     sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
     correction_f = sfpi::int32_to_float(correction, 0);
 
+    // tmp = correction * (b2<<22 + b1<<11 + b0)
     sfpi::vFloat low = correction_f * b0 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat mid = correction_f * b1 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
@@ -98,56 +112,26 @@ sfpi_inline void calculate_fmod_int32_body(
     tmp += sfpi::exman9(mid) << 11;
     tmp += sfpi::exman9(top) << 22;
 
+    // Adjust FMOD based on its sign
     v_if(r < 0) { r += tmp; }
     v_else { r -= tmp; }
     v_endif;
 
+    // Since the correction might have been rounded, we may need to correct one
+    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
     v_if(r < 0 && (r - 1) < 0) { r += b; }
     v_elseif(r >= b) { r -= b; }
     v_endif;
 
-    // ---- Trunc fmod fix (torch.fmod) ----
+    // Reload original signed a for sign handling
+    // Equivalent to: sfpi::vUInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vInt a_signed = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
-    // sfpi::vInt b_signed = __builtin_rvtt_sfpload(
-    //     4, sfpi::SFPLOAD_ADDR_MODE_NOINC,
-    //     sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
 
     v_if(a_signed < 0) { r = -r; }
     v_endif;
 
-    // v_if((a_signed < 0) && (b_signed > 0) && (r != 0)) {
-    //     r = b_signed - r;
-    // }
-    // v_endif;
-    // v_if((a_signed > 0) && (b_signed < 0) && (r != 0)) {
-    //     r += b_signed;
-    // }
-    // v_endif;
-    // /* apply sign of b */
-    // v_if((a_signed < 0) && (b_signed < 0) && (r != 0)) {
-    //     r = -r;
-    // }
-    // v_endif;
-
-    // sfpi::vInt sign = a_signed ^ b_signed;
-    // v_if(r != 0) {
-    //     v_if (sign < 0) {  // signs differ
-    //         v_if (a_signed < 0) {
-    //             r = b_signed - r;
-    //         } v_else {
-    //             r += b_signed;
-    //         }
-    //         v_endif;
-    //     }
-    //     v_elseif (a_signed < 0 && b_signed < 0) {  // both negative
-    //         r = -r;
-    //     }
-    //     v_endif;
-    // }
-    // v_endif;
-
-    // ---- Store remainder ----
+    // Equivalent to: sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
     __builtin_rvtt_sfpstore(
         r.get(), 4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].get());
 }
@@ -163,7 +147,6 @@ inline void calculate_fmod_int32(const uint dst_index_in0, const uint dst_index_
 
 template <bool APPROXIMATION_MODE>
 inline void fmod_int32_init() {
-    // Use the same initialization as div_floor_init since we're using the floor division kernel
     div_floor_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -19,8 +19,10 @@ sfpi_inline void calculate_fmod_int32_body(
     constexpr uint dst_tile_size_sfpi = 32;
 
     // Load signed inputs
+    // Equivalent to: sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi] = a_signed;
     sfpi::vInt a_signed = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
+    // Equivalent to: sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi] = b_signed;
     sfpi::vInt b_signed = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
 
@@ -38,7 +40,7 @@ sfpi_inline void calculate_fmod_int32_body(
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_fmod_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-#pragma GCC unroll 8
+#pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         calculate_fmod_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod_int32.h
@@ -6,128 +6,25 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "ckernel_sfpu_div_int32_floor.h"
+#include "ckernel_sfpu_remainder_int32.h"
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
 
 // FMOD = a - trunc(a / b) * b
-// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
+// Implemented using 32-bit integer remainder kernel (see ckernel_sfpu_remainder_int32.h)
 sfpi_inline void calculate_fmod_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
-    // Equivalent to: sfpi::vUInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-    sfpi::vUInt b = __builtin_rvtt_sfpload(
-        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
+    // Compute unsigned remainder
+    sfpi::vInt r;
+    sfpi::vInt a_signed;
+    sfpi::vInt b_signed;
+    compute_unsigned_remainder_int32(dst_index_in0, dst_index_in1, r, a_signed, b_signed);
 
-    // When converting to float, integers are treated as sign-magnitude.
-    // Convert inputs to positive values to avoid conversion problems
-    b = sfpi::abs(b);
-
-    // Convert to float for reciprocal computation
-    // Handle edge case: if conversion results in negative
-    sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
-    v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
-    v_endif;
-
-    // Compute reciprocal of b
-    sfpi::vFloat neg_b_f = sfpi::setman(sfpi::vConstNeg1, sfpi::reinterpret<sfpi::vInt>(b_f));
-
-    sfpi::vFloat inv_b_f = sfpi::vConstFloatPrgm2 + sfpi::vConstFloatPrgm1 * neg_b_f;
-
-    sfpi::vFloat scale = sfpi::setman(b_f, 0);
-
-    // First Newton-Raphson iteration: inv_b_f = inv_b_f * (2 - inv_b_f * b_f)
-    sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
-    scale = sfpi::reinterpret<sfpi::vFloat>((254 << 23) - sfpi::reinterpret<sfpi::vInt>(scale));
-    inv_b_f = t * inv_b_f + inv_b_f;
-
-    // Halley's Method
-    sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
-
-    // Equivalent to: sfpi::vUInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-    sfpi::vUInt a = __builtin_rvtt_sfpload(
-        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
-
-    a = sfpi::abs(a);
-
-    // Continue Halley's Method
-    e = e * e + e;
-    inv_b_f = e * inv_b_f + inv_b_f;
-
-    // Apply scaling factor to finalize reciprocal
-    sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
-    v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
-    v_endif;
-
-    inv_b_f = inv_b_f * scale;
-
-    // Initial quotient approximation : q = a * 1/b
-    sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
-    sfpi::vUInt q = sfpi::exman9(q_f);
-
-    sfpi::vUInt MASK_11 = 0x7ff;
-
-    // Split q and b into 11-bit chunks to compute q * b
-    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);          // Lower 11 bits of q
-    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);              // Upper bits of q
-    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);  // Middle 11 bits of b
-    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);          // Lower 11 bits of b
-    q = q << 11;
-
-    sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
-
-    // hi = q2 * b0 + q1 * b1 (high part)
-    // lo = q1 * b0 (low part)
-    sfpi::vFloat hi = q2 * b0 + MANTISSA_ALIGNMENT_OFFSET;
-    sfpi::vFloat lo = q1 * b0 + MANTISSA_ALIGNMENT_OFFSET;
-    hi = q1 * b1 + hi;
-
-    sfpi::vInt qb = sfpi::exman9(lo) << 11;
-    qb += sfpi::exman9(hi) << 22;
-
-    // Compute FMOD
-    a = __builtin_rvtt_sfpload(
-        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
-    a = sfpi::abs(a);
-
-    sfpi::vInt r = a - qb;
-
-    sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
-
-    // Compute correction: r / b in float32
-    sfpi::vFloat correction_f = r_f * inv_b_f;
-    sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, 0);
-    sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
-    correction_f = sfpi::int32_to_float(correction, 0);
-
-    // tmp = correction * (b2<<22 + b1<<11 + b0)
-    sfpi::vFloat low = correction_f * b0 + MANTISSA_ALIGNMENT_OFFSET;
-    sfpi::vFloat mid = correction_f * b1 + MANTISSA_ALIGNMENT_OFFSET;
-    sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
-
-    sfpi::vInt tmp = sfpi::exman9(low);
-    tmp += sfpi::exman9(mid) << 11;
-    tmp += sfpi::exman9(top) << 22;
-
-    // Adjust FMOD based on its sign
-    v_if(r < 0) { r += tmp; }
-    v_else { r -= tmp; }
-    v_endif;
-
-    // Since the correction might have been rounded, we may need to correct one
-    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
-    v_if(r < 0 && (r - 1) < 0) { r += b; }
-    v_elseif(r >= b) { r -= b; }
-    v_endif;
-
-    // Reload original signed a for sign handling
-    // Equivalent to: sfpi::vUInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-    sfpi::vInt a_signed = __builtin_rvtt_sfpload(
-        4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
-
+    // FMOD sign handling (result has the same sign as a)
     v_if(a_signed < 0) { r = -r; }
     v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_div_int32_floor.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+    // Use a temporary index to store the quotient from floor division
+    // We'll use the output index as temporary since we'll overwrite it anyway
+    // constexpr uint tmp_quotient_index = dst_index_out;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        // First, compute floor division to get the quotient
+        calculate_div_int32_body<true>(dst_index_in0, dst_index_in1, dst_index_out);
+
+        // Load the quotient, in0, and in1
+        // Equivalent to: sfpi::vInt quotient = sfpi::dst_reg[tmp_quotient_index * dst_tile_size_sfpi];
+        sfpi::vInt quotient = __builtin_rvtt_sfpload(
+            4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].get());
+
+        // Reload in0 and in1
+        sfpi::vInt in0 = __builtin_rvtt_sfpload(
+            4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
+        sfpi::vInt in1 = __builtin_rvtt_sfpload(
+            4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
+
+        // Compute remainder: remainder = in0 - quotient * in1
+        sfpi::vInt remainder = in0 - quotient * in1;
+
+        // Store the remainder result
+        __builtin_rvtt_sfpstore(
+            remainder.get(), 4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].get());
+
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_int32_init() {
+    // Use the same initialization as div_floor_init since we're using the floor division kernel
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,39 +11,49 @@
 
 namespace ckernel::sfpu {
 
+// Remainder = a - floor(a / b) * b
+// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 sfpi_inline void calculate_remainder_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
     constexpr uint dst_tile_size_sfpi = 32;
 
-    // ---- Load |b| ----
+    // Equivalent to: sfpi::vUInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
     sfpi::vUInt b = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
 
+    // When converting to float, integers are treated as sign-magnitude.
+    // Convert inputs to positive values to avoid conversion problems.
     b = sfpi::abs(b);
 
+    // Convert to float for reciprocal computation
+    // Handle edge case: if conversion results in negative
     sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
     v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
     v_endif;
 
-    // ---- Compute reciprocal of b ----
+    // Compute reciprocal of b
     sfpi::vFloat neg_b_f = sfpi::setman(sfpi::vConstNeg1, sfpi::reinterpret<sfpi::vInt>(b_f));
 
     sfpi::vFloat inv_b_f = sfpi::vConstFloatPrgm2 + sfpi::vConstFloatPrgm1 * neg_b_f;
 
     sfpi::vFloat scale = sfpi::setman(b_f, 0);
 
+    // First Newton-Raphson iteration: inv_b_f = inv_b_f * (2 - inv_b_f * b_f)
     sfpi::vFloat t = inv_b_f * neg_b_f + sfpi::vConst1;
     scale = sfpi::reinterpret<sfpi::vFloat>((254 << 23) - sfpi::reinterpret<sfpi::vInt>(scale));
     inv_b_f = t * inv_b_f + inv_b_f;
 
+    // Halley's Method
     sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
 
-    // ---- Load |a| ----
+    // Equivalent to: sfpi::vUInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vUInt a = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
 
     a = sfpi::abs(a);
 
+    // Continue Halley's Method
     e = e * e + e;
     inv_b_f = e * inv_b_f + inv_b_f;
 
@@ -51,23 +61,26 @@ sfpi_inline void calculate_remainder_int32_body(
     v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
     v_endif;
 
+    // Apply scaling factor to finalize reciprocal
     inv_b_f = inv_b_f * scale;
 
-    // ---- Initial quotient approximation ----
+    // Initial quotient approximation : q = a * 1/b
     sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
     sfpi::vUInt q = sfpi::exman9(q_f);
 
     sfpi::vUInt MASK_11 = 0x7ff;
 
-    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);
-    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);
-    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);
-    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);
-
+    // Split q and b into 11-bit chunks to compute q * b
+    sfpi::vFloat q1 = int32_to_float(q & MASK_11, 0);          // Lower 11 bits of q
+    sfpi::vFloat q2 = int32_to_float(q >> 11, 0);              // Upper bits of q
+    sfpi::vFloat b1 = int32_to_float((b >> 11) & MASK_11, 0);  // Middle 11 bits of b
+    sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);          // Lower 11 bits of b
     q = q << 11;
 
     sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
 
+    // hi = q2 * b0 + q1 * b1 (high part)
+    // lo = q1 * b0 (low part)
     sfpi::vFloat hi = q2 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat lo = q1 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     hi = q1 * b1 + hi;
@@ -75,21 +88,20 @@ sfpi_inline void calculate_remainder_int32_body(
     sfpi::vInt qb = sfpi::exman9(lo) << 11;
     qb += sfpi::exman9(hi) << 22;
 
-    // ---- Compute truncating remainder ----
+    // Compute remainder
     a = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
-    a = sfpi::abs(a);
-
+    a = sfpi::abs(sfpi::reinterpret<sfpi::vInt>(a));
     sfpi::vInt r = a - qb;
-
     sfpi::vFloat r_f = sfpi::int32_to_float(sfpi::abs(r), 0);
 
+    // Compute correction: r / b in float32
     sfpi::vFloat correction_f = r_f * inv_b_f;
     sfpi::vFloat b2 = sfpi::int32_to_float(b >> 22, 0);
-
     sfpi::vInt correction = sfpi::float_to_uint16(correction_f, 0);
     correction_f = sfpi::int32_to_float(correction, 0);
 
+    // tmp = correction * (b2<<22 + b1<<11 + b0)
     sfpi::vFloat low = correction_f * b0 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat mid = correction_f * b1 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
@@ -98,35 +110,39 @@ sfpi_inline void calculate_remainder_int32_body(
     tmp += sfpi::exman9(mid) << 11;
     tmp += sfpi::exman9(top) << 22;
 
+    // Adjust remainder based on its sign
     v_if(r < 0) { r += tmp; }
     v_else { r -= tmp; }
     v_endif;
 
+    // Since the correction might have been rounded, we may need to correct one
+    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
     v_if(r < 0 && (r - 1) < 0) { r += b; }
     v_elseif(r >= b) { r -= b; }
     v_endif;
 
-    // ---- Floor remainder fix (torch.remainder) ----
+    // Reload original signed values for sign handling
+    // Equivalent to: sfpi::vUInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
     sfpi::vInt a_signed = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].get());
+    // Equivalent to: sfpi::vUInt b_signed = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
     sfpi::vInt b_signed = __builtin_rvtt_sfpload(
         4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].get());
 
     sfpi::vInt sign = a_signed ^ b_signed;
     v_if(r != 0) {
-        v_if(sign < 0) {  // signs differ
+        v_if(sign < 0) {  // signs differ: need to adjust for floor division
+            // When signs differ, floor(a/b) = trunc(a/b) - 1, so remainder needs adjustment
             v_if(a_signed < 0) { r = b_signed - r; }
             v_else { r += b_signed; }
             v_endif;
         }
-        v_elseif(a_signed < 0 && b_signed < 0) {  // both negative
-            r = -r;
-        }
+        v_elseif(a_signed < 0 && b_signed < 0) { r = -r; }
         v_endif;
     }
     v_endif;
 
-    // ---- Store remainder ----
+    // Equivalent to: sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
     __builtin_rvtt_sfpstore(
         r.get(), 4, sfpi::SFPLOAD_ADDR_MODE_NOINC, sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].get());
 }
@@ -142,7 +158,6 @@ inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_i
 
 template <bool APPROXIMATION_MODE>
 inline void remainder_int32_init() {
-    // Use the same initialization as div_floor_init since we're using the floor division kernel
     div_floor_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -11,6 +11,9 @@
 
 namespace ckernel::sfpu {
 
+// 2^31 as float (used for INT32 sign-magnitude conversion edge cases)
+constexpr float TWO_POW_31 = 2147483648.0f;
+
 // Computes the unsigned remainder: |a| - floor(|a| / |b|) * |b|
 // Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 // Returns: r (unsigned remainder), a_signed, b_signed (original signed values)
@@ -30,7 +33,7 @@ sfpi_inline void compute_unsigned_remainder_int32(
     // Convert to float for reciprocal computation
     // Handle edge case: if conversion results in negative
     sfpi::vFloat b_f = sfpi::int32_to_float(b, 0);
-    v_if(b_f < 0.0f) { b_f = 2147483648.0f; }
+    v_if(b_f < 0.0f) { b_f = TWO_POW_31; }
     v_endif;
 
     // Compute reciprocal of b
@@ -59,7 +62,7 @@ sfpi_inline void compute_unsigned_remainder_int32(
     inv_b_f = e * inv_b_f + inv_b_f;
 
     sfpi::vFloat a_f = sfpi::int32_to_float(a, 0);
-    v_if(a_f < 0.0f) { a_f = 2147483648.0f; }
+    v_if(a_f < 0.0f) { a_f = TWO_POW_31; }
     v_endif;
 
     // Apply scaling factor to finalize reciprocal
@@ -78,6 +81,10 @@ sfpi_inline void compute_unsigned_remainder_int32(
     sfpi::vFloat b0 = int32_to_float(b & MASK_11, 0);          // Lower 11 bits of b
     q = q << 11;
 
+    // 8388608.0f = 2^23 is used as a Bias.
+    // Adding this value to a float pushes it into a range where the lower 23 bits of the
+    // mantissa directly represent the integer portion of the number.
+    // This allows integer extraction from a floating-point value without explicit casting.
     sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
 
     // hi = q2 * b0 + q1 * b1 (high part)
@@ -131,7 +138,6 @@ sfpi_inline void compute_unsigned_remainder_int32(
 }
 
 // Remainder = a - floor(a / b) * b
-// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
 sfpi_inline void calculate_remainder_int32_body(
     const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     // Size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder_int32.h
@@ -162,7 +162,7 @@ sfpi_inline void calculate_remainder_int32_body(
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_remainder_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
-#pragma GCC unroll 0
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         calculate_remainder_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_fmod_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_fmod_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_fmod_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_fmod_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::fmod_int32, APPROXIMATE>(sfpu::fmod_int32_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_fmod_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_fmod_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_remainder_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_remainder_int32.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_remainder_int32.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_remainder_int32_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::remainder_int32, APPROXIMATE>(sfpu::remainder_int32_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_remainder_int32(
+    uint dst_index0, uint32_t dst_index1, uint32_t odst, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_remainder_int32<APPROXIMATE, 8>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -86,6 +86,7 @@ enum class SfpuType {
     div_int32_floor,
     div_int32_trunc,
     remainder_int32,
+    fmod_int32,
     lt,
     gt,
     ge,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -85,6 +85,7 @@ enum class SfpuType {
     div_int32,
     div_int32_floor,
     div_int32_trunc,
+    remainder_int32,
     lt,
     gt,
     ge,

--- a/tt_metal/include/compute_kernel_api/fmod_int32.h
+++ b/tt_metal/include/compute_kernel_api/fmod_int32.h
@@ -13,7 +13,7 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Performs an elementwise remainder operation with the two 32-bit integer inputs: y = remainder(x0,x1)
+ * Performs an elementwise fmod operation with the two 32-bit integer inputs: y = fmod(x0,x1)
  * Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
@@ -34,7 +34,7 @@ ALWI void fmod_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 }
 
 /**
- * Please refer to documentation for remainder_int32_tile.
+ * Please refer to documentation for fmod_int32_tile.
  */
 ALWI void fmod_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_fmod_int32_init<APPROX>())); }
 

--- a/tt_metal/include/compute_kernel_api/fmod_int32.h
+++ b/tt_metal/include/compute_kernel_api/fmod_int32.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_fmod_int32.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise remainder operation with the two 32-bit integer inputs: y = remainder(x0,x1)
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     */
+// clang-format on
+ALWI void fmod_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_fmod_int32<APPROX>(idst0, idst1, odst)));
+}
+
+/**
+ * Please refer to documentation for remainder_int32_tile.
+ */
+ALWI void fmod_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_fmod_int32_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/remainder_int32.h
+++ b/tt_metal/include/compute_kernel_api/remainder_int32.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_remainder_int32.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise remainder operation with the two 32-bit integer inputs: y = remainder(x0,x1)
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     */
+// clang-format on
+ALWI void remainder_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((llk_math_eltwise_binary_sfpu_remainder_int32<APPROX>(idst0, idst1, odst)));
+}
+
+/**
+ * Please refer to documentation for remainder_int32_tile.
+ */
+ALWI void remainder_int32_tile_init() { MATH((llk_math_eltwise_binary_sfpu_remainder_int32_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -2580,14 +2580,14 @@ void py_module(nb::module_& mod) {
         ttnn::fmod,
         R"doc(Performs an eltwise-fmod operation.)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|fmod|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        R"doc(BFLOAT16, FLOAT32)doc");
+        R"doc(BFLOAT16, FLOAT32, INT32)doc");
 
     detail::bind_binary_overload_operation(
         mod,
         ttnn::remainder,
         R"doc(Performs an eltwise-modulus operation.)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|remainder|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        R"doc(BFLOAT16)doc");
+        R"doc(BFLOAT16, FLOAT32, INT32)doc");
 
     detail::bind_inplace_operation(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -27,6 +27,7 @@ enum class BinaryOpType {
     DIV,
     DIV_FLOOR,
     DIV_TRUNC,
+    REMAINDER,
     RSUB,
     POWER,
     BITWISE_XOR,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -28,6 +28,7 @@ enum class BinaryOpType {
     DIV_FLOOR,
     DIV_TRUNC,
     REMAINDER,
+    FMOD,
     RSUB,
     POWER,
     BITWISE_XOR,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -504,6 +504,7 @@ Tensor ExecutePrelu::invoke(
     Tensor result = ttnn::where(ttnn::ltz(input_a, output_mem_config), ttnn::multiply(input_a, b), input_a);
     return result;
 }
+
 Tensor run_remainder(
     const Tensor& input_a,
     const Tensor& input_b,
@@ -658,7 +659,6 @@ Tensor ExecuteBinaryFmod::invoke(
         return ttnn::prim::binary_ng(
             input_a, input_b, BinaryOpType::FMOD, std::nullopt, output_mem_config, std::nullopt);
     }
-    
     Tensor div_res = ttnn::div(input_a, input_b, false, "trunc", std::nullopt, output_mem_config);
 
     // No typecast for FP32 input

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -5,6 +5,7 @@
 #include "binary_composite_op.hpp"
 #include <utility>
 #include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/bfloat16.hpp>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -18,6 +18,7 @@
 #include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
+#include "compute_kernel_api/remainder_int32.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/xlogy.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -19,6 +19,7 @@
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/remainder_int32.h"
+#include "compute_kernel_api/fmod_int32.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/xlogy.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -45,7 +45,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case BITWISE_OR:
         case BITWISE_AND: return a == b && (a == INT32 || a == UINT32 || a == UINT16);
         case DIV_FLOOR:
-        case DIV_TRUNC: return (a == INT32 && b == INT32);
+        case DIV_TRUNC:
+        case REMAINDER: return (a == INT32 && b == INT32);
         case QUANT:
         case REQUANT:
         case DEQUANT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -46,7 +46,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case BITWISE_AND: return a == b && (a == INT32 || a == UINT32 || a == UINT16);
         case DIV_FLOOR:
         case DIV_TRUNC:
-        case REMAINDER: return (a == INT32 && b == INT32);
+        case REMAINDER:
+        case FMOD: return (a == INT32 && b == INT32);
         case QUANT:
         case REQUANT:
         case DEQUANT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -146,6 +146,7 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             break;
         case BinaryOpType::DIV_FLOOR: binary_op = SfpuBinaryOp::DIV_FLOOR; break;
         case BinaryOpType::DIV_TRUNC: binary_op = SfpuBinaryOp::DIV_TRUNC; break;
+        case BinaryOpType::REMAINDER: binary_op = SfpuBinaryOp::REMAINDER; break;
         // b - a
         case BinaryOpType::RSUB:
             if (is_sfpu_op()) {
@@ -399,6 +400,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             }
         case DIV_FLOOR: return {"div_int32_floor_tile_init();", "div_int32_floor_tile"};
         case DIV_TRUNC: return {"div_int32_trunc_tile_init();", "div_int32_trunc_tile"};
+        case REMAINDER: return {"remainder_int32_tile_init();", "remainder_int32_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB:
             if (dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -147,6 +147,7 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
         case BinaryOpType::DIV_FLOOR: binary_op = SfpuBinaryOp::DIV_FLOOR; break;
         case BinaryOpType::DIV_TRUNC: binary_op = SfpuBinaryOp::DIV_TRUNC; break;
         case BinaryOpType::REMAINDER: binary_op = SfpuBinaryOp::REMAINDER; break;
+        case BinaryOpType::FMOD: binary_op = SfpuBinaryOp::FMOD; break;
         // b - a
         case BinaryOpType::RSUB:
             if (is_sfpu_op()) {
@@ -401,6 +402,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case DIV_FLOOR: return {"div_int32_floor_tile_init();", "div_int32_floor_tile"};
         case DIV_TRUNC: return {"div_int32_trunc_tile_init();", "div_int32_trunc_tile"};
         case REMAINDER: return {"remainder_int32_tile_init();", "remainder_int32_tile"};
+        case FMOD: return {"fmod_int32_tile_init();", "fmod_int32_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB:
             if (dtype == DataType::INT32) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -51,6 +51,7 @@ struct OpConfig {
         DIV,
         DIV_FLOOR,
         DIV_TRUNC,
+        REMAINDER,
         POWER,
         RSUB,
         GCD,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -52,6 +52,7 @@ struct OpConfig {
         DIV_FLOOR,
         DIV_TRUNC,
         REMAINDER,
+        FMOD,
         POWER,
         RSUB,
         GCD,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -17,6 +17,7 @@
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/remainder_int32.h"
+#include "compute_kernel_api/fmod_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -16,6 +16,7 @@
 #include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
+#include "compute_kernel_api/remainder_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -17,6 +17,7 @@
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/remainder_int32.h"
+#include "compute_kernel_api/fmod_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -16,6 +16,7 @@
 #include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
+#include "compute_kernel_api/remainder_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -17,6 +17,7 @@
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
 #include "compute_kernel_api/remainder_int32.h"
+#include "compute_kernel_api/fmod_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -16,6 +16,7 @@
 #include "compute_kernel_api/mul_int32_sfpu.h"
 #include "compute_kernel_api/div_int32_floor.h"
 #include "compute_kernel_api/div_int32_sfpu.h"
+#include "compute_kernel_api/remainder_int32.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"


### PR DESCRIPTION
### Ticket
#34967 
#27884 

### Problem description
Remainder and FMOD currently typecasts INT32 inputs to FLOAT32 in composite structure. This provides  INT32 support for range ( INT_MIN -1 , INT_MAX) 

### What's changed
LLK implementations for Remainder and FMOD INT32

**Note:** Once FMOD LLK for float datatypes (https://github.com/tenstorrent/tt-metal/issues/35977) is supported, this op will be moved to binary_ng infra from binary_composite

### Summary of Improvements
**Range Supported:** Improved from [-9e3, 9e3] → [INT_MIN+1, INT_MAX]

**Accuracy:**
- Previously: abs difference of 1 in [-9e3, 9e3] ; abs difference >1000 for other ranges
- Now: abs difference of 0 in [INT_MIN+1, INT_MAX]

**Remainder Perf Results ([Report](https://docs.google.com/spreadsheets/d/16Eh8s8Ly2oVSan37OePlJmGuC0U7ny4jRdZh_4v20AM/edit?gid=0#gid=0)):**
Remainder kernel duration improved by an average of **86.45%**
| Shape Tested       | Composite Duration (ns) | LLK Duration (ns) | Duration Improved (ns) | % Improvement |
| ------------------ | ----------------------- | ----------------- | ---------------------- | ------------- |
| [1, 1, 32, 32]     | 37,931                  | 7,463             | 30,468                 | 80.30%        |
| [1, 1, 1024, 1024] | 960,938                 | 93,624            | 867,314                | 90.30%        |
| [1, 1, 4096, 4096] | 11,761,842              | 1,308,499         | 10,453,343             | 88.89%        |

**FMOD Perf Results ([Report](https://docs.google.com/spreadsheets/d/16Eh8s8Ly2oVSan37OePlJmGuC0U7ny4jRdZh_4v20AM/edit?gid=1976109804#gid=1976109804)):**
FMOD kernel duration improved by an average of **77.27%**
| Shape Tested       | Composite Duration (ns) | LLK Duration (ns) | Duration Improved (ns) | % Improvement |
| ------------------ | ----------------------- | ----------------- | ---------------------- | ------------- |
| [1, 1, 32, 32]     | 21,847                  | 6,747             | 15,100                 | 69.10%        |
| [1, 1, 1024, 1024] | 475,896                 | 88,314            | 387,582                | 81.40%        |
| [1, 1, 4096, 4096] | 5,945,444               | 1,112,318         | 4,833,126              | 81.30%        |



### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=anasuya/remainder_llk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:anasuya/remainder_llk)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anasuya/remainder_llk)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anasuya/remainder_llk)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/remainder_llk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/remainder_llk)
- [x] New/Existing tests provide coverage for changes