### PR TITLE
Updated the ttnn.reshape documentation to display correct parameter name

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -101,7 +101,7 @@ void bind_reshape_view(nb::module_& mod) {
 
             Args:
                 * input_tensor: Input Tensor.
-                * new_shape: New shape of tensor.
+                * shape: Shape of tensor.
 
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
@@ -26,7 +26,7 @@ void bind_view(nb::module_& mod) {
             * In Layout::TILE the second last two dimensions must not change OR there is no padding on the second last dimension
         Args:
             * input_tensor: Input Tensor.
-            * new_shape: New shape of tensor.
+            * shape: New shape of tensor.
         Returns:
             ttnn.Tensor: the output tensor with the new shape.
         Example:

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view_nanobind.cpp
@@ -26,7 +26,7 @@ void bind_view(nb::module_& mod) {
             * In Layout::TILE the second last two dimensions must not change OR there is no padding on the second last dimension
         Args:
             * input_tensor: Input Tensor.
-            * shape: New shape of tensor.
+            * shape: Shape of tensor.
         Returns:
             ttnn.Tensor: the output tensor with the new shape.
         Example:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34347)

### Problem description
Documentation was showing 'new_shape' instead of 'shape'.

### What's changed
Changed the name to 'shape' which correctly reflects argument name.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20786044845)

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.