### PR TITLE
[tt-train] Remove TT_METAL_HOME environment variable dependency

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -317,13 +317,19 @@ if(NOT TARGET TT::Metalium)
     find_package(TT-NN)
 
     if(NOT TT-NN_FOUND)
-        # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
-        # From tt-train/sources/ttml/, go up THREE levels to reach the repository root
-        set(TT_METAL_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
-        if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
-            message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
+        # Try to get TT_METAL_HOME from environment, otherwise infer from directory structure
+        if(DEFINED ENV{TT_METAL_HOME})
+            set(TT_METAL_HOME "$ENV{TT_METAL_HOME}")
+            message(STATUS "Using TT_METAL_HOME from environment: ${TT_METAL_HOME}")
         else()
-            message(FATAL_ERROR "Failed to infer tt-metal location from ${TT_METAL_HOME}")
+            # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
+            # From tt-train/sources/ttml/, go up THREE levels to reach the repository root
+            set(TT_METAL_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+            if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
+                message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
+            else()
+                message(FATAL_ERROR "Failed to infer tt-metal location from ${TT_METAL_HOME}")
+            endif()
         endif()
 
         set(METALIUM_INCLUDE_DIRS

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -317,36 +317,41 @@ if(NOT TARGET TT::Metalium)
     find_package(TT-NN)
 
     if(NOT TT-NN_FOUND)
-        if("$ENV{TT_METAL_HOME}" STREQUAL "")
-            message(FATAL_ERROR "TT_METAL_HOME is not set")
+        # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
+        # From tt-train/sources/ttml/, go up THREE levels to reach the repository root
+        set(TT_METAL_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+        if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
+            message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
+        else()
+            message(FATAL_ERROR "Failed to infer tt-metal location from ${TT_METAL_HOME}")
         endif()
 
         set(METALIUM_INCLUDE_DIRS
             # Metalium
-            "$ENV{TT_METAL_HOME}"
-            "$ENV{TT_METAL_HOME}/tt_metal"
-            "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd"
-            "$ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public"
-            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/wormhole"
-            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/wormhole/wormhole_b0_defines"
-            "$ENV{TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/blackhole"
-            "$ENV{TT_METAL_HOME}/tt_metal/api/"
-            "$ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api"
-            "$ENV{TT_METAL_HOME}/tt_metal/hostdevcommon/api"
-            "$ENV{TT_METAL_HOME}/tt_metal/include"
-            "$ENV{TT_METAL_HOME}/tt_stl"
+            "${TT_METAL_HOME}"
+            "${TT_METAL_HOME}/tt_metal"
+            "${TT_METAL_HOME}/tt_metal/third_party/umd"
+            "${TT_METAL_HOME}/tt_metal/third_party/tracy/public"
+            "${TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/wormhole"
+            "${TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/wormhole/wormhole_b0_defines"
+            "${TT_METAL_HOME}/tt_metal/hw/inc/internal/tt-1xx/blackhole"
+            "${TT_METAL_HOME}/tt_metal/api/"
+            "${TT_METAL_HOME}/tt_metal/third_party/umd/device/api"
+            "${TT_METAL_HOME}/tt_metal/hostdevcommon/api"
+            "${TT_METAL_HOME}/tt_metal/include"
+            "${TT_METAL_HOME}/tt_stl"
             # TTNN
-            "$ENV{TT_METAL_HOME}/ttnn"
-            "$ENV{TT_METAL_HOME}/ttnn/api"
-            "$ENV{TT_METAL_HOME}/ttnn/cpp"
-            "$ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated"
+            "${TT_METAL_HOME}/ttnn"
+            "${TT_METAL_HOME}/ttnn/api"
+            "${TT_METAL_HOME}/ttnn/cpp"
+            "${TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated"
             "${reflect_SOURCE_DIR}"
         )
 
         message(STATUS "Metalium not found, attempting to locate")
 
         # Define the path to look for the library
-        set(METALIUM_LIB_PATH "$ENV{TT_METAL_HOME}/build/lib")
+        set(METALIUM_LIB_PATH "${TT_METAL_HOME}/build/lib")
 
         # Try to find the library
         find_library(TT_METAL_LIBRARY NAMES "tt_metal" PATHS "${METALIUM_LIB_PATH}" NO_DEFAULT_PATH)
@@ -362,7 +367,7 @@ if(NOT TARGET TT::Metalium)
                     IMPORTED_LOCATION
                         "${TT_STL_LIBRARY}"
                     INTERFACE_INCLUDE_DIRECTORIES
-                        "$ENV{TT_METAL_HOME}/tt_stl"
+                        "${TT_METAL_HOME}/tt_stl"
             )
             message(STATUS "Successfully found libtt_stl.so at ${TT_STL_LIBRARY}")
         else()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/13726

### Problem description
PR https://github.com/tenstorrent/tt-metal/pull/30502 removed the `TT_METAL_HOME` environment variable requirement from tt-metal. However, tt-train's `sources/ttml/CMakeLists.txt` still requires this environment variable, creating an inconsistent developer experience and unnecessary setup complexity.

### What's changed
Modified `CMakeLists.txt` to make the `TT_METAL_HOME` environment variable optional. The build system now:
1. First checks if `TT_METAL_HOME` is set in the environment (backward compatibility)
2. If not set, automatically infers tt-metal location by traversing up from `tt-train/sources/ttml/` to locate the repository root

This eliminates the requirement for manual environment configuration in the standard `tt-metal/tt-train` repository layout while maintaining backward compatibility for custom setups.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/cmake_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/cmake_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/cmake_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/cmake_fix)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/cmake_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/cmake_fix)
- [ ] New/Existing tests provide coverage for changes
