### PR TITLE
Changing DM PCC check to bitwise comparison

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -22,9 +22,9 @@ By the end of the test, every master core should have received the same data fro
 
 Test attributes such as pages per transaction and number of transactions per subordinate core, and latency measures such as kernel and pre-determined scope cycles are recorded by the profiler.
 
-A pcc check is performed by cross-checking the data of all the subordinate cores pieced-together against the data received by each master core. This ensures that the data integrity is maintained throughout the data movement process.
+An equality check is performed by cross-checking the data of all the subordinate cores pieced-together against the data received by each master core. This ensures that the data integrity is maintained throughout the data movement process.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -177,25 +177,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
 
     vector<uint32_t> packed_output;
 
-    bool pcc = false;
+    bool is_equal = false;
 
     for (auto& mst_logical_core : corerange_to_cores(mst_logical_core_set)) {
         detail::ReadFromDeviceL1(device, mst_logical_core, mst_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
-        pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-            packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
-        if (!pcc) {
-            log_error(LogTest, "PCC Check failed");  // TO-DO: Print the failed core's coordinates here
+        is_equal = (packed_output == packed_golden);
+        if (!is_equal) {
+            log_error(LogTest, "Equality Check failed");  // TO-DO: Print the failed core's coordinates here
             log_info(LogTest, "Golden vector");
             print_vector<uint32_t>(packed_golden);
             log_info(LogTest, "Output vector");
             print_vector<uint32_t>(packed_output);
-            return pcc;
+            return is_equal;
         }
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -22,9 +22,9 @@ By the end of the test, every subordinate core should have received the same dat
 
 Test attributes such as pages per transaction and number of transactions per master core, and latency measures such as kernel and pre-determined scope cycles are recorded by the profiler.
 
-A pcc check is performed by cross-checking the data of all the master cores pieced-together against the data received by each subordinate core. This ensures that the data integrity is maintained throughout the data movement process.
+An equality check is performed by cross-checking the data of all the master cores pieced-together against the data received by each subordinate core. This ensures that the data integrity is maintained throughout the data movement process.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -187,25 +187,24 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
     vector<uint32_t> packed_output;
     packed_output.reserve(bytes_per_transaction / sizeof(uint32_t));
 
-    bool pcc = false;
+    bool is_equal = false;
 
     for (auto& sub_logical_core : corerange_to_cores(sub_logical_core_set)) {
         detail::ReadFromDeviceL1(device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
-        pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-            packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
-        if (!pcc) {
-            log_error(LogTest, "PCC Check failed");  // TO-DO: Print the failed core's coordinates here
+        is_equal = (packed_output == packed_golden);
+        if (!is_equal) {
+            log_error(LogTest, "Equality Check failed");  // TO-DO: Print the failed core's coordinates here
             log_info(LogTest, "Golden vector");
             print_vector<uint32_t>(packed_golden);
             log_info(LogTest, "Output vector");
             print_vector<uint32_t>(packed_output);
-            return pcc;
+            return is_equal;
         }
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on two Tensix cores: one master core and one subordinate core. The master core can run either a single kernel that performs both sending and receiving operations, or separate sender and receiver kernels. Data is written into both cores' L1 memory. The kernels perform simultaneous NOC write and read transactions between the two cores. Hardware barriers ensure data validity and completion of all transactions.
 
-Test attributes such as transaction sizes, number of transactions, and virtual channel configuration are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes, number of transactions, and virtual channel configuration are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/core_bidirectional/test_core_bidirectional.cpp
@@ -180,14 +180,12 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
         device, test_config.master_core_coord, l1_base_read_address, bytes_per_transaction, packed_requestor_output);
 
     // Compare output with golden vector
-    bool pcc;
-    pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_sender_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
-    pcc &= is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_requestor_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal;
+    is_equal = (packed_sender_output == packed_golden);
+    is_equal &= (packed_requestor_output == packed_golden);
 
-    if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(tt::LogTest, "Equality Check failed");
         log_info(tt::LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(tt::LogTest, "Sender output vector");
@@ -197,7 +195,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const CoreBi
         return false;
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/README.md
@@ -10,11 +10,11 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 Runs the reader kernel on a Tensix core. After initializing a sharded DRAM buffer with data, the kernel issues NOC instructions to read this data into L1 memory using the stateful one_packet APIs. A read barrier is placed after these transactions to ensure data validity.
 
-Test attributes such as number of DRAM banks to shard into and number of tiles per bank, as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as number of DRAM banks to shard into and number of tiles per bank, as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
 An additional flag can be set to use a stateful read with transaction IDs, for testing the functionality of those APIs.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -132,18 +132,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
         device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(tt::LogTest, "Equality Check failed");
         log_info(tt::LogTest, "Golden vector");
         print_vector(unpack_vector<bfloat16, uint32_t>(packed_golden));
         log_info(tt::LogTest, "Output vector");
         print_vector(unpack_vector<bfloat16, uint32_t>(packed_output));
     }
 
-    return pcc;
+    return is_equal;
 }
 }  // namespace unit_tests::dm::dram_sharded
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 Data is loaded into an L1 circular buffer by the reader kernel and written out to DRAM from the same L1 buffer by the writer kernel. A compute kernel is omitted as these tests are purely for data movement. Hardware barriers ensure data validity and completion of transactions.
 
-Test attributes such as transaction sizes, number of transactions, core locations, and DRAM channels as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes, number of transactions, core locations, and DRAM channels as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -150,18 +150,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
         device, test_config.dram_channel, output_dram_address, total_size_bytes, packed_output);
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/README.md
@@ -14,9 +14,9 @@ The reader kernel issues NOC instructions to read data from an interleaved buffe
 
 The writer kernel issues NOC instructions to write data from the L1 address of the Tensix core into an interleaved buffer. A write barrier is placed after these transactions in order to ensure data validity.
 
-Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through a pcc check.
+Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -181,18 +181,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     }
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(tt::LogTest, "Equality Check failed");
         log_info(tt::LogTest, "Golden vector");
         print_vector(unpack_vector<bfloat16, uint32_t>(packed_golden));
         log_info(tt::LogTest, "Output vector");
         print_vector(unpack_vector<bfloat16, uint32_t>(packed_output));
     }
 
-    return pcc;
+    return is_equal;
 }
 }  // namespace unit_tests::dm::interleaved_page
 

--- a/tests/tt_metal/tt_metal/data_movement/loopback/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on a single Tensix core with separate address offsets for input and output data. Data is written into the input L1 memory location. The sender kernel issues NOC transactions to transfer this data from the input L1 address to the output L1 address within the same core (loopback). Once data is transferred, the sender kernel uses hardware barriers to ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -130,16 +130,15 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Loopba
         device, test_config.master_core_coord, subordinate_l1_byte_address, transaction_size_bytes, packed_output);
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    bool is_equal = (packed_output == packed_golden);
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
-    return pcc;
+    return is_equal;
 }
 }  // namespace unit_tests::dm::core_loopback
 

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
@@ -14,9 +14,9 @@ The reader kernel issues NOC instructions to read data from an interleaved DRAM 
 
 The writer kernel issues NOC instructions to write data from the L1 address of the Tensix cores into an interleaved DRAM buffer. A write barrier is placed after these transactions in order to ensure data validity.
 
-Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through a pcc check.
+Transactions exceeding 16 pages will consecutively overwrite the same 16 pages so as not to take up excess L1 memory. Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is read from the output interleaved buffer if the writer kernel is run (or directly from L1 memory otherwise), cross-checked with original data, and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on multiple Tensix cores: multiple subordinate cores (senders) and one master core (receiver). Data is written into L1 memory on all subordinate cores. The master core issues NOC read transactions to retrieve data from all subordinate cores' L1 memory. Once data is transferred from all subordinate cores, the master core uses hardware barriers to ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -149,18 +149,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
         device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on two Tensix cores: one subordinate core (sender) and one master core (receiver). Data is written into the L1 memory on the subordinate core. The master core issues NOC read transactions to retrieve data from the subordinate core's L1 memory. Once data is transferred, the master core uses hardware barriers to ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -127,18 +127,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneFro
         device, test_config.master_core_coord, l1_base_address, transaction_size_bytes, packed_output);
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/README.md
@@ -14,9 +14,9 @@ If the reader kernel is run, data is written directly into the L1 memory of the 
 
 If the writer kernel is run, data is written directly into the L1 memory of the master core, and the kernel issues NOC instructions to write this data into the L1 address of the subordinate core using the one_packet APIs. A write barrier is placed after these transactions in order to ensure data validity.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -151,18 +151,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
     }
 
     // Results comparison
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(tt::LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(tt::LogTest, "Equality Check failed");
         log_info(tt::LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(tt::LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
-    return pcc;
+    return is_equal;
 }
 }  // namespace unit_tests::dm::one_packet
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on multiple Tensix cores: one master core (sender) and multiple subordinate cores (receivers). Data is written into the L1 memory on the master core. The master core issues NOC transactions (either unicast or multicast) to transfer its data to L1 memory on all subordinate cores. Once data is transferred to all subordinate cores, hardware barriers ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes, number of transactions, and grid configurations as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes, number of transactions, and grid configurations as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -223,11 +223,10 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
         detail::ReadFromDeviceL1(device, sub_logical_core, sub_l1_base_address, bytes_per_transaction, packed_output);
 
         // Results comparison
-        bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-            packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+        bool is_equal = (packed_output == packed_golden);
 
-        if (!pcc) {
-            log_error(LogTest, "PCC Check failed");
+        if (!is_equal) {
+            log_error(LogTest, "Equality Check failed");
             log_info(LogTest, "Golden vector");
             print_vector<uint32_t>(packed_golden);
             log_info(LogTest, "Output vector");

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -10,9 +10,9 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ## Test Flow
 L1 memory is allocated on two Tensix cores: one sender and one receiver core. Data is written into the L1 memory on the sender core. The sender kernel issues NOC transactions to transfer this data into the L1 memory on the receiver core. Once data is transferred, the sender kernel uses hardware barriers to ensure data validity and completion of the transaction.
 
-Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through an equality check.
 
-Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+Test expectations are that the equality checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Running the Tests
 The tests use the Mesh Device API with fast dispatch mode:

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -148,18 +148,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToO
         device, test_config.subordinate_core_coord, l1_base_address, bytes_per_transaction, packed_output);
 
     // Compare output with golden vector
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output == packed_golden);
 
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden vector");
         print_vector<uint32_t>(packed_golden);
         log_info(LogTest, "Output vector");
         print_vector<uint32_t>(packed_output);
     }
 
-    return pcc;
+    return is_equal;
 }
 
 void directed_ideal_test(

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/README.md
@@ -14,13 +14,13 @@ L1 memory is allocated on three Tensix cores: one master core and two subordinat
 1. **Data Setup**: Random data is written to both the master core and sub1 core L1 memory
 2. **Write Phase**: The master core issues NOC write transactions with unique transaction IDs to transfer data to the sub0 core
 3. **Read-After-Write**: The master core waits for write transactions to complete using transaction ID barriers (`noc_async_write_flushed_with_trid`), then immediately reads data from the sub1 core. Note that the transaction ID barriers prevent write-after-read (WAR) hazards where the data we are writing from the master core is not corrupted by our reads from the sub1 core.
-4. **Validation**: Data integrity is verified through PCC (Pearson Correlation Coefficient) checks. Initial data in sub1 and master cores are compared with resulting data in master and sub0 cores, respectively.
+4. **Validation**: Data integrity is verified through a simple equality check. Initial data in sub1 and master cores are compared with resulting data in master and sub0 cores, respectively.
 
 ### Write-After-Read:
 1. **Data Setup**: Random data is written to both the master core and sub1 core L1 memory
 2. **Read Phase**: The master core issues NOC read transactions with unique transaction IDs to transfer data from the sub1 core
 3. **Write-After-Read**: The master core waits for read transactions to complete using transaction ID barriers (`noc_async_read_barrier_with_trid`), then immediately writes that same data to the sub0 core.
-4. **Validation**: Data integrity is verified through PCC (Pearson Correlation Coefficient) checks. Initial data in sub1 and master cores are compared with resulting data in master and sub0 cores, respectively.
+4. **Validation**: Data integrity is verified through a simple equality check. Initial data in sub1 and master cores are compared with resulting data in master and sub0 cores, respectively.
 
 This pattern tests the benefits of using transaction IDs on performance, ensuring that the NOC is kept busy at the highest rate possible.
 

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -168,15 +168,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
         device, test_config.master_core_coord, l1_base_address, bytes_per_transaction, packed_output_sub1);
 
     // Compare output with golden vector
-    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output_master, packed_golden_master, [&](const bfloat16& a, const bfloat16& b) {
-            return is_close(a, b);
-        });
-    pcc &= is_close_packed_vectors<bfloat16, uint32_t>(
-        packed_output_sub1, packed_golden_sub1, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+    bool is_equal = (packed_output_master == packed_golden_master);
+    is_equal &= (packed_output_sub1 == packed_golden_sub1);
 
-    if (!pcc) {
-        log_error(LogTest, "PCC Check failed");
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
         log_info(LogTest, "Golden master vector");
         print_vector<uint32_t>(packed_golden_master);
         log_info(LogTest, "Output master vector");
@@ -187,7 +183,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
         print_vector<uint32_t>(packed_output_sub1);
     }
 
-    return pcc;
+    return is_equal;
 }
 }  // namespace unit_tests::dm::transaction_id
 


### PR DESCRIPTION
### Ticket
#30547 

### Problem description
Previous tests were using PCC checks instead of bitwise equality for simple DM

### What's changed
PCC -> Bitwise equality

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gagandeepsingh/pcc-to-bitwise-issue-30547)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gagandeepsingh/pcc-to-bitwise-issue-30547)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs