### PR TITLE
Add dst addrs to NoC async read/write debug packets

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -345,36 +345,95 @@ def test_device_api_debugger_non_dropping():
     assert isinstance(noc_trace_data, list), f"noc trace file '{expected_trace_file}' format is incorrect"
     assert len(noc_trace_data) > 0, f"noc trace file '{expected_trace_file}' is empty"
 
-    brisc_dst_addrs_found = set()
-    ncrisc_dst_addrs_found = set()
+    # Track READ and WRITE events separately for each RISC
+    brisc_read_dst_addrs_found = set()
+    brisc_write_dst_addrs_found = set()
+    ncrisc_read_dst_addrs_found = set()
+    ncrisc_write_dst_addrs_found = set()
+
+    # Track barrier events
+    read_barrier_start_count = 0
+    read_barrier_end_count = 0
+    write_barrier_start_count = 0
+    write_barrier_end_count = 0
 
     for event in noc_trace_data:
         assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"
-        if event.get("type") == "READ" and "dst_addr" in event and "proc" in event:
+        event_type = event.get("type")
+
+        # Count barrier events
+        if event_type == "READ_BARRIER_START":
+            read_barrier_start_count += 1
+        elif event_type == "READ_BARRIER_END":
+            read_barrier_end_count += 1
+        elif event_type == "WRITE_BARRIER_START":
+            write_barrier_start_count += 1
+        elif event_type == "WRITE_BARRIER_END":
+            write_barrier_end_count += 1
+
+        if "dst_addr" in event and "proc" in event:
             proc = event["proc"]
             dst_addr = event["dst_addr"]
+
             if proc == "BRISC":
-                brisc_dst_addrs_found.add(dst_addr)
+                if event_type == "READ":
+                    brisc_read_dst_addrs_found.add(dst_addr)
+                elif event_type == "WRITE_":
+                    brisc_write_dst_addrs_found.add(dst_addr)
             elif proc == "NCRISC":
-                ncrisc_dst_addrs_found.add(dst_addr)
+                if event_type == "READ":
+                    ncrisc_read_dst_addrs_found.add(dst_addr)
+                elif event_type == "WRITE_":
+                    ncrisc_write_dst_addrs_found.add(dst_addr)
 
     expected_dst_addrs = set(range(10000))  # 0 to 9999
 
-    # Verify BRISC has all expected dst_addr values
-    missing_brisc_dst_addrs = expected_dst_addrs - brisc_dst_addrs_found
-    assert len(missing_brisc_dst_addrs) == 0, (
-        f"Missing dst_addr values in BRISC JSON events: {sorted(missing_brisc_dst_addrs)[:20]}"
-        f"{'...' if len(missing_brisc_dst_addrs) > 20 else ''} "
-        f"(found {len(brisc_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    # Verify BRISC READ has all expected dst_addr values
+    missing_brisc_read_dst_addrs = expected_dst_addrs - brisc_read_dst_addrs_found
+    assert len(missing_brisc_read_dst_addrs) == 0, (
+        f"Missing dst_addr values in BRISC READ JSON events: {sorted(missing_brisc_read_dst_addrs)[:20]}"
+        f"{'...' if len(missing_brisc_read_dst_addrs) > 20 else ''} "
+        f"(found {len(brisc_read_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
     )
 
-    # Verify NCRISC has all expected dst_addr values
-    missing_ncrisc_dst_addrs = expected_dst_addrs - ncrisc_dst_addrs_found
-    assert len(missing_ncrisc_dst_addrs) == 0, (
-        f"Missing dst_addr values in NCRISC JSON events: {sorted(missing_ncrisc_dst_addrs)[:20]}"
-        f"{'...' if len(missing_ncrisc_dst_addrs) > 20 else ''} "
-        f"(found {len(ncrisc_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    # Verify BRISC WRITE has all expected dst_addr values
+    missing_brisc_write_dst_addrs = expected_dst_addrs - brisc_write_dst_addrs_found
+    assert len(missing_brisc_write_dst_addrs) == 0, (
+        f"Missing dst_addr values in BRISC WRITE JSON events: {sorted(missing_brisc_write_dst_addrs)[:20]}"
+        f"{'...' if len(missing_brisc_write_dst_addrs) > 20 else ''} "
+        f"(found {len(brisc_write_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
     )
+
+    # Verify NCRISC READ has all expected dst_addr values
+    missing_ncrisc_read_dst_addrs = expected_dst_addrs - ncrisc_read_dst_addrs_found
+    assert len(missing_ncrisc_read_dst_addrs) == 0, (
+        f"Missing dst_addr values in NCRISC READ JSON events: {sorted(missing_ncrisc_read_dst_addrs)[:20]}"
+        f"{'...' if len(missing_ncrisc_read_dst_addrs) > 20 else ''} "
+        f"(found {len(ncrisc_read_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    )
+
+    # Verify NCRISC WRITE has all expected dst_addr values
+    missing_ncrisc_write_dst_addrs = expected_dst_addrs - ncrisc_write_dst_addrs_found
+    assert len(missing_ncrisc_write_dst_addrs) == 0, (
+        f"Missing dst_addr values in NCRISC WRITE JSON events: {sorted(missing_ncrisc_write_dst_addrs)[:20]}"
+        f"{'...' if len(missing_ncrisc_write_dst_addrs) > 20 else ''} "
+        f"(found {len(ncrisc_write_dst_addrs_found)} out of {len(expected_dst_addrs)} expected)"
+    )
+
+    # Verify barrier event counts
+    expected_barrier_count = 20000
+    assert (
+        read_barrier_start_count == expected_barrier_count
+    ), f"Expected {expected_barrier_count} READ_BARRIER_START events, found {read_barrier_start_count}"
+    assert (
+        read_barrier_end_count == expected_barrier_count
+    ), f"Expected {expected_barrier_count} READ_BARRIER_END events, found {read_barrier_end_count}"
+    assert (
+        write_barrier_start_count == expected_barrier_count
+    ), f"Expected {expected_barrier_count} WRITE_BARRIER_START events, found {write_barrier_start_count}"
+    assert (
+        write_barrier_end_count == expected_barrier_count
+    ), f"Expected {expected_barrier_count} WRITE_BARRIER_END events, found {write_barrier_end_count}"
 
 
 def wildcard_match(pattern, words):

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -319,6 +319,7 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
+@pytest.mark.skip_post_commit
 def test_device_api_debugger_non_dropping():
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in ["grayskull", "wormhole_b0", "blackhole"]

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1024,7 +1024,7 @@ FORCE_INLINE void noc_async_read_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, page_size, -1);
+        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, page_size, -1);
     }
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, page_size, noc);
@@ -1047,7 +1047,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1068,7 +1068,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<TensorAccessor<DSpec>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1089,7 +1089,7 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1116,7 +1116,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1137,7 +1137,7 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, 1 << addrgen.log_base_2_of_page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1);
     noc_async_read_page<InterleavedPow2AddrGenFast<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1184,7 +1184,8 @@ FORCE_INLINE void noc_async_write_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, size ? size : page_size, NOC_UNICAST_WRITE_VC);
+        RECORD_NOC_EVENT_WITH_ID(
+            NocEventType::WRITE_, id, addrgen, offset, size ? size : page_size, NOC_UNICAST_WRITE_VC);
     }
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
         src_local_l1_addr, addrgen.get_noc_addr(id, offset, noc), size ? size : page_size, noc);
@@ -1214,7 +1215,7 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t write_size_bytes,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, write_size_bytes, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1231,7 +1232,7 @@ template <bool DRAM>
 [[deprecated("Use <typename AddrGen> noc_async_write_page instead.")]]
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const InterleavedAddrGen<DRAM>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1257,7 +1258,7 @@ FORCE_INLINE void noc_async_write_tile(
     const InterleavedAddrGenFast<DRAM, tile_hw>& addrgen,
     uint32_t src_local_l1_addr,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1275,7 +1276,8 @@ template <typename DSpec>
 [[deprecated("Use <typename AddrGen> noc_async_write_page instead.")]]
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const TensorAccessor<DSpec>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<TensorAccessor<DSpec>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1305,7 +1307,7 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t write_size_bytes,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, write_size_bytes, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedPow2AddrGenFast<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }

--- a/tt_metal/impl/profiler/profiler_state_manager.cpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <cstdint>
 #include <thread>
 #include <vector>
@@ -155,8 +156,8 @@ void ProfilerStateManager::add_runtime_id_to_trace(ChipId device_id, uint32_t tr
 void ProfilerStateManager::start_debug_dump_thread(
     std::vector<IDevice*> active_devices, std::unordered_map<ChipId, std::vector<CoreCoord>> virtual_cores_map) {
     TT_ASSERT(!this->debug_dump_thread.joinable());
-    const auto interval = std::chrono::seconds(
-        MetalContext::instance().rtoptions().get_experimental_device_debug_dump_interval_seconds());
+    // Faster polling to unblock cores quickly at the expensive of more NoC PCIe traffic
+    constexpr auto interval = std::chrono::milliseconds(500);
 
     this->debug_dump_thread = std::thread([this,
                                            active_devices = std::move(active_devices),

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -854,7 +854,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             if (is_env_enabled(value)) {
                 this->profiler_enabled = true;
                 this->profiler_noc_events_enabled = true;
-                this->experimental_device_debug_dump_interval_seconds = std::stoi(value);
+                this->experimental_device_debug_dump_enabled = true;
             }
             break;
         }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -180,7 +180,7 @@ class RunTimeOptions {
     bool profiler_disable_dump_to_files = false;
     bool profiler_disable_push_to_tracy = false;
     std::optional<uint32_t> profiler_program_support_count = std::nullopt;
-    uint32_t experimental_device_debug_dump_interval_seconds = 0;
+    bool experimental_device_debug_dump_enabled = false;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -523,12 +523,7 @@ public:
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
     bool get_profiler_disable_dump_to_files() const { return profiler_disable_dump_to_files; }
     bool get_profiler_disable_push_to_tracy() const { return profiler_disable_push_to_tracy; }
-    bool get_experimental_device_debug_dump_enabled() const {
-        return experimental_device_debug_dump_interval_seconds > 0;
-    }
-    uint32_t get_experimental_device_debug_dump_interval_seconds() const {
-        return experimental_device_debug_dump_interval_seconds;
-    }
+    bool get_experimental_device_debug_dump_enabled() const { return experimental_device_debug_dump_enabled; }
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -3,17 +3,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "tools/profiler/event_metadata.hpp"
-#include "tools/profiler/noc_event_profiler.hpp"
-
-using EMD = KernelProfilerNocEventMetadata;
+#include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
-#if defined(PROFILE_NOC_EVENTS)
     riscv_wait(START_DELAY);
-    // Make this really large so it exceeds the max profiler sizes to test mid run dumps
+
+    experimental::Noc noc;
+    experimental::CoreLocalMem<uint32_t> local_buffer(L1_BUFFER_ADDR);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    constexpr uint32_t num_bytes = 64;
     for (uint32_t i = 0; i < 10000; ++i) {
-        noc_event_profiler::recordNocEvent(EMD::NocEventType::READ, my_x[0], my_y[0], 1000, 0, 0, i);
+        noc.async_read(
+            unicast_endpoint,
+            local_buffer,
+            num_bytes,
+            {
+                .noc_x = OTHER_CORE_X,
+                .noc_y = OTHER_CORE_Y,
+                .addr = i,
+            },
+            {});
+        noc.async_read_barrier();
+        noc.async_write(
+            local_buffer,
+            unicast_endpoint,
+            num_bytes,
+            {},
+            {
+                .noc_x = OTHER_CORE_X,
+                .noc_y = OTHER_CORE_Y,
+                .addr = i,
+            });
+        noc.async_write_barrier();
     }
-#endif
 }

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc.h"
+#include "experimental/core_local_mem.h"
+#include "experimental/endpoints.h"
 
 void kernel_main() {
     riscv_wait(START_DELAY);

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -791,7 +791,7 @@ __attribute__((noinline)) void trace_only_init() {
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
-#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, offset, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -29,6 +29,9 @@ std::pair<uint32_t, uint32_t> decode_noc_addr_to_coord(uint64_t noc_addr) {
 }
 
 FORCE_INLINE
+uint32_t decode_noc_addr_to_local_addr(uint64_t noc_addr) { return NOC_LOCAL_ADDR_OFFSET(noc_addr); }
+
+FORCE_INLINE
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> decode_noc_addr_to_multicast_coord(uint64_t noc_addr) {
     // coordinates are stored as two packed pairs. End coordinate is in lower
     // bits like normal noc address; Start coordinate is in higher bits
@@ -54,9 +57,8 @@ FORCE_INLINE KernelProfilerNocEventMetadata createNocEventDstTrailer(uint32_t ds
     return ev_md;
 }
 
-template <uint32_t STATIC_ID = 12345>
+template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, uint32_t STATIC_ID = 12345>
 FORCE_INLINE void recordNocEvent(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
     int32_t dst_x = -1,
     int32_t dst_y = -1,
     uint32_t num_bytes = 0,
@@ -117,27 +119,32 @@ FORCE_INLINE void recordMulticastNocEvent(
     kernel_profiler::timeStampedData<STATIC_ID, kernel_profiler::DoingDispatch::DISPATCH>(ev_md.asU64());
 }
 
-template <typename AddrGen, typename NocIDU32>
+template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, typename AddrGen, typename NocIDU32>
 FORCE_INLINE void recordNocEventWithID(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type,
-    NocIDU32 noc_id,
-    AddrGen addrgen,
-    uint32_t num_bytes,
-    int8_t vc) {
+    NocIDU32 noc_id, AddrGen addrgen, uint32_t num_bytes, uint32_t offset, int8_t vc) {
     static_assert(std::is_same_v<NocIDU32, uint32_t>);
     static_assert(
         has_required_addrgen_traits_v<AddrGen>,
         "AddrGen must have get_noc_addr() and either page_size or log_base_2_of_page_size member variable");
     auto [decoded_x, decoded_y] = decode_noc_id_into_coord<addrgen.is_dram>(noc_id);
-    recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
+    if constexpr (kernel_profiler::NON_DROPPING) {
+        auto addr = decode_noc_addr_to_local_addr(get_noc_addr_from_bank_id<addrgen.is_dram>(noc_id, offset, noc_index));
+        recordNocEvent<noc_event_type>(decoded_x, decoded_y, num_bytes, vc, noc_index, addr);
+    } else {
+        recordNocEvent<noc_event_type>(decoded_x, decoded_y, num_bytes, vc, noc_index, 0);
+    }
 }
 
-template <typename NocAddrU64>
-FORCE_INLINE void recordNocEventWithAddr(
-    KernelProfilerNocEventMetadata::NocEventType noc_event_type, NocAddrU64 noc_addr, uint32_t num_bytes, int8_t vc) {
+template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, typename NocAddrU64>
+FORCE_INLINE void recordNocEventWithAddr(NocAddrU64 noc_addr, uint32_t num_bytes, int8_t vc) {
     static_assert(std::is_same_v<NocAddrU64, uint64_t>);
     auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr);
-    recordNocEvent(noc_event_type, decoded_x, decoded_y, num_bytes, vc);
+    if constexpr (kernel_profiler::NON_DROPPING) {
+        auto addr = decode_noc_addr_to_local_addr(noc_addr);
+        recordNocEvent<noc_event_type>(decoded_x, decoded_y, num_bytes, vc, noc_index, addr);
+    } else {
+        recordNocEvent<noc_event_type>(decoded_x, decoded_y, num_bytes, vc, noc_index, 0);
+    }
 }
 }  // namespace noc_event_profiler
 
@@ -145,7 +152,7 @@ FORCE_INLINE void recordNocEventWithAddr(
     {                                                                                                               \
         using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                                          \
         if constexpr (event_type != NocEventType::WRITE_MULTICAST) {                                                \
-            noc_event_profiler::recordNocEventWithAddr(event_type, noc_addr, num_bytes, vc);                        \
+            noc_event_profiler::recordNocEventWithAddr<event_type>(noc_addr, num_bytes, vc);                        \
         } else {                                                                                                    \
             auto [mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y] =                         \
                 noc_event_profiler::decode_noc_addr_to_multicast_coord(noc_addr);                                   \
@@ -154,16 +161,16 @@ FORCE_INLINE void recordNocEventWithAddr(
         }                                                                                                           \
     }
 
-#define RECORD_NOC_EVENT_WITH_ID(event_type, noc_id, addrgen, num_bytes, vc)                  \
-    {                                                                                         \
-        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                    \
-        noc_event_profiler::recordNocEventWithID(event_type, noc_id, addrgen, num_bytes, vc); \
+#define RECORD_NOC_EVENT_WITH_ID(event_type, noc_id, addrgen, offset, num_bytes, vc)                  \
+    {                                                                                                 \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                            \
+        noc_event_profiler::recordNocEventWithID<event_type>(noc_id, addrgen, offset, num_bytes, vc); \
     }
 
 #define RECORD_NOC_EVENT(event_type)                                       \
     {                                                                      \
         using NocEventType = KernelProfilerNocEventMetadata::NocEventType; \
-        noc_event_profiler::recordNocEvent(event_type);                    \
+        noc_event_profiler::recordNocEvent<event_type>();                  \
     }
 
 // preemptive quick push if transitioning from unlinked state to linked state
@@ -176,7 +183,7 @@ FORCE_INLINE void recordNocEventWithAddr(
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
-#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, offset, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35354

### Problem description
- Need to collect the destination address of NoC Reads and Writes for Device 2.0 debugging

### What's changed
- Record the destination address when NoC Debug is enabled. The host can figure out if the address is in L1 or DRAM using the existing X/Y fields.
- Uplifted the unit test to use the experimental NoC API
- Removed a branch in recordNocEventTrailer by moving the noc event type to a template arg

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/noc-event-trailers)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/noc-event-trailers)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/noc-event-trailers)
- [ ] New/Existing tests provide coverage for changes

Profiler CI Run
https://github.com/tenstorrent/tt-metal/actions/runs/20870375614


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/noc-event-trailers)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/noc-event-trailers)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/noc-event-trailers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/noc-event-trailers)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs