### PR TITLE
#28087 revert the binary compute core optimization revert and more changes

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -4258,17 +4258,18 @@ def test_binary_reshard(device):
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     mem_config_32 = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec_32)
-    # a_sharded = ttnn.to_memory_config(a, mem_config_64)
-    # b_sharded = ttnn.to_memory_config(b, mem_config_64)
-    # result = ttnn.add(a_sharded, b_sharded, memory_config=mem_config_32, use_legacy=None)
+
+    expected = torch_a + torch_b
+    a_sharded = ttnn.to_memory_config(a, mem_config_64)
+    b_sharded = ttnn.to_memory_config(b, mem_config_64)
+    result = ttnn.add(a_sharded, b_sharded, memory_config=mem_config_32, use_legacy=None)
+    result = ttnn.to_torch(result)
+    assert_with_pcc(expected, result)
 
     a_sharded = ttnn.to_memory_config(a, mem_config_32)
     b_sharded = ttnn.to_memory_config(b, mem_config_32)
-
-    # Multiply completes but hangs afterward
-    result = ttnn.add(a_sharded, b_sharded, memory_config=mem_config_32, use_legacy=None)
+    result = ttnn.add(a_sharded, b_sharded, memory_config=mem_config_64, use_legacy=None)
     result = ttnn.to_torch(result)
-    expected = torch_a + torch_b
     assert_with_pcc(expected, result)
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -3724,7 +3724,7 @@ def test_binary_sharded_bcast_hw_mixed_orientation_output(device, dtype_pt, dtyp
             dtype=dtype_tt,
             device=device,
             layout=ttnn.TILE_LAYOUT,
-            memory_config=out_sharded_config,
+            memory_config=dst_config,
         )
 
         out_pt = torch.add(a_pt, b_pt)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -444,12 +444,12 @@ inline auto invoke_binary_ng(
         sub_core_grids);
     return typecast_out ? ttnn::typecast(result, out_dtype, mem_config, output) : result;
 }
-}
-
 }  // namespace detail
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperation<binary_op_type>::invoke(
+}  // namespace ttnn::operations::binary
+
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
     const std::optional<const DataType>& dtype,
@@ -475,123 +475,123 @@ Tensor BinaryOperation<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperation<binary_op_type>::invoke(
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return detail::invoke_binary_ng(
-        lhs,
-        rhs,
-        binary_op_type,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy,
-        /*fast_and_approximate_mode*/ false,
-        sub_core_grids);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy,
-    const std::optional<bool>& fast_and_approximate_mode,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return detail::invoke_binary_ng(
-        lhs,
-        rhs,
-        binary_op_type,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy,
-        fast_and_approximate_mode,
-        sub_core_grids);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    float rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy,
-    const std::optional<bool>& fast_and_approximate_mode,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return detail::invoke_binary_ng(
-        lhs,
-        rhs,
-        binary_op_type,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy,
-        fast_and_approximate_mode,
-        sub_core_grids);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor RelationalBinary<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
-    const std::optional<bool>& use_legacy,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    return detail::invoke_binary_ng(
-        lhs,
-        rhs,
-        binary_op_type,
-        dtype,
-        memory_config,
-        output,
-        post_activations,
-        lhs_activations,
-        rhs_activations,
-        use_legacy,
-        /*fast_and_approximate_mode*/ false,
-        sub_core_grids);
-}
-
-template <BinaryOpType binary_op_type>
-Tensor RelationalBinary<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const float rhs,
     const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
+    const std::optional<ttnn::Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
+}
+
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
+    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode,
+        sub_core_grids);
+}
+
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    float rhs,
+    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<bool>& fast_and_approximate_mode,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        fast_and_approximate_mode,
+        sub_core_grids);
+}
+
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
+    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
+    tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
+    const std::optional<bool>& use_legacy,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return detail::invoke_binary_ng(
+        lhs,
+        rhs,
+        binary_op_type,
+        dtype,
+        memory_config,
+        output,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy,
+        /*fast_and_approximate_mode*/ false,
+        sub_core_grids);
+}
+
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const float rhs,
+    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -620,20 +620,20 @@ Tensor RelationalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 // scalar - tensor combination not available on Pytorch for this op
-template <BinaryOpType binary_op_type>
-Tensor RelationalBinary<binary_op_type>::invoke(
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
     const float lhs,
     const ttnn::Tensor& rhs,
-    const std::optional<const DataType>& /*dtype*/,
+    const std::optional<const ttnn::DataType>& /*dtype*/,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
+    const std::optional<ttnn::Tensor>& output) {
     return detail::binary_impl(binary_op_type, lhs, rhs, memory_config, output);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceRelationalBinary<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -652,8 +652,8 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceRelationalBinary<binary_op_type>::invoke(
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -674,10 +674,10 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceLogicalBinary<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceLogicalBinary<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -696,10 +696,10 @@ Tensor InplaceLogicalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryOperation<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -718,8 +718,8 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryOperation<binary_op_type>::invoke(
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -740,10 +740,10 @@ Tensor InplaceBinaryOperation<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -764,8 +764,8 @@ Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -788,13 +788,13 @@ Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationSfpu<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
-    const std::optional<const DataType>& dtype,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationSfpu<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
+    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -814,36 +814,36 @@ Tensor BinaryOperationSfpu<binary_op_type>::invoke(
         /*sub_core_grids*/ std::nullopt);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationAddalpha<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     float alpha,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output) {
     SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
         lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
-    const Tensor& lhs,
-    const Tensor& rhs,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationSubalpha<binary_op_type>::invoke(
+    const ttnn::Tensor& lhs,
+    const ttnn::Tensor& rhs,
     float alpha,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& output) {
     SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
         lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
-template <BinaryOpType binary_op_type>
-Tensor BinaryOperationHypot<binary_op_type>::invoke(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::BinaryOperationHypot<binary_op_type>::invoke(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor) {
     return detail::invoke_binary_ng(
         input_tensor_a,
         input_tensor_b,
@@ -859,14 +859,14 @@ Tensor BinaryOperationHypot<binary_op_type>::invoke(
         std::nullopt);  // sub_core_grids
 }
 
-template <BinaryOpType binary_op_type>
-Tensor WhereOperationWithScalar<binary_op_type>::invoke(
-    const Tensor& condition,
-    const Tensor& true_false_tensor,
+template <ttnn::operations::binary::BinaryOpType binary_op_type>
+ttnn::Tensor ttnn::operations::binary::WhereOperationWithScalar<binary_op_type>::invoke(
+    const ttnn::Tensor& condition,
+    const ttnn::Tensor& true_false_tensor,
     unary::ScalarVariant scalar_value,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::Tensor>& optional_output_tensor,
+    const std::optional<ttnn::CoreRangeSet>& sub_core_grids) {
     constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
     return ttnn::prim::binary_ng(
         condition,
@@ -883,80 +883,81 @@ Tensor WhereOperationWithScalar<binary_op_type>::invoke(
         sub_core_grids);  // sub_core_grids
 }
 
-template struct BinaryOperation<BinaryOpType::ADD>;
-template struct InplaceBinaryOperation<BinaryOpType::ADD>;
-template struct BinaryOperation<BinaryOpType::SUB>;
-template struct InplaceBinaryOperation<BinaryOpType::SUB>;
-template struct BinaryOperation<BinaryOpType::MUL>;
-template struct InplaceBinaryOperation<BinaryOpType::MUL>;
-template struct BinaryOperation<BinaryOpType::LOGICAL_AND>;
-template struct BinaryOperation<BinaryOpType::LOGICAL_OR>;
-template struct BinaryOperation<BinaryOpType::LOGICAL_XOR>;
-template struct BinaryOperation<BinaryOpType::LDEXP>;
-template struct InplaceBinaryOperation<BinaryOpType::LDEXP>;
-template struct BinaryOperation<BinaryOpType::LOGADDEXP>;
-template struct InplaceBinaryOperation<BinaryOpType::LOGADDEXP>;
-template struct BinaryOperation<BinaryOpType::LOGADDEXP2>;
-template struct InplaceBinaryOperation<BinaryOpType::LOGADDEXP2>;
-template struct BinaryOperation<BinaryOpType::SQUARED_DIFFERENCE>;
-template struct InplaceBinaryOperation<BinaryOpType::SQUARED_DIFFERENCE>;
-template struct BinaryOperation<BinaryOpType::DIV>;
-template struct InplaceBinaryOperation<BinaryOpType::DIV>;
-template struct BinaryOperation<BinaryOpType::DIV_FLOOR>;
-template struct InplaceBinaryOperation<BinaryOpType::DIV_FLOOR>;
-template struct BinaryOperation<BinaryOpType::DIV_TRUNC>;
-template struct InplaceBinaryOperation<BinaryOpType::DIV_TRUNC>;
-template struct BinaryOperation<BinaryOpType::BIAS_GELU>;
-template struct InplaceBinaryOperation<BinaryOpType::BIAS_GELU>;
-template struct BinaryOperation<BinaryOpType::RSUB>;
-template struct InplaceBinaryOperation<BinaryOpType::RSUB>;
-template struct BinaryOperation<BinaryOpType::BITWISE_AND>;
-template struct BinaryOperation<BinaryOpType::BITWISE_OR>;
-template struct BinaryOperation<BinaryOpType::BITWISE_XOR>;
-template struct BinaryOperation<BinaryOpType::LEFT_SHIFT>;
-template struct BinaryOperation<BinaryOpType::RIGHT_SHIFT>;
-template struct BinaryOperation<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
-template struct BinaryOperation<BinaryOpType::XLOGY>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::SUB>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::SUB>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::MUL>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::MUL>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_AND>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_OR>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_XOR>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LDEXP>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LDEXP>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP2>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP2>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::SQUARED_DIFFERENCE>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<
+    ttnn::operations::binary::BinaryOpType::SQUARED_DIFFERENCE>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_FLOOR>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_FLOOR>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_TRUNC>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_TRUNC>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BIAS_GELU>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::BIAS_GELU>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::RSUB>;
+template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::RSUB>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_AND>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_OR>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_XOR>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LEFT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::RIGHT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_RIGHT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::XLOGY>;
 
-template struct RelationalBinary<BinaryOpType::EQ>;
-template struct RelationalBinary<BinaryOpType::NE>;
-template struct RelationalBinary<BinaryOpType::GE>;
-template struct RelationalBinary<BinaryOpType::GT>;
-template struct RelationalBinary<BinaryOpType::LE>;
-template struct RelationalBinary<BinaryOpType::LT>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::EQ>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::NE>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::GE>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::GT>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::LE>;
+template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::LT>;
 
-template struct InplaceRelationalBinary<BinaryOpType::GT>;
-template struct InplaceRelationalBinary<BinaryOpType::LT>;
-template struct InplaceRelationalBinary<BinaryOpType::GE>;
-template struct InplaceRelationalBinary<BinaryOpType::LE>;
-template struct InplaceRelationalBinary<BinaryOpType::EQ>;
-template struct InplaceRelationalBinary<BinaryOpType::NE>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::GT>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::LT>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::GE>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::LE>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::EQ>;
+template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::NE>;
 
-template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_AND>;
-template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_OR>;
-template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_XOR>;
+template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_AND>;
+template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_OR>;
+template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_XOR>;
 
-template struct BinaryOperationSfpu<BinaryOpType::POWER>;
-template struct BinaryOperationSfpu<BinaryOpType::BITWISE_AND>;
-template struct BinaryOperationSfpu<BinaryOpType::BITWISE_XOR>;
-template struct BinaryOperationSfpu<BinaryOpType::BITWISE_OR>;
-template struct BinaryOperationSfpu<BinaryOpType::LEFT_SHIFT>;
-template struct BinaryOperationSfpu<BinaryOpType::RIGHT_SHIFT>;
-template struct BinaryOperationSfpu<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
-template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
-template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
-template struct BinaryOperationSfpu<BinaryOpType::GCD>;
-template struct BinaryOperationSfpu<BinaryOpType::LCM>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::POWER>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_AND>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_XOR>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_OR>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::LEFT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::RIGHT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<
+    ttnn::operations::binary::BinaryOpType::LOGICAL_RIGHT_SHIFT>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::MAXIMUM>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::MINIMUM>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::GCD>;
+template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::LCM>;
 
-template struct BinaryOperationAddalpha<BinaryOpType::ADDALPHA>;
-template struct BinaryOperationSubalpha<BinaryOpType::SUBALPHA>;
-template struct BinaryOperationHypot<BinaryOpType::HYPOT>;
+template struct ttnn::operations::binary::BinaryOperationAddalpha<ttnn::operations::binary::BinaryOpType::ADDALPHA>;
+template struct ttnn::operations::binary::BinaryOperationSubalpha<ttnn::operations::binary::BinaryOpType::SUBALPHA>;
+template struct ttnn::operations::binary::BinaryOperationHypot<ttnn::operations::binary::BinaryOpType::HYPOT>;
 
 // Explicit template instantiations for BinaryOperationWithFastApprox
-template struct BinaryOperationWithFastApprox<BinaryOpType::DIV>;
-template struct InplaceBinaryOperationWithFastApprox<BinaryOpType::DIV>;
+template struct ttnn::operations::binary::BinaryOperationWithFastApprox<ttnn::operations::binary::BinaryOpType::DIV>;
+template struct ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<
+    ttnn::operations::binary::BinaryOpType::DIV>;
 
-template struct WhereOperationWithScalar<BinaryOpType::WHERE_TST>;
-template struct WhereOperationWithScalar<BinaryOpType::WHERE_TTS>;
-
-}  // namespace ttnn::operations::binary
+template struct ttnn::operations::binary::WhereOperationWithScalar<ttnn::operations::binary::BinaryOpType::WHERE_TST>;
+template struct ttnn::operations::binary::WhereOperationWithScalar<ttnn::operations::binary::BinaryOpType::WHERE_TTS>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -406,7 +406,7 @@ inline auto invoke_binary_ng(
             input_b,
             binary_op_type,
             out_dtype,
-            mem_config,
+            memory_config,
             output,
             fast_and_approximate_mode,
             lhs_activations,
@@ -434,7 +434,7 @@ inline auto invoke_binary_ng(
         input_b,
         binary_op_type,
         input_a.dtype(),
-        mem_config,
+        memory_config,
         output_tensor,
         fast_and_approximate_mode,
         lhs_activations,
@@ -443,6 +443,7 @@ inline auto invoke_binary_ng(
         std::nullopt,
         sub_core_grids);
     return typecast_out ? ttnn::typecast(result, out_dtype, mem_config, output) : result;
+}
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -446,10 +446,8 @@ inline auto invoke_binary_ng(
 }
 }  // namespace detail
 
-}  // namespace ttnn::operations::binary
-
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperation<binary_op_type>::invoke(
     const Tensor& lhs,
     const Tensor& rhs,
     const std::optional<const DataType>& dtype,
@@ -475,13 +473,13 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperation<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     float rhs,
     const std::optional<const DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -502,13 +500,13 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperation<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
-    const std::optional<const ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -530,13 +528,13 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_t
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationWithFastApprox<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     float rhs,
-    const std::optional<const ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -558,13 +556,13 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperationWithFastApprox<binary_op_t
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
-    const std::optional<const ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+template <BinaryOpType binary_op_type>
+Tensor RelationalBinary<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -585,13 +583,13 @@ ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor RelationalBinary<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
-    const std::optional<const ttnn::DataType>& dtype,
+    const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -620,20 +618,20 @@ ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
         sub_core_grids);
 }
 // scalar - tensor combination not available on Pytorch for this op
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::RelationalBinary<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor RelationalBinary<binary_op_type>::invoke(
     const float lhs,
     const ttnn::Tensor& rhs,
-    const std::optional<const ttnn::DataType>& /*dtype*/,
+    const std::optional<const DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output) {
+    const std::optional<Tensor>& output) {
     return detail::binary_impl(binary_op_type, lhs, rhs, memory_config, output);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor InplaceRelationalBinary<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -652,8 +650,8 @@ ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -674,10 +672,10 @@ ttnn::Tensor ttnn::operations::binary::InplaceRelationalBinary<binary_op_type>::
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceLogicalBinary<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor InplaceLogicalBinary<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -696,10 +694,10 @@ ttnn::Tensor ttnn::operations::binary::InplaceLogicalBinary<binary_op_type>::inv
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperation<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -718,8 +716,8 @@ ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::i
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperation<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -740,10 +738,10 @@ ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperation<binary_op_type>::i
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -764,8 +762,8 @@ ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<bina
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
+template <BinaryOpType binary_op_type>
+Tensor InplaceBinaryOperationWithFastApprox<binary_op_type>::invoke(
     const ttnn::Tensor& lhs,
     const float rhs,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
@@ -788,13 +786,13 @@ ttnn::Tensor ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<bina
         sub_core_grids);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationSfpu<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
-    const std::optional<const ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output,
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationSfpu<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    const std::optional<const DataType>& dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> post_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> rhs_activations,
@@ -814,36 +812,36 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperationSfpu<binary_op_type>::invo
         /*sub_core_grids*/ std::nullopt);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationAddalpha<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationAddalpha<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     float alpha,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
     SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::ADD>::invoke(
         lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationSubalpha<binary_op_type>::invoke(
-    const ttnn::Tensor& lhs,
-    const ttnn::Tensor& rhs,
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationSubalpha<binary_op_type>::invoke(
+    const Tensor& lhs,
+    const Tensor& rhs,
     float alpha,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& output) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
     SmallVector<unary::EltwiseUnaryWithParam> rhs_activations{{unary::UnaryOpType::MUL_UNARY_SFPU, alpha}};
     return BinaryOperation<operations::binary::BinaryOpType::SUB>::invoke(
         lhs, rhs, std::nullopt, memory_config, output, {}, {}, rhs_activations, false);
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::BinaryOperationHypot<binary_op_type>::invoke(
-    const ttnn::Tensor& input_tensor_a,
-    const ttnn::Tensor& input_tensor_b,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& optional_output_tensor) {
+template <BinaryOpType binary_op_type>
+Tensor BinaryOperationHypot<binary_op_type>::invoke(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
     return detail::invoke_binary_ng(
         input_tensor_a,
         input_tensor_b,
@@ -859,14 +857,14 @@ ttnn::Tensor ttnn::operations::binary::BinaryOperationHypot<binary_op_type>::inv
         std::nullopt);  // sub_core_grids
 }
 
-template <ttnn::operations::binary::BinaryOpType binary_op_type>
-ttnn::Tensor ttnn::operations::binary::WhereOperationWithScalar<binary_op_type>::invoke(
-    const ttnn::Tensor& condition,
-    const ttnn::Tensor& true_false_tensor,
+template <BinaryOpType binary_op_type>
+Tensor WhereOperationWithScalar<binary_op_type>::invoke(
+    const Tensor& condition,
+    const Tensor& true_false_tensor,
     unary::ScalarVariant scalar_value,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::Tensor>& optional_output_tensor,
-    const std::optional<ttnn::CoreRangeSet>& sub_core_grids) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     constexpr tt::stl::Span<const ttnn::operations::unary::EltwiseUnaryWithParam> none{};
     return ttnn::prim::binary_ng(
         condition,
@@ -883,81 +881,80 @@ ttnn::Tensor ttnn::operations::binary::WhereOperationWithScalar<binary_op_type>:
         sub_core_grids);  // sub_core_grids
 }
 
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::ADD>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::SUB>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::SUB>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::MUL>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::MUL>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_AND>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_OR>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_XOR>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LDEXP>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LDEXP>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP2>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::LOGADDEXP2>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::SQUARED_DIFFERENCE>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<
-    ttnn::operations::binary::BinaryOpType::SQUARED_DIFFERENCE>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_FLOOR>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_FLOOR>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_TRUNC>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::DIV_TRUNC>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BIAS_GELU>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::BIAS_GELU>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::RSUB>;
-template struct ttnn::operations::binary::InplaceBinaryOperation<ttnn::operations::binary::BinaryOpType::RSUB>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_AND>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_OR>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::BITWISE_XOR>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LEFT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::RIGHT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::LOGICAL_RIGHT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperation<ttnn::operations::binary::BinaryOpType::XLOGY>;
+template struct BinaryOperation<BinaryOpType::ADD>;
+template struct InplaceBinaryOperation<BinaryOpType::ADD>;
+template struct BinaryOperation<BinaryOpType::SUB>;
+template struct InplaceBinaryOperation<BinaryOpType::SUB>;
+template struct BinaryOperation<BinaryOpType::MUL>;
+template struct InplaceBinaryOperation<BinaryOpType::MUL>;
+template struct BinaryOperation<BinaryOpType::LOGICAL_AND>;
+template struct BinaryOperation<BinaryOpType::LOGICAL_OR>;
+template struct BinaryOperation<BinaryOpType::LOGICAL_XOR>;
+template struct BinaryOperation<BinaryOpType::LDEXP>;
+template struct InplaceBinaryOperation<BinaryOpType::LDEXP>;
+template struct BinaryOperation<BinaryOpType::LOGADDEXP>;
+template struct InplaceBinaryOperation<BinaryOpType::LOGADDEXP>;
+template struct BinaryOperation<BinaryOpType::LOGADDEXP2>;
+template struct InplaceBinaryOperation<BinaryOpType::LOGADDEXP2>;
+template struct BinaryOperation<BinaryOpType::SQUARED_DIFFERENCE>;
+template struct InplaceBinaryOperation<BinaryOpType::SQUARED_DIFFERENCE>;
+template struct BinaryOperation<BinaryOpType::DIV>;
+template struct InplaceBinaryOperation<BinaryOpType::DIV>;
+template struct BinaryOperation<BinaryOpType::DIV_FLOOR>;
+template struct InplaceBinaryOperation<BinaryOpType::DIV_FLOOR>;
+template struct BinaryOperation<BinaryOpType::DIV_TRUNC>;
+template struct InplaceBinaryOperation<BinaryOpType::DIV_TRUNC>;
+template struct BinaryOperation<BinaryOpType::BIAS_GELU>;
+template struct InplaceBinaryOperation<BinaryOpType::BIAS_GELU>;
+template struct BinaryOperation<BinaryOpType::RSUB>;
+template struct InplaceBinaryOperation<BinaryOpType::RSUB>;
+template struct BinaryOperation<BinaryOpType::BITWISE_AND>;
+template struct BinaryOperation<BinaryOpType::BITWISE_OR>;
+template struct BinaryOperation<BinaryOpType::BITWISE_XOR>;
+template struct BinaryOperation<BinaryOpType::LEFT_SHIFT>;
+template struct BinaryOperation<BinaryOpType::RIGHT_SHIFT>;
+template struct BinaryOperation<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
+template struct BinaryOperation<BinaryOpType::XLOGY>;
 
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::EQ>;
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::NE>;
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::GE>;
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::GT>;
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::LE>;
-template struct ttnn::operations::binary::RelationalBinary<ttnn::operations::binary::BinaryOpType::LT>;
+template struct RelationalBinary<BinaryOpType::EQ>;
+template struct RelationalBinary<BinaryOpType::NE>;
+template struct RelationalBinary<BinaryOpType::GE>;
+template struct RelationalBinary<BinaryOpType::GT>;
+template struct RelationalBinary<BinaryOpType::LE>;
+template struct RelationalBinary<BinaryOpType::LT>;
 
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::GT>;
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::LT>;
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::GE>;
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::LE>;
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::EQ>;
-template struct ttnn::operations::binary::InplaceRelationalBinary<ttnn::operations::binary::BinaryOpType::NE>;
+template struct InplaceRelationalBinary<BinaryOpType::GT>;
+template struct InplaceRelationalBinary<BinaryOpType::LT>;
+template struct InplaceRelationalBinary<BinaryOpType::GE>;
+template struct InplaceRelationalBinary<BinaryOpType::LE>;
+template struct InplaceRelationalBinary<BinaryOpType::EQ>;
+template struct InplaceRelationalBinary<BinaryOpType::NE>;
 
-template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_AND>;
-template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_OR>;
-template struct ttnn::operations::binary::InplaceLogicalBinary<ttnn::operations::binary::BinaryOpType::LOGICAL_XOR>;
+template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_AND>;
+template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_OR>;
+template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_XOR>;
 
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::POWER>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_AND>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_XOR>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::BITWISE_OR>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::LEFT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::RIGHT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<
-    ttnn::operations::binary::BinaryOpType::LOGICAL_RIGHT_SHIFT>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::MAXIMUM>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::MINIMUM>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::GCD>;
-template struct ttnn::operations::binary::BinaryOperationSfpu<ttnn::operations::binary::BinaryOpType::LCM>;
+template struct BinaryOperationSfpu<BinaryOpType::POWER>;
+template struct BinaryOperationSfpu<BinaryOpType::BITWISE_AND>;
+template struct BinaryOperationSfpu<BinaryOpType::BITWISE_XOR>;
+template struct BinaryOperationSfpu<BinaryOpType::BITWISE_OR>;
+template struct BinaryOperationSfpu<BinaryOpType::LEFT_SHIFT>;
+template struct BinaryOperationSfpu<BinaryOpType::RIGHT_SHIFT>;
+template struct BinaryOperationSfpu<BinaryOpType::LOGICAL_RIGHT_SHIFT>;
+template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
+template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
+template struct BinaryOperationSfpu<BinaryOpType::GCD>;
+template struct BinaryOperationSfpu<BinaryOpType::LCM>;
 
-template struct ttnn::operations::binary::BinaryOperationAddalpha<ttnn::operations::binary::BinaryOpType::ADDALPHA>;
-template struct ttnn::operations::binary::BinaryOperationSubalpha<ttnn::operations::binary::BinaryOpType::SUBALPHA>;
-template struct ttnn::operations::binary::BinaryOperationHypot<ttnn::operations::binary::BinaryOpType::HYPOT>;
+template struct BinaryOperationAddalpha<BinaryOpType::ADDALPHA>;
+template struct BinaryOperationSubalpha<BinaryOpType::SUBALPHA>;
+template struct BinaryOperationHypot<BinaryOpType::HYPOT>;
 
 // Explicit template instantiations for BinaryOperationWithFastApprox
-template struct ttnn::operations::binary::BinaryOperationWithFastApprox<ttnn::operations::binary::BinaryOpType::DIV>;
-template struct ttnn::operations::binary::InplaceBinaryOperationWithFastApprox<
-    ttnn::operations::binary::BinaryOpType::DIV>;
+template struct BinaryOperationWithFastApprox<BinaryOpType::DIV>;
+template struct InplaceBinaryOperationWithFastApprox<BinaryOpType::DIV>;
 
-template struct ttnn::operations::binary::WhereOperationWithScalar<ttnn::operations::binary::BinaryOpType::WHERE_TST>;
-template struct ttnn::operations::binary::WhereOperationWithScalar<ttnn::operations::binary::BinaryOpType::WHERE_TTS>;
+template struct WhereOperationWithScalar<BinaryOpType::WHERE_TST>;
+template struct WhereOperationWithScalar<BinaryOpType::WHERE_TTS>;
+
+}  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -622,7 +622,7 @@ template <BinaryOpType binary_op_type>
 Tensor RelationalBinary<binary_op_type>::invoke(
     const float lhs,
     const ttnn::Tensor& rhs,
-    const std::optional<const DataType>& dtype,
+    const std::optional<const DataType>& /*dtype*/,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
     return detail::binary_impl(binary_op_type, lhs, rhs, memory_config, output);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -134,7 +134,8 @@ CoreRangeSet get_worker_grid(
                 "Native L1 sharding using input tensor A grid for worker grid {}",
                 input_tensor_a.shard_spec()->grid.str());
             return get_tensor_grid(input_tensor_a);
-        } else if (input_tensor_b && input_tensor_b->is_sharded()) {
+        }
+        if (input_tensor_b && input_tensor_b->is_sharded()) {
             log_debug(
                 tt::LogOp,
                 "Native L1 sharding using input tensor B grid for worker grid {}",

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -117,10 +117,14 @@ CoreRangeSet get_worker_grid(
     }
 
     // now c is not specified, gets its shard spec from a or b
-    TensorSpec c = input_tensor_b ? input_tensor_a.is_sharded()    ? input_tensor_a.tensor_spec()
-                                    : input_tensor_b->is_sharded() ? input_tensor_b->tensor_spec()
-                                                                   : input_tensor_a.tensor_spec()
-                                  : input_tensor_a.tensor_spec();
+    TensorSpec c = input_tensor_a.tensor_spec();
+    if (input_tensor_b && input_tensor_b->is_sharded()) {
+        if (!input_tensor_a.is_sharded()) {
+            c = input_tensor_b->tensor_spec();
+        } else if (input_tensor_b->shard_spec()->grid.size() > input_tensor_a.shard_spec()->grid.size()) {
+            c = input_tensor_b->tensor_spec();
+        }
+    }
 
     if (is_native_L1_sharding(
             input_tensor_a.tensor_spec(),
@@ -517,38 +521,49 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
 
     DataType dtype_a = input_tensor_a.dtype();
     DataType dtype_b = input_tensor_b.dtype();
-    bool is_sfpu_op = (ttnn::operations::binary_ng::utils::is_binary_sfpu_op(
-        binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
-    bool is_quant_op = ttnn::operations::binary_ng::utils::is_quant_op(binary_op_type);
-    bool is_where_op =
-        (binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TTS ||
-         binary_op_type == ttnn::operations::binary_ng::BinaryOpType::WHERE_TST);
-    auto operation_attributes = OperationType::operation_attributes_t{
-        binary_op_type,
-        {lhs_activations.begin(), lhs_activations.end()},
-        {rhs_activations.begin(), rhs_activations.end()},
-        {post_activations.begin(), post_activations.end()},
-        scalar_value,
-        memory_config.value_or(
-            output_tensor.has_value()                     ? output_tensor->memory_config()
-            : input_tensor_a.memory_config().is_sharded() ? input_tensor_a.memory_config()
-                                                          : input_tensor_b.memory_config()),
-        is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
-                                          // dtype depending on which LLK is meant to be used.
-        output_dtype,
-        ttnn::operations::binary_ng::get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor, sub_core_grids),
-        std::nullopt,
-        sub_core_grids,
-        subtile_broadcast_type,
-        is_sfpu_op,
-        is_quant_op,
-        is_where_op};
-    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
+    bool is_sfpu_op =
+        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = utils::is_quant_op(binary_op_type);
+    bool is_where_op = (binary_op_type == BinaryOpType::WHERE_TTS || binary_op_type == BinaryOpType::WHERE_TST);
 
-    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+    MemoryConfig mem_config = input_tensor_a.memory_config();
+    if (!memory_config.has_value() && !output_tensor.has_value()) {
+        if (input_tensor_b.memory_config().is_sharded()) {
+            if (!input_tensor_a.memory_config().is_sharded()) {
+                mem_config = input_tensor_b.memory_config();
+            } else if (input_tensor_b.shard_spec()->grid.size() > input_tensor_a.shard_spec()->grid.size()) {
+                mem_config = input_tensor_b.memory_config();
+            }
+        }
+    } else if (memory_config.has_value()) {
+        mem_config = *memory_config;
+    } else {
+        mem_config = output_tensor->memory_config();
+    }
+
+    return {
+        operation_attributes_t{
+            binary_op_type,
+            {lhs_activations.begin(), lhs_activations.end()},
+            {rhs_activations.begin(), rhs_activations.end()},
+            {post_activations.begin(), post_activations.end()},
+            scalar_value,
+            mem_config,
+            is_where_op ? dtype_b : dtype_a,  // TODO: For mixed dtypes we need to set this value to the appropriate
+                                              // dtype depending on which LLK is meant to be used.
+            output_dtype,
+            get_worker_grid(input_tensor_a, &input_tensor_b, output_tensor, memory_config, sub_core_grids),
+            std::nullopt,
+            sub_core_grids,
+            subtile_broadcast_type,
+            is_sfpu_op,
+            is_quant_op,
+            is_where_op},
+        tensor_args_t{input_tensor_a, input_tensor_b, output_tensor}};
 }
 
-ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t binary_ng(
+std::tuple<BinaryNgDeviceOperation::operation_attributes_t, BinaryNgDeviceOperation::tensor_args_t>
+BinaryNgDeviceOperation::invoke(
     const Tensor& input_tensor_a,
     float scalar,
     ttnn::operations::binary_ng::BinaryOpType binary_op_type,
@@ -563,29 +578,30 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
     const std::optional<CoreRangeSet>& sub_core_grids) {
     using OperationType = ttnn::operations::binary_ng::BinaryNgDeviceOperation;
     DataType dtype_a = input_tensor_a.dtype();
-    bool is_sfpu_op = (ttnn::operations::binary_ng::utils::is_binary_sfpu_op(
-        binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
-    bool is_quant_op = ttnn::operations::binary_ng::utils::is_quant_op(binary_op_type);
-    auto operation_attributes = OperationType::operation_attributes_t{
-        binary_op_type,
-        {lhs_activations.begin(), lhs_activations.end()},
-        {rhs_activations.begin(), rhs_activations.end()},
-        {post_activations.begin(), post_activations.end()},
-        scalar,
-        memory_config.value_or(
-            output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config()),
-        input_tensor_a.dtype(),
-        output_dtype,
-        ttnn::operations::binary_ng::get_worker_grid(input_tensor_a, nullptr, output_tensor, sub_core_grids),
-        std::nullopt,
-        sub_core_grids,
-        ttnn::operations::binary_ng::SubtileBroadcastType::NONE,
-        is_sfpu_op,
-        is_quant_op,
-        false};
-    auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
+    bool is_sfpu_op =
+        (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a, fast_and_approximate_mode.value_or(false)));
+    bool is_quant_op = utils::is_quant_op(binary_op_type);
+    MemoryConfig mem_config = memory_config.value_or(
+        output_tensor.has_value() ? output_tensor->memory_config() : input_tensor_a.memory_config());
 
-    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+    return {
+        operation_attributes_t{
+            binary_op_type,
+            {lhs_activations.begin(), lhs_activations.end()},
+            {rhs_activations.begin(), rhs_activations.end()},
+            {post_activations.begin(), post_activations.end()},
+            scalar,
+            mem_config,
+            input_tensor_a.dtype(),
+            output_dtype,
+            get_worker_grid(input_tensor_a, nullptr, output_tensor, memory_config, sub_core_grids),
+            std::nullopt,
+            sub_core_grids,
+            SubtileBroadcastType::NONE,
+            is_sfpu_op,
+            is_quant_op,
+            false},
+        tensor_args_t{input_tensor_a, std::nullopt, output_tensor}};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -532,7 +532,6 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
                 }
             } else if (input_tensor_b.shard_spec()->grid.size() > input_tensor_a.shard_spec()->grid.size()) {
                 mem_config_actual = compute_mem_config_actual(input_tensor_b, input_tensor_a.logical_shape());
-                ;
                 log_debug(
                     tt::LogOp,
                     "BinaryNgDeviceOperation: Using memory config from input tensor B since it has a larger shard "

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -79,68 +79,6 @@ TensorMemoryLayout get_memory_layout(const Tensor& a, const std::optional<Tensor
     return TensorMemoryLayout::INTERLEAVED;
 }
 
-const std::optional<ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
-    return tensor_spec.memory_config().shard_spec();
-}
-
-inline auto is_uneven(const TensorSpec& t) {
-    if (not t.memory_config().is_sharded()) {
-        return false;
-    }
-
-    const auto& shape = t.padded_shape();
-    const auto& shard = get_shard_spec(t)->shape;
-    const auto rank = shape.rank();
-
-    // Compute product of all dimensions except the last
-    uint64_t volume_except_last = 1;
-    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
-        volume_except_last *= shape[i];
-    }
-
-    return (volume_except_last % shard[0]) != 0 or (shape[-1] % shard[1]) != 0;
-}
-
-bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c) {
-    // scalar value treated as interleaved
-    if (!b.has_value()) {
-        return false;
-    }
-
-    // does not work for width and block sharding, pcc error,
-    // maybe support later to improve performance
-    // if (!b.has_value() && a.memory_config().is_sharded()) {
-    //     return !is_uneven(a);
-    // }
-
-    if (!c.memory_config().is_sharded()) {
-        return false;
-    }
-
-    // a and b identical shape, no broadcast on any dimension
-    if (b.has_value() && (a.logical_shape() == b->logical_shape()) && (a.memory_config() == b->memory_config())) {
-        if (is_uneven(a) || is_uneven(*b) || is_uneven(c)) {
-            return false;
-        }
-        if (a.memory_config().buffer_type() == BufferType::DRAM ||
-            b->memory_config().buffer_type() == BufferType::DRAM ||
-            c.memory_config().buffer_type() == BufferType::DRAM) {
-            return false;
-        }
-        if ((a.memory_config().is_sharded() && a.memory_config().buffer_type() == BufferType::L1)) {
-            return true;
-        }
-        if (b->memory_config().is_sharded() && b->memory_config().buffer_type() == BufferType::L1) {
-            return true;
-        }
-        if (c.memory_config().is_sharded() && c.memory_config().buffer_type() == BufferType::L1) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 std::optional<AllShardSpecs> get_shard_specs(
     const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c) {
     bool a_sharded = a.memory_config().is_sharded();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -89,7 +89,7 @@ std::optional<AllShardSpecs> get_shard_specs(
         return std::nullopt;
     }
 
-    if (!is_native_L1_sharding(a, b, c)) {
+    if (!is_native_L1_sharding(a, b, c.memory_config())) {
         // treat as interleaved
         return std::nullopt;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -641,4 +641,67 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     ret.shape[1] = std::max((ret.shape[1] * to_width) / from_width, 32u);
     return ret;
 }
+
+const std::optional<ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
+    return tensor_spec.memory_config().shard_spec();
+}
+
+inline auto is_uneven(const TensorSpec& t) {
+    if (not t.memory_config().is_sharded()) {
+        return false;
+    }
+
+    const auto& shape = t.padded_shape();
+    const auto& shard = get_shard_spec(t)->shape;
+    const auto rank = shape.rank();
+
+    // Compute product of all dimensions except the last
+    uint64_t volume_except_last = 1;
+    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
+        volume_except_last *= shape[i];
+    }
+
+    return (volume_except_last % shard[0]) != 0 or (shape[-1] % shard[1]) != 0;
+}
+
+bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c) {
+    // scalar value treated as interleaved
+    if (!b.has_value()) {
+        return false;
+    }
+
+    // does not work for width and block sharding, pcc error,
+    // maybe support later to improve performance
+    // if (!b.has_value() && a.memory_config().is_sharded()) {
+    //     return !is_uneven(a);
+    // }
+
+    if (!c.memory_config().is_sharded()) {
+        return false;
+    }
+
+    // a and b identical shape, no broadcast on any dimension
+    if (b.has_value() && (a.logical_shape() == b->logical_shape()) &&
+        (a.memory_config().memory_layout() == b->memory_config().memory_layout())) {
+        if (is_uneven(a) || is_uneven(*b) || is_uneven(c)) {
+            return false;
+        }
+        if (a.memory_config().buffer_type() == BufferType::DRAM ||
+            b->memory_config().buffer_type() == BufferType::DRAM ||
+            c.memory_config().buffer_type() == BufferType::DRAM) {
+            return false;
+        }
+        if ((a.memory_config().is_sharded() && a.memory_config().buffer_type() == BufferType::L1)) {
+            return true;
+        }
+        if (b->memory_config().is_sharded() && b->memory_config().buffer_type() == BufferType::L1) {
+            return true;
+        }
+        if (c.memory_config().is_sharded() && c.memory_config().buffer_type() == BufferType::L1) {
+            return true;
+        }
+    }
+
+    return false;
+}
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -681,8 +681,7 @@ bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>&
     }
 
     // a and b identical shape, no broadcast on any dimension
-    if (b.has_value() && (a.logical_shape() == b->logical_shape()) &&
-        (a.memory_config().memory_layout() == b->memory_config().memory_layout())) {
+    if (b.has_value() && (a.logical_shape() == b->logical_shape()) && (a.memory_config() == b->memory_config())) {
         if (is_uneven(a) || is_uneven(*b) || is_uneven(c)) {
             return false;
         }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -642,7 +642,7 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     return ret;
 }
 
-const std::optional<ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
+const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec) {
     return tensor_spec.memory_config().shard_spec();
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -118,7 +118,5 @@ std::optional<AllShardVolumes> get_shard_volumes(
 
 const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec);
 
-inline auto is_uneven(const TensorSpec& t);
-
 bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -118,5 +118,7 @@ std::optional<AllShardVolumes> get_shard_volumes(
 
 const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec);
 
-bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
+bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const MemoryConfig& c);
+
+ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::Shape& shape_b);
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -121,4 +121,6 @@ const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& t
 bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const MemoryConfig& c);
 
 ttnn::Shape compute_broadcasted_output(const ttnn::Shape& shape_a, const ttnn::Shape& shape_b);
+
+MemoryConfig compute_mem_config_actual(const ttnn::Tensor& input_tensor_a, const ttnn::Shape& shape_b);
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -116,4 +116,9 @@ struct AllShardVolumes {
 std::optional<AllShardVolumes> get_shard_volumes(
     const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
 
+const std::optional<tt::tt_metal::ShardSpec>& get_shard_spec(const TensorSpec& tensor_spec);
+
+inline auto is_uneven(const TensorSpec& t);
+
+bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const TensorSpec& c);
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1561,8 +1561,8 @@ std::vector<std::optional<ttnn::Tensor>> ExecuteUnaryBackwardGelu::invoke(
         input_grad = ttnn::empty_like(grad);
     }
 
-    auto output_memory_config = output_mem_config.value_or(
-        input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
+    auto output_memory_config =
+        input_grad.has_value() ? input_grad->memory_config() : output_mem_config.value_or(input.memory_config());
     TT_FATAL((approximate == "none" || approximate == "tanh"), "Incorrect approximate mode (expected 'None', 'tanh')");
 
     if (approximate == "tanh") {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/28086
https://github.com/tenstorrent/tt-metal/issues/28087
https://github.com/tenstorrent/tt-metal/issues/24316
https://github.com/tenstorrent/tt-metal/issues/34765

### Problem description
Revert the binary compute core optimization revert, plus a fix for sdxl model L1 out of memory error. 

### What's changed
1. For the original PR, output memory selection has priority of using sharded input tensor over interleaved tensor, and do not distinguish L1 vs DRAM interleaved. Now it treats L1 vs DRAM interleaved differently. If one input tensor is interleaved in L1, even if the other one is sharded, output memory config will use interleaved memory config.
2. Previous code use input tensor either A and B's mem config for program cache hash, now it uses the actual calculated output mem config as hash, because for sharded broadcast case, output tensor spec is derived from either A or B but not the same as A or B.
3. Basic support for output mem config as half mem config such as ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG. Half mem config means it has sharding strategy but shard spec is empty. Note the feature is not thoroughly verified as complete. It will be followed by future PR. The issue is tracked as https://github.com/tenstorrent/tt-metal/issues/24316
4. Fixed issue https://github.com/tenstorrent/tt-metal/issues/34765. When output mem config is overid to use difference shard spec than input, it will not be considered as direct L1 sharding anymore.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dchen/28087-core_revert)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/28087-core_revert)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/28087-core_revert)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/28087-core_revert)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/28087-core_revert)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/28087-core_revert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/28087-core_revert)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs