### PR TITLE
#0: [skip ci] Add P100 support in git bisect

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -20,6 +20,7 @@ on:
           - N150
           - N300
           - P150
+          - P100
           - config-t3000
           - BH-LoudBox
           - topology-6u-wormhole_b0


### PR DESCRIPTION
P100 not available in git bisect workflow tooling.

Adding option here

test run:
https://github.com/tenstorrent/tt-metal/actions/runs/20802063418/job/59748843366