### PR TITLE
Data Movement Program Cache Fixes

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -233,17 +233,13 @@ tt::stl::hash::hash_t BcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "BcastDeviceOperation::compute_program_hash is called");
 
-    const ttnn::Tensor& input_a = tensor_args.input_a;
-    const ttnn::Tensor& input_b = tensor_args.input_b;
-    const std::optional<ttnn::Tensor>& preallocated_output_tensor = tensor_args.preallocated_output;
-
-    const bool bcast_scalar =
-        (input_b.padded_shape()[-2] * input_b.padded_shape()[-1] == 1) && operation_attributes.dim == BcastOpDim::HW;
+    const bool bcast_scalar = (tensor_args.input_b.padded_shape()[-2] * tensor_args.input_b.padded_shape()[-1] == 1) &&
+                              operation_attributes.dim == BcastOpDim::HW;
 
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 
     return operation::hash_operation<BcastDeviceOperation>(
-        operation_attributes, bcast_scalar, input_a, input_b, preallocated_output_tensor, program_factory.index());
+        operation_attributes, tensor_args, bcast_scalar, program_factory.index());
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> BcastDeviceOperation::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -231,18 +231,19 @@ Tensor BcastDeviceOperation::create_output_tensors(
 
 tt::stl::hash::hash_t BcastDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const program_factory_t program_factory = select_program_factory(operation_attributes, tensor_args);
-    const bool bcast_scalar = (tensor_args.input_b.padded_shape()[-2] * tensor_args.input_b.padded_shape()[-1] == 1) &&
-                              operation_attributes.dim == BcastOpDim::HW;
+    log_trace(tt::LogOp, "BcastDeviceOperation::compute_program_hash is called");
+
+    const ttnn::Tensor& input_a = tensor_args.input_a;
+    const ttnn::Tensor& input_b = tensor_args.input_b;
+    const std::optional<ttnn::Tensor>& preallocated_output_tensor = tensor_args.preallocated_output;
+
+    const bool bcast_scalar =
+        (input_b.padded_shape()[-2] * input_b.padded_shape()[-1] == 1) && operation_attributes.dim == BcastOpDim::HW;
+
+    auto program_factory = select_program_factory(operation_attributes, tensor_args);
+
     return operation::hash_operation<BcastDeviceOperation>(
-        operation_attributes,
-        program_factory.index(),
-        tensor_args.input_a.memory_config(),
-        tensor_args.input_a.dtype(),
-        tensor_args.input_b.memory_config(),
-        tensor_args.input_b.dtype(),
-        bcast_scalar,
-        operation_attributes.in_place);
+        operation_attributes, bcast_scalar, input_a, input_b, preallocated_output_tensor, program_factory.index());
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> BcastDeviceOperation::create_op_performance_model(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -61,27 +61,21 @@ ReshapeDeviceOperation::tensor_return_value_t ReshapeDeviceOperation::create_out
 
 tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.logical_shape();
-    const auto& input_dtype = input_tensor.dtype();
-    const auto layout = input_tensor.layout();
-    const auto& input_mem_config = input_tensor.memory_config();
+    log_trace(tt::LogOp, "ReshapeDeviceOperation::compute_program_hash is called");
+
+    const ttnn::Tensor& input_tensor = tensor_args.input;
 
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 
     // don't hash on operation_attributes_t::recreate_mapping_tensor
-
-    return tt::stl::hash::hash_objects(
-        program_factory.index(),
-        input_shape,
-        layout,
-        input_mem_config,
-        input_dtype,
+    return tt::tt_metal::operation::hash_operation<ReshapeDeviceOperation>(
         operation_attributes.logical_output_shape,
         operation_attributes.output_mem_config,
         operation_attributes.sub_core_grid.has_value(),
         operation_attributes.sub_core_grid.has_value() ? operation_attributes.sub_core_grid.value()
-                                                       : CoreRangeSet(CoreRange({0, 0}, {0, 0})));
+                                                       : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
+        input_tensor,
+        program_factory.index());
 }
 }  // namespace ttnn::operations::data_movement::reshape
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -63,8 +63,6 @@ tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     log_trace(tt::LogOp, "ReshapeDeviceOperation::compute_program_hash is called");
 
-    const ttnn::Tensor& input_tensor = tensor_args.input;
-
     auto program_factory = select_program_factory(operation_attributes, tensor_args);
 
     // don't hash on operation_attributes_t::recreate_mapping_tensor
@@ -74,7 +72,7 @@ tt::stl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
         operation_attributes.sub_core_grid.has_value(),
         operation_attributes.sub_core_grid.has_value() ? operation_attributes.sub_core_grid.value()
                                                        : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
-        input_tensor,
+        tensor_args,
         program_factory.index());
 }
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -111,13 +111,14 @@ Tensor PaddedSliceDeviceOperation::create_output_tensors(
 
 tt::stl::hash::hash_t PaddedSliceDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    log_trace(tt::LogOp, "PaddedSliceDeviceOperation::compute_program_hash is called");
+
     auto program_factory = select_program_factory(args, tensor_args);
+
     // Include input shape last dimension as it affects pad_output_row decision (RM factory)
     // and max_num_tiles_per_row calculation (Tile factory), which affect kernel selection and CB configs
-    operation::Hash hash =
-        operation::hash_operation<PaddedSliceDeviceOperation>(args, program_factory.index(), tensor_args);
-
-    return hash;
+    return tt::tt_metal::operation::hash_operation<PaddedSliceDeviceOperation>(
+        args, tensor_args, program_factory.index());
 }
 
 }  // namespace ttnn::operations::experimental::padded_slice

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -96,28 +96,12 @@ TensorSpec SliceWriteDeviceOperation::compute_output_specs(
 
 tt::stl::hash::hash_t SliceWriteDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& output_tensor = tensor_args.output;
-    const auto& input_shape = input_tensor.padded_shape();
+    log_trace(tt::LogOp, "SliceWriteDeviceOperation::compute_program_hash is called");
 
     auto program_factory = select_program_factory(args, tensor_args);
 
-    operation::Hash hash = operation::hash_operation<SliceWriteDeviceOperation>(
-        args,                            // Includes slice_start, slice_end, step
-        program_factory.index(),         // ✅ CRITICAL: Factory variant index (3 factories)
-        input_tensor.dtype(),            // Affects CB data formats
-        input_tensor.element_size(),     // Affects compile-time args, CB configs
-        input_tensor.memory_config(),    // Affects factory selection, num_cores_channels
-        input_tensor.layout(),           // Affects factory selection
-        input_shape,                     // Affects CB sizes, num_unpadded_sticks
-        input_tensor.physical_volume(),  // Affects num_unpadded_sticks → CB sizes
-        input_tensor.shard_spec(),       // Affects core ranges, CB sizes (if sharded)
-        output_tensor.dtype(),           // Affects compile-time args (RMInterleaved)
-        output_tensor.element_size(),    // Affects compile-time args (RMInterleaved)
-        output_tensor.padded_shape()     // Affects defines (TiledSharded)
-    );
-
-    return hash;
+    return tt::tt_metal::operation::hash_operation<SliceWriteDeviceOperation>(
+        args, tensor_args, program_factory.index());
 }
 
 Tensor SliceWriteDeviceOperation::create_output_tensors(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35286#issuecomment-3711446125)

### Problem description
Bug sweep for data movement program cache issues

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/program-cache-pure-data-movement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/program-cache-pure-data-movement)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs