### PR TITLE
[skip ci] Update Wheel Artifact Naming Convention in CI

### DIFF
--- a/.github/actions/download-artifacts-from-run/action.yml
+++ b/.github/actions/download-artifacts-from-run/action.yml
@@ -107,7 +107,7 @@ runs:
         fi
 
         # Find wheel artifact
-        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "eager-dist|ttnn" | head -1 || true)
+        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "ttnn-dist|ttnn" | head -1 || true)
 
         # Find packages artifact (optional)
         PACKAGES_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "packages-" | head -1 || true)

--- a/.github/workflows/_test-wheels-impl.yaml
+++ b/.github/workflows/_test-wheels-impl.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         timeout-minutes: 10
         with:
-          name: eager-dist-${{ matrix.os }}-any
+          name: ttnn-dist-${{ matrix.os }}-Release
       - name: Set up end-to-end tests environment
         run: ./tests/scripts/set_up_end_to_end_tests_env.sh
       - name: Activate env and run release tests - host

--- a/.github/workflows/_test-wheels-impl.yaml
+++ b/.github/workflows/_test-wheels-impl.yaml
@@ -3,33 +3,14 @@ name: "[internal] Python wheels test impl"
 on:
   workflow_call:
     inputs:
-      from-precompiled:
-        description: "Use precompiled assets for wheel build"
-        default: True
-        type: boolean
-
-# THIS COMMENT NEEDS REEVALUATION AND THE WORKFLOW NEEDS CLEANUP
-# Since pre-compiled assets are only built on ubuntu-20.04, we force tests
-# to only be run on ubuntu-20.04.
-#
-# Otherwise, we run across 20.04 and 22.04 as we should have assets for both
-# from previous wheel builds if from-precompiled is false.
-#
-# I chose the more heavy-handed approach because:
-# - This should all go away soon once we have more OSes + more Docker up and
-# running so we can matrix properly across more stuff
-# - though provides less flexibility to caller workflows, we want to be pretty
-# strict with the matrix + doesn't change often
+      wheel-artifact-name:
+        description: "Name of the wheel artifact to download and test"
+        required: true
+        type: string
 
 jobs:
   test-wheels-host:
-    strategy:
-      matrix:
-        os: ${{ fromJson(inputs.from-precompiled && '["ubuntu-22.04"]' || '["ubuntu-22.04", "ubuntu-24.04"]') }}
-        runner-hw-info: [
-          {arch: wormhole_b0}
-        ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies
@@ -38,7 +19,7 @@ jobs:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         timeout-minutes: 10
         with:
-          name: ttnn-dist-${{ matrix.os }}-Release
+          name: ${{ inputs.wheel-artifact-name }}
       - name: Set up end-to-end tests environment
         run: ./tests/scripts/set_up_end_to_end_tests_env.sh
       - name: Activate env and run release tests - host

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -16,6 +16,8 @@ jobs:
   test-wheels:
     needs: build-artifact
     uses: ./.github/workflows/_test-wheels-impl.yaml
+    with:
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   publish-wheels:
     name: "Publish wheels to internal PyPI"
     needs: [build-artifact, test-wheels]

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -404,6 +404,7 @@ jobs:
     needs: build-docker-image
     secrets: inherit
     with:
+      build-type: ${{ inputs.build-type }}
       python-version: ${{ inputs.version == '22.04' && '3.10' || '3.12' }}
       docker-image: ${{ needs.build-docker-image.outputs.manylinux-tag || 'docker-image-unresolved!' }}
       ref: ${{ inputs.ref || '' }}

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Download ALL wheels (separate folders)
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
         with:
-          pattern: eager-dist-*
+          pattern: ttnn-dist-*
           path: artifacts
           merge-multiple: false
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -101,7 +101,7 @@ jobs:
           # Sanitize ref/SHA by replacing invalid characters with hyphens
           RAW_REF="${{ inputs.ref || github.sha }}"
           SANITIZED_REF=$(echo "$RAW_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
-          ARTIFACT_NAME="eager-dist-cp${{ steps.format_python_version.outputs.python_version_nodot }}-any-${SANITIZED_REF}-${{ github.run_id }}"
+          ARTIFACT_NAME="ttnn-dist-cp${{ steps.format_python_version.outputs.python_version_nodot }}-${{ inputs.build-type }}-${SANITIZED_REF}-${{ github.run_id }}"
           echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
           echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
1. Old name eager-dist has legacy meaning?
2. build-type needs to be part of artifact name, else we can't have a single workflow with multiple build types (name collision)
3. We are not passing the build-type from build-artifact into wheels.yaml ... this is a bug.
4. We were not passing correct artifact name from build-and-test-wheels.yaml into _test-wheel-impl.yaml ... this is a bug.

### What's changed
- Fix everything

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-wheel-artifact-name)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-wheel-artifact-name)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-wheel-artifact-name)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano-wheel-artifact-name)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano-wheel-artifact-name)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano-wheel-artifact-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano-wheel-artifact-name)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs