### PR TITLE
Fix for failing Mixtral 8x7B T3K pipeline test

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1004,6 +1004,7 @@ def test_demo_text(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
+                enable_trace=False, # WARNING! Enabling tracing for prefill warmup can cause memory corruption issues
             )
             profiler.end(f"compile_prefill", iteration=batch_idx)
             logger.info("Finished prefill warmup")


### PR DESCRIPTION
### Problem description
During the recurring CI pipeline model test on the T3K ("not performance-ci-stress-1") the Mixtral 8x7B model hangs on user 8 in the batch of 32 during the "performance-ci-eval-32" part of the test during the prefill phase after prefill warmup. The log example of this issue is shown below:
2025-12-30 20:55:57.035 | INFO     | models.tt_transformers.demo.simple_text_demo:test_demo_text:1011 - Starting prefill...
2025-12-30 20:55:57.035 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 1 up to 393 tokens
2025-12-30 20:55:57.035 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 1024, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.042 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 2 up to 820 tokens
2025-12-30 20:55:57.042 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 1024, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.044 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 3 up to 38 tokens
2025-12-30 20:55:57.044 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.046 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 4 up to 42 tokens
2025-12-30 20:55:57.046 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.048 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 5 up to 50 tokens
2025-12-30 20:55:57.048 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.049 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 6 up to 92 tokens
2025-12-30 20:55:57.049 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.050 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 7 up to 33 tokens
2025-12-30 20:55:57.050 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:55:57.052 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:301 - Prefilling User 8 up to 25 tokens
2025-12-30 20:55:57.052 | INFO     | models.tt_transformers.tt.generator:prefill_forward_text:311 - Prefill seq len: 128, max_prefill_chunk_size: 4096, trace: True
2025-12-30 20:56:57.042 | info     |          Always | Timeout detected - serializing Inspector RPC data (system_memory_manager.cpp:587)

Because of this the test fails.

### What's changed
The main problem turned out to be that we ran all 32 users through traced execution twice in a row:

In prefill warmup we ran all 32 users with tracing enabled with the call to the "prefill_forward_text". This call triggers trace capture during warmup_model_refill. We then replayed traces for all 32 users. The warning "Allocating device buffers is unsafe due to the existence of an active trace" indicated memory corruption could be occurring (at it almost 100% did).

After that we ran prefill run on all 32 users again with tracing but at this moment, the device memory state was corrupted from the first run and it hang on user 8 (seemingly random, but actually where corruption manifested and this is perfectly reproducible).

The fix for this is to disable the tracing for the warmup run and then enable it for the real prefill run.
This should work since the first call (with enable_trace=False) compiles all operators without capturing traces because
"warmup_model_prefill" inside "prefill_forward_text" should still run and capture traces with single-user dummy inputs
The second call with enabled tracing then reuses those captured traces cleanly without memory corruption.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ctr-ifabijanic/mixtral_t3k_test_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ctr-ifabijanic/mixtral_t3k_test_prefill_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-ifabijanic/mixtral_t3k_test_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-ifabijanic/mixtral_t3k_test_prefill_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/mixtral_t3k_test_prefill_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/mixtral_t3k_test_prefill_fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [pass] [![(T3K) T3000 demo tests; branch "ctr-ifabijanic/mixtral_t3k_test_prefill_fix"; t3k_mixtral_tests: https://github.com/tenstorrent/tt-metal/actions/runs/20816996776