### PR TITLE
Fix reduce init for fp32 dest

### DIFF
--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -51,6 +51,10 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t 
     state_configure(icb, icb_scaler, ocb, call_line);
     UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim, enforce_fp32_accumulation>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, enforce_fp32_accumulation>()));
+    if constexpr (enforce_fp32_accumulation) {
+        MATH((tensix_sync()));
+        MATH((reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 1 << 11)));
+    }
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
 }
 


### PR DESCRIPTION
This PR is motivated by ongoing work in the [llk_helper_library branch](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/llk_helper_library), where most `reduce_tile` calls have been migrated under a higher-level reduce abstraction.

### Issue Description
Enabling the proper `reduce_uninit` pattern—where the `fp32_dest_acc` flag is passed as a template parameter—causes failures. The root cause lies in `reduce_uninit`: for 32-bit destination accumulation, it clears **bit 11** via:
`MATH((reg_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0)));`
This is necessary for some kernels to function correctly, but it breaks others, leading to inconsistent behavior. For example:
`reduce_uninit<false>(); // NOTE: Cannot pass use_float32_reduction here, or outputs are incorrect?`

The inconsistency arises because:
- `reduce_init` sets bit 11 on the **UNPACK** thread (from TRISC0).
- `reduce_uninit` clears it on the **MATH** thread (from TRISC1).

Back-to-back (b2b) reduce calls can thus trigger race conditions.

### Proposed Fix
This PR sets bit 11 on the **MATH** thread *in addition* to the UNPACK thread. While not ideal, alternatives like moving `uninit` to UNPACK or removing `init` from UNPACK (to consolidate bit manipulation on a single thread) did not work.

I'm very open to suggestions from the LLK team on better approaches.

### Additional Concern
This PR does not address a related issue: UNPACK performs the `reg_write` during `init` *without synchronization*, which could also cause race conditions.

  - [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/20799308751)
  - [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20798551900)
  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20798553683)
  - [x] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20798534798)