### PR TITLE
Add checks for cgroup memory since Docker uses namespaces to limit things

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -40,7 +40,8 @@ jobs:
       volumes:
         - /work
         - ${{ (!contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
-      options: --device /dev/tenstorrent
+      # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
+      options: --device /dev/tenstorrent ${{ contains(['N300-llmbox', 'in-service-dedicated-merge-gate'], inputs.runner) && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash
@@ -57,6 +58,9 @@ jobs:
         with:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
+
+      - name: Check available memory in container
+        run: cat /sys/fs/cgroup/memory.max
 
       - name: Install packages
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -41,7 +41,7 @@ jobs:
         - /work
         - ${{ (!contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
-      options: --device /dev/tenstorrent ${{ contains(['N300-llmbox', 'in-service-dedicated-merge-gate'], inputs.runner) && '--memory 256g' || '' }}
+      options: --device /dev/tenstorrent ${{ contains(fromJSON('["N300-llmbox", "in-service-dedicated-merge-gate"]', inputs.runner) && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -59,11 +59,29 @@ jobs:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
 
-      - name: Check available memory in container
+      - name: Check available memory in container for WH LB 2
         run: |
-          cat /sys/fs/cgroup/memory.max 2>/dev/null || \
-            cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || \
-            echo "Unable to read memory limit from cgroup (v1 or v2)"
+          # You never know with GH!!!
+          set -e
+
+          # Read memory limit for container cgroup from cgroup v2 or v1
+          memory_bytes=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || \
+                         cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+
+          if [ -z "$memory_bytes" ]; then
+              echo "Unable to read memory limit from cgroup (v1 or v2)" >&2
+              exit 1
+          fi
+
+          # 256GB = 274877906944 bytes
+          max_bytes_wh_lb2=274877906944
+
+          if [ "$memory_bytes" -gt "$max_bytes_wh_lb2" ]; then
+              echo "Error: Container memory limit ${memory_bytes} upcoming max of 256GB (${max_bytes_wh_lb2} bytes)" >&2
+              exit 1
+          fi
+
+          echo "Memory limit validated: ${memory_bytes} bytes"
 
       - name: Install packages
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -41,7 +41,7 @@ jobs:
         - /work
         - ${{ (!contains(inputs.runner, 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
-      options: --device /dev/tenstorrent ${{ contains(fromJSON('["N300-llmbox", "in-service-dedicated-merge-gate"]', inputs.runner) && '--memory 256g' || '' }}
+      options: --device /dev/tenstorrent ${{ contains(fromJSON('["N300-llmbox", "in-service-dedicated-merge-gate"]'), inputs.runner) && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -60,7 +60,10 @@ jobs:
           path: /work/pkgs/
 
       - name: Check available memory in container
-        run: cat /sys/fs/cgroup/memory.max
+        run: |
+          cat /sys/fs/cgroup/memory.max 2>/dev/null || \
+            cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || \
+            echo "Unable to read memory limit from cgroup (v1 or v2)"
 
       - name: Install packages
         run: |

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -63,7 +63,8 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
+      options: --device /dev/tenstorrent --memory 256g
     defaults:
       run:
         shell: bash
@@ -82,6 +83,8 @@ jobs:
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+      - name: Check available memory in container
+        run: cat /sys/fs/cgroup/memory.max
       - name: Run t3k fabric tests
         id: t3k-fabric-tests
         timeout-minutes: 20

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -83,8 +83,6 @@ jobs:
           enable-watcher: ${{ inputs.enable-watcher || false }}
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
-      - name: Check available memory in container
-        run: cat /sys/fs/cgroup/memory.max
       - name: Run t3k fabric tests
         id: t3k-fabric-tests
         timeout-minutes: 20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# Hello
+# REVERT MEEEEEEEE
 
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# REVERT MEEEEEEEE
-
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")


### PR DESCRIPTION
…

### Ticket

https://github.com/tenstorrent/metal-internal-workflows/issues/786

### Problem description

WH LB is getting a reduction in memory of half in WH LB 2.

### What's changed

Let's start running tests for that.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rkim/miw-786-apc-mg-ram)  https://github.com/tenstorrent/tt-metal/actions/runs/21032301091
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rkim/miw-786-apc-mg-ram)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rkim/miw-786-apc-mg-ram)
- [ ] New/Existing tests provide coverage for changes
- [ ] Merge gate https://github.com/tenstorrent/tt-metal/actions/runs/21032291309


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rkim/miw-786-apc-mg-ram)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rkim/miw-786-apc-mg-ram)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rkim/miw-786-apc-mg-ram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rkim/miw-786-apc-mg-ram)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs