### PR TITLE
33696: Remove sub_device_manager_tracker from device

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -34,7 +34,6 @@
 #include "program/program_impl.hpp"
 #include "core_coord.hpp"
 #include "device.hpp"
-#include "impl/context/metal_context.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "dispatch/dispatch_query_manager.hpp"
 #include "hal_types.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -16,7 +16,6 @@
 #include <tt_metal.hpp>
 #include <tt_stl/span.hpp>
 #include <algorithm>
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -25,7 +24,6 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "allocator.hpp"
@@ -38,8 +36,9 @@
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "dispatch/dispatch_query_manager.hpp"
 #include "hal_types.hpp"
-#include "jit_build/build.hpp"
+#include "impl/context/metal_context.hpp"
 #include "lightmetal/lightmetal_capture.hpp"
 #include "llrt.hpp"
 #include <tt-logger/tt-logger.hpp>
@@ -53,7 +52,6 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 #include "tt_metal/fabric/fabric_init.hpp"
-#include "sub_device/sub_device_manager_tracker.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <umd/device/coordinates/coordinate_manager.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -130,39 +128,14 @@ bool Device::is_mmio_capable() const {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_) == this->id_;
 }
 
-CoreRangeSet Device::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).cores(core_type);
+CoreRangeSet Device::worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
+    TT_FATAL(false, "worker_cores is deprecated for device");
+    return CoreRangeSet{};
 }
 
-uint32_t Device::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()
-        ->sub_device(sub_device_id)
-        .impl()
-        ->num_cores(core_type);
-}
-
-void Device::initialize_default_sub_device_state(
-    size_t l1_small_size,
-    size_t trace_region_size,
-    size_t worker_l1_unreserved_start,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
-    // Create the default sub-device manager representing the entire chip
-    const auto& compute_grid_size = this->compute_with_storage_grid_size();
-    const auto& active_eth_cores = this->get_active_ethernet_cores(true);
-    std::vector<CoreRange> active_eth_core_ranges;
-    active_eth_core_ranges.reserve(active_eth_cores.size());
-    for (const auto& core : active_eth_cores) {
-        active_eth_core_ranges.emplace_back(core, core);
-    }
-
-    auto sub_devices = {SubDevice(std::array{
-        CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1})),
-        CoreRangeSet(std::move(active_eth_core_ranges))})};
-
-    sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
-        this,
-        this->initialize_allocator(l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap),
-        sub_devices);
+uint32_t Device::num_worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
+    TT_FATAL(false, "num_worker_cores is deprecated for device");
+    return 0U;
 }
 
 std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
@@ -263,8 +236,9 @@ void Device::init_command_queue_host() {
     cq_shared_state->sub_device_cq_owner.resize(1);
     command_queues_.reserve(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
-        command_queues_.push_back(std::make_unique<HWCommandQueue>(
-            this, cq_shared_state, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
+        command_queues_.push_back(
+            std::make_unique<HWCommandQueue>(
+                this, cq_shared_state, cq_id, k_dispatch_downstream_noc, completion_queue_reader_core_));
     }
 }
 
@@ -346,11 +320,31 @@ void Device::init_command_queue_device() {
                 this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH));
         }
     }
+
+    // Precompute NOC data for go signals and set on dispatch command queues
+    const auto& active_eth_cores = get_active_ethernet_cores(true);
+    std::vector<CoreRange> active_eth_core_ranges;
+    active_eth_core_ranges.reserve(active_eth_cores.size());
+    for (const auto& core : active_eth_cores) {
+        active_eth_core_ranges.emplace_back(core, core);
+    }
+
+    const NOC noc_index = MetalContext::instance().get_dispatch_query_manager().go_signal_noc();
+    uint32_t idx = 0U;
+    vector_aligned<uint32_t> noc_mcast_unicast_data;
+    for (uint32_t i = 0U; i < num_sub_devices(); ++i) {
+        for (const auto& core_range : active_eth_core_ranges) {
+            noc_mcast_unicast_data.resize(idx + core_range.size());
+            for (const auto& core : core_range) {
+                const auto virtual_core = virtual_core_from_logical_core(core, CoreType::ETH);
+                noc_mcast_unicast_data[idx++] = get_noc_unicast_encoding(noc_index, virtual_core);
+            }
+        }
+    }
+
     // Set num_worker_sems and go_signal_noc_data on dispatch for the default sub device config
     for (auto& hw_cq : this->command_queues_) {
-        hw_cq->set_go_signal_noc_data_and_dispatch_sems(
-            sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices(),
-            sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_unicast_data());
+        hw_cq->set_go_signal_noc_data_and_dispatch_sems(num_sub_devices(), noc_mcast_unicast_data);
     }
 }
 
@@ -436,13 +430,14 @@ bool Device::initialize(
         worker_l1_size,
         max_worker_l1_size);
     log_debug(tt::LogMetal, "Worker L1 size: {} Max: {}", worker_l1_size, max_worker_l1_size);
-    std::uint32_t max_alignment = std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
-    uint32_t worker_l1_unreserved_start = tt::align(
+
+    const uint32_t max_alignment = std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
+    const uint32_t worker_l1_unreserved_start = tt::align(
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
             hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
         max_alignment);
-    this->initialize_default_sub_device_state(
-        l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap);
+    default_allocator_ =
+        initialize_allocator(l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap);
 
     // For minimal setup, don't initialize FW, watcher, dprint. They won't work if we're attaching to a hung chip.
     if (minimal) {
@@ -463,7 +458,7 @@ bool Device::close() {
     this->disable_and_clear_program_cache();
     this->set_program_cache_misses_allowed(true);
 
-    sub_device_manager_tracker_.reset(nullptr);
+    default_allocator_.reset();
 
     this->ethernet_cores_.clear();
     this->command_queue_programs_.clear();
@@ -589,23 +584,23 @@ uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& 
         virtual_noc_end.x, virtual_noc_end.y, virtual_noc_start.x, virtual_noc_start.y);
 }
 
-const std::unique_ptr<AllocatorImpl>& Device::allocator_impl() const {
-    return sub_device_manager_tracker_->get_default_sub_device_manager()->allocator(SubDeviceId{0});
+const std::unique_ptr<AllocatorImpl>& Device::allocator_impl() const { return default_allocator_; }
+
+const std::unique_ptr<Allocator>& Device::allocator() const {
+    const auto& allocator{this->allocator_impl()};
+    return allocator->view();
 }
 
-const std::unique_ptr<Allocator>& Device::allocator() const { return this->allocator_impl()->view(); }
-
-const std::unique_ptr<AllocatorImpl>& Device::allocator_impl(SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_default_sub_device_manager()->allocator(sub_device_id);
+const std::unique_ptr<AllocatorImpl>& Device::allocator_impl(SubDeviceId /*sub_device_id*/) const {
+    return default_allocator_;
 }
 
 const std::unique_ptr<Allocator>& Device::allocator(SubDeviceId sub_device_id) const {
-    return this->allocator_impl(sub_device_id)->view();
+    const auto& allocator{this->allocator_impl(sub_device_id)};
+    return allocator->view();
 }
 
-uint32_t Device::num_sub_devices() const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices();
-}
+uint32_t Device::num_sub_devices() const { return 1U; }
 
 CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel, NOC noc) const {
     return tt::tt_metal::MetalContext::instance()
@@ -637,13 +632,11 @@ uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) c
     TT_THROW("Virtual core {} is not a DRAM core", virtual_core.str());
 }
 
-std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const {
-    return sub_device_manager_tracker_->lowest_occupied_compute_l1_address();
-}
+std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const { return std::nullopt; }
 
 std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(
-    tt::stl::Span<const SubDeviceId> sub_device_ids) const {
-    return sub_device_manager_tracker_->lowest_occupied_compute_l1_address(sub_device_ids);
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) const {
+    return std::nullopt;
 }
 
 CommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {
@@ -681,68 +674,73 @@ void Device::mark_allocations_unsafe() { this->allocator_impl()->mark_allocation
 // NOLINTNEXTLINE(readability-make-member-function-const)
 void Device::mark_allocations_safe() { this->allocator_impl()->mark_allocations_safe(); }
 
-bool Device::has_noc_mcast_txns(SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->has_noc_mcast_txns(sub_device_id);
+bool Device::has_noc_mcast_txns(SubDeviceId /*sub_device_id*/) const {
+    TT_FATAL(false, "has_noc_mcast_txns is deprecated for device");
+    return false;
 }
 
-uint8_t Device::num_noc_unicast_txns(SubDeviceId sub_device_id) const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->num_noc_unicast_txns(sub_device_id);
+uint8_t Device::num_noc_unicast_txns(SubDeviceId /*sub_device_id*/) const {
+    TT_FATAL(false, "num_noc_unicast_txns is deprecated for device");
+    return 0U;
 }
 
-uint8_t Device::noc_data_start_index(SubDeviceId sub_device_id, bool unicast_data) const {
+uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast_data) const {
     if (unicast_data) {
-        return sub_device_manager_tracker_->get_active_sub_device_manager()->noc_unicast_data_start_index(
-            sub_device_id);
+        TT_FATAL(false, "noc_data_start_index is deprecated for unicast mode for device");
     }
-    return 0;
+    return 0U;
 }
 
 CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
     return this->command_queues_[cq_id]->virtual_enqueue_program_dispatch_core();
 }
 
-SubDeviceManagerId Device::get_active_sub_device_manager_id() const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->id();
-}
+SubDeviceManagerId Device::get_active_sub_device_manager_id() const { return SubDeviceManagerId{0U}; }
 
-SubDeviceManagerId Device::get_default_sub_device_manager_id() const {
-    return sub_device_manager_tracker_->get_default_sub_device_manager()->id();
+SubDeviceManagerId Device::get_default_sub_device_manager_id() const { return SubDeviceManagerId{0U}; }
+
+SubDeviceManagerId Device::create_sub_device_manager(
+    std::initializer_list<SubDevice> /*sub_devices*/, DeviceAddr /*local_l1_size*/) {
+    TT_FATAL(false, "create_sub_device_manager is deprecated for device");
+    return SubDeviceManagerId{0U};
 }
 
 SubDeviceManagerId Device::create_sub_device_manager(
-    std::initializer_list<SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
+    tt::stl::Span<const SubDevice> /*sub_devices*/, DeviceAddr /*local_l1_size*/) {
+    TT_FATAL(false, "create_sub_device_manager is deprecated for device");
+    return SubDeviceManagerId{0U};
 }
 
-SubDeviceManagerId Device::create_sub_device_manager(
-    tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) {
-    return sub_device_manager_tracker_->create_sub_device_manager(sub_devices, local_l1_size);
+void Device::load_sub_device_manager(SubDeviceManagerId /*sub_device_manager_id*/) {
+    TT_FATAL(false, "load_sub_device_manager is deprecated for device");
 }
 
-void Device::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
-    sub_device_manager_tracker_->load_sub_device_manager(sub_device_manager_id);
+void Device::clear_loaded_sub_device_manager() {
+    TT_FATAL(false, "clear_loaded_sub_device_manager is deprecated for device");
 }
 
-void Device::clear_loaded_sub_device_manager() { sub_device_manager_tracker_->clear_loaded_sub_device_manager(); }
-
-void Device::remove_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
-    sub_device_manager_tracker_->remove_sub_device_manager(sub_device_manager_id);
+void Device::remove_sub_device_manager(SubDeviceManagerId /*sub_device_manager_id*/) {
+    TT_FATAL(false, "remove_sub_device_manager is deprecated for device");
 }
 
 const std::vector<SubDeviceId>& Device::get_sub_device_ids() const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_ids();
+    static std::vector<SubDeviceId> ids;
+    TT_FATAL(false, "get_sub_device_ids is deprecated for device");
+    return ids;
 }
 
 const std::vector<SubDeviceId>& Device::get_sub_device_stall_group() const {
-    return sub_device_manager_tracker_->get_active_sub_device_manager()->get_sub_device_stall_group();
+    static std::vector<SubDeviceId> ids;
+    TT_FATAL(false, "get_sub_device_stall_group is deprecated for device");
+    return ids;
 }
 
-void Device::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    sub_device_manager_tracker_->get_active_sub_device_manager()->set_sub_device_stall_group(sub_device_ids);
+void Device::set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
+    TT_FATAL(false, "set_sub_device_stall_group is deprecated for device");
 }
 
 void Device::reset_sub_device_stall_group() {
-    sub_device_manager_tracker_->get_active_sub_device_manager()->reset_sub_device_stall_group();
+    TT_FATAL(false, "reset_sub_device_stall_group is deprecated for device");
 }
 
 std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {


### PR DESCRIPTION
### Ticket
[Remove sub_device_manager_tracker_ from Device](https://github.com/tenstorrent/tt-metal/issues/33696)

### Problem description
All usage of subdevices should be going through MeshDevice, so we should be able to rip out the sub_device_manager_tracker_ and supporting code (like potentially CommandQueue::reset_worker_state) from Device.

### What's changed
sub_device_manager_tracker_ was removed from device.  The functions that used sub_devive_manager_tracker_ now either throw TT_FATAL or return a default value of a single sub device with an id of 0.  Allocations that used to be handled in the sub device are now handle by a default allocator in device.

### Checklist

- [X] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [X] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [X] other selection - specify runs - T3K Profiler Tests

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs