### PR TITLE
Fix t3k frequent llama3 tests

### DIFF
--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -92,7 +92,7 @@ jobs:
                   "model": "llama3",
                   "arch": "wormhole_b0",
                   "cmd": "run_t3000_llama3_tests",
-                  "timeout": 45,
+                  "timeout": 47,
                   "owner_id": "U03PUAKE719" # Miguel Tairum Cruz
               },
               {

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -153,7 +153,7 @@ def test_chunked_prefill_single_user(
             kv_cache=tt_kv_cache,
         )
 
-        tt_output_torch = tt_model.process_output_prefill(tt_output_device, last_token_idx=(last_token_idx % 32))
+        tt_output_torch = tt_model.process_output_prefill(tt_output_device.cpu(), last_token_idx=(last_token_idx % 32))
         tt_output_torch = tt_output_torch.reshape(batch_size, 1, -1)
 
         ref_output_slice = ref_output[:, last_token_idx : last_token_idx + 1, :]


### PR DESCRIPTION
### Problem description
t3000-frequent-tests / t3k llama3 tests where failing on test_chunked_generation test.
See more [in slack](https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1767388894548839?thread_ts=1767388877.405339&cid=C05GRJC4J4A).

### What's changed
Moved output tensor to host for further processing.
Increased timeout for t3k frequent llama3 test by 2 minutes (since now it's very tight and 10-20% of runs can fail because of <1 minute is needed to complete the tests)

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20823591684) - CI passes

#### Model tests

- [x] [T3K frequent llama3 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20822975910) - CI passes