### PR TITLE
Cleanup rms norm function

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_rms_norm.py
@@ -86,7 +86,6 @@ def test_llama_rms_norm_inference(
     tt_model = DistributedNorm(
         tt_inner_norm,
         model_args,
-        TG=model_args.is_galaxy,
         tt_ccl=tt_ccl,
         ccl_topology=model_args.model_config["CCL_TOPOLOGY"],
     )

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -1273,7 +1273,7 @@ def tt_sharded_distributed_rmsnorm(
     cluster_axis = 1
     semaphore = tt_ccl.gather_semaphore_handles[cluster_axis][tt_ccl.gather_idx[cluster_axis]]
     persistent_buffer = tt_ccl.all_gather_buffers.get("LAYERNORM", None)
-    tt_out = ttnn.fused_rms_1_1_32_8192(
+    tt_out = ttnn.fused_rms_minimal(
         inp,
         ln_sharded_progcfg,
         cluster_axis,

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -21,7 +21,7 @@ SKIPPED_OPS = [
     "ttnn.allocate_tensor_on_host",  # Missing docs for OP causing docs build crash, need to create documentation and add to docs page, GH issue: #34681
     "ttnn.composite_example",  # Example operation.
     "ttnn.composite_example_multiple_return",  # Example operation.
-    "ttnn.fused_rms_1_1_32_8192",  # Internal operation only.
+    "ttnn.fused_rms_minimal",  # Internal operation only.
     "ttnn.matmul_batched_weights",  # Internal operation only.
     "ttnn.moreh_abs_pow",  # Moreh operation.
     "ttnn.moreh_adam",  # Moreh operation.

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -99,10 +99,8 @@ def run_rms_trace_deepseek(
         ),
     )
 
-    output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
     if output_shard_grid is None:
         output_shard_grid = input_shard_grid
-    padded_out_w = math.ceil(input_shape[3] / num_devices / output_shard_grid.num_cores() / 32) * 32
     output_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
@@ -227,7 +225,6 @@ def run_rms_trace_deepseek(
     ttnn.release_trace(mesh_device, trace_id)
     profiler.end("rms-trace")
     signpost("stop")
-    time_taken = profiler.get_duration("rms-trace") - profiler.get_duration("rms-trace-warmup")
     mesh_device.reset_sub_device_stall_group()
 
 

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -16,6 +16,221 @@ def get_torch_rms(x, dim, gamma, eps):
     return x * torch.rsqrt(x.pow(2).mean([-i for i in range(1, len(dim) + 1)], keepdim=True) + eps) * gamma
 
 
+def run_rms_trace_deepseek(
+    mesh_device,
+    num_devices,
+    elements_per_batch,
+    num_links,
+    function_level_defaults,
+    input_shard_grid,
+    output_shard_grid,
+    all_gather_topology,
+    fused_add,
+    num_iters=1,
+    input_dtype=ttnn.bfloat16,
+    residual_dtype=ttnn.bfloat16,
+    layout=ttnn.TILE_LAYOUT,
+    epsilon=1e-05,
+    warmup_iters=0,
+    trace_mode=False,
+    use_noc1_only=False,
+    profiler=BenchmarkProfiler(),
+):
+    ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 7))})
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+    torch.manual_seed(1234)
+    num_cores = input_shard_grid.num_cores()
+    total_cores = num_cores * num_devices
+    padded_dim_per_core = int(math.ceil(elements_per_batch / total_cores / 32) * 32)
+    padded_dim = padded_dim_per_core * total_cores
+
+    size_per_device = padded_dim // num_devices
+    input_shape = (1, 1, 32, padded_dim)
+    input_memory_config = ttnn.create_sharded_memory_config(
+        shape=(
+            32,
+            32,
+        ),
+        core_grid=input_shard_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    layer_norm_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(4, 8),
+        subblock_w=1,
+        block_h=1,
+        block_w=(size_per_device // num_cores) // 32,
+        inplace=False,
+    )
+
+    ccl_semaphore_handles = ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0)
+
+    ag_memory_config = ttnn.create_sharded_memory_config(
+        shape=(
+            32,
+            32,
+        ),
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    ag_shape = [1, 1, 32, num_devices]
+    stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
+    tt_stats = ttnn.from_torch(
+        stats_tensor,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ag_memory_config,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+    )
+
+    output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
+    if output_shard_grid is None:
+        output_shard_grid = input_shard_grid
+    padded_out_w = math.ceil(input_shape[3] / num_devices / output_shard_grid.num_cores() / 32) * 32
+    output_memory_config = ttnn.create_sharded_memory_config(
+        shape=(
+            32,
+            32,
+        ),
+        core_grid=output_shard_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    input_tensor_torch = torch.randn(input_shape)
+    residual_torch = torch.randn(input_shape)
+    gamma_torch = torch.randn((1, 1, 1, input_shape[3]))
+    input_tensor = ttnn.as_tensor(
+        input_tensor_torch,
+        dtype=input_dtype,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device=mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+        layout=layout,
+        memory_config=input_memory_config,
+    )
+    if fused_add:
+        residual_tensor = ttnn.as_tensor(
+            residual_torch,
+            dtype=residual_dtype,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device=mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+            ),
+            layout=layout,
+            memory_config=input_memory_config,
+        )
+    else:
+        residual_tensor = None
+    gamma_tensor = ttnn.as_tensor(
+        gamma_torch.reshape(
+            [
+                1,
+                1,
+                padded_dim // 32,
+                32,
+            ]
+        ),
+        dtype=ttnn.bfloat16,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device=mesh_device, dims=(2, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    logger.info("Compiling model")
+    tt_out = ttnn.fused_rms_minimal(
+        input_tensor,
+        layer_norm_config,
+        0,
+        mesh_device,
+        ccl_semaphore_handles,
+        topology=all_gather_topology,
+        memory_config=output_memory_config,
+        epsilon=epsilon,
+        weight=gamma_tensor,
+        residual_input_tensor=residual_tensor,
+        stats=tt_stats,
+        use_noc1_only=use_noc1_only,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    logger.info("Capturing trace")
+    if warmup_iters > 0:
+        trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for _ in range(warmup_iters):
+            tt_out = ttnn.fused_rms_minimal(
+                input_tensor,
+                layer_norm_config,
+                0,
+                mesh_device,
+                ccl_semaphore_handles,
+                topology=all_gather_topology,
+                memory_config=output_memory_config,
+                epsilon=epsilon,
+                weight=gamma_tensor,
+                residual_input_tensor=residual_tensor,
+                stats=tt_stats,
+                use_noc1_only=use_noc1_only,
+            )
+            tt_out.deallocate(True)
+        ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for _ in range(num_iters):
+        tt_out = ttnn.fused_rms_minimal(
+            input_tensor,
+            layer_norm_config,
+            0,
+            mesh_device,
+            ccl_semaphore_handles,
+            topology=all_gather_topology,
+            memory_config=output_memory_config,
+            epsilon=epsilon,
+            weight=gamma_tensor,
+            residual_input_tensor=residual_tensor,
+            stats=tt_stats,
+            use_noc1_only=use_noc1_only,
+        )
+        tt_out.deallocate(True)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    logger.info("Starting Trace perf test...")
+
+    profiler.start("rms-trace-warmup")
+    if warmup_iters > 0:
+        ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id_warmup)
+    profiler.end("rms-trace-warmup")
+
+    signpost("start")
+    profiler.start("rms-trace")
+
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    profiler.end("rms-trace")
+    signpost("stop")
+    time_taken = profiler.get_duration("rms-trace") - profiler.get_duration("rms-trace-warmup")
+    mesh_device.reset_sub_device_stall_group()
+
+
 def run_rms_trace(
     mesh_device,
     num_devices,
@@ -159,7 +374,7 @@ def run_rms_trace(
     )
     logger.info("Compiling model")
     if use_new_version:
-        tt_out = ttnn.fused_rms_1_1_32_8192(
+        tt_out = ttnn.fused_rms_minimal(
             input_tensor,
             layer_norm_config,
             1,
@@ -179,7 +394,7 @@ def run_rms_trace(
         if warmup_iters > 0:
             trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
             for _ in range(warmup_iters):
-                tt_out = ttnn.fused_rms_1_1_32_8192(
+                tt_out = ttnn.fused_rms_minimal(
                     input_tensor,
                     layer_norm_config,
                     1,
@@ -198,7 +413,7 @@ def run_rms_trace(
             ttnn.synchronize_device(mesh_device)
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         for _ in range(num_iters):
-            tt_out = ttnn.fused_rms_1_1_32_8192(
+            tt_out = ttnn.fused_rms_minimal(
                 input_tensor,
                 layer_norm_config,
                 1,
@@ -440,7 +655,7 @@ def run_rms_trace_qwen(
     )
     logger.info("Compiling model")
     if use_new_version:
-        tt_out = ttnn.fused_rms_1_1_32_8192(
+        tt_out = ttnn.fused_rms_minimal(
             input_tensor,
             layer_norm_config,
             1,
@@ -460,7 +675,7 @@ def run_rms_trace_qwen(
         if warmup_iters > 0:
             trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
             for _ in range(warmup_iters):
-                tt_out = ttnn.fused_rms_1_1_32_8192(
+                tt_out = ttnn.fused_rms_minimal(
                     input_tensor,
                     layer_norm_config,
                     1,
@@ -479,7 +694,7 @@ def run_rms_trace_qwen(
             ttnn.synchronize_device(mesh_device)
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         for _ in range(num_iters):
-            tt_out = ttnn.fused_rms_1_1_32_8192(
+            tt_out = ttnn.fused_rms_minimal(
                 input_tensor,
                 layer_norm_config,
                 1,
@@ -737,7 +952,7 @@ def run_rms_fuse_impl(
         )
     for i in range(num_iters):
         # TODO: Change OP infra so that pre makes the post shape, also create external tensor
-        tt_out = ttnn.fused_rms_1_1_32_8192(
+        tt_out = ttnn.fused_rms_minimal(
             input_tensor[i],
             layer_norm_config,
             1,
@@ -931,7 +1146,7 @@ def run_rms_fuse_impl_qwen(
         )
     for i in range(num_iters):
         # TODO: Change OP infra so that pre makes the post shape, also create external tensor
-        tt_out = ttnn.fused_rms_1_1_32_8192(
+        tt_out = ttnn.fused_rms_minimal(
             input_tensor[i],
             layer_norm_config,
             1,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_nanobind.cpp
@@ -31,7 +31,7 @@
 namespace ttnn::operations::experimental::ccl {
 
 void py_module(nb::module_& mod) {
-    ccl::bind_fused_rms_1_1_32_8192(mod);
+    ccl::bind_fused_rms_minimal(mod);
     ccl::bind_all_gather_matmul_async(mod);
     ccl::bind_strided_all_gather_minimal_matmul_async(mod);
     ccl::bind_llama_all_gather_matmul_async(mod);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -37,7 +37,7 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         a.logical_shape()[0] == 1 && a.logical_shape()[1] == 1 && a.logical_shape()[2] == 32 &&
             a.logical_shape()[3] % 32 == 0,
-        "Input tensor shape does not meet the requirements set by this OP");
+        "Input tensor shape does not meet the requirements set by this OP: input tensor shape must be (1,1,32,M) where M is a multiple of 32");
     TT_FATAL(
         (tt::tt_metal::hal::get_arch_name() != "blackhole") || (a.memory_config().buffer_type() != BufferType::DRAM),
         "This kernel does not support blackhole dram as it does not use an accessor to get the noc address as needed "

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -35,6 +35,10 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(a.padded_shape().rank() == 4, "Input shape must be rank 4");
     TT_FATAL(
+        a.logical_shape()[0] == 1 && a.logical_shape()[1] == 1 && a.logical_shape()[2] == 32 &&
+            a.logical_shape()[3] % 32 == 0,
+        "Input tensor shape does not meet the requirements set by this OP");
+    TT_FATAL(
         (tt::tt_metal::hal::get_arch_name() != "blackhole") || (a.memory_config().buffer_type() != BufferType::DRAM),
         "This kernel does not support blackhole dram as it does not use an accessor to get the noc address as needed "
         "by the fabric api");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp
@@ -37,7 +37,7 @@ struct ExecuteFusedRMSNorm {
 
 }  // namespace operations::fused::normalization
 
-constexpr auto fused_rms_1_1_32_8192 = ttnn::
-    register_operation<"ttnn::fused_rms_1_1_32_8192", ttnn::operations::fused::normalization::ExecuteFusedRMSNorm>();
+constexpr auto fused_rms_minimal =
+    ttnn::register_operation<"ttnn::fused_rms_minimal", ttnn::operations::fused::normalization::ExecuteFusedRMSNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -14,36 +14,39 @@
 
 namespace ttnn::operations::experimental::ccl {
 
-void bind_fused_rms_1_1_32_8192(nb::module_& mod) {
+void bind_fused_rms_minimal(nb::module_& mod) {
     ttnn::bind_registered_operation(
         mod,
-        ttnn::fused_rms_1_1_32_8192,
-        R"doc(Only works for sharded shape (1,1,32,8192) sharded on 1 core
+        ttnn::fused_rms_minimal,
+        R"doc(
+            This fuses pre RMS, all gather, post rms, residual add, gamma operations, and output resharding into one.
+            Requires a pre-allocated persistent tensor for the intermediate all gather that is tiled,
+                shape per device (32,32) and sharded with a shard shape (32,32) on core (0,0)
+            Requires that the tensor be of shape (1,1,32,32*N) for some integer N
         )doc",
         // Stats is internally computed
-        ttnn::nanobind_arguments_t{
-            // Used by all
-            nb::arg("input_tensor"),
-            nb::arg("program_config"),
-            nb::arg("cluster_axis"),
-            nb::arg("mesh_device"),
-            nb::arg("global_semaphore"),  // TODO: Build this internally
-            nb::kw_only(),
-            // all gather
-            nb::arg("persistent_output_tensor") = nb::none(),
-            nb::arg("num_links") = nb::none(),
-            nb::arg("topology") = ttnn::ccl::Topology::Linear,
-            nb::arg("subdevice_id") = nb::none(),
-            // common
-            nb::arg("dtype") = nb::none(),  // Should default to BFLOAT 16 on pre, nullopt on post
-            nb::arg("compute_kernel_config") = nb::none(),
-            nb::arg("memory_config") = nb::none(),
-            // on pre only
-            nb::arg("residual_input_tensor") = nb::none(),
-            // on post only
-            nb::arg("epsilon") = 1e-12,  // constant 1e-12 on pre, value only affects post
-            nb::arg("weight") = nb::none(),
-            nb::arg("stats") = nb::none(),
-            nb::arg("use_noc1_only") = false});
+        ttnn::nanobind_arguments_t{// Used by all
+                                   nb::arg("input_tensor"),
+                                   nb::arg("program_config"),
+                                   nb::arg("cluster_axis"),
+                                   nb::arg("mesh_device"),
+                                   nb::arg("global_semaphore"),
+                                   nb::kw_only(),
+                                   // all gather
+                                   nb::arg("persistent_output_tensor") = nb::none(),
+                                   nb::arg("num_links") = nb::none(),
+                                   nb::arg("topology") = ttnn::ccl::Topology::Linear,
+                                   nb::arg("subdevice_id") = nb::none(),
+                                   // common
+                                   nb::arg("dtype") = nb::none(),
+                                   nb::arg("compute_kernel_config") = nb::none(),
+                                   nb::arg("memory_config") = nb::none(),
+                                   // on pre only
+                                   nb::arg("residual_input_tensor") = nb::none(),
+                                   // on post only
+                                   nb::arg("epsilon") = 1e-12,
+                                   nb::arg("weight") = nb::none(),
+                                   nb::arg("stats") = nb::none(),
+                                   nb::arg("use_noc1_only") = false});
 }
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -22,7 +22,7 @@ void bind_fused_rms_minimal(nb::module_& mod) {
             This fuses pre RMS, all gather, post rms, residual add, gamma operations, and output resharding into one.
             Requires a pre-allocated persistent tensor for the intermediate all gather that is tiled,
                 shape per device (32,32) and sharded with a shard shape (32,32) on core (0,0)
-            Requires that the tensor be of shape (1,1,32,32*N) for some integer N
+            Requires that input the tensor be of shape (1,1,32,M) where M is a multiple of 32
         )doc",
         // Stats is internally computed
         ttnn::nanobind_arguments_t{// Used by all

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.hpp
@@ -9,6 +9,6 @@
 namespace ttnn::operations::experimental::ccl {
 
 namespace nb = nanobind;
-void bind_fused_rms_1_1_32_8192(nb::module_& mod);
+void bind_fused_rms_minimal(nb::module_& mod);
 
 }  // namespace ttnn::operations::experimental::ccl


### PR DESCRIPTION
### Ticket
We are wanting to add rms_norm_1_1_32_8192 to deepseek, however the original function was only meant to work for the very specific llama70b shape in its name, but in places where it didn't cost perf to do so we maintained some generic aspects. As a result I have now tested that it can also work for the deepseek shapes. In this PR I cleanup the OP to prep it for integration into the deepseek model. I renamed it rms_norm_minimal, I made the doc strings more explicit in how the op is to be used and setup, and since I can no longer assume the specific llama shape will be used I improved the op validator functions

In this I found some bugs in the standard RMS tests that are now fixed

Adds Deepseek specific unit tests for the OP

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jvega/rms_norm_deep)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/rms_norm_deep)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/rms_norm_deep)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jvega/rms_norm_deep)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jvega/rms_norm_deep)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jvega/rms_norm_deep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jvega/rms_norm_deep)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs