### PR TITLE
#35441: Fix `ttnn.visualize_tensor()` crash on multi-host systems

### DIFF
--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -78,7 +78,7 @@ public:
     bool all_local() const { return global_shape_ == local_shape_; }
 };
 
-// NOLINTBEGIN(bugprone-unused-raii)
+// NOLINTBEGIN(bugprone-unused-raii),
 // NOLINTBEGIN(misc-redundant-expression)
 void py_module_types(nb::module_& mod) {
     using namespace tt::tt_metal::distributed::multihost;

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -78,7 +78,7 @@ public:
     bool all_local() const { return global_shape_ == local_shape_; }
 };
 
-// NOLINTBEGIN(bugprone-unused-raii),
+// NOLINTBEGIN(bugprone-unused-raii)
 // NOLINTBEGIN(misc-redundant-expression)
 void py_module_types(nb::module_& mod) {
     using namespace tt::tt_metal::distributed::multihost;

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -421,7 +421,7 @@ def _get_rich_table(
 
                 locality = "" if fully_local else locality
                 coords = f"({row_idx}, {col_idx})\n"
-                if annotate_cell:
+                if annotate_cell and device_id is not None:
                     try:
                         annotation = annotate_cell(device_id, coord)
                     except TypeError:

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -135,7 +135,10 @@ class TensorShardingInfo:
         mapping = {}
         try:
             mesh_device = self.tensor.device()
+            view = mesh_device.get_view()
             for i, mesh_coord in enumerate(self.mesh_coords):
+                if not view.is_local(mesh_coord):
+                    continue
                 dev_id = mesh_device.get_device_id(mesh_coord)
                 mapping[dev_id] = i
 
@@ -266,6 +269,9 @@ def _compute_global_slice_ranges(device_coord, sharding_info):
 
 def _create_shard_annotation_text(device_id, device_coord, sharding_info):
     """Create annotation text showing shard information for a device."""
+    if device_id is None:
+        return ""
+
     shard_index = sharding_info.device_to_shard_map.get(device_id)
     if shard_index is None:
         if sharding_info.tensor.storage_type() == ttnn.StorageType.HOST:
@@ -312,11 +318,14 @@ def _create_replication_color_mapping(sharding_info):
             device_to_group[device_id] = slice_key_to_group[slice_key]
     else:
         mesh_device = sharding_info.tensor.device()
+        view = mesh_device.get_view()
 
         # Only assign colors to devices that actually have tensor shards
         for device_id in sharding_info.device_to_shard_map.keys():
             coord = None
             for test_coord in ttnn.MeshCoordinateRange(mesh_device.shape):
+                if not view.is_local(test_coord):
+                    continue
                 if mesh_device.get_device_id(test_coord) == device_id:
                     coord = test_coord
                     break
@@ -398,18 +407,21 @@ def _get_rich_table(
         for col_idx in range(cols):
             try:
                 coord = ttnn.MeshCoordinate(row_idx, col_idx)
+                is_local = (
+                    view.is_local(coord) if storage_type == ttnn.StorageType.DEVICE else host_buffer.is_local(coord)
+                )
                 if storage_type == ttnn.StorageType.DEVICE:
-                    locality = "Local\n" if view.is_local(coord) else "Remote\n"
-                    device_id = mesh_device.get_device_id(ttnn.MeshCoordinate(row_idx, col_idx))
-                    device_id_str = f"Dev. ID: {device_id}\n" if view.is_local(coord) else "Unknown\n"
+                    locality = "Local\n" if is_local else "Remote\n"
+                    device_id = mesh_device.get_device_id(coord) if is_local else None
+                    device_id_str = f"Dev. ID: {device_id}\n" if is_local else "Unknown ID\n"
                 else:
-                    locality = "Local\n" if host_buffer.is_local(coord) else "Remote\n"
+                    locality = "Local\n" if is_local else "Remote\n"
                     device_id = row_idx * cols + col_idx
                     device_id_str = ""
 
                 locality = "" if fully_local else locality
                 coords = f"({row_idx}, {col_idx})\n"
-                if annotate_cell and device_id is not None:
+                if annotate_cell:
                     try:
                         annotation = annotate_cell(device_id, coord)
                     except TypeError:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35441)

### Problem description
`ttnn.visualize_tensor()` has unprotected calls to `mesh_device.get_device_id(coord)`, which fatals when `coord` is non-local. This crashes tensor visualization on multi-host systems.

### What's changed

- `get_device_id(coord)` calls are protected by checking if `coord` is local first

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ssundaram/fix_tensor_vis)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssundaram/fix_tensor_vis)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ssundaram/fix_tensor_vis)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ssundaram/fix_tensor_vis)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssundaram/fix_tensor_vis)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ssundaram/fix_tensor_vis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ssundaram/fix_tensor_vis)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs