### PR TITLE
Add override_output_sharding_config param to BlockShardedStrategyConfiguration

### DIFF
--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -122,6 +122,7 @@ class BlockShardedStrategyConfiguration(ShardedStrategyConfiguration):
     override_core_grid: Optional[ttnn.CoreRangeSet] = None
     act_block_h_override: int = 0
     act_block_w_div: int = 1
+    override_output_sharding_config: bool = False
 
     def get_tensor_memory_layout(self):
         return ttnn.TensorMemoryLayout.BLOCK_SHARDED
@@ -455,6 +456,7 @@ def sharding_strategy_to_conv2d_config(sharding_strategy: ShardingStrategy):
     elif isinstance(sharding_strategy, BlockShardedStrategyConfiguration):
         output["act_block_h_override"] = sharding_strategy.act_block_h_override
         output["act_block_w_div"] = sharding_strategy.act_block_w_div
+        output["override_output_sharding_config"] = sharding_strategy.override_output_sharding_config
     else:
         raise ValueError(f"Invalid sharding ShardedStrategyConfiguration was encountered: {sharding_strategy}")
 


### PR DESCRIPTION
### Problem description
I encountered a specific scenario where I needed to override core grid for the output of block sharded conv2d. This parameter [`override_output_sharding_config`](https://github.com/tenstorrent/tt-metal/blob/fa0763757e3109b3b83346cc7c00e9fadc788af9/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_nanobind.cpp#L507) enables it but it wasn't availabe in `builder.py`. Since the parameter is marked as experimental, I decided to create a separate PR for it, so it can be tracked and reverted quickly if needed. 

### What's changed
The parameter is added to `models/tt_cnn/tt/builder.py`, by default it is `False` and used only for BLOCK_SHARDED layout in L1. 

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20823639245)