### PR TITLE
Improve accuracy of atan/atan2

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -6,7 +6,12 @@ import torch
 import ttnn
 
 import pytest
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import (
+    assert_with_pcc,
+    assert_with_ulp,
+    generate_all_bfloat16_bitpatterns,
+    flush_subnormal_values_to_zero,
+)
 
 pytestmark = pytest.mark.use_module_device
 
@@ -106,6 +111,30 @@ def test_relu_fp32(device, ttnn_function):
     assert status
 
 
+def test_atan_fp32(device):
+    all_bf16_values = generate_all_bfloat16_bitpatterns(torch.float32)
+
+    # Flush subnormal inputs
+    # Hardware does not handle subnormal values and will flush these values to 0.0 (known behavior)
+    # For testing, we set these values to 0.0 beforehand so that golden function also gets 0.0
+    x_torch = flush_subnormal_values_to_zero(all_bf16_values)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Execute atan operation
+    y_tt = ttnn.atan(x_tt)
+    y_torch = torch.atan(x_torch)
+
+    # Compare results
+    tt_out = ttnn.to_torch(y_tt)
+
+    # If function is expected to return subnormal value, then hardware is expected to flush it to 0.0
+    # Thus, we flush golden output to 0.0 as well to verify this behavior
+    y_torch = flush_subnormal_values_to_zero(y_torch)
+
+    assert_with_ulp(y_torch, tt_out, 3, allow_nonfinite=True)
+
+
 def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     torch.manual_seed(0)
 
@@ -167,12 +196,6 @@ def test_asin(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_acos(device, h, w):
     run_unary_test(device, h, w, ttnn.acos, pcc=0.998)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-def test_atan(device, h, w):
-    run_unary_test(device, h, w, ttnn.atan)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -462,8 +462,6 @@ def flush_subnormal_values_to_zero(tensor):
         - This function only works for float32 and bfloat16 as they share the same exponent range.
         - For float32 and bfloat16, subnormal values are those where the exponent bits are all zero,
           which corresponds to absolute values less than 2^(-126).
-        - The sign of zero is preserved (i.e., -0.0 remains -0.0, though the mask will convert both
-          +/-subnormals to +0.0).
     """
     # Float32 and bfloat16 numbers are subnormal if exponent == 0
     # This corresponds to absolute values < 2^(-126)

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -398,3 +398,76 @@ def maybe_trace(op_func, enable_trace, device):
     else:
         output = op_func()
     return output
+
+
+def generate_all_bfloat16_bitpatterns(dtype=torch.bfloat16):
+    """
+    Generate all possible bfloat16 bit patterns as a test tensor.
+
+    This function creates an exhaustive test dataset by generating all 65,536 (2^16) possible
+    bfloat16 bit patterns. This is useful for comprehensive testing of operations across the
+    entire bfloat16 value space, including edge cases like infinities, NaNs, and subnormals.
+
+    Args:
+        dtype (torch.dtype, optional): The target dtype to cast the bit patterns to.
+                                       Defaults to torch.bfloat16.
+
+    Returns:
+        torch.Tensor: A tensor of shape (256, 256) containing all possible bfloat16 values,
+                     cast to the specified dtype. The tensor is shaped as a square grid for
+                     convenient TILE_LAYOUT compatibility (32x32 tile divisibility).
+
+    Notes:
+        - The function generates values by iterating through all 16-bit integer patterns
+          and reinterpreting them as bfloat16 values.
+        - The resulting tensor includes all special values: +/-0, +/-infinity, NaNs,
+          subnormals, and all normal values in the bfloat16 range.
+        - When dtype is set to a higher precision format (e.g., torch.float32), the bfloat16
+          values are promoted without loss of information.
+
+    Example:
+        >>> all_bf16 = generate_all_bfloat16_bitpatterns(torch.float32)
+        >>> all_bf16.shape
+        torch.Size([256, 256])
+    """
+    # Generate all possible bfloat16 bit patterns (2^16 = 65536 values)
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    bf16_bitpatterns = all_bitpatterns.view(torch.bfloat16)  # Reinterpret as bfloat16
+
+    # Cast to target dtype
+    bitpatterns = bf16_bitpatterns.to(dtype)
+
+    # Reshape tensor to 256 x 256 for tile layout compatibility
+    bitpatterns = bitpatterns.reshape(256, 256)
+
+    return bitpatterns
+
+
+def flush_subnormal_values_to_zero(tensor):
+    """
+    Flush subnormal (denormalized) floating-point values to zero.
+
+    Subnormal numbers are floating-point values smaller than the smallest normalized number.
+    Tenstorrent hardware flushes subnormals to zero for performance reasons.
+    This function replicates that behavior for testing purposes.
+
+    Args:
+        tensor (torch.Tensor): Input tensor with floating-point values.
+
+    Returns:
+        torch.Tensor: The input tensor with all subnormal values replaced by zero.
+                     The tensor is modified in-place.
+
+    Notes:
+        - This function only works for float32 and bfloat16 as they share the same exponent range.
+        - For float32 and bfloat16, subnormal values are those where the exponent bits are all zero,
+          which corresponds to absolute values less than 2^(-126).
+        - The sign of zero is preserved (i.e., -0.0 remains -0.0, though the mask will convert both
+          +/-subnormals to +0.0).
+    """
+    # Float32 and bfloat16 numbers are subnormal if exponent == 0
+    # This corresponds to absolute values < 2^(-126)
+    SUBNORMAL_THRESHOLD = 2.0 ** (-126)
+    mask = torch.abs(tensor) < SUBNORMAL_THRESHOLD
+    tensor[mask] = 0.0
+    return tensor

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -8,6 +8,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_exp.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -190,7 +191,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 
         t1 = t1 * t0;
 
-        v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
+        v_if(sfpi::abs(val) > 1) { t1 = PI_2 - t1; }
         v_endif;
 
         result = sfpi::setsgn(t1, val);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -151,42 +151,53 @@ inline void calculate_sfpu_trig() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vFloat t0 = sfpi::abs(val);
-    v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
-    v_endif;
+    sfpi::vFloat result = sfpi::vConst0;
 
-    sfpi::vFloat t1 = t0 * t0;
+    // If input is NaN then output must be NaN as well
+    sfpi::vInt exponent = sfpi::exexp_nodebias(val);
+    sfpi::vInt mantissa = sfpi::exman9(val);
+    v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
+    v_else {
+        v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
+        v_endif;
 
-    if constexpr (!is_fp32_dest_acc_en) {
-        // Found using Sollya
-        // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
-        t1 = PolynomialEvaluator::eval(
-            t1,
-            0.999787867069244384765625f,
-            -0.325808584690093994140625f,
-            0.1555790007114410400390625f,
-            -4.4326744973659515380859375e-2f);
-    } else {
-        // Found using Sollya
-        // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
-        t1 = PolynomialEvaluator::eval(
-            t1,
-            sfpi::vConst1,
-            -0.3333314359188079833984375f,
-            0.19993579387664794921875f,
-            -0.14209578931331634521484375f,
-            0.1066047251224517822265625f,
-            -7.5408883392810821533203125e-2f,
-            4.3082617223262786865234375e-2f,
-            -1.62907354533672332763671875e-2f,
-            2.90188402868807315826416015625e-3f);
+        sfpi::vFloat t1 = t0 * t0;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            // Found using Sollya
+            // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
+            t1 = PolynomialEvaluator::eval(
+                t1,
+                0.999787867069244384765625f,
+                -0.325808584690093994140625f,
+                0.1555790007114410400390625f,
+                -4.4326744973659515380859375e-2f);
+        } else {
+            // Found using Sollya
+            // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
+            t1 = PolynomialEvaluator::eval(
+                t1,
+                sfpi::vConst1,
+                -0.3333314359188079833984375f,
+                0.19993579387664794921875f,
+                -0.14209578931331634521484375f,
+                0.1066047251224517822265625f,
+                -7.5408883392810821533203125e-2f,
+                4.3082617223262786865234375e-2f,
+                -1.62907354533672332763671875e-2f,
+                2.90188402868807315826416015625e-3f);
+        }
+
+        t1 = t1 * t0;
+
+        v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
+        v_endif;
+
+        result = sfpi::setsgn(t1, val);
     }
-
-    t1 = t1 * t0;
-
-    v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
     v_endif;
 
-    return sfpi::setsgn(t1, val);
+    return result;
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -148,18 +148,38 @@ inline void calculate_sfpu_trig() {
     }
 }
 
-#define POLYVAL6(coef5, coef4, coef3, coef2, coef1, coef0, t4) \
-    (t4 * (t4 * (t4 * (t4 * (coef5 * t4 + coef4) + coef3) + coef2) + coef1) + coef0)
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat sfpu_atan_maclaurin_series(vFloat val) {
-    vFloat t0 = sfpi::abs(val);
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
+    sfpi::vFloat t0 = sfpi::abs(val);
     v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
     v_endif;
 
-    vFloat t1 = t0 * t0;
+    sfpi::vFloat t1 = t0 * t0;
 
-    t1 = POLYVAL6(-0.013480470f, 0.057477314f, -0.121239071f, 0.195635925f, -0.332994597f, 0.999995630f, t1);
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Found using Sollya
+        // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
+        t1 = PolynomialEvaluator::eval(
+            t1,
+            0.999787867069244384765625f,
+            -0.325808584690093994140625f,
+            0.1555790007114410400390625f,
+            -4.4326744973659515380859375e-2f);
+    } else {
+        // Found using Sollya
+        // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
+        t1 = PolynomialEvaluator::eval(
+            t1,
+            sfpi::vConst1,
+            -0.3333314359188079833984375f,
+            0.19993579387664794921875f,
+            -0.14209578931331634521484375f,
+            0.1066047251224517822265625f,
+            -7.5408883392810821533203125e-2f,
+            4.3082617223262786865234375e-2f,
+            -1.62907354533672332763671875e-2f,
+            2.90188402868807315826416015625e-3f);
+    }
 
     t1 = t1 * t0;
 
@@ -169,11 +189,19 @@ sfpi_inline vFloat sfpu_atan_maclaurin_series(vFloat val) {
     return sfpi::setsgn(t1, val);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atan() {
     for (int d = 0; d < ITERATIONS; d++) {
-        dst_reg[0] = sfpu_atan_maclaurin_series<APPROXIMATION_MODE>(dst_reg[0]);
-        dst_reg++;
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
+
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -159,7 +159,9 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vInt mantissa = sfpi::exman9(val);
     v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
     v_else {
-        v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
+        sfpi::vFloat absval_minus_1 = t0 - sfpi::vConst1;
+
+        v_if(absval_minus_1 > 0.0f) { t0 = sfpu_reciprocal<false>(t0); }
         v_endif;
 
         sfpi::vFloat t1 = t0 * t0;
@@ -191,7 +193,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 
         t1 = t1 * t0;
 
-        v_if(sfpi::abs(val) > 1) { t1 = PI_2 - t1; }
+        v_if(absval_minus_1 > 0.0f) { t1 = PI_2 - t1; }
         v_endif;
 
         result = sfpi::setsgn(t1, val);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -151,42 +151,53 @@ inline void calculate_sfpu_trig() {
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vFloat t0 = sfpi::abs(val);
-    v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
-    v_endif;
+    sfpi::vFloat result = sfpi::vConst0;
 
-    sfpi::vFloat t1 = t0 * t0;
+    // If input is NaN then output must be NaN as well
+    sfpi::vInt exponent = sfpi::exexp_nodebias(val);
+    sfpi::vInt mantissa = sfpi::exman9(val);
+    v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
+    v_else {
+        v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
+        v_endif;
 
-    if constexpr (!is_fp32_dest_acc_en) {
-        // Found using Sollya
-        // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
-        t1 = PolynomialEvaluator::eval(
-            t1,
-            0.999787867069244384765625f,
-            -0.325808584690093994140625f,
-            0.1555790007114410400390625f,
-            -4.4326744973659515380859375e-2f);
-    } else {
-        // Found using Sollya
-        // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
-        t1 = PolynomialEvaluator::eval(
-            t1,
-            sfpi::vConst1,
-            -0.3333314359188079833984375f,
-            0.19993579387664794921875f,
-            -0.14209578931331634521484375f,
-            0.1066047251224517822265625f,
-            -7.5408883392810821533203125e-2f,
-            4.3082617223262786865234375e-2f,
-            -1.62907354533672332763671875e-2f,
-            2.90188402868807315826416015625e-3f);
+        sfpi::vFloat t1 = t0 * t0;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            // Found using Sollya
+            // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
+            t1 = PolynomialEvaluator::eval(
+                t1,
+                0.999787867069244384765625f,
+                -0.325808584690093994140625f,
+                0.1555790007114410400390625f,
+                -4.4326744973659515380859375e-2f);
+        } else {
+            // Found using Sollya
+            // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
+            t1 = PolynomialEvaluator::eval(
+                t1,
+                sfpi::vConst1,
+                -0.3333314359188079833984375f,
+                0.19993579387664794921875f,
+                -0.14209578931331634521484375f,
+                0.1066047251224517822265625f,
+                -7.5408883392810821533203125e-2f,
+                4.3082617223262786865234375e-2f,
+                -1.62907354533672332763671875e-2f,
+                2.90188402868807315826416015625e-3f);
+        }
+
+        t1 = t1 * t0;
+
+        v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
+        v_endif;
+
+        result = sfpi::setsgn(t1, val);
     }
-
-    t1 = t1 * t0;
-
-    v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
     v_endif;
 
-    return sfpi::setsgn(t1, val);
+    return result;
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -148,18 +148,38 @@ inline void calculate_sfpu_trig() {
     }
 }
 
-#define POLYVAL6(coef5, coef4, coef3, coef2, coef1, coef0, t4) \
-    (t4 * (t4 * (t4 * (t4 * (coef5 * t4 + coef4) + coef3) + coef2) + coef1) + coef0)
-
-template <bool APPROXIMATION_MODE>
-sfpi_inline vFloat sfpu_atan_maclaurin_series(vFloat val) {
-    vFloat t0 = sfpi::abs(val);
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
+    sfpi::vFloat t0 = sfpi::abs(val);
     v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
     v_endif;
 
-    vFloat t1 = t0 * t0;
+    sfpi::vFloat t1 = t0 * t0;
 
-    t1 = POLYVAL6(-0.013480470f, 0.057477314f, -0.121239071f, 0.195635925f, -0.332994597f, 0.999995630f, t1);
+    if constexpr (!is_fp32_dest_acc_en) {
+        // Found using Sollya
+        // > fpminimax(atan(x), [|1,3,5,7|], [|single...|], [2^(-40); 1], relative);
+        t1 = PolynomialEvaluator::eval(
+            t1,
+            0.999787867069244384765625f,
+            -0.325808584690093994140625f,
+            0.1555790007114410400390625f,
+            -4.4326744973659515380859375e-2f);
+    } else {
+        // Found using Sollya
+        // > fpminimax(atan(x), [|1,3,5,7,9,11,13,15,17|], [|single...|], [2^(-40); 1], relative);
+        t1 = PolynomialEvaluator::eval(
+            t1,
+            sfpi::vConst1,
+            -0.3333314359188079833984375f,
+            0.19993579387664794921875f,
+            -0.14209578931331634521484375f,
+            0.1066047251224517822265625f,
+            -7.5408883392810821533203125e-2f,
+            4.3082617223262786865234375e-2f,
+            -1.62907354533672332763671875e-2f,
+            2.90188402868807315826416015625e-3f);
+    }
 
     t1 = t1 * t0;
 
@@ -169,11 +189,19 @@ sfpi_inline vFloat sfpu_atan_maclaurin_series(vFloat val) {
     return sfpi::setsgn(t1, val);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atan() {
     for (int d = 0; d < ITERATIONS; d++) {
-        dst_reg[0] = sfpu_atan_maclaurin_series<APPROXIMATION_MODE>(dst_reg[0]);
-        dst_reg++;
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[0] = result;
+
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -9,7 +9,9 @@
 #include "sfpi.h"
 #include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_recip.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_exp.h"
+
 using namespace sfpi;
 
 namespace ckernel::sfpu {
@@ -190,7 +192,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 
         t1 = t1 * t0;
 
-        v_if(sfpi::abs(val) > 1) { t1 = 1.570796327f - t1; }
+        v_if(sfpi::abs(val) > 1) { t1 = PI_2 - t1; }
         v_endif;
 
         result = sfpi::setsgn(t1, val);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -160,7 +160,9 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
     sfpi::vInt mantissa = sfpi::exman9(val);
     v_if(exponent == 255 && mantissa != 0) { result = std::numeric_limits<float>::quiet_NaN(); }
     v_else {
-        v_if(t0 > 1) { t0 = sfpu_reciprocal<false>(t0); }
+        sfpi::vFloat absval_minus_1 = t0 - sfpi::vConst1;
+
+        v_if(absval_minus_1 > 0.0f) { t0 = sfpu_reciprocal<false>(t0); }
         v_endif;
 
         sfpi::vFloat t1 = t0 * t0;
@@ -192,7 +194,7 @@ sfpi_inline sfpi::vFloat sfpu_atan(sfpi::vFloat val) {
 
         t1 = t1 * t0;
 
-        v_if(sfpi::abs(val) > 1) { t1 = PI_2 - t1; }
+        v_if(absval_minus_1 > 0.0f) { t1 = PI_2 - t1; }
         v_endif;
 
         result = sfpi::setsgn(t1, val);

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/trigonometry.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/trigonometry.h
@@ -180,7 +180,9 @@ ALWI void asin_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(asin, true)); }
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void atan_tile(uint32_t idst) { MATH(SFPU_UNARY_NO_PARAM_KERNEL(atan, RC, true, idst)); }
+ALWI void atan_tile(uint32_t idst) {
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8, idst, (int)VectorMode::RC));
+}
 
 /**
  * Please refer to documentation for any_init.


### PR DESCRIPTION
### Ticket
#33751

### Problem description
Accuracy of ttnn.atan2 (and ttnn.atan)

### What's changed
This PR improves the accuracy of `ttnn.atan` (and as a result, atan2) for both bfloat16 and float32

- Improve accuracy of atan (including special value handling)
- Add stricter ULP tests for fp32 atan
- Add utility functions to `utils_for_testing.py`: so far, these are only called from `test_atan_fp32()`, but other ULP tests re-implement this features (which is why we may as well put this in one place).

#### Accuracy evaluation 

##### atan 

| DType | Branch | Max ULP Error |
| - | - | - |  
| bfloat16 | main | 1 | 
| bfloat16 | this | ~0.5 | 
| float32 | main | 70 | 
| float32 | this | 2.5 | 


__bfloat16__

<img width="686" height="378" alt="atan-accurate-bfloat16" src="https://github.com/user-attachments/assets/d76ccef9-db15-4a09-b34a-2a302a891bf0" />


__float32__


<img width="567" height="378" alt="atan-accurate-float32" src="https://github.com/user-attachments/assets/25ba1a80-96cd-4bd8-8fc5-1d64e3e8809f" />

<img width="540" height="378" alt="atan-accurate-zoom-float32" src="https://github.com/user-attachments/assets/6f046574-9a6e-4832-9bbb-e3d168c0959a" />

##### atan2

__bfloat16__

Error is comparable to before, as it was likely not coming from atan but likely quantization errors in intermediate results. 

<img width="373" height="241" alt="atan2 bfloat16" src="https://github.com/user-attachments/assets/c503ea30-4265-41c6-9404-0ec833fda421" />
<img width="373" height="241" alt="atan2-new bfloat16" src="https://github.com/user-attachments/assets/b549a79f-1405-4b7a-a324-8137a87e5c8d" />


__float32__

While there are errors spikes near infinity, ULP of atan2 improves significantly:

<img width="373" height="241" alt="atan2 float32" src="https://github.com/user-attachments/assets/8735ec8c-d9af-4a56-bdfa-68a9ab77caf9" />
<img width="373" height="241" alt="atan2-new float32" src="https://github.com/user-attachments/assets/bbb35e8b-5472-4d54-be6c-90f33f24119a" />

As can be seen on the following heat map (x-axis = x value, y-axis = y value), most 'high ULPs' are from extreme values. (darker is better; yellow = infinite/NaN output).

<img width="286" height="238" alt="atan2 float32" src="https://github.com/user-attachments/assets/a182d6c2-297a-4eac-98e3-8d943ac6c439" />
<img width="286" height="238" alt="atan2-new float32" src="https://github.com/user-attachments/assets/990fc897-91f1-463d-a6bd-381610fe2007" />


Notes:
- atan2 is a composite operations, and suffers from quantization errors when using bfloat16. A further improvement would be to fuse it. 

#### Performance evaluation

##### atan

The execution of atan increases by a factor of at most 1.3 compared to before. 

On wormhole: 

Type | Branch | Cycles/Datum | Cycles/Tile
-- | -- | -- | --
bfloat16 | main | 1.97 |  2018  
bfloat16 | new |  2.19 |  2242
float32 | main | 2.08 | 2132
float32 | new | 2.73 | 2794

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/accurate-fp32-atan)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/accurate-fp32-atan)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/accurate-fp32-atan)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/accurate-fp32-atan)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))  [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20828840270) and [OK](https://github.com/tenstorrent/tt-metal/actions/runs/20828842896)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/accurate-fp32-atan)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/accurate-fp32-atan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/accurate-fp32-atan)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml)) (fails on main)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs