### PR TITLE
Add 6u cyclic multiprocess tests to CI

### DIFF
--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -38,6 +38,7 @@ jobs:
           { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          { name: "Galaxy Multi-Process tests", arch: wormhole_b0, cmd: "python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py && tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args \"--allow-run-as-root --tag-output\" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml", timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           # {
           #   name: "Llama Galaxy Accuracy Test",
           #   arch: wormhole_b0,

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -38,7 +38,6 @@ jobs:
           { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
           { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
-          { name: "Galaxy Multi-Process tests", arch: wormhole_b0, cmd: "python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py && tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args \"--allow-run-as-root --tag-output\" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml", timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
           # {
           #   name: "Llama Galaxy Accuracy Test",
           #   arch: wormhole_b0,

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -198,6 +198,9 @@ jobs:
           tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--tag-output --allow-run-as-root"  python3 tests/ttnn/distributed/test_multi_mesh.py
           tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_mesh_rank_binding.yaml ./build/test/tt_metal/multi_host_socket_tests
           tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml  ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter="*Socket*"
+          tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_acyclic.yaml
+          tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_wh_6u_quad_2x4_cyclic.yaml
+          tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root --tag-output" ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml
       - name: Run Llama3-70b unit tests
         if: ${{ matrix.test-group.model == 'llama3-70b' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -105,6 +105,13 @@ def generate_supported_rank_bindings():
         2: [3],
         3: [4],
     }
+    # Process Rank ID To Tray ID Mapping for 2x4 cyclic mesh configuration
+    WH_GLX_2X4_CYCLIC_RANK_TO_TRAY_MAPPING = {
+        0: [1],
+        1: [3],
+        2: [4],
+        3: [2],
+    }
 
     # Rank bindings for Dual Mesh Setup (1 process per mesh)
     DUAL_MESH_RANK_BINDINGS = [
@@ -167,6 +174,29 @@ def generate_supported_rank_bindings():
         },
     ]
 
+    CYCLIC_MESH_RANK_BINDINGS = [
+        {
+            "rank": 0,
+            "mesh_id": 0,
+            "mesh_host_rank": 0,
+        },
+        {
+            "rank": 1,
+            "mesh_id": 1,
+            "mesh_host_rank": 0,
+        },
+        {
+            "rank": 2,
+            "mesh_id": 2,
+            "mesh_host_rank": 0,
+        },
+        {
+            "rank": 3,
+            "mesh_id": 3,
+            "mesh_host_rank": 0,
+        },
+    ]
+
     mapping_file = "tray_to_pcie_device_mapping.yaml"
     generate_tray_to_pcie_device_mapping(mapping_file)
     with open(mapping_file, "r") as f:
@@ -193,6 +223,13 @@ def generate_supported_rank_bindings():
         WH_GLX_QUAD_RANK_TO_TRAY_MAPPING,
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x2_multi_mesh.textproto",
         "4x2_multi_mesh_rank_binding.yaml",
+    )
+    generate_rank_binding_yaml(
+        tray_to_pcie_device_mapping,
+        CYCLIC_MESH_RANK_BINDINGS,
+        WH_GLX_2X4_CYCLIC_RANK_TO_TRAY_MAPPING,
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto",
+        "2x4_multi_mesh_cyclic_rank_binding.yaml",
     )
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml
@@ -14,4 +14,4 @@ Tests:
       num_packets: 10000
 
     patterns:
-      - type: sequential_all_to_all
+      - type: all_to_all


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35462)

### Problem description
Needed to add these tests to a CI pipeline to test handling of multi-mesh cyclic traffic

### What's changed
Added tests to the multiprocess suite in galaxy-unit-tests.yaml

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/add-6u-fabric-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/add-6u-fabric-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs