### PR TITLE
[skip ci] Optimize clang-tidy presets: disable tt-train and switch to Debug config

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,7 +27,8 @@
           "CMAKE_CXX_CLANG_TIDY": {"value": "clang-tidy-20;--warnings-as-errors=*"},
           "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {"value": "TRUE"},
           "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"},
-          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"}
+          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"},
+          "BUILD_TT_TRAIN": {"value": "OFF"}
         }
       },
       {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -112,7 +112,7 @@
       {
         "name": "clang-tidy",
         "configurePreset": "clang-tidy",
-        "configuration": "RelWithDebInfo",
+        "configuration": "Debug",
         "targets": ["all", "all_verify_interface_header_sets"],
         "nativeToolOptions": ["-k0"]
       },


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The clang-tidy presets were building tt-train unnecessarily and using `RelWithDebInfo` configuration, both of which add compilation time without providing benefit for static analysis.

### What's changed
1. Added `BUILD_TT_TRAIN: OFF` to the `clang-tidy` configure preset. Since `clang-tidy-fix` and `clang-tidy-fix-parallel` both inherit from `clang-tidy`, this change applies to all clang-tidy related presets.

2. Changed the `clang-tidy` build preset configuration from `RelWithDebInfo` to `Debug` for faster compilation during static analysis runs.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-remove-train-clang-tidy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-remove-train-clang-tidy)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-remove-train-clang-tidy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-remove-train-clang-tidy)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-remove-train-clang-tidy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-remove-train-clang-tidy)
- [x] New/Existing tests provide coverage for changes
metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)