### PR TITLE
Fix swapped BASE_DIRS in kernel_helper_functions CMakeLists.txt

### DIFF
--- a/ttnn/cpp/ttnn/operations/kernel_helper_functions/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/kernel_helper_functions/CMakeLists.txt
@@ -13,11 +13,11 @@ target_sources(
     INTERFACE
         FILE_SET api
         TYPE HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        BASE_DIRS ${FixmeOpAPIDir}
         FILES # None (yet)
         FILE_SET kernels
         TYPE HEADERS
-        BASE_DIRS ${FixmeOpAPIDir}
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES pad_tile.hpp
 )
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33290

### Problem description

When testing with installed Debian packages, the `TTNNFixtureWithDevice.TestGenericOpMatmul` test was failing because kernel JIT compilation couldn't find `pad_tile.hpp`:

```
fatal error: ttnn/operations/kernel_helper_functions/pad_tile.hpp: No such file or directory
```

Investigation of the Debian package contents revealed that `pad_tile.hpp` was being installed to an incorrect doubled path:
```
/usr/libexec/tt-metalium/ttnn/cpp/ttnn/operations/kernel_helper_functions/ttnn/operations/kernel_helper_functions/pad_tile.hpp
```

Instead of the expected:
```
/usr/libexec/tt-metalium/ttnn/cpp/ttnn/operations/kernel_helper_functions/pad_tile.hpp
```

### What's changed

The root cause was a typo in `ttnn/cpp/ttnn/operations/kernel_helper_functions/CMakeLists.txt` where the `BASE_DIRS` values for `FILE_SET api` and `FILE_SET kernels` were swapped compared to all other operations:

**Before (incorrect):**
```cmake
FILE_SET api     -> BASE_DIRS \${CMAKE_CURRENT_SOURCE_DIR}
FILE_SET kernels -> BASE_DIRS \${FixmeOpAPIDir}
```

**After (correct, matching other operations):**
```cmake
FILE_SET api     -> BASE_DIRS \${FixmeOpAPIDir}
FILE_SET kernels -> BASE_DIRS \${CMAKE_CURRENT_SOURCE_DIR}
```

This fix ensures `pad_tile.hpp` is installed to the correct location, allowing kernels to find it via:
```cpp
#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
```

**Note:** After this fix is verified, follow-up work can remove the workarounds that were added:
- Remove duplicate `pad_tile.hpp` in `matmul/device/kernels/dataflow/`
- Change relative includes back to absolute includes

### Checklist

- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/20829951888)
- [x] New/Existing tests provide coverage for changes (existing Merge Gate tests should pass with this fix)