### PR TITLE
[skip ci] update merge gate alerts

### DIFF
--- a/.github/actions/slack-report-merge-gate-main/action.yaml
+++ b/.github/actions/slack-report-merge-gate-main/action.yaml
@@ -2,7 +2,7 @@ name: "Report Workflow Status to Slack"
 description: "Report the workflow status to Slack to help identify breakages faster."
 inputs:
   owner:
-    description: "The Slack ID of the person to be tagged."
+    description: "The Slack ID of the person or group to be tagged (user IDs start with U, group IDs start with S)."
     default: "U014XCQ9CF8" # @Raymond Kim
   slack_webhook_url:
     description: "Webhook URL for the Slack channel to be posted to. Generated via slack app!"
@@ -13,7 +13,22 @@ runs:
     - name: Format Slack User Mentions
       id: format_mentions
       run: |
-        MENTIONS=$(echo "<@${{ inputs.owner }}>" | sed 's/,/> <@/g')
+        # Split comma-separated IDs and format each appropriately
+        # User IDs (U...) use <@U...>, Group IDs (S...) use <!subteam^S...>
+        MENTIONS=""
+        IFS=',' read -ra IDS <<< "${{ inputs.owner }}"
+        for ID in "${IDS[@]}"; do
+          ID=$(echo "$ID" | xargs)  # trim whitespace
+          [[ -z "$ID" ]] && continue  # skip empty IDs
+          if [[ "$ID" =~ ^S ]]; then
+            # Group/subteam ID
+            MENTIONS="${MENTIONS}<!subteam^${ID}> "
+          else
+            # User ID
+            MENTIONS="${MENTIONS}<@${ID}> "
+          fi
+        done
+        MENTIONS=$(echo "$MENTIONS" | sed 's/[[:space:]]*$//')  # trim trailing space
         echo "mentions=$MENTIONS" >> $GITHUB_OUTPUT
       shell: bash
     - name: Report Github Pipeline Status Slack Action

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -401,4 +401,4 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/slack-report-merge-gate-main@main
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_WEBHOOK_URL }}
-          owner: "U08GTDV8MDH,U0908S3LUMD,U0982FCD80N,U08VC9954CE,U08TVGQGGAE,U08LG51QALX,U08DEGUJY3H,U08BNDNLUCD,U084DCKE0B0,U0883RN6CRE,U088NCP32NP,U07J3K6KS1K,U07HTBQPHFG,U085LTYEC00,U014XCQ9CF8"
+          owner: "S0985AN7TC5"


### PR DESCRIPTION
change merge gate slack alerts to ping @metalinfra instead of all of us hardcoded individually when merge gate fails on main. This way we don't have to change it whenever someone new gets added to our team.

### What's changed
changed how slack IDs are parsed and switched from hardcoded slack IDs to just hardcoding the metalinfra group slack id.