### PR TITLE
Add owners of vLLM integration tech report

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -400,3 +400,6 @@ tt_telemetry/docker/ @btrzynadlowski-tt @kluongTT @tenstorrent/codeowner-bypass 
 
 # .clang-tidy files - Metalium infra team owns all clang-tidy configuration files
 **/.clang-tidy @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+
+# Tech reports
+tech_reports/LLMs/vLLM_integration.md @skhorasganiTT @viktorpusTT @tenstorrent/codeowner-bypass


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- We had no owners for the vllm integration tech report (or any tech reports for that matter)

### What's changed
- Added owners of vllm integration tech report