### PR TITLE
Fix models/common/tests CI failure

### DIFF
--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -39,7 +39,7 @@ jobs:
           {
             name: "models_common_unit_tests",
             arch: wormhole_b0,
-            cmd: pytest --tb=short models/common/tests,
+            cmd: pytest --tb=short --ignore=models/common/tests/test_sampling.py models/common/tests && pytest --tb=short models/common/tests/test_sampling.py,
             timeout: 5,
             owner_id: U07RY6B5FLJ,  #Gongyu Wang
           },

--- a/conftest.py
+++ b/conftest.py
@@ -722,7 +722,12 @@ def reset_default_device(request):
     if "no_reset_default_device" in request.keywords:
         yield
         return
-    device = ttnn.GetDefaultDevice()
+
+    try:
+        device = ttnn.GetDefaultDevice()
+    except:
+        logger.warning("Device handle is stale/crashed - setting saved device to None")
+        device = None
 
     yield
 

--- a/conftest.py
+++ b/conftest.py
@@ -725,7 +725,7 @@ def reset_default_device(request):
 
     try:
         device = ttnn.GetDefaultDevice()
-    except:
+    except Exception:
         logger.warning("Device handle is stale/crashed - setting saved device to None")
         device = None
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Example of failed CI: https://github.com/tenstorrent/tt-metal/actions/runs/20796515672/job/59733839080

The root cause is incompatible ways of constructing devices-under-test between TTTv2 and tt-metal. We can look for a proper fix in the future (after https://github.com/tenstorrent/tt-metal/pull/35095 is merged, which updates the way TTTv2 gets devices-under-test). For now, I aim to find a workaround.

### What's changed
Separately run tttv2 unit tests and rest of the tests in models/common/tests/ for now, such that the devices-under-test do not collide.

### Checklist

- [x] T3K nightly: https://github.com/tenstorrent/tt-metal/actions/runs/20832379379