### PR TITLE
Cleanup dispatch_core_common.hpp

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -16,7 +16,7 @@
 #include "compile_program_with_kernel_path_env_var_fixture.hpp"
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/dispatch_core_common.hpp>
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "mesh_dispatch_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "gtest/gtest.h"

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -66,7 +66,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
         auto& program_ = workload.get_programs().at(device_range);
 
         const auto& dispatch_core_config = get_dispatch_core_config();
-        CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+        CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
         std::vector<CoreCoord> dispatch_cores =
             tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_config);
         std::set<CoreRange> dispatch_core_ranges;

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -53,10 +53,6 @@ public:
     bool operator==(const DispatchCoreConfig& other) const { return (type_ == other.type_) && (axis_ == other.axis_); }
 };
 
-// Helper functions to get the dispatch core config/type
-DispatchCoreConfig get_dispatch_core_config();
-CoreType get_dispatch_core_type();
-
 }  // namespace tt::tt_metal
 
 namespace std {

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -9,8 +9,6 @@
 #include <tt-metalium/data_types.hpp>
 #include <tt_stl/reflection.hpp>
 
-#include <umd/device/types/core_coordinates.hpp>  // CoreType
-
 namespace tt::tt_metal {
 
 enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
@@ -34,14 +32,6 @@ public:
     static constexpr auto attribute_names = std::forward_as_tuple("type", "axis");
     auto attribute_values() const { return std::forward_as_tuple(this->type_, this->axis_); }
 
-    CoreType get_core_type() const {
-        switch (type_) {
-            case DispatchCoreType::WORKER: return CoreType::WORKER;
-            case DispatchCoreType::ETH: return CoreType::ETH;
-            default: TT_THROW("invalid dispatch core type");
-        }
-    }
-
     DispatchCoreType get_dispatch_core_type() const { return type_; }
 
     void set_dispatch_core_type(DispatchCoreType new_type) { type_ = new_type; }
@@ -50,7 +40,7 @@ public:
 
     void set_dispatch_core_axis(DispatchCoreAxis new_axis) { axis_ = new_axis; }
 
-    bool operator==(const DispatchCoreConfig& other) const { return (type_ == other.type_) && (axis_ == other.axis_); }
+    bool operator==(const DispatchCoreConfig& other) const = default;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -13,21 +13,6 @@
 
 namespace tt::tt_metal {
 
-enum DispatchWorkerType : uint32_t {
-    PREFETCH = 0,
-    PREFETCH_HD = 1,
-    PREFETCH_H = 2,
-    PREFETCH_D = 3,
-    DISPATCH = 4,
-    DISPATCH_HD = 5,
-    DISPATCH_H = 6,
-    DISPATCH_D = 7,
-    DISPATCH_S = 8,
-    FABRIC_MUX = 17,         // Downstream from MMIO to remote mux. Tunnel index is required.
-    RETURN_FABRIC_MUX = 18,  // Upstream from remote to MMIO mux. Tunnel index will be determined from the device id.
-    COUNT,
-};
-
 enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
 
 enum class DispatchCoreAxis { ROW, COL, COUNT };

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -24,7 +24,7 @@
 #include "buffer_types.hpp"
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
-#include "dispatch_core_common.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
@@ -226,7 +226,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     auto mesh_device_id = mesh_device_->id();
     auto& sysmem_manager = this->reference_sysmem_manager();
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     if (!sysmem_manager.get_bypass_mode()) {
         auto& sub_device_cq_owner = cq_shared_state_->sub_device_cq_owner;
         auto& sub_device = sub_device_cq_owner[*sub_device_id];
@@ -914,7 +914,7 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     std::unordered_set<uint32_t>& chip_ids_in_workload,
     uint32_t program_runtime_id) {
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
         auto device = mesh_device_->get_device(coord);
         this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
@@ -954,7 +954,7 @@ void FDMeshCommandQueue::capture_program_trace_on_subgrid(
     bool stall_before_program,
     uint32_t program_runtime_id) {
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
 
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled()) {
         // Host Memory Intensive Path (when profiler is enabled): The launch messages across devices are unique, since

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -38,6 +38,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 
 namespace tt::tt_metal {
 class Program;
@@ -890,8 +891,8 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     size_t num_sender_channels = config.num_used_sender_channels;
     size_t num_receiver_channels = config.num_used_receiver_channels;
 
-    auto dispatch_core_type =
-        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config().get_core_type();
+    auto dispatch_core_type = get_core_type_from_config(
+        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config());
     uint32_t my_eth_channel_ = [&]() -> uint32_t {
         if (dispatch_core_type == CoreType::WORKER) {
             return this->my_eth_channel;

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -27,6 +27,7 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_metal {
@@ -178,7 +179,7 @@ AllocatorConfig L1BankingAllocator::generate_config(
     const auto& hal = MetalContext::instance().hal();
     const metal_SocDescriptor& soc_desc = cluster.get_soc_desc(device_id);
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     // Construct allocator config from soc_desc
     // Take max alignment to satisfy NoC rd/wr constraints
     // Tensix/Eth -> PCIe/DRAM src and dst addrs must be L1_ALIGNMENT aligned

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -28,6 +28,7 @@
 #include "debug/noc_logging.hpp"
 #include "debug/watcher_server.hpp"
 #include "dispatch/topology.hpp"
+#include "dispatch/dispatch_core_common.hpp"
 #include "profiler/profiler_state_manager.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "llrt/get_platform_architecture.hpp"
@@ -540,7 +541,7 @@ DispatchQueryManager& MetalContext::get_dispatch_query_manager() {
 }
 
 const DispatchMemMap& MetalContext::dispatch_mem_map() const {
-    return dispatch_mem_map(dispatch_core_config_.get_core_type());
+    return dispatch_mem_map(get_core_type_from_config(dispatch_core_config_));
 }
 
 const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) const {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -10,6 +10,7 @@
 #include "llrt/core_descriptor.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "llrt.hpp"
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <llrt/tt_cluster.hpp>
@@ -57,7 +58,7 @@ inline static CoreDescriptorSet GetAllCores(ChipId device_id) {
     unsigned num_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
     const auto& dispatch_core_config =
         tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     log_debug(tt::LogAlways, "Dispatch Core Type = {}", dispatch_core_type);
     for (auto logical_core : tt::get_logical_dispatch_cores(device_id, num_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include "impl/program/program_impl.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "mesh_coord.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/debug/inspector/types.hpp
+++ b/tt_metal/impl/debug/inspector/types.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "impl/program/program_impl.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 
 namespace tt::tt_metal {
     class Inspector;

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -20,6 +20,14 @@ DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
     return DispatchCoreAxis::ROW;
 }
 
+CoreType get_core_type_from_config(const DispatchCoreConfig& config) {
+    switch (config.get_dispatch_core_type()) {
+        case DispatchCoreType::WORKER: return CoreType::WORKER;
+        case DispatchCoreType::ETH: return CoreType::ETH;
+        default: TT_THROW("invalid dispatch core type");
+    }
+}
+
 DispatchCoreConfig get_dispatch_core_config() {
     return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
 }

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dispatch_core_common.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -23,9 +23,5 @@ DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
 DispatchCoreConfig get_dispatch_core_config() {
     return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
 }
-
-CoreType get_dispatch_core_type() {
-    return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-};
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include <tt-metalium/dispatch_core_common.hpp>
+
+namespace tt::tt_metal {
+
+enum DispatchWorkerType : uint32_t {
+    PREFETCH = 0,
+    PREFETCH_HD = 1,
+    PREFETCH_H = 2,
+    PREFETCH_D = 3,
+    DISPATCH = 4,
+    DISPATCH_HD = 5,
+    DISPATCH_H = 6,
+    DISPATCH_D = 7,
+    DISPATCH_S = 8,
+    FABRIC_MUX = 17,         // Downstream from MMIO to remote mux. Tunnel index is required.
+    RETURN_FABRIC_MUX = 18,  // Upstream from remote to MMIO mux. Tunnel index will be determined from the device id.
+    COUNT,
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include <tt-metalium/dispatch_core_common.hpp>
+#include <umd/device/types/core_coordinates.hpp>  // CoreType
 
 namespace tt::tt_metal {
 
@@ -24,6 +25,8 @@ enum DispatchWorkerType : uint32_t {
     RETURN_FABRIC_MUX = 18,  // Upstream from remote to MMIO mux. Tunnel index will be determined from the device id.
     COUNT,
 };
+
+CoreType get_core_type_from_config(const DispatchCoreConfig& config);
 
 // Helper functions to get the dispatch core config/type
 DispatchCoreConfig get_dispatch_core_config();

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -25,4 +25,7 @@ enum DispatchWorkerType : uint32_t {
     COUNT,
 };
 
+// Helper functions to get the dispatch core config/type
+DispatchCoreConfig get_dispatch_core_config();
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -12,7 +12,7 @@
 #include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
 #include "core_descriptor.hpp"
-#include "dispatch_core_common.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
@@ -167,7 +167,9 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(ChipId device_id, ui
     return assignment.dispatcher_s.value();
 }
 
-CoreType dispatch_core_manager::get_dispatch_core_type() { return this->dispatch_core_config_.get_core_type(); }
+CoreType dispatch_core_manager::get_dispatch_core_type() {
+    return get_core_type_from_config(this->dispatch_core_config_);
+}
 
 DispatchCoreConfig dispatch_core_manager::get_dispatch_core_config() { return this->dispatch_core_config_; }
 
@@ -206,7 +208,7 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         // When running Multiple CQs using Ethernet Dispatch, we may need more dispatch cores than those allocated in
         // the core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
         // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
-        if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+        if (get_core_type_from_config(dispatch_core_config) == CoreType::ETH) {
             for (const auto& idle_eth_core :
                  tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(device_id)) {
                 add_dispatch_core_to_device(device_id, idle_eth_core);

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -17,7 +17,7 @@
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dispatch_core_common.hpp"
+#include "dispatch/dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "hal_types.hpp"
 #include "prefetch.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -14,6 +14,7 @@
 #include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <tt_stl/tt_stl/reflection.hpp>

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <device.hpp>
-#include <stdint.h>
 #include <memory>
 #include <set>
 #include <vector>
@@ -14,6 +13,7 @@
 #include "data_types.hpp"
 #include "tt-metalium/program.hpp"
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -16,7 +16,7 @@
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/command_queue_common.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dispatch_core_common.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/strong_type.hpp>
@@ -84,7 +84,7 @@ void issue_record_event_commands(
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
 
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         auto offset_index = *sub_device_ids[i];

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -26,6 +26,7 @@
 #include <tt_stl/assert.hpp>
 #include "dispatch/hardware_command_queue.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include "profiler_analysis.hpp"
 #include "hal_types.hpp"
 #include "hostdevcommon/profiler_common.h"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -353,7 +353,7 @@ bool doAllDispatchCoresComeAfterNonDispatchCores(const IDevice* device, const st
     std::vector<CoreCoord> virtual_dispatch_cores;
     for (const CoreCoord& core : logical_dispatch_cores) {
         const CoreCoord virtual_dispatch_core =
-            device->virtual_core_from_logical_core(core, dispatch_core_config.get_core_type());
+            device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config));
         virtual_dispatch_cores.push_back(virtual_dispatch_core);
     }
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <core_descriptor.hpp>
 #include <device.hpp>
-#include <dispatch_core_common.hpp>
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include <host_api.hpp>
 #include <profiler.hpp>
 #include <mesh_workload.hpp>

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -59,7 +59,6 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
-#include "impl/dispatch/dispatch_core_common.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -59,6 +59,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "impl/dispatch/dispatch_core_common.hpp"
 
 #if !defined(TRACY_ENABLE) && defined(__clang__)
 #pragma clang diagnostic push
@@ -775,7 +776,7 @@ bool areAllCoresDispatchCores(IDevice* device, const std::vector<CoreCoord>& vir
     std::vector<CoreCoord> dispatch_cores;
     for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
         const CoreCoord virtual_dispatch_core =
-            device->virtual_core_from_logical_core(core, dispatch_core_config.get_core_type());
+            device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config));
         dispatch_cores.push_back(virtual_dispatch_core);
     }
 
@@ -973,7 +974,7 @@ std::vector<CoreCoord> getVirtualCoresForProfiling(const IDevice* device, const 
         for (const CoreCoord& core :
              tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_config)) {
             const CoreCoord curr_core =
-                device->virtual_core_from_logical_core(core, dispatch_core_config.get_core_type());
+                device->virtual_core_from_logical_core(core, get_core_type_from_config(dispatch_core_config));
             virtual_cores.push_back(curr_core);
         }
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -40,6 +40,7 @@
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "dispatch/dispatch_core_common.hpp"
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "math.hpp"
@@ -1743,7 +1744,7 @@ void assemble_device_commands(
     bool use_prefetcher_cache) {
     CommandConstants constants{};
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    constants.dispatch_core_type = dispatch_core_config.get_core_type();
+    constants.dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     constants.noc_index = k_dispatch_downstream_noc;
     constants.max_prefetch_command_size =
         MetalContext::instance().dispatch_mem_map(constants.dispatch_core_type).max_prefetch_command_size();
@@ -2657,7 +2658,7 @@ void set_core_go_message_mapping_on_device(
     std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds;
     std::vector<std::pair<uint32_t, uint32_t>> payload;
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    auto dispatch_core_type = dispatch_core_config.get_core_type();
+    auto dispatch_core_type = get_core_type_from_config(dispatch_core_config);
     uint32_t noc_index = k_dispatch_downstream_noc;
     uint32_t max_prefetch_command_size =
         MetalContext::instance().dispatch_mem_map(dispatch_core_type).max_prefetch_command_size();

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -69,6 +69,7 @@
 #include "tt_metal/impl/debug/inspector/inspector.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
@@ -115,7 +116,7 @@ void validate_kernel_placement(bool force_slow_dispatch, std::shared_ptr<Kernel>
     bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
 
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    tt::CoreType dispatch_core_type = dispatch_core_config.get_core_type();
+    tt::CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
 
     // Kernels used to implement fast dispatch can be placed on dispatch cores
     if (not slow_dispatch and not force_slow_dispatch) {

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -295,7 +295,7 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
     // Get logical compute grid dimensions and num workers
     static std::unordered_map<uint32_t, std::tuple<uint32_t, CoreRange>> physical_grid_config_cache = {};
     // Unique hash generated based on the config that's being queried
-    uint32_t config_hash = ((uint8_t)(dispatch_core_config.get_core_type())) |
+    uint32_t config_hash = ((uint8_t)(get_core_type_from_config(dispatch_core_config))) |
                            ((uint8_t)(dispatch_core_config.get_dispatch_core_axis()) << 4) | (num_hw_cqs << 8) |
                            (device_id << 16);
     if (!physical_grid_config_cache.contains(config_hash)) {

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -21,6 +21,7 @@
 #include "metal_soc_descriptor.h"
 #include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/dispatch/dispatch_core_common.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/simulation/simulation_chip.hpp>
@@ -73,12 +74,13 @@ inline std::string get_core_descriptor_file(
             tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
         bool use_fabric_tensix = (fabric_tensix_config != tt_fabric::FabricTensixConfig::DISABLED);
 
+        auto core_type = get_core_type_from_config(dispatch_core_config);
         switch (arch) {
             default:
                 throw std::runtime_error(
                     "Invalid arch not supported");  // will be overwritten in tt_global_state constructor
             case tt::ARCH::WORMHOLE_B0:
-                if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+                if (core_type == CoreType::ETH) {
                     return core_desc_dir + "wormhole_b0_80_arch_eth_dispatch.yaml";
                 } else if (use_fabric_tensix) {
                     return core_desc_dir + "wormhole_b0_80_arch_fabric_mux.yaml";
@@ -86,7 +88,7 @@ inline std::string get_core_descriptor_file(
                     return core_desc_dir + "wormhole_b0_80_arch.yaml";
                 }
             case tt::ARCH::BLACKHOLE:
-                if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+                if (core_type == CoreType::ETH) {
                     return core_desc_dir + "blackhole_140_arch_eth_dispatch.yaml";
                 } else if (use_fabric_tensix) {
                     return core_desc_dir + "blackhole_140_arch_fabric_mux.yaml";
@@ -220,7 +222,7 @@ const core_descriptor_t& get_core_descriptor_config(
         if (core_node.IsSequence()) {
             // Logical coord
             coord = RelativeCoreCoord({.x = core_node[0].as<int>(), .y = core_node[1].as<int>()});
-            if (dispatch_core_config.get_core_type() == CoreType::ETH) {
+            if (get_core_type_from_config(dispatch_core_config) == CoreType::ETH) {
                 auto logical_coord = get_core_coord_from_relative(coord, grid_size);
                 if (logical_active_eth_cores.contains(logical_coord)) {
                     continue;


### PR DESCRIPTION
### Ticket
Close #31869
Contributes to: #15632

### Problem description
Runtime is reducing their host API surface area, there are constructs in `dispatch_core_common.hpp` that are identified to be internal API.
Meanwhile, a parallel effort exist to reduce umd header leaking from API headers.

### What's changed
Moves internally these structs and functions into a Runtime internal header:
- `DispatchWorkerType`
- `get_core_type_from_config`

Detach out `get_core_type` member function from `DispatchCoreConfig` as a free function,
and renamed it to `get_core_type_from_config`.
which it's return type (`CoreType`) leads to need to leak umd header to our consumer.

All use sites (includes and function calls) are updated.

### Why not pimpl-ify `DispatchCoreConfig`
This is done instead of pimpl-ify the config class as the class is a simple data class with the single `get_core_type` exception.

### Note

Do we want to expose the ability to customize dispatch core?

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=riverwu/rm_dispatch_core_common)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:riverwu/rm_dispatch_core_common)