### PR TITLE
32 Bit Indexing Support for MPWI

### DIFF
--- a/tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_with_indices_common.py
@@ -15,6 +15,7 @@ def validate_indices(input_tensor, torch_indices, ttnn_indices, kernel_size, str
     """
     Validate indices using logic from test_mpwi.py
     Note input tensors should be in [N, H, W, C] format
+    Supports both uint16 and uint32 index tensors (indices should be converted to int64 before calling)
     Returns (indices_valid, tie_breaking_differences, actual_errors, value_differences, window_violations)
     """
     batch_size, input_h, input_w, channels = input_tensor.shape
@@ -215,10 +216,18 @@ def run_max_pool2d_with_indices(
         )
 
     ttnn_output_torch = ttnn.to_torch(ttnn_output)
-    # convert indexes to int64 for compatability with torch
+
+    # convert indexes to int64 for compatibility with torch
     ttnn_indices_torch = ttnn.to_torch(ttnn_indices, dtype=torch.int64)
-    # manually fix the wrapping since TTNN uint16 tensors get converted to int16 torch tensors, even when data type is specified as int64
-    ttnn_indices_torch = torch.where(ttnn_indices_torch < 0, ttnn_indices_torch + 65536, ttnn_indices_torch)
+
+    # manually fix the wrapping since TTNN uint16/uint32 tensors get converted to int16/int32 torch tensors
+    # even when data type is specified as int64
+    if ttnn_indices.dtype == ttnn.uint16:
+        # uint16: wraps at 65536 (2^16)
+        ttnn_indices_torch = torch.where(ttnn_indices_torch < 0, ttnn_indices_torch + 65536, ttnn_indices_torch)
+    elif ttnn_indices.dtype == ttnn.uint32:
+        # uint32: wraps at 4294967296 (2^32)
+        ttnn_indices_torch = torch.where(ttnn_indices_torch < 0, ttnn_indices_torch + 4294967296, ttnn_indices_torch)
 
     torch_output, torch_indices = torch.nn.functional.max_pool2d(
         torch_input,

--- a/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
@@ -82,9 +82,9 @@ def test_mpwi_20_core_C_dims(device, in_c):
         [4, 64, 30, 40, 4, 8, 1, 1, 2, 4, 1, 1, False],
     ],
 )
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @skip_with_watcher("Test is not passing with watcher enabled github issue #37195")
-def test_mpwi_kernel_sizes(device, ttnn_dtype, input_spec):
+def test_mpwi_small_kernel_sizes(device, ttnn_dtype, input_spec):
     (
         in_n,
         in_c,
@@ -129,11 +129,6 @@ def test_mpwi_kernel_sizes(device, ttnn_dtype, input_spec):
     [
         # Contains following parameters
         # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
-        # DILATION / MULTI-BATCH CASES
-        [2, 40, 100, 100, 3, 3, 2, 2, 0, 1, 2, 2, True],
-        [3, 56, 85, 85, 3, 3, 3, 3, 1, 0, 2, 2, False],
-        [4, 24, 56, 64, 3, 3, 2, 1, 1, 1, 3, 2, True],
-        # LARGE KERNEL CASES
         [2, 64, 159, 159, 13, 13, 2, 2, 6, 6, 2, 2, True],
         [2, 40, 100, 100, 9, 9, 2, 2, 0, 1, 2, 2, True],
         [3, 56, 85, 85, 8, 8, 3, 3, 1, 0, 2, 2, False],
@@ -146,7 +141,7 @@ def test_mpwi_kernel_sizes(device, ttnn_dtype, input_spec):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @skip_with_watcher("Test is not passing with watcher enabled github issue #37195")
-def test_mpwi_general(device, ttnn_dtype, input_spec):
+def test_mpwi_large_kernel_sizes(device, ttnn_dtype, input_spec):
     (
         in_n,
         in_c,
@@ -198,21 +193,28 @@ def test_mpwi_general(device, ttnn_dtype, input_spec):
     )
 
 
-@pytest.mark.skip(reason="DRAM slicing with return_indices is not yet supported")
 @pytest.mark.parametrize(
     "input_spec",
     [
         # Contains following parameters
-        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode, num_slices]
-        # DILATION / MULTI-BATCH CASES
-        [2, 40, 1024, 1024, 3, 3, 2, 2, 0, 1, 2, 2, True, 8],
-        [3, 56, 512, 512, 3, 3, 3, 3, 1, 0, 2, 2, False, 8],
-        [4, 24, 768, 768, 3, 3, 2, 1, 1, 1, 3, 2, True, 8],
+        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
+        [3, 16, 80, 80, 9, 9, 3, 3, 3, 1, 2, 2, True],
+        [2, 48, 60, 60, 6, 6, 2, 2, 2, 0, 2, 2, False],
+        [4, 56, 65, 55, 5, 5, 1, 2, 1, 1, 1, 2, False],
+        [4, 24, 56, 64, 3, 3, 2, 1, 0, 1, 3, 2, True],
     ],
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize(
+    "sharding_scheme",
+    [
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    ],
+)
 @skip_with_watcher("Test is not passing with watcher enabled github issue #37195")
-def test_mpwi_dram_slice(device, ttnn_dtype, input_spec):
+def test_mpwi_general(device, ttnn_dtype, sharding_scheme, input_spec):
     (
         in_n,
         in_c,
@@ -227,9 +229,11 @@ def test_mpwi_dram_slice(device, ttnn_dtype, input_spec):
         dilation_h,
         dilation_w,
         ceil_mode,
-        num_slices,
     ) = input_spec
-    dram_slice_config = ttnn.Conv2dSliceConfig(num_slices=num_slices, slice_type=ttnn.Conv2dDRAMSliceWidth)
+
+    if sharding_scheme == ttnn.TensorMemoryLayout.WIDTH_SHARDED and ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("this case runs OOM")
+
     run_max_pool2d_with_indices(
         in_n,
         in_c,
@@ -245,10 +249,61 @@ def test_mpwi_dram_slice(device, ttnn_dtype, input_spec):
         dilation_w,
         ttnn_dtype,
         device,
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        sharding=sharding_scheme,
+        ceil_mode=ceil_mode,
+        memory_config=None,
+        run_twice=True,
+        config_tensor_in_dram=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_spec",
+    [
+        [1, 32, 384, 384, 3, 3, 1, 1, 1, 1, 1, 1, False],
+        [1, 48, 350, 350, 5, 5, 1, 1, 2, 2, 1, 1, False],
+        [1, 64, 350, 350, 6, 6, 1, 1, 3, 3, 1, 1, False],
+        [3, 32, 300, 300, 7, 7, 1, 1, 3, 3, 1, 1, False],
+        [2, 48, 300, 300, 9, 9, 2, 2, 4, 4, 1, 1, False],
+    ],
+)
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@skip_with_watcher("Test is not passing with watcher enabled github issue #37195")
+def test_mpwi_32_bit_index(device, ttnn_dtype, input_spec):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
         ceil_mode,
-        None,  # no memory_config
-        False,  # not in place
-        dram_slice_config=dram_slice_config,
+    ) = input_spec
+
+    run_max_pool2d_with_indices(
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dilation_h,
+        dilation_w,
+        ttnn_dtype,
+        device,
+        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ceil_mode=ceil_mode,
+        memory_config=None,
+        run_twice=True,
         config_tensor_in_dram=True,
     )

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -595,14 +595,12 @@ ALWI void topk_tile_init() { MATH((llk_math_eltwise_unary_sfpu_topk_init<true>()
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
- * Only a reduction of 9 rows is supported at this time.
- *
  * | Argument        | Description                                                                 | Type       | Valid Range                                           | Required |
  * |-----------------|-----------------------------------------------------------------------------|------------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register containing the data to be reduced     | uint32_t   | Must be less than the size of the DST register buffer | True     |
  * | idst_idx        | The index of the tile in DST register containing the indices of the data    | uint32_t   | Must be less than the size of the DST register buffer | True     |
  * | chunk           | The index of the intra-kernel "chunk" of data for large kernel accumulation | uint32_t   | 0 to UINT_MAX                                         | False    |
- * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | {9}                                                   | False    |
+ * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | <= 32, but note either 9 or 32 rows will be reduced   | False    |
  * | layout          | The data layout of the data in DST                                          | DataLayout | TILE or ROW_MAJOR                                     | False    |
  * | accumulate      | Whether to accumulate results for large kernels                             | bool       | true, false                                           | False    |
  * | ITERATIONS      | The number of iterations to perform (unused)                                | int        | 1 to 8                                                | False    |

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp
@@ -73,6 +73,9 @@ void kernel_main() {
     constexpr uint32_t kernel_h = get_compile_time_arg_val(34);
     constexpr uint32_t kernel_w = get_compile_time_arg_val(35);
     constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(36);
+    constexpr uint32_t indexes_32_bit = get_compile_time_arg_val(37);
+
+    constexpr DataFormat copy_format = indexes_32_bit ? DataFormat::UInt32 : DataFormat::UInt16;
 
     constexpr uint32_t mpwi_cb_tile_idx = 0;
     constexpr uint32_t data_dst_idx = 0;
@@ -111,8 +114,8 @@ void kernel_main() {
 
     uint32_t current_idx_col;
     uint32_t current_idx_row;
-    const uint16_t start_row = (uint16_t)get_arg_val<uint32_t>(2);
-    const uint16_t start_col = (uint16_t)get_arg_val<uint32_t>(3);
+    const uint32_t start_row = get_arg_val<uint32_t>(2);
+    const uint32_t start_col = get_arg_val<uint32_t>(3);
     current_idx_col = start_col;
     current_idx_row = start_row;
 
@@ -127,7 +130,6 @@ void kernel_main() {
     }
 
     unary_op_init_common(in_cb_id_0, in_cb_id_0);
-    copy_tile_to_dst_init_short(in_cb_id_0);
     max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
 
     // if max out sticks is non-zero then this will be used as the number of out sticks for every core
@@ -144,6 +146,7 @@ void kernel_main() {
             tile_regs_acquire();
             uint32_t intra_kernel_h = 0;
             uint32_t intra_kernel_w = 0;
+            copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
             reconfig_data_format_srca(compute_tmp_idx_cb_id);
             if (first_iteration) {  // move the initial indexes from the reader to DST
                 cb_wait_front(in_idx_cb_id, 1);
@@ -159,17 +162,19 @@ void kernel_main() {
                 // clear the accumulation tiles since they will contain garbage data which is partially loaded
                 // since max SFPU offset if 62 DST rows, but 4 rows are loaded each time so we load 2 rows of
                 // DST tiles 1 and 3 during the reduction of tiles 0 and 2
+                copy_tile_to_dst_init_short(clear_value_cb_id);
                 reconfig_data_format_srca(clear_value_cb_id);
                 copy_tile(clear_value_cb_id, mpwi_cb_tile_idx, data_accum_dst_idx);
 
                 // make a copy of the initial indexes to be used for restoring between C blocks
-                copy_dest_values<DataFormat::UInt16>(index_dst_idx, index_temp_dst_idx);
+                copy_dest_values<copy_format>(index_dst_idx, index_temp_dst_idx);
             }
 
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
                 bool last_chunk = chunk == interm_reduction_chunks - 1;
 
                 cb_wait_front(curr_in_cb_id, 1);
+                copy_tile_to_dst_init_short(curr_in_cb_id);
                 reconfig_data_format_srca(curr_in_cb_id);
                 copy_tile(curr_in_cb_id, mpwi_cb_tile_idx, data_dst_idx);
 
@@ -177,6 +182,7 @@ void kernel_main() {
                 bool increment_needed = false;
                 if (last_c_block && last_chunk) {  // increment for the next kernel position
                     increment_needed = true;
+                    copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
                     reconfig_data_format_srca(compute_tmp_idx_cb_id);
                     // update the current index column
                     if (current_idx_col + stride_w + eff_kernel_w > in_w_padded) {
@@ -198,6 +204,7 @@ void kernel_main() {
                 } else if (is_large_kernel) {  // only need to increment within C block if multiple chunks
                     if (!last_chunk) {         // increment for the next chunk within the same C block
                         increment_needed = true;
+                        copy_tile_to_dst_init_short(compute_tmp_idx_cb_id);
                         reconfig_data_format_srca(compute_tmp_idx_cb_id);
                         if (intra_kernel_w + sticks_per_chunk < kernel_w) {  // move right in this row
                             intra_kernel_w += sticks_per_chunk;
@@ -210,23 +217,22 @@ void kernel_main() {
                     }
                 }
                 if (!increment_needed) {
-                    copy_dest_values<DataFormat::UInt16>(index_dst_idx, index_scratch_out_dst_idx);
+                    copy_dest_values<copy_format>(index_dst_idx, index_scratch_out_dst_idx);
                 } else {
                     // we allow overflow here for negative values as this only occurs in padding regions
                     add_int_tile_init();
-                    add_int_tile<DataFormat::UInt16>(index_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
+                    add_int_tile<copy_format>(index_dst_idx, inc_dst_idx, index_scratch_out_dst_idx);
                     max_reduce_with_indices_init<ckernel::DataLayout::ROW_MAJOR>();
                 }
 
-                // TODO # 27845: implement accumulation for <=9 MPWI SFPU so we can use this version for large kernels
-                // as well
+                // TODO implement accumulation for <=9 MPWI SFPU so we can use this version for large kernels as well
                 constexpr uint32_t max_mpwi_kernel_size = window_size_hw <= 9 ? 9 : 32;
                 max_reduce_with_indices<max_mpwi_kernel_size, ckernel::DataLayout::ROW_MAJOR, is_large_kernel>(
                     data_dst_idx, index_dst_idx, chunk);
 
                 if constexpr (is_large_kernel) {
                     if (!last_chunk) {
-                        copy_dest_values<DataFormat::UInt16>(index_scratch_out_dst_idx, index_dst_idx);
+                        copy_dest_values<copy_format>(index_scratch_out_dst_idx, index_dst_idx);
                     }
                 }
 
@@ -236,7 +242,7 @@ void kernel_main() {
             // After all chunks: if not last C block, restore base indices for next C block
             if constexpr (is_large_kernel) {
                 if (!last_c_block) {
-                    copy_dest_values<DataFormat::UInt16>(index_temp_dst_idx, index_scratch_out_dst_idx);
+                    copy_dest_values<copy_format>(index_temp_dst_idx, index_scratch_out_dst_idx);
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -423,12 +423,12 @@ void kernel_main() {
     constexpr bool zero_pages = (bool)get_compile_time_arg_val(43);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(44);
     constexpr uint32_t out_idx_cb_id = get_compile_time_arg_val(45);
-    constexpr uint32_t config_in_dram = get_compile_time_arg_val(50);
-    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(51);
-    constexpr uint32_t config_page_size = get_compile_time_arg_val(52);
-    constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(53);
-    constexpr uint32_t reader_page_size = get_compile_time_arg_val(54);
-    constexpr uint32_t reader_tensor_args_index = 55;
+    constexpr uint32_t config_in_dram = get_compile_time_arg_val(51);
+    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(52);
+    constexpr uint32_t config_page_size = get_compile_time_arg_val(53);
+    constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(54);
+    constexpr uint32_t reader_page_size = get_compile_time_arg_val(55);
+    constexpr uint32_t reader_tensor_args_index = 56;
 
     constexpr bool use_split_reader = split_reader && !return_indices;
     constexpr uint32_t eff_kernel_w = (kernel_w - 1) * dilation_w + 1;

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -219,13 +219,13 @@ static Tensor create_scalar_config_tensor(
     return Tensor(std::move(buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
 
-std::vector<uint16_t> generate_core_starting_indices(
+std::vector<uint32_t> generate_core_starting_indices(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<sliding_window::ShardBoundary>& shard_boundaries,
     const tt::tt_metal::TensorMemoryLayout shard_scheme,
     const uint32_t num_cores_x,
     const uint32_t ncores) {
-    std::vector<uint16_t> starting_indices;
+    std::vector<uint32_t> starting_indices;
     uint32_t repeat_factor = 0;
     switch (shard_scheme) {
         case tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED: repeat_factor = 1; break;
@@ -276,7 +276,7 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t ceil_pad_w,
     bool ceil_mode,
     bool return_indices,
-    std::vector<uint16_t> core_starting_indices,
+    std::vector<uint32_t> core_starting_indices,
     bool count_include_pad,
     uint32_t dilation_h,
     uint32_t dilation_w,
@@ -299,6 +299,12 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
     const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
     const uint32_t max_out_nhw_per_core = outputs[0].shard_spec()->shape[0];
+    const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
+    TT_FATAL(
+        max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
+        "Input nhw per core {} exceeds uint16_t limit, this will cause overflow because the reader indices are stored "
+        "as uint16_t",
+        max_in_nhw_per_core);
 
     const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
     const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
@@ -311,6 +317,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_c,
         pool_type,
         return_indices,
+        in_h,
+        in_w,
         output_layout);
     uint32_t eff_kernel_h = ((kernel_h - 1) * dilation_h) + 1;
     uint32_t eff_kernel_w = ((kernel_w - 1) * dilation_w) + 1;
@@ -442,16 +450,19 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t intra_kernel_right_inc_cb_id = 32;
     uint32_t intra_kernel_down_left_wrap_inc_cb_id = 32;
     uint32_t compute_tmp_idx_cb_id = 32;
-    uint16_t right_inc = 0;
-    uint16_t down_left_wrap_inc = 0;
-    uint16_t up_left_wrap_inc = 0;
-    uint16_t intra_kernel_right_inc = 0;
-    uint16_t intra_kernel_down_left_wrap_inc = 0;
+    uint32_t right_inc = 0;
+    uint32_t down_left_wrap_inc = 0;
+    uint32_t up_left_wrap_inc = 0;
+    uint32_t intra_kernel_right_inc = 0;
+    uint32_t intra_kernel_down_left_wrap_inc = 0;
+    bool indexes_32_bit = false;
     if (return_indices) {
+        indexes_32_bit = params.index_format == tt::DataFormat::UInt32;
         uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
         in_idx_cb_id = next_cb_index++;
-        tt::tt_metal::create_cb(in_idx_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id, params.nbytes * tile_elems, 1);
+        tt::tt_metal::create_cb(
+            in_idx_cb_id, program, all_cores, params.index_nbytes * tile_elems, 1, params.index_format);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id, params.index_nbytes * tile_elems, 1);
         pack_tmp_cb_id = next_cb_index++;
         tt::tt_metal::create_cb(pack_tmp_cb_id, program, all_cores, params.nbytes * tile_elems, 1, params.data_format);
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_tmp_cb_id, params.nbytes * tile_elems, 1);
@@ -519,14 +530,14 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             // batches this means we process multiple top left positions within the kernel for a single top left
             // position in the tensor, so when we move the kernel to a new position in the tensor we need to subtract
             // the difference between the first top left index in the kernel and the last one
-            uint16_t sticks_per_chunk =
+            uint32_t sticks_per_chunk =
                 kernel_w <= params.max_rows_for_reduction ? kernel_w : params.max_rows_for_reduction;
-            uint16_t w_chunks =
+            uint32_t w_chunks =
                 kernel_w % sticks_per_chunk == 0 ? kernel_w / sticks_per_chunk : (kernel_w / sticks_per_chunk) + 1;
-            uint16_t last_w_chunk_w_offset = (w_chunks - 1) * sticks_per_chunk * dilation_w;
-            uint16_t first_top_left_kernel_index = 0;
-            uint16_t last_top_left_kernel_index = ((kernel_h - 1) * dilation_h * in_w) + last_w_chunk_w_offset;
-            uint16_t index_correction = last_top_left_kernel_index - first_top_left_kernel_index;
+            uint32_t last_w_chunk_w_offset = (w_chunks - 1) * sticks_per_chunk * dilation_w;
+            uint32_t first_top_left_kernel_index = 0;
+            uint32_t last_top_left_kernel_index = ((kernel_h - 1) * dilation_h * in_w) + last_w_chunk_w_offset;
+            uint32_t index_correction = last_top_left_kernel_index - first_top_left_kernel_index;
             right_inc -= index_correction;
             down_left_wrap_inc -= index_correction;
             up_left_wrap_inc -= index_correction;
@@ -721,11 +732,12 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         intra_kernel_down_left_wrap_inc,                                                     // 47
         intra_kernel_right_inc_cb_id,                                                        // 48
         intra_kernel_down_left_wrap_inc_cb_id,                                               // 49
-        config_tensor_in_dram,                                                               // 50
-        one_scalar_per_core ? 0 : config_tensor.device_storage().get_buffer()->address(),    // 51
-        one_scalar_per_core ? 0 : config_tensor.device_storage().get_buffer()->page_size(),  // 52
-        reader_indices_storage.get_buffer()->address(),                                      // 53
-        reader_indices_storage.get_buffer()->page_size(),                                    // 54
+        (uint32_t)indexes_32_bit,                                                            // 50
+        config_tensor_in_dram,                                                               // 51
+        one_scalar_per_core ? 0 : config_tensor.device_storage().get_buffer()->address(),    // 52
+        one_scalar_per_core ? 0 : config_tensor.device_storage().get_buffer()->page_size(),  // 53
+        reader_indices_storage.get_buffer()->address(),                                      // 54
+        reader_indices_storage.get_buffer()->page_size(),                                    // 55
     };
 
     tt::tt_metal::TensorAccessorArgs(reader_indices_storage.get_buffer()).append_to(reader0_ct_args);
@@ -795,7 +807,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         compute_tmp_idx_cb_id,                  // 33
         kernel_h,                               // 34
         kernel_w,                               // 35
-        clear_value_cb_id                       // 36
+        clear_value_cb_id,                      // 36
+        (uint32_t)indexes_32_bit                // 37
     };
 
     // Get device arch for compute kernel config initialization
@@ -806,10 +819,10 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         device_arch,
         compute_kernel_config,
         MathFidelity::HiFi4,
-        false,                                         // math_approx_mode
-        params.is_avg_pool && params.is_large_kernel,  // fp32_dest_acc_en
-        false,                                         // packer_l1_acc
-        params.is_large_kernel && return_indices       // dst_full_sync_en
+        false,                                                             // math_approx_mode
+        (params.is_avg_pool && params.is_large_kernel) || indexes_32_bit,  // fp32_dest_acc_en
+        false,                                                             // packer_l1_acc
+        (params.is_large_kernel && return_indices) || indexes_32_bit       // dst_full_sync_en
     );
 
     auto compute_config = tt::tt_metal::ComputeConfig{
@@ -857,8 +870,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             const uint32_t start_row = start_mod_batch / in_w_padded;
             const uint32_t start_col = start_mod_batch % in_w_padded;
 
-            args.push_back((uint32_t)(start_row));
-            args.push_back((uint32_t)(start_col));
+            args.push_back(start_row);
+            args.push_back(start_col);
         }
         SetRuntimeArgs(program, reader0_kernel, core, args);
         SetRuntimeArgs(program, compute_kernel, core, args);
@@ -870,6 +883,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
     uint32_t l1_usage = calculate_L1_usage(
         input.dtype(),
+        in_h,
+        in_w,
         in_c,
         pad_h,
         pad_w,
@@ -1026,7 +1041,7 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
     std::vector<std::vector<uint16_t>> top_left_indices =
         sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, stride_w);
-    std::vector<uint16_t> core_starting_indices;
+    std::vector<uint32_t> core_starting_indices;
     if (return_indices) {
         const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
         const uint32_t ncores = input.shard_spec().value().grid.num_cores();

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -682,6 +682,8 @@ pool2d_slice_l1_usage calculate_L1_usage_for_pool2d_slice(
 
     uint32_t pool_cb_usage = calculate_L1_usage(
         dtype,
+        sliding_window_config.input_hw.first,
+        sliding_window_config.input_hw.second,
         sliding_window_config.channels,
         slice_padding[0],  // pad_h (top)
         slice_padding[2],  // pad_w (left)

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -107,6 +107,17 @@ std::optional<ParallelConfig> determine_valid_parallel_config(
     return pconfig;
 }
 
+DataType get_index_data_type(uint32_t in_h, uint32_t in_w) {
+    uint32_t hw = in_h * in_w;
+    if (hw <= std::numeric_limits<uint16_t>::max()) {
+        return DataType::UINT16;
+    }
+    if (hw <= std::numeric_limits<uint32_t>::max()) {
+        return DataType::UINT32;
+    }
+    TT_THROW("Input HW {} is too large to be indexed with uint32", hw);
+}
+
 FactoryParameters get_factory_parameters(
     uint32_t num_shards_c,
     const DataType& input_dtype,
@@ -116,6 +127,8 @@ FactoryParameters get_factory_parameters(
     uint32_t in_channels,
     Pool2DType pool_type,
     bool return_indices,
+    uint32_t in_h,
+    uint32_t in_w,
     const Layout& output_layout) {
     uint32_t multi_buffering_factor = 2;
     bool split_reader = true;
@@ -125,7 +138,8 @@ FactoryParameters get_factory_parameters(
     // since block float formats don't have a fixed datum size per element (they use block compression)
     auto dtype = is_block_float(input_dtype) ? DataType::BFLOAT16 : input_dtype;
     tt::DataFormat data_format = datatype_to_dataformat_converter(dtype);
-    tt::DataFormat index_format = datatype_to_dataformat_converter(DataType::UINT16);
+    auto index_dtype = get_index_data_type(in_h, in_w);
+    tt::DataFormat index_format = datatype_to_dataformat_converter(index_dtype);
     tt::DataFormat output_data_format = datatype_to_dataformat_converter(output_dtype);
 
     uint32_t nbytes = datum_size(data_format);
@@ -177,6 +191,8 @@ FactoryParameters get_factory_parameters(
 
 uint32_t calculate_L1_usage(
     DataType input_dtype,
+    uint32_t in_h,
+    uint32_t in_w,
     uint32_t in_channels,
     uint32_t pad_h,
     uint32_t pad_w,
@@ -217,6 +233,8 @@ uint32_t calculate_L1_usage(
         in_channels,
         pool_type,
         return_indices,
+        in_h,
+        in_w,
         output_layout);
 
     bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
@@ -272,7 +290,7 @@ uint32_t calculate_L1_usage(
     const bool is_output_tiled = output_layout == Layout::TILE;
 
     if (is_output_tiled) {
-        out_cb_pagesize = tt::tile_size(datatype_to_dataformat_converter(output_dtype));
+        out_cb_pagesize = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype));
         out_cb_npages = output_memory.shard_spec().value().shape[0] * output_memory.shard_spec().value().shape[1] /
                         tt::constants::TILE_HW;
     } else {
@@ -293,10 +311,10 @@ uint32_t calculate_L1_usage(
 
     uint32_t out_idx_cb_config_size = 0;
     if (return_indices) {
-        uint32_t out_cb_pagesize =
+        uint32_t out_idx_cb_pagesize =
             std::min(static_cast<uint32_t>(tt::constants::FACE_WIDTH), output_memory.shard_spec().value().shape[1]) *
             params.index_nbytes;
-        out_idx_cb_config_size = out_cb_npages * out_cb_pagesize;
+        out_idx_cb_config_size = out_cb_npages * out_idx_cb_pagesize;
     }
     uint32_t config_tensor_l1_CB_size = 0;
     if (config_tensor_in_dram) {
@@ -381,6 +399,8 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
         }
         uint32_t l1_usage = calculate_L1_usage(
             input_dtype,
+            sliding_window_config.input_hw.first,
+            sliding_window_config.input_hw.second,
             sliding_window_config.channels,
             sliding_window_config.get_pad_h(),
             sliding_window_config.get_pad_w(),

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -99,6 +99,8 @@ std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_sha
     const DataType& output_dtype,
     bool config_tensor_in_dram);
 
+DataType get_index_data_type(uint32_t in_h, uint32_t in_w);
+
 FactoryParameters get_factory_parameters(
     uint32_t num_shards_c,
     const DataType& input_dtype,
@@ -108,10 +110,14 @@ FactoryParameters get_factory_parameters(
     uint32_t in_channels,
     Pool2DType pool_type,
     bool return_indices,
+    uint32_t in_h,
+    uint32_t in_w,
     const Layout& output_layout);
 
 uint32_t calculate_L1_usage(
     DataType input_dtype,
+    uint32_t in_h,
+    uint32_t in_w,
     uint32_t in_channels,
     uint32_t pad_h,
     uint32_t pad_w,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27845

### Problem description
MPWI currently only suppports HW < 2^16.

### What's changed
- MPWI has been updated to support sizes up to HW < 2^32.
- FP32 DST is used for these cases
- A check has been added to sliding window to ensure the per-core HW does not exceed Uint16 limits since sliding window still uses Uint16 config tensors.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884522066
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884517960
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884549209
same failure as main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884545637
same failure as main
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884525760
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884532202
same failures as main
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21884537542
same failures as main