### PR TITLE
#35342: Revert PR #32045

### DIFF
--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -89,7 +89,7 @@ private:
     RunMode run_mode = RunMode::NORMAL;
     std::stack<node_id> current_op_id;
     std::unordered_map<std::int64_t, node_id> buffer_id_to_counter;
-    std::unordered_map<std::uint64_t, node_id> tensor_id_to_counter;
+    std::unordered_map<std::int64_t, node_id> tensor_id_to_counter;
     node_id last_finished_op_id = -1;
     std::vector<Vertex> graph;
     std::vector<node_id> current_input_tensors;

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -310,14 +310,17 @@ node_id GraphProcessor::add_tensor(const Tensor& t) {
         },
         storage);
 
-    std::uint64_t tensor_id = t.get_id();
-    if (tensor_id == Tensor::INVALID_TENSOR_ID) {
-        log_warning(
+    // TODO #32045: Remove the check for INVALID_TENSOR_ID since IDs are assigned in the constructor.
+    std::uint64_t tensor_id = t.tensor_id;
+    if (tensor_id == tt::tt_metal::Tensor::INVALID_TENSOR_ID) {
+        log_debug(
             tt::LogAlways,
-            "Tensor doesn't have a valid ID, this tensor must have been moved and should therefore not be tracked");
-        return -1;
+            "Tensor doesn't have tensor_id (sentinel value is INVALID_TENSOR_ID), generating new one. Ideally this "
+            "should not happen. "
+            "Please set tensor_id "
+            "for this tensor ahead of time.");
+        tensor_id = tt::tt_metal::Tensor::next_tensor_id();
     }
-
     node_id tensor_counter = tensor_id_to_counter.contains(tensor_id) ? tensor_id_to_counter[tensor_id] : graph.size();
     auto shape = t.logical_shape();
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -45,6 +45,7 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, std::optional<Queue
     GraphTracker::instance().track_function_start("Tensor::cpu", input_tensor, blocking);
 
     auto output = tensor_impl::to_host(input_tensor, blocking, cq_id);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -54,6 +55,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout) {
     TT_FATAL(
         input_tensor.storage_type() != StorageType::DEVICE, "Bring tensor to host before converting to target layout");
     Tensor output = tensor_impl::to_layout(input_tensor, target_layout);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -76,6 +78,7 @@ Tensor tensor_pad(
     }
 
     auto output = tensor_impl::pad(input_tensor, output_padded_shape, input_tensor_start, pad_value);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -88,6 +91,7 @@ Tensor tensor_unpad(
         "Tensor::unpad", input_tensor, output_tensor_start, output_tensor_end);
     TT_ASSERT(input_tensor.layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for unpadding");
     auto output = tensor_impl::unpad(input_tensor, output_tensor_start, output_tensor_end);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -114,6 +118,7 @@ Tensor tensor_pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
     auto output = input_tensor.pad(
         tt::tt_metal::Shape(std::move(padded_shape)), tt::tt_metal::Shape{std::move(input_tensor_start)}, pad_value);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -140,6 +145,7 @@ Tensor tensor_unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Sh
         output_tensor_end[index] = output_tensor_shape[index];
     }
     auto output = input_tensor.unpad(output_tensor_start, output_tensor_end);
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 }
@@ -243,6 +249,7 @@ Tensor tensor_view(const Tensor& input_tensor, const Shape& new_logical_shape, c
             }
         },
         input_tensor.storage());
+    output = tt::tt_metal::set_tensor_id(output);
     tt::tt_metal::GraphTracker::instance().track_function_end(output);
     return output;
 }

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -316,7 +316,16 @@ NB_MODULE(_ttnn, mod) {
         []() -> std::uint64_t { return ttnn::CoreIDs::instance().fetch_and_increment_python_operation_id(); },
         "Increment tensor id and return the previously held id");
 
-    mod.def("next_tensor_id", &tt::tt_metal::Tensor::next_id, "Atomically fetch and increment the tensor ID counter");
+    mod.def("get_tensor_id", &tt::tt_metal::Tensor::get_tensor_id_counter, "Get the current tensor ID counter value");
+    mod.def(
+        "set_tensor_id",
+        &tt::tt_metal::Tensor::set_tensor_id_counter,
+        nb::arg("id"),
+        "Set the tensor ID counter to a specific value");
+    mod.def(
+        "fetch_and_increment_tensor_id",
+        &tt::tt_metal::Tensor::next_tensor_id,
+        "Atomically fetch and increment the tensor ID counter");
 
     mod.def(
         "get_device_operation_id",

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -312,6 +312,7 @@ Tensor convert_python_tensor_to_tt_tensor(
         pad_value,
         mesh_mapper);
 
+    output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
 
@@ -1585,7 +1586,10 @@ void pytensor_module(nb::module_& mod) {
 
                     topology = tt_tensor.tensor_topology()
             )doc")
-        .def_prop_ro("tensor_id", [](const Tensor& self) { return self.get_id(); });
+        .def_prop_rw(
+            "tensor_id",
+            [](const Tensor& self) { return self.tensor_id; },
+            [](Tensor& self, std::size_t tensor_id) { self.tensor_id = tensor_id; });
 }
 
 }  // namespace ttnn::tensor

--- a/ttnn/ttnn/database.py
+++ b/ttnn/ttnn/database.py
@@ -109,8 +109,8 @@ class OutputTensor:
 
 @dataclasses.dataclass
 class TensorComparisonRecord:
-    tensor_id: int | None
-    golden_tensor_id: int | None
+    tensor_id: int
+    golden_tensor_id: int
     matches: bool
     desired_pcc: bool
     actual_pcc: float


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35342)

### Problem description
[The offending PR](https://github.com/tenstorrent/tt-metal/pull/32332) caused unforeseen issues with ttnn visualizer. In order to unblock developers, this PR should be reverted

### What's changed

- Reverted all changes described in the offending PR

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ssundaram/revert_tensor_id)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssundaram/revert_tensor_id)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ssundaram/revert_tensor_id)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ssundaram/revert_tensor_id)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssundaram/revert_tensor_id)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ssundaram/revert_tensor_id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ssundaram/revert_tensor_id)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs