### PR TITLE
Add optional APC-test-count check to PR gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -145,7 +145,7 @@ jobs:
       upload-coverage: false
 
   build:
-    if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    # if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -271,12 +271,12 @@ jobs:
       product: tt-nn
 
   APC-test-count-check:
-    needs: [ build, find-changed-files ]
-    if: ${{
-        github.ref_name == 'main' ||
-        needs.find-changed-files.outputs.cmake-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-nn-changed == 'true'
-      }}
+    needs: [ build ]
+    # if: ${{
+    #     github.ref_name == 'main' ||
+    #     needs.find-changed-files.outputs.cmake-changed == 'true' ||
+    #     needs.find-changed-files.outputs.tt-nn-changed == 'true'
+    #   }}
     uses: ./.github/workflows/validate-test-count.yaml
     with:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -270,6 +270,18 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
+  APC-test-count-check:
+    needs: [ build, find-changed-files ]
+    if: ${{
+        github.ref_name == 'main' ||
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-nn-changed == 'true'
+      }}
+    uses: ./.github/workflows/validate-test-count.yaml
+    with:
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
+
   ttsim-integration-tests:
     needs: [ build ]
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
@@ -417,6 +429,6 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "asan-build, build, build-tt-train"
-          optional-jobs: "metalium-smoke-tests, ttnn-smoke-tests, metalium-examples, ttsim-integration-tests, model-charts-sync, build-docs"
+          optional-jobs: "metalium-smoke-tests, ttnn-smoke-tests, metalium-examples, ttsim-integration-tests, model-charts-sync, build-docs, APC-test-count-check"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -145,7 +145,7 @@ jobs:
       upload-coverage: false
 
   build:
-    #if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -271,12 +271,12 @@ jobs:
       product: tt-nn
 
   APC-test-count-check:
-    needs: [ build ]
-    # if: ${{
-    #     github.ref_name == 'main' ||
-    #     needs.find-changed-files.outputs.cmake-changed == 'true' ||
-    #     needs.find-changed-files.outputs.tt-nn-changed == 'true'
-    #   }}
+    needs: [ build, find-changed-files ]
+    if: ${{
+        github.ref_name == 'main' ||
+        needs.find-changed-files.outputs.cmake-changed == 'true' ||
+        needs.find-changed-files.outputs.tt-nn-changed == 'true'
+      }}
     uses: ./.github/workflows/validate-test-count.yaml
     with:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -145,7 +145,7 @@ jobs:
       upload-coverage: false
 
   build:
-    if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    #if: github.event.action != 'destroyed' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -271,12 +271,12 @@ jobs:
       product: tt-nn
 
   APC-test-count-check:
-    needs: [ build, find-changed-files ]
-    if: ${{
-        github.ref_name == 'main' ||
-        needs.find-changed-files.outputs.cmake-changed == 'true' ||
-        needs.find-changed-files.outputs.tt-nn-changed == 'true'
-      }}
+    needs: [ build ]
+    # if: ${{
+    #     github.ref_name == 'main' ||
+    #     needs.find-changed-files.outputs.cmake-changed == 'true' ||
+    #     needs.find-changed-files.outputs.tt-nn-changed == 'true'
+    #   }}
     uses: ./.github/workflows/validate-test-count.yaml
     with:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check Test Count"
     container:
-      image: ${{ format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) }}
+      image: ${{ inputs.docker-image }}
       env:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -62,9 +62,9 @@ jobs:
           name: ${{ inputs.wheel-artifact-name }}
           path: ./wheels
 
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install pytest torch loguru transformers
+      # - name: Install Python dependencies
+      #   run: |
+      #     python3 -m pip install pytest torch loguru transformers
 
       - name: Install tt-metal wheel (for ttnn Python module)
         if: ${{ inputs.wheel-artifact-name != '' }}

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -1,0 +1,156 @@
+name: "Validate Test Count"
+
+on:
+  workflow_call:
+    inputs:
+      wheel-artifact-name:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - 'tests/ttnn/unit_tests/operations/eltwise/**'
+      - 'tests/ttnn/unit_tests/operations/conv/**'
+      - 'tests/ttnn/unit_tests/operations/matmul/**'
+      - 'tests/ttnn/unit_tests/operations/pool/**'
+      - 'tests/ttnn/unit_tests/operations/fused/**'
+      - 'tests/ttnn/unit_tests/operations/transformers/**'
+      - 'tests/ttnn/unit_tests/operations/reduce/**'
+      - 'tests/ttnn/unit_tests/tensor/**'
+      - 'tests/ttnn/unit_tests/operations/debug/**'
+      - 'tests/ttnn/unit_tests/base_functionality/**'
+      - 'tests/ttnn/unit_tests/benchmarks/**'
+jobs:
+  check-test-count:
+    runs-on: ubuntu-latest
+    name: "Check Test Count"
+    container:
+      image: ${{ format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) }}
+      env:
+        LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
+        GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
+      volumes:
+        - ${{ github.workspace }}:/work
+        - /dev/hugepages-1G:/dev/hugepages-1G
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git and pip
+        run: |
+          apt-get update
+          apt-get install -y python3-pip git
+      - name: Download built wheel
+        if: ${{ inputs.wheel-artifact-name != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.wheel-artifact-name }}
+          path: ./wheels
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install pytest torch loguru transformers
+
+      - name: Install tt-metal wheel (for ttnn Python module)
+        if: ${{ inputs.wheel-artifact-name != '' }}
+        run: |
+          python3 -m pip install ./wheels/*.whl
+
+      - name: Count and compare tests
+        run: |
+          # Define repository URL
+          REPO_URL="https://github.com/tenstorrent/tt-metal.git"
+
+          # Define the paths to check for test counts
+          declare -a PATHS=(
+            "tests/ttnn/unit_tests/operations/eltwise"
+            "tests/ttnn/unit_tests/operations/conv"
+            "tests/ttnn/unit_tests/operations/matmul"
+            "tests/ttnn/unit_tests/operations/pool"
+            "tests/ttnn/unit_tests/operations/fused"
+            "tests/ttnn/unit_tests/operations/transformers"
+            "tests/ttnn/unit_tests/operations/reduce"
+            "tests/ttnn/unit_tests/tensor"
+            "tests/ttnn/unit_tests/operations/debug"
+            "tests/ttnn/unit_tests/base_functionality"
+            "tests/ttnn/unit_tests/benchmarks"
+          )
+
+          # Function to count test functions using pytest collect-only
+          count_tests() {
+            local dir=$1
+            echo "Collecting from: $dir" >&2
+            output=$(pytest --collect-only -q "$dir" --noconftest 2>&1)
+            echo "Pytest output:" >&2
+            echo "$output" >&2
+            count=$(echo "$output" | tail -1 | grep -oE '[0-9]+' | head -1)
+            if [ -z "$count" ]; then
+              echo "0"
+            else
+              echo "$count"
+            fi
+          }
+
+          # Count tests in PR branch
+          echo "=== PR branch test counts ==="
+          declare -A pr_counts
+          for path in "${PATHS[@]}"; do
+            count=$(count_tests "$path")
+            pr_counts[$path]=$count
+            echo "  $path: $count"
+          done
+
+          # Clone main branch into separate directory
+          echo "=== Cloning main branch ==="
+          cd /tmp
+          git clone --depth 1 --branch main "$REPO_URL" main-branch
+          cd /work
+
+          # Count tests in base branch
+          echo "=== Base branch test counts ==="
+          declare -A base_counts
+          for path in "${PATHS[@]}"; do
+            count=$(count_tests "/tmp/main-branch/$path")
+            base_counts[$path]=$count
+            echo "  $path: $count"
+          done
+
+          # Compare and generate report
+          FAILED=0
+          echo "## Test Count Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Directory | Base | PR | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|------|-------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          for path in "${PATHS[@]}"; do
+            pr_count=${pr_counts[$path]}
+            base_count=${base_counts[$path]}
+            if [ "$pr_count" -gt "$base_count" ]; then
+              echo "| $path | $base_count | $pr_count | ❌ New tests added (+$((pr_count - base_count))) |" >> $GITHUB_STEP_SUMMARY
+              echo "::error::New tests detected in $path/ ($base_count → $pr_count)"
+              FAILED=1
+            else
+              echo "| $path | $base_count | $pr_count | ✅ No new tests |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **This PR adds new tests to APC.**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These test directories have a locked test count to maintain stable APC runtime." >> $GITHUB_STEP_SUMMARY
+            echo "Please look into removing existing lower priority tests to add new tests." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **No new tests added - validation passed**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -9,6 +9,7 @@ on:
       docker-image:
         required: true
         type: string
+
   pull_request:
     paths:
       - 'tests/ttnn/unit_tests/operations/eltwise/**'
@@ -22,10 +23,12 @@ on:
       - 'tests/ttnn/unit_tests/operations/debug/**'
       - 'tests/ttnn/unit_tests/base_functionality/**'
       - 'tests/ttnn/unit_tests/benchmarks/**'
+
 jobs:
   check-test-count:
     runs-on: ubuntu-latest
     name: "Check Test Count"
+
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -35,10 +38,12 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/work
         - /dev/hugepages-1G:/dev/hugepages-1G
+
     defaults:
       run:
         shell: bash
         working-directory: /work
+
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -49,6 +54,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y python3-pip git
+
       - name: Download built wheel
         if: ${{ inputs.wheel-artifact-name != '' }}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### What's changed
Add validation-test-count workflow to check APC test count for ttnn-unit-test job in PR gate

PR-gate CI run passes with running test-count check: https://github.com/tenstorrent/tt-metal/actions/runs/20834791534
PR-gate CI run: https://github.com/tenstorrent/tt-metal/actions/runs/20831891156/

Adding a new test to `ttnn-unit-test` job in APC in this run: https://github.com/tenstorrent/tt-metal/actions/runs/20827693478 ails the check as expected

Once the newly added test is removed, it passes because the counts match between the PR and main branch: https://github.com/tenstorrent/tt-metal/actions/runs/20828218402/attempts/1#summary-59835081502