### PR TITLE
Modify Quasar DM cores FW build to only build a single FW binary that is shared amongst all the DM cores 

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1290,7 +1290,7 @@ void MetalContext::initialize_firmware(
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                auto [build_idx, num_build_states] =
+                auto [_, num_build_states] =
                     BuildEnvManager::get_instance().get_build_index_and_state_count(core_type_idx, processor_class);
                 for (uint32_t riscv_id = 0; riscv_id < num_build_states; riscv_id++) {
                     auto fw_path = BuildEnvManager::get_instance()

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1290,8 +1290,8 @@ void MetalContext::initialize_firmware(
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                auto [_, num_build_states] =
-                    BuildEnvManager::get_instance().get_build_index_and_state_count(core_type_idx, processor_class);
+                auto [_, num_build_states] = BuildEnvManager::get_instance().get_build_index_and_state_count(
+                    core_type_idx, processor_class, true);
                 for (uint32_t riscv_id = 0; riscv_id < num_build_states; riscv_id++) {
                     auto fw_path = BuildEnvManager::get_instance()
                                        .get_firmware_build_state(device_id, core_type_idx, processor_class, riscv_id)

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -258,9 +258,8 @@ BuildIndexAndTypeCount BuildEnvManager::get_build_index_and_state_count(
     const std::lock_guard<std::mutex> lock(this->lock);
     if (is_fw) {
         return get_firmware_build_index_and_state_count(programmable_core, processor_class);
-    } else {
-        return get_kernel_build_index_and_state_count(programmable_core, processor_class);
     }
+    return get_kernel_build_index_and_state_count(programmable_core, processor_class);
 }
 
 void BuildEnvManager::build_firmware(ChipId device_id) {

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -140,21 +140,21 @@ std::vector<JitBuildState> create_build_state(JitBuildEnv& build_env, bool is_fw
 
     // Prepare the container for build states
     const auto& hal = MetalContext::instance().hal();
-    uint32_t num_build_states = 0;
+    uint32_t total_num_build_states = 0;
     if (is_fw) {
         for (uint32_t programmable_core = 0; programmable_core < hal.get_programmable_core_type_count();
              programmable_core++) {
             const uint32_t processor_class_count =
                 hal.get_processor_classes_count(hal.get_programmable_core_type(programmable_core));
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                num_build_states += hal.get_processor_class_num_fw_binaries(programmable_core, processor_class);
+                total_num_build_states += hal.get_processor_class_num_fw_binaries(programmable_core, processor_class);
             }
         }
     } else {
-        num_build_states = hal.get_total_num_risc_processors();
+        total_num_build_states = hal.get_total_num_risc_processors();
     }
     std::vector<JitBuildState> build_states;
-    build_states.reserve(num_build_states);
+    build_states.reserve(total_num_build_states);
 
     // Loop through programmable core types and their processor classes/types.
     uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
@@ -170,25 +170,17 @@ std::vector<JitBuildState> create_build_state(JitBuildEnv& build_env, bool is_fw
                 .is_cooperative = hal.get_eth_fw_is_cooperative(),
             };
 
-            if (is_fw) {
-                const uint32_t processor_class_num_fw_binaries =
-                    hal.get_processor_class_num_fw_binaries(programmable_core, processor_class);
-                for (uint32_t processor_type = 0; processor_type < processor_class_num_fw_binaries; processor_type++) {
-                    config.processor_id = processor_type;
-                    build_states.emplace_back(build_env, config);
-                }
-            } else {
-                const uint32_t processor_types_count =
-                    hal.get_processor_types_count(programmable_core, processor_class);
-                for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
-                    config.processor_id = processor_type;
-                    build_states.emplace_back(build_env, config);
-                }
+            const uint32_t num_build_states =
+                is_fw ? hal.get_processor_class_num_fw_binaries(programmable_core, processor_class)
+                      : hal.get_processor_types_count(programmable_core, processor_class);
+            for (uint32_t build_state_idx = 0; build_state_idx < num_build_states; build_state_idx++) {
+                config.processor_id = build_state_idx;
+                build_states.emplace_back(build_env, config);
             }
         }
     }
 
-    TT_ASSERT(build_states.size() == num_build_states);
+    TT_ASSERT(build_states.size() == total_num_build_states);
     return build_states;
 }
 
@@ -217,20 +209,20 @@ const DeviceBuildEnv& BuildEnvManager::get_device_build_env(ChipId device_id) {
 const JitBuildState& BuildEnvManager::get_firmware_build_state(
     ChipId device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id) {
     const uint32_t state_idx =
-        get_build_index_and_state_count(programmable_core, processor_class, true).first + processor_id;
+        get_firmware_build_index_and_state_count(programmable_core, processor_class).first + processor_id;
     return get_device_build_env(device_id).firmware_build_states[state_idx];
 }
 
 const JitBuildState& BuildEnvManager::get_kernel_build_state(
     ChipId device_id, uint32_t programmable_core, uint32_t processor_class, int processor_id) {
     const uint32_t state_idx =
-        get_build_index_and_state_count(programmable_core, processor_class, false).first + processor_id;
+        get_kernel_build_index_and_state_count(programmable_core, processor_class).first + processor_id;
     return get_device_build_env(device_id).kernel_build_states[state_idx];
 }
 
 JitBuildStateSubset BuildEnvManager::get_kernel_build_states(
     ChipId device_id, uint32_t programmable_core, uint32_t processor_class) {
-    auto [b_id, count] = get_build_index_and_state_count(programmable_core, processor_class, false);
+    auto [b_id, count] = get_kernel_build_index_and_state_count(programmable_core, processor_class);
     const auto& kernel_build_states = get_device_build_env(device_id).kernel_build_states;
     return {kernel_build_states.begin() + b_id, static_cast<size_t>(count)};
 }

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -60,7 +60,8 @@ public:
 
     // Helper function to get the unique build id and number of states for a given programmable_core and
     // processor_class.
-    BuildIndexAndTypeCount get_build_index_and_state_count(uint32_t programmable_core, uint32_t processor_class);
+    BuildIndexAndTypeCount get_build_index_and_state_count(
+        uint32_t programmable_core, uint32_t processor_class, bool is_fw);
 
     // Method to get the build environment info for all devices
     std::vector<BuildEnvInfo> get_all_build_envs_info();
@@ -73,8 +74,14 @@ private:
 
     // A device-agnostic mapping from programmable_core_type and processor_class to unique index + processor_type_count.
     // TODO: processor_type_count can be looked up in the hal, do we need this in here?
-    ProgCoreMapping build_state_indices_;
+    ProgCoreMapping kernel_build_state_indices_;
+    ProgCoreMapping firmware_build_state_indices_;
     std::mutex lock;
+
+    BuildIndexAndTypeCount get_kernel_build_index_and_state_count(
+        uint32_t programmable_core, uint32_t processor_class) const;
+    BuildIndexAndTypeCount get_firmware_build_index_and_state_count(
+        uint32_t programmable_core, uint32_t processor_class) const;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -108,6 +108,11 @@ const std::string& HalCoreInfoType::get_processor_class_name(uint32_t processor_
     return this->processor_classes_names_[processor_class_idx][processor_type_idx].second;
 }
 
+uint32_t HalCoreInfoType::get_processor_class_num_fw_binaries(uint32_t processor_class_idx) const {
+    TT_ASSERT(processor_class_idx < this->processor_classes_num_fw_binaries_.size());
+    return this->processor_classes_num_fw_binaries_[processor_class_idx];
+}
+
 uint32_t generate_risc_startup_addr(uint32_t firmware_base) {
     // Options for handling brisc fw not starting at mem[0]:
     // 1) Program the register for the start address out of reset - no reset PC register on GS/WH/BH

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -146,6 +146,8 @@ private:
     CoreType core_type_;
     // indices represents processor class and type positions, value is build configuration params
     std::vector<std::vector<HalJitBuildConfig>> processor_classes_;
+    // Number of firmware binaries generated for each processor class
+    std::vector<uint8_t> processor_classes_num_fw_binaries_;
     // indices represents processor class and type positions, values are abbreviated name and full name pairs
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names_;
     std::vector<DeviceAddr> mem_map_bases_;
@@ -161,6 +163,7 @@ public:
         HalProgrammableCoreType programmable_core_type,
         CoreType core_type,
         std::vector<std::vector<HalJitBuildConfig>> processor_classes,
+        std::vector<uint8_t> processor_classes_num_fw_binaries,
         std::vector<DeviceAddr> mem_map_bases,
         std::vector<uint32_t> mem_map_sizes,
         std::vector<uint32_t> eth_fw_mailbox_msgs,
@@ -172,6 +175,7 @@ public:
         programmable_core_type_(programmable_core_type),
         core_type_(core_type),
         processor_classes_(std::move(processor_classes)),
+        processor_classes_num_fw_binaries_(std::move(processor_classes_num_fw_binaries)),
         processor_classes_names_(std::move(processor_classes_names)),
         mem_map_bases_(std::move(mem_map_bases)),
         mem_map_sizes_(std::move(mem_map_sizes)),
@@ -189,6 +193,7 @@ public:
     std::pair<HalProcessorClassType, uint32_t> get_processor_class_and_type_from_index(uint32_t processor_index) const;
     const HalJitBuildConfig& get_jit_build_config(uint32_t processor_class_idx, uint32_t processor_type_idx) const;
     const std::string& get_processor_class_name(uint32_t processor_index, bool is_abbreviated) const;
+    uint32_t get_processor_class_num_fw_binaries(uint32_t processor_class_idx) const;
     const dev_msgs::Factory& get_dev_msgs_factory() const;
     const tt::tt_fabric::fabric_telemetry::Factory& get_fabric_telemetry_factory() const;
 };
@@ -469,6 +474,9 @@ public:
     const std::string& get_processor_class_name(
         HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const;
 
+    uint32_t get_processor_class_num_fw_binaries(
+        uint32_t programmable_core_type_index, uint32_t processor_class_idx) const;
+
     uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0, bool has_shared_local_mem = false) const {
         return relocate_func_(addr, local_init_addr, has_shared_local_mem);
     }
@@ -668,6 +676,12 @@ inline const std::string& Hal::get_processor_class_name(
     HalProgrammableCoreType programmable_core_type, uint32_t processor_index, bool is_abbreviated) const {
     auto idx = get_programmable_core_type_index(programmable_core_type);
     return this->core_info_[idx].get_processor_class_name(processor_index, is_abbreviated);
+}
+
+inline uint32_t Hal::get_processor_class_num_fw_binaries(
+    uint32_t programmable_core_type_index, uint32_t processor_class_idx) const {
+    TT_ASSERT(programmable_core_type_index < this->core_info_.size());
+    return this->core_info_[programmable_core_type_index].get_processor_class_num_fw_binaries(processor_class_idx);
 }
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix initializers to build HalJitBuildConfig

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -153,12 +153,15 @@ HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode) {
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes;
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names;
+    std::vector<uint8_t> processor_classes_num_fw_binaries;
     if (enable_2_erisc_mode) {
         processor_classes = configure_for_2erisc();
         processor_classes_names = {{{"ER0", "ERISC0"}, {"ER1", "ERISC1"}}};
+        processor_classes_num_fw_binaries = {/*DM*/ 2};
     } else {
         processor_classes = configure_for_1erisc();
         processor_classes_names = {{{"ER", "ERISC"}}};
+        processor_classes_num_fw_binaries = {/*DM*/ 1};
     }
 
     static_assert(sizeof(mailboxes_t) <= MEM_AERISC_MAILBOX_SIZE);
@@ -166,6 +169,7 @@ HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode) {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -106,11 +106,14 @@ HalCoreInfoType create_idle_eth_mem_map() {
             {"ER1", "ERISC1"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 2};
+
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -140,11 +140,14 @@ HalCoreInfoType create_tensix_mem_map() {
             {"TR2", "TRISC2"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 2, /*COMPUTE*/ 3};
+
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -123,12 +123,14 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
             {"ER", "ERISC"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 1};
 
     static_assert(sizeof(mailboxes_t) <= eth_l1_mem::address_map::ERISC_MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -101,12 +101,14 @@ HalCoreInfoType create_idle_eth_mem_map() {
             {"ER", "ERISC"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 1};
 
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -139,12 +139,14 @@ HalCoreInfoType create_tensix_mem_map() {
             {"TR2", "TRISC2"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 2, /*COMPUTE*/ 3};
 
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
@@ -124,12 +124,14 @@ HalCoreInfoType create_active_eth_mem_map() {
     //     processor_classes[processor_class_idx] = processor_types;
     // }
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names(0);
+    std::vector<uint8_t> processor_classes_num_fw_binaries(0);
 
     static_assert(sizeof(mailboxes_t) <= MEM_AERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::ACTIVE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
@@ -115,12 +115,14 @@ HalCoreInfoType create_idle_eth_mem_map() {
     //     processor_classes[processor_class_idx] = processor_types;
     // }
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names(0);
+    std::vector<uint8_t> processor_classes_num_fw_binaries(0);
 
     static_assert(sizeof(mailboxes_t) <= MEM_IERISC_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::IDLE_ETH,
         CoreType::ETH,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -181,11 +181,14 @@ HalCoreInfoType create_tensix_mem_map() {
             {"TR2", "TRISC2"},
         },
     };
+    std::vector<uint8_t> processor_classes_num_fw_binaries = {/*DM*/ 1};
+
     static_assert(sizeof(mailboxes_t) <= MEM_MAILBOX_SIZE);
     return {
         HalProgrammableCoreType::TENSIX,
         CoreType::WORKER,
         std::move(processor_classes),
+        std::move(processor_classes_num_fw_binaries),
         std::move(mem_map_bases),
         std::move(mem_map_sizes),
         std::move(fw_mailbox_addr),


### PR DESCRIPTION
### Problem description
On Quasar, currently we build 8 DM FW binaries - one for each DM core - but only end up using one of them. The rest of the binaries aren't used at all.

### What's changed
Instead of building 8 DM FW binaries, this PR makes it so that only a single DM FW binary is built. I verified the correctness of this change by running `test_single_dm_l1_write` and looking at the number of firmware binaries that were generated under `~/.cache/tt-metal-cache/`. With this change, only a FW binary for DM0 was generated, whereas on `main`, FW binaries for DM0 - DM7 are generated.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sagarwal/quasar_fw_build_once)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sagarwal/quasar_fw_build_once)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/quasar_fw_build_once)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/quasar_fw_build_once)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/quasar_fw_build_once)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/quasar_fw_build_once)
- [x] New/Existing tests provide coverage for changes