### PR TITLE
[skip ci] #35313 [GPT-OSS] disable 4k prefill unit tests

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -200,7 +200,7 @@ def run_full_mlp_pipeline(mesh_device, hidden_shape, reference_layer, decoder_la
     [
         (1, 1),  # decode
         (1, 128),  # prefill
-        (1, 4096),  # prefill 4k
+        # (1, 4096),  # prefill 4k TODO: Disabling until #35313 is resolved - instability observed
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Temporarily disable 4k prefill unit tests for gpt-oss until #35313 is investigated and fixed. Test is leading to ND failures on main (https://github.com/tenstorrent/tt-metal/actions/runs/20810036168/job/59772379269)