### PR TITLE
[UPSAMPLE] Fix hang if empty cores are present in core grid in sharded upsample

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -441,7 +441,7 @@ def test_bilinear_multi_core(
     "scale_h, scale_w",
     (
         (2, 2),
-        (4, 4),
+        # (4, 4),
     ),
 )
 @pytest.mark.parametrize(
@@ -490,6 +490,39 @@ def test_bilinear_multi_core(
             32,
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ),
+        (
+            1,
+            128,
+            13,
+            13,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7)),
+                }
+            ),
+            3,
+            128,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        # TEST: 57 cores for shape (1, 13, 13, 128)
+        # 13*13 = 169 sticks, ceil(169/57) = 3 sticks per core
+        # 57 cores * 3 sticks = 171 capacity (sufficient)
+        # Core grid: 7 full rows (56 cores) + 1 core = 57 cores total
+        (
+            1,
+            128,  # channels
+            13,  # height
+            13,  # width
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),  # 8 cols * 7 rows = 56 cores
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(0, 7)),  # 1 more core = 57 total
+                }
+            ),
+            3,  # shard_height = ceil(169/57) = 3
+            128,  # shard_width = channels
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
     ),
 )
 @pytest.mark.parametrize("run_twice", [False])
@@ -511,7 +544,7 @@ def test_nearest_upsample_with_uneven_input_shards(
         pytest.skip("Not enough cores for specified core grid")
 
     assert (
-        shard_height * core_grid.num_cores() > height
+        shard_height * core_grid.num_cores() > batch_size * height * width
     ), "Expected all test cases in this test suite to contain uneven shards (i.e. physical size > logical size)"
     if shard_strategy == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
         assert shard_width == channels, "Shard width must match number of input channels when height sharding"

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -504,21 +504,6 @@ def test_bilinear_multi_core(
             128,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
-        # Test when empty shards are present
-        (
-            1,
-            128,
-            13,
-            13,
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7)),
-                }
-            ),
-            3,
-            128,
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-        ),
     ),
 )
 @pytest.mark.parametrize("run_twice", [False])

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -441,7 +441,7 @@ def test_bilinear_multi_core(
     "scale_h, scale_w",
     (
         (2, 2),
-        # (4, 4),
+        (4, 4),
     ),
 )
 @pytest.mark.parametrize(
@@ -504,23 +504,19 @@ def test_bilinear_multi_core(
             128,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
-        # TEST: 57 cores for shape (1, 13, 13, 128)
-        # 13*13 = 169 sticks, ceil(169/57) = 3 sticks per core
-        # 57 cores * 3 sticks = 171 capacity (sufficient)
-        # Core grid: 7 full rows (56 cores) + 1 core = 57 cores total
+        # Test when empty shards are present
         (
             1,
-            128,  # channels
-            13,  # height
-            13,  # width
+            128,
+            13,
+            13,
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),  # 8 cols * 7 rows = 56 cores
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(0, 7)),  # 1 more core = 57 total
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7)),
                 }
             ),
-            3,  # shard_height = ceil(169/57) = 3
-            128,  # shard_width = channels
+            3,
+            128,
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
     ),

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/work_split.hpp>
 
 #include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/host_buffer/functions.hpp"
@@ -199,6 +200,48 @@ static Tensor create_config_tensor(
     return Tensor(std::move(config_buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
 
+// Returns a reduced CoreRangeSet containing only cores that have actual work.
+// For height sharding: returns first N cores from the grid.
+// For block sharding: keeps all channel cores, reduces NHW dimension.
+static CoreRangeSet get_cores_with_work(
+    const CoreRangeSet& all_cores,
+    uint32_t total_nhw,
+    uint32_t nsticks_per_core,
+    bool is_height_sharded,
+    ShardOrientation orientation) {
+    const uint32_t num_cores = all_cores.num_cores();
+    const uint32_t actual_nhw_cores = tt::div_up(total_nhw, nsticks_per_core);
+
+    if (is_height_sharded) {
+        if (actual_nhw_cores >= num_cores) {
+            return all_cores;
+        }
+        return num_cores_to_corerangeset_in_subcoregrids(
+            all_cores.ranges().begin()->start_coord,
+            actual_nhw_cores,
+            all_cores,
+            orientation == ShardOrientation::ROW_MAJOR);
+    }
+
+    // Block sharding: keep all channel cores, reduce NHW dimension
+    const auto& range = *all_cores.ranges().begin();
+    const bool row_major = orientation == ShardOrientation::ROW_MAJOR;
+
+    // NHW is on Y axis for ROW_MAJOR, X axis for COL_MAJOR
+    const uint32_t nhw_start = row_major ? range.start_coord.y : range.start_coord.x;
+    const uint32_t nhw_end = row_major ? range.end_coord.y : range.end_coord.x;
+    const uint32_t nhw_cores_in_grid = nhw_end - nhw_start + 1;
+    const uint32_t nhw_cores_needed = std::min(actual_nhw_cores, nhw_cores_in_grid);
+
+    if (nhw_cores_needed >= nhw_cores_in_grid) {
+        return all_cores;
+    }
+
+    const CoreCoord new_end = row_major ? CoreCoord(range.end_coord.x, nhw_start + nhw_cores_needed - 1)
+                                        : CoreCoord(nhw_start + nhw_cores_needed - 1, range.end_coord.y);
+    return CoreRangeSet(CoreRange(range.start_coord, new_end));
+}
+
 UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreShardedProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -250,6 +293,12 @@ UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreSharde
 
     const uint32_t input_nsticks_per_core = shard_spec.shape[0];
     const uint32_t output_nsticks_per_core = input_nsticks_per_core * scale_factor_h * scale_factor_w;
+    const bool is_height_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const uint32_t total_nhw = input.padded_shape()[0] * input.padded_shape()[1] * in_w;
+
+    // Get reduced core set - only cores that actually have work
+    const CoreRangeSet cores_with_work =
+        get_cores_with_work(all_cores, total_nhw, input_nsticks_per_core, is_height_sharded, shard_spec.orientation);
 
     uint32_t next_cb_index = CBIndex::c_0;
     const uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
@@ -298,7 +347,8 @@ UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreSharde
     auto config_tensor_shard_orientation = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED
                                                ? ShardOrientation::COL_MAJOR
                                                : shard_spec.orientation;
-    ShardSpec config_shard_spec(input.shard_spec().value().grid, shard_shape, config_tensor_shard_orientation);
+    // Use cores_with_work for config tensor sharding - only cores that have actual work need config data
+    ShardSpec config_shard_spec(cores_with_work, shard_shape, config_tensor_shard_orientation);
     MemoryConfig memory_config{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
     auto config_tensor_device = config_tensor.to_device(device, memory_config);
 
@@ -307,8 +357,9 @@ UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreSharde
     auto* config_buffer = config_storage.get_buffer();
     auto config_buffer_page_size = config_buffer->page_size();
 
+    // Create config CB only for cores that have work
     auto [config_cb_id, config_cb] = tt::tt_metal::create_cb(
-        next_cb_index++, program, all_cores, config_buffer_page_size, 1, config_df, &*config_buffer);
+        next_cb_index++, program, cores_with_work, config_buffer_page_size, 1, config_df, &*config_buffer);
 
     // Kernels
 
@@ -324,17 +375,18 @@ UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreSharde
         // number of intervals in config tensor per core, 4 is number of bfloat16 elements per entry
         static_cast<uint32_t>(config_tensor.logical_shape()[-1] / 4),
     };
+    // Only dispatch kernels to cores that have actual work
     std::string writer_kernel_fname =
         "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp";
     auto writer_kernel =
-        CreateKernel(program, writer_kernel_fname, all_cores, WriterDataMovementConfig(writer_compile_time_args));
+        CreateKernel(program, writer_kernel_fname, cores_with_work, WriterDataMovementConfig(writer_compile_time_args));
 
     std::vector<uint32_t> reader_compile_time_args = writer_compile_time_args;
     reader_compile_time_args[2] = true;  // reader
 
     std::string reader_kernel_fname =
         "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp";
-    CreateKernel(program, reader_kernel_fname, all_cores, ReaderDataMovementConfig(reader_compile_time_args));
+    CreateKernel(program, reader_kernel_fname, cores_with_work, ReaderDataMovementConfig(reader_compile_time_args));
 
     return cached_program_t{
         std::move(program),


### PR DESCRIPTION
### Problem description
Upsample was hanging in cases when some of the cores had an empty shard

### What's changed

Do not dispatch kernels, or shard config tensor, to cores which do not have any work to do

- [ ] [All post commit] (https://github.com/tenstorrent/tt-metal/actions/runs/20826088264)
- [ ] [BH post commit] (https://github.com/tenstorrent/tt-metal/actions/runs/20826092257)
- [ ] [L2 Nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/20826097310)
- [ ] [Device perf] (https://github.com/tenstorrent/tt-metal/actions/runs/20826103763)