### PR TITLE
[tt-train] Maximal core grid in tt-train matmuls

### DIFF
--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -91,7 +91,7 @@ autograd::TensorPtr linear_op(
     auto out = autograd::create_tensor();
 
     const auto grid_size = tensor->get_value().device()->compute_with_storage_grid_size();
-    std::optional<ttnn::CoreGrid> core_grid = ttnn::CoreGrid{grid_size.x, grid_size.y};
+    auto core_grid = std::make_optional<ttnn::CoreGrid>(grid_size.x, grid_size.y);
 
     out->set_value(ttnn::linear(
         tensor->get_value(),

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -90,6 +90,9 @@ autograd::TensorPtr linear_op(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& weight, const autograd::TensorPtr& bias) {
     auto out = autograd::create_tensor();
 
+    const auto grid_size = tensor->get_value().device()->compute_with_storage_grid_size();
+    std::optional<ttnn::CoreGrid> core_grid = ttnn::CoreGrid{grid_size.x, grid_size.y};
+
     out->set_value(ttnn::linear(
         tensor->get_value(),
         weight->get_value(),
@@ -102,7 +105,7 @@ autograd::TensorPtr linear_op(
         /* program_config */ std::nullopt,
         /* activation */ std::nullopt,
         /* compute_kernel_config */ core::ComputeKernelConfig::matmul(),
-        /* core_grid */ ttnn::CoreGrid{7, 8}));
+        /* core_grid */ core_grid));
 
     autograd::GradFunction grad = [weight, bias, tensor, out]() {
         auto tensor_shape = tensor->get_value().logical_shape();

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
@@ -10,7 +10,7 @@ namespace ttml::ttnn_fixed {
 tt::tt_metal::Tensor matmul(
     const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b, bool transpose_a, bool transpose_b) {
     const auto grid_size = a.device()->compute_with_storage_grid_size();
-    std::optional<ttnn::CoreGrid> core_grid = ttnn::CoreGrid{grid_size.x, grid_size.y};
+    auto core_grid = std::make_optional<ttnn::CoreGrid>(grid_size.x, grid_size.y);
 
     return ttnn::matmul(
         a,

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
@@ -7,7 +7,6 @@
 #include "core/compute_kernel_config.hpp"
 
 namespace ttml::ttnn_fixed {
-
 tt::tt_metal::Tensor matmul(
     const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b, bool transpose_a, bool transpose_b) {
     const auto grid_size = a.device()->compute_with_storage_grid_size();

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
@@ -7,8 +7,12 @@
 #include "core/compute_kernel_config.hpp"
 
 namespace ttml::ttnn_fixed {
+
 tt::tt_metal::Tensor matmul(
     const tt::tt_metal::Tensor& a, const tt::tt_metal::Tensor& b, bool transpose_a, bool transpose_b) {
+    const auto grid_size = a.device()->compute_with_storage_grid_size();
+    std::optional<ttnn::CoreGrid> core_grid = ttnn::CoreGrid{grid_size.x, grid_size.y};
+
     return ttnn::matmul(
         a,
         b,
@@ -20,7 +24,7 @@ tt::tt_metal::Tensor matmul(
         /* activation */ std::nullopt,
         /* compute_kernel_config */
         ttml::core::ComputeKernelConfig::matmul(),
-        /* core_grid */ ttnn::CoreGrid{7, 8},
+        /* core_grid */ core_grid,
         /* output_tile */ std::nullopt);
 }
 

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -108,3 +108,22 @@ endif()
 
 include(GoogleTest)
 gtest_discover_tests(ttml_tests)
+
+############################################################################################################################
+# Benchmark tests (using Google Benchmark)
+# Only available when building via tt-metal (Build from tt-train would require adding new dependency)
+############################################################################################################################
+
+if(TARGET benchmark::benchmark)
+    set(BENCHMARK_SOURCES benchmark/matmuls_benchmark.cpp)
+
+    add_executable(ttml_benchmarks ${BENCHMARK_SOURCES})
+    target_link_libraries(
+        ttml_benchmarks
+        PUBLIC
+            ttml
+            TTNN::TTNN
+            benchmark::benchmark
+    )
+    target_include_directories(ttml_benchmarks PRIVATE "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>")
+endif()

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -62,7 +62,7 @@ struct BenchmarkResult {
 
 struct TestConfig {
     int num_warmup_iterations = 2;
-    int num_measurement_iterations = 10;
+    int num_measurement_iterations = 25;
 };
 
 // CoreGrid configurations to compare
@@ -70,8 +70,10 @@ const std::vector<CoreGridConfig> core_grid_configs = {
     {std::nullopt, "std::nullopt"},
     {ttnn::CoreGrid{7, 8}, "7x8"},
     {ttnn::CoreGrid{8, 8}, "8x8"},
-    {ttnn::CoreGrid{13, 10}, "13x10"},
+    {ttnn::CoreGrid{10, 10}, "10x10"},
+    {ttnn::CoreGrid{11, 10}, "11x10"},
     {ttnn::CoreGrid{12, 10}, "12x10"},
+    {ttnn::CoreGrid{13, 10}, "13x10"},
 };
 
 // Test shapes from tt-train workloads

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -211,8 +211,8 @@ BenchmarkResult RunSingleMatmulBenchmark(
     constexpr int HiFi4_cycles_per_tile = 64;
     int num_cores_full_grid = compute_grid_size.x * compute_grid_size.y;
 
-    const double dim_per_tile = static_cast<double>(M) * K * N / 32.0 / 32.0;
-    double ideal_cycle_full_grid = dim_per_tile / 32 * HiFi4_cycles_per_tile / num_cores_full_grid;
+    const double num_tile_ops = static_cast<double>(M) * K * N / (32.0 * 32.0 * 32.0);
+    double ideal_cycle_full_grid = num_tile_ops * HiFi4_cycles_per_tile / num_cores_full_grid;
 
     const int freq_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
     double inference_cycle = inference_time_avg_s * freq_mhz * 1e6;

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <llrt/tt_cluster.hpp>
+#include <memory>
+#include <optional>
+#include <random>
+#include <span>
+#include <string>
+#include <tracy/Tracy.hpp>
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <vector>
+
+#include "core/random.hpp"
+#include "impl/context/metal_context.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+
+// tt-train compute kernel config for matmul
+ttnn::WormholeComputeKernelConfig get_tt_train_matmul_config() {
+    ttnn::WormholeComputeKernelConfig config;
+    config.fp32_dest_acc_en = true;
+    config.math_approx_mode = false;
+    config.math_fidelity = MathFidelity::HiFi4;
+    config.packer_l1_acc = true;
+    return config;
+}
+
+struct CoreGridConfig {
+    std::optional<ttnn::CoreGrid> core_grid;
+    std::string name;
+
+    bool is_supported(const tt::tt_metal::CoreCoord& device_grid) const {
+        if (!core_grid.has_value()) {
+            return true;
+        }
+        return static_cast<int>(core_grid->x) <= device_grid.x && static_cast<int>(core_grid->y) <= device_grid.y;
+    }
+};
+
+struct MatmulTestShape {
+    std::vector<uint32_t> a_shape;
+    std::vector<uint32_t> b_shape;
+    bool transpose_a;
+    bool transpose_b;
+    std::string name;
+};
+
+struct BenchmarkResult {
+    std::string grid_name;
+    double time_us = std::numeric_limits<double>::quiet_NaN();
+    double tflops = 0.0;
+    double utilization_pct = 0.0;
+    bool skipped = false;
+};
+
+struct TestConfig {
+    int num_warmup_iterations = 2;
+    int num_measurement_iterations = 10;
+};
+
+// CoreGrid configurations to compare
+const std::vector<CoreGridConfig> core_grid_configs = {
+    {std::nullopt, "std::nullopt"},
+    {ttnn::CoreGrid{7, 8}, "7x8"},
+    {ttnn::CoreGrid{8, 8}, "8x8"},
+    {ttnn::CoreGrid{13, 10}, "13x10"},
+    {ttnn::CoreGrid{12, 10}, "12x10"},
+};
+
+// Test shapes from tt-train workloads
+const std::vector<MatmulTestShape> tt_train_shapes = {
+    // Attention matmuls
+    {{64, 6, 256, 64}, {64, 6, 256, 64}, false, true, "attn_64x6x256x64_x_64x6x256x64_Tb"},
+    {{64, 6, 256, 256}, {64, 6, 256, 64}, false, false, "attn_64x6x256x256_x_64x6x256x64"},
+    {{64, 6, 256, 256}, {64, 6, 256, 64}, true, false, "attn_64x6x256x256_x_64x6x256x64_Ta"},
+    {{4, 12, 1024, 64}, {4, 12, 1024, 64}, false, true, "attn_4x12x1024x64_x_4x12x1024x64_Tb"},
+    {{4, 12, 1024, 1024}, {4, 12, 1024, 64}, false, false, "attn_4x12x1024x1024_x_4x12x1024x64"},
+    {{4, 12, 1024, 1024}, {4, 12, 1024, 64}, true, false, "attn_4x12x1024x1024_x_4x12x1024x64_Ta"},
+
+    // Linear layer forward matmuls (2D x 4D broadcast)
+    {{16384, 96}, {1, 1, 96, 384}, false, false, "fwd_16384x96_x_96x384"},
+    {{16384, 384}, {1, 1, 384, 1536}, false, false, "fwd_16384x384_x_384x1536"},
+    {{16384, 1536}, {1, 1, 1536, 384}, false, false, "fwd_16384x1536_x_1536x384"},
+    {{16384, 384}, {1, 1, 384, 384}, false, false, "fwd_16384x384_x_384x384"},
+    {{16384, 1152}, {1, 1, 1152, 384}, false, false, "fwd_16384x1152_x_1152x384"},
+    {{4096, 96}, {1, 1, 96, 768}, false, false, "fwd_4096x96_x_96x768"},
+    {{4096, 768}, {1, 1, 768, 3072}, false, false, "fwd_4096x768_x_768x3072"},
+    {{4096, 3072}, {1, 1, 3072, 768}, false, false, "fwd_4096x3072_x_3072x768"},
+    {{4096, 768}, {1, 1, 768, 768}, false, false, "fwd_4096x768_x_768x768"},
+    {{4096, 2304}, {1, 1, 2304, 768}, false, false, "fwd_4096x2304_x_2304x768"},
+
+    // Linear layer backward matmuls (2D x 2D with transpose_a)
+    {{16384, 96}, {16384, 384}, true, false, "bwd_16384x96_x_16384x384_Ta"},
+    {{16384, 384}, {16384, 1536}, true, false, "bwd_16384x384_x_16384x1536_Ta"},
+    {{16384, 1536}, {16384, 384}, true, false, "bwd_16384x1536_x_16384x384_Ta"},
+    {{16384, 384}, {16384, 384}, true, false, "bwd_16384x384_x_16384x384_Ta"},
+    {{16384, 1152}, {16384, 384}, true, false, "bwd_16384x1152_x_16384x384_Ta"},
+    {{4096, 96}, {4096, 768}, true, false, "bwd_4096x96_x_4096x768_Ta"},
+    {{4096, 768}, {4096, 3072}, true, false, "bwd_4096x768_x_4096x3072_Ta"},
+    {{4096, 3072}, {4096, 768}, true, false, "bwd_4096x3072_x_4096x768_Ta"},
+    {{4096, 768}, {4096, 768}, true, false, "bwd_4096x768_x_4096x768_Ta"},
+    {{4096, 2304}, {4096, 768}, true, false, "bwd_4096x2304_x_4096x768_Ta"},
+};
+
+const TestConfig test_config = {
+    .num_warmup_iterations = 2,
+    .num_measurement_iterations = 10,
+};
+
+namespace {
+
+// Get effective M, K, N for TFLOPS calculation
+std::tuple<uint64_t, uint64_t, uint64_t> get_mkn_from_shapes(
+    const ttnn::Tensor& input_a, const ttnn::Tensor& input_b, bool transpose_a, bool transpose_b) {
+    // For matmul A[..., M, K] x B[..., K, N] = C[..., M, N]
+    // If transpose_a: A[..., K, M] -> A^T[..., M, K]
+    // If transpose_b: B[..., N, K] -> B^T[..., K, N]
+    const auto& a_shape = input_a.logical_shape();
+    const auto& b_shape = input_b.logical_shape();
+
+    uint64_t M = transpose_a ? a_shape[-1] : a_shape[-2];
+    uint64_t K = transpose_a ? a_shape[-2] : a_shape[-1];
+    uint64_t N = transpose_b ? b_shape[-2] : b_shape[-1];
+
+    uint64_t batch = tt::tt_metal::get_batch_size(a_shape);
+
+    return {batch * M, K, N};
+}
+
+BenchmarkResult RunSingleMatmulBenchmark(
+    const MatmulTestShape& matmul_shape,
+    const CoreGridConfig& grid_config,
+    const std::shared_ptr<ttnn::device::MeshDevice>& device,
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const int device_id = 0) {
+    const int num_warmup_iterations = test_config.num_warmup_iterations;
+    const int num_measurement_iterations = test_config.num_measurement_iterations;
+
+    auto* dev_ptr = device.get();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+
+    if (!grid_config.is_supported(compute_grid_size)) {
+        return BenchmarkResult{.grid_name = grid_config.name, .skipped = true};
+    }
+
+    // Get tt-train compute kernel config
+    auto compute_kernel_config = get_tt_train_matmul_config();
+
+    ttnn::Tensor output_tensor;
+
+    // Warmup iterations
+    for (int iter = 0; iter < num_warmup_iterations; ++iter) {
+        output_tensor = ttnn::matmul(
+            input_tensor_a,
+            input_tensor_b,
+            /*transpose_a=*/matmul_shape.transpose_a,
+            /*transpose_b=*/matmul_shape.transpose_b,
+            /*memory_config=*/std::nullopt,
+            /*dtype=*/std::nullopt,
+            /*program_config=*/std::nullopt,
+            /*activation=*/std::nullopt,
+            /*compute_kernel_config=*/compute_kernel_config,
+            /*core_grid=*/grid_config.core_grid,
+            /*output_tile=*/std::nullopt);
+        tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
+        output_tensor.deallocate();
+    }
+
+    std::chrono::duration<double> total_time = std::chrono::duration<double>::zero();
+
+    // Performance measurement iterations
+    {
+        ZoneScopedN("TTTrain Matmul iterations");
+        for (int iter = 0; iter < num_measurement_iterations; ++iter) {
+            auto start_time = std::chrono::high_resolution_clock::now();
+            output_tensor = ttnn::matmul(
+                input_tensor_a,
+                input_tensor_b,
+                /*transpose_a=*/matmul_shape.transpose_a,
+                /*transpose_b=*/matmul_shape.transpose_b,
+                /*memory_config=*/std::nullopt,
+                /*dtype=*/std::nullopt,
+                /*program_config=*/std::nullopt,
+                /*activation=*/std::nullopt,
+                /*compute_kernel_config=*/compute_kernel_config,
+                /*core_grid=*/grid_config.core_grid,
+                /*output_tile=*/std::nullopt);
+            tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
+            auto end_time = std::chrono::high_resolution_clock::now();
+            total_time += end_time - start_time;
+            output_tensor.deallocate();
+        }
+    }
+
+    const double inference_time_avg_s = total_time.count() / num_measurement_iterations;
+
+    // Calculate TFLOPS
+    auto [M, K, N] =
+        get_mkn_from_shapes(input_tensor_a, input_tensor_b, matmul_shape.transpose_a, matmul_shape.transpose_b);
+    double tflops = 2.0 * M * K * N / 1e12 / inference_time_avg_s;
+
+    // Calculate utilization against full grid
+    constexpr int HiFi4_cycles_per_tile = 64;
+    int num_cores_full_grid = compute_grid_size.x * compute_grid_size.y;
+
+    const double dim_per_tile = static_cast<double>(M) * K * N / 32.0 / 32.0;
+    double ideal_cycle_full_grid = dim_per_tile / 32 * HiFi4_cycles_per_tile / num_cores_full_grid;
+
+    const int freq_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
+    double inference_cycle = inference_time_avg_s * freq_mhz * 1e6;
+
+    double utilization_full_grid = ideal_cycle_full_grid / inference_cycle;
+
+    return BenchmarkResult{
+        .grid_name = grid_config.name,
+        .time_us = inference_time_avg_s * 1e6,
+        .tflops = tflops,
+        .utilization_pct = utilization_full_grid * 100,
+    };
+}
+
+void PrintComparisonTable(const std::string& shape_name, const std::vector<BenchmarkResult>& results) {
+    std::cout << "\n";
+    std::cout << "╔══════════════════════════════════════════════════════════════╗\n";
+    std::cout << "║ Shape: " << std::left << std::setw(53) << shape_name << " ║\n";
+    std::cout << "╠══════════════╦═══════════════╦═══════════════╦═══════════════╣\n";
+    std::cout << "║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║\n";
+    std::cout << "╠══════════════╬═══════════════╬═══════════════╬═══════════════╣\n";
+
+    for (const auto& result : results) {
+        std::cout << "║ " << std::setw(12) << std::left << result.grid_name << " ║ ";
+        if (result.skipped) {
+            std::cout << std::setw(13) << std::right << "SKIP"
+                      << " ║ " << std::setw(13) << std::right << "-"
+                      << " ║ " << std::setw(13) << std::right << "-"
+                      << " ║\n";
+        } else {
+            std::cout << std::setw(13) << std::right << std::fixed << std::setprecision(1) << result.time_us << " ║ "
+                      << std::setw(13) << std::fixed << std::setprecision(2) << result.tflops << " ║ " << std::setw(12)
+                      << std::fixed << std::setprecision(2) << result.utilization_pct << "% ║\n";
+        }
+    }
+
+    std::cout << "╚══════════════╩═══════════════╩═══════════════╩═══════════════╝\n";
+}
+
+// Benchmark function - for each shape, compares all grid configs and prints table
+void BM_TTTrainMatmulComparison(benchmark::State& state) {
+    const int shape_index = static_cast<int>(state.range(0));
+    const MatmulTestShape& matmul_shape = tt_train_shapes[shape_index];
+
+    // Open device
+    const auto device_id = 0;
+    auto device = ttnn::device::open_mesh_device(device_id, /*l1_small_size=*/200000, /*trace_region_size=*/1048576);
+    device->enable_program_cache();
+
+    std::vector<BenchmarkResult> results;
+
+    for (auto _ : state) {
+        results.clear();
+
+        // Create inputs once per shape so each grid config sees identical tensors
+        const auto dtype = ttnn::DataType::BFLOAT16;
+        const uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(matmul_shape.name));
+
+        ttnn::Shape a_shape(matmul_shape.a_shape);
+        ttnn::Shape b_shape(matmul_shape.b_shape);
+
+        std::vector<float> data_a(a_shape.volume());
+        ttml::core::parallel_generate(
+            std::span{data_a.data(), data_a.size()},
+            []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); },
+            seed);
+        ttnn::Tensor input_tensor_a = ttnn::Tensor::from_vector(
+            data_a,
+            ttnn::TensorSpec(
+                a_shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG)),
+            device.get());
+
+        std::vector<float> data_b(b_shape.volume());
+        ttml::core::parallel_generate(
+            std::span{data_b.data(), data_b.size()},
+            []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); },
+            seed + 1);
+        ttnn::Tensor input_tensor_b = ttnn::Tensor::from_vector(
+            data_b,
+            ttnn::TensorSpec(
+                b_shape, tt::tt_metal::TensorLayout(dtype, tt::tt_metal::Layout::TILE, ttnn::DRAM_MEMORY_CONFIG)),
+            device.get());
+
+        // Run benchmark for each grid configuration
+        for (const auto& grid_config : core_grid_configs) {
+            auto result =
+                RunSingleMatmulBenchmark(matmul_shape, grid_config, device, input_tensor_a, input_tensor_b, device_id);
+            results.push_back(result);
+        }
+
+        // Print comparison table
+        PrintComparisonTable(matmul_shape.name, results);
+
+        // Report the best time to benchmark framework
+        auto fastest = std::min_element(results.begin(), results.end(), [](const auto& a, const auto& b) {
+            if (a.skipped != b.skipped) {
+                return !a.skipped;  // non-skipped beats skipped
+            }
+            if (a.skipped && b.skipped) {
+                return false;
+            }
+            return a.time_us < b.time_us;
+        });
+
+        if (fastest == results.end() || fastest->skipped) {
+            state.SkipWithError("No valid core grid configs for this device");
+            input_tensor_a.deallocate();
+            input_tensor_b.deallocate();
+            continue;
+        }
+
+        state.SetIterationTime(fastest->time_us / 1e6);
+        state.counters["Best_TFLOPs"] = fastest->tflops;
+        state.counters["Best_Time_us"] = fastest->time_us;
+
+        state.counters["Best_Grid"] = std::distance(results.begin(), fastest);
+
+        // Cleanup inputs
+        input_tensor_a.deallocate();
+        input_tensor_b.deallocate();
+    }
+
+    // Close device
+    device->close();
+}
+
+}  // namespace
+
+// Register one benchmark per shape - each will compare all grid configs
+BENCHMARK(BM_TTTrainMatmulComparison)
+    ->DenseRange(0, static_cast<int>(tt_train_shapes.size()) - 1, 1)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime()
+    ->Iterations(1)
+    ->Name("TTTrainMatmul");
+
+BENCHMARK_MAIN();

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/device.hpp>
 #include <vector>
 
+#include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
 #include "impl/context/metal_context.hpp"
 #include "ttnn/device.hpp"
@@ -30,16 +31,6 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
-
-// tt-train compute kernel config for matmul
-ttnn::WormholeComputeKernelConfig get_tt_train_matmul_config() {
-    ttnn::WormholeComputeKernelConfig config;
-    config.fp32_dest_acc_en = true;
-    config.math_approx_mode = false;
-    config.math_fidelity = MathFidelity::HiFi4;
-    config.packer_l1_acc = true;
-    return config;
-}
 
 struct CoreGridConfig {
     std::optional<ttnn::CoreGrid> core_grid;
@@ -161,7 +152,7 @@ BenchmarkResult RunSingleMatmulBenchmark(
     }
 
     // Get tt-train compute kernel config
-    auto compute_kernel_config = get_tt_train_matmul_config();
+    auto compute_kernel_config = ttml::core::ComputeKernelConfig::matmul();
 
     ttnn::Tensor output_tensor;
 

--- a/tt-train/tests/benchmark/matmuls_benchmark.cpp
+++ b/tt-train/tests/benchmark/matmuls_benchmark.cpp
@@ -131,7 +131,7 @@ std::tuple<uint64_t, uint64_t, uint64_t> get_mkn_from_shapes(
     uint64_t K = transpose_a ? a_shape[-2] : a_shape[-1];
     uint64_t N = transpose_b ? b_shape[-2] : b_shape[-1];
 
-    uint64_t batch = tt::tt_metal::get_batch_size(a_shape);
+    uint64_t batch = ttnn::get_batch_size(a_shape);
 
     return {batch * M, K, N};
 }


### PR DESCRIPTION
### Ticket
#34851 

### Problem description
Matmul operations in tt-train previously used a hard-coded compute grid (ttnn::CoreGrid{7, 8}) regardless of device.
This resulted in suboptimal matmul performance on Blackhole cards.

### What's changed
- Matmul compute grid is now fetched from the maximum available compute grid of the device associated with input tensor A and passed to the matmul configuration in `tt-train/sources/ttml/ttnn_fixed/matmuls.cpp`
- Added a benchmark covering matmul shapes used in NanoGPT and GPT2s across different compute grids in 
`tt-train/tests/benchmark/matmuls_benchmark.cpp` inspired by 
`tt-metal/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp`

## Impact
- **Blackhole P100**: Measurable matmul speedup across NanoGPT and GPT2s workloads
- **Wormhole N150**: Negligible speedup

### NanoGPT
![NanoGPT benchmark 1](https://github.com/user-attachments/assets/9a095055-f460-4f7b-bef2-c51c1d528dc1)

Speedup: **6.89%**

![NanoGPT benchmark 2](https://github.com/user-attachments/assets/5eb0758c-b1f5-46ec-aa45-750c3c73aac3)

Speedup: **2.46%**

---

### GPT2s

![GPT2s benchmark 1](https://github.com/user-attachments/assets/52a64a50-3c39-48a3-a274-26e41d985052)

Speedup: **8.65%**

![GPT2s benchmark 2](https://github.com/user-attachments/assets/2d211c7f-ae09-4c7c-8696-f76c3355e1cd)

Speedup: **0.24%**

## Benchmark results
*Run on Blackhole P100*
```bash=

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_64x6x256x64_x_64x6x256x64_Tb                     ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         806.6 ║          3.99 ║         2.63% ║
║ 7x8          ║         306.8 ║         10.50 ║         6.90% ║
║ 8x8          ║         275.6 ║         11.69 ║         7.69% ║
║ 10x10        ║         277.0 ║         11.63 ║         7.65% ║
║ 11x10        ║         277.7 ║         11.60 ║         7.63% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
----------------------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------
TTTrainMatmul/0/iterations:1/manual_time       0.276 ms          200 ms            1 Best_Grid=2 Best_TFLOPs=11.6883 Best_Time_us=275.595

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_64x6x256x256_x_64x6x256x64                       ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║        2202.3 ║          1.46 ║         0.96% ║
║ 7x8          ║         250.0 ║         12.89 ║         8.47% ║
║ 8x8          ║         225.4 ║         14.29 ║         9.40% ║
║ 10x10        ║         230.3 ║         13.99 ║         9.20% ║
║ 11x10        ║         233.9 ║         13.77 ║         9.06% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/1/iterations:1/manual_time       0.225 ms          466 ms            1 Best_Grid=2 Best_TFLOPs=14.2929 Best_Time_us=225.372

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_64x6x256x256_x_64x6x256x64_Ta                    ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║        2152.8 ║          1.50 ║         0.98% ║
║ 7x8          ║         255.9 ║         12.59 ║         8.28% ║
║ 8x8          ║         227.5 ║         14.16 ║         9.31% ║
║ 10x10        ║         232.2 ║         13.87 ║         9.12% ║
║ 11x10        ║         236.3 ║         13.63 ║         8.96% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/2/iterations:1/manual_time       0.228 ms          450 ms            1 Best_Grid=2 Best_TFLOPs=14.1583 Best_Time_us=227.515

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_4x12x1024x64_x_4x12x1024x64_Tb                   ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         515.8 ║         12.49 ║         8.21% ║
║ 7x8          ║         566.0 ║         11.38 ║         7.49% ║
║ 8x8          ║         552.9 ║         11.65 ║         7.66% ║
║ 10x10        ║         557.5 ║         11.56 ║         7.60% ║
║ 11x10        ║         517.1 ║         12.46 ║         8.19% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/3/iterations:1/manual_time       0.516 ms         65.9 ms            1 Best_Grid=0 Best_TFLOPs=12.4914 Best_Time_us=515.753

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_4x12x1024x1024_x_4x12x1024x64                    ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         844.2 ║          7.63 ║         5.02% ║
║ 7x8          ║         345.0 ║         18.67 ║        12.28% ║
║ 8x8          ║         335.7 ║         19.19 ║        12.62% ║
║ 10x10        ║         347.9 ║         18.52 ║        12.18% ║
║ 11x10        ║         349.3 ║         18.44 ║        12.13% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/4/iterations:1/manual_time       0.336 ms          732 ms            1 Best_Grid=2 Best_TFLOPs=19.1897 Best_Time_us=335.724

╔══════════════════════════════════════════════════════════════╗
║ Shape: attn_4x12x1024x1024_x_4x12x1024x64_Ta                 ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         854.5 ║          7.54 ║         4.96% ║
║ 7x8          ║         355.9 ║         18.10 ║        11.90% ║
║ 8x8          ║         358.5 ║         17.97 ║        11.82% ║
║ 10x10        ║         368.4 ║         17.49 ║        11.50% ║
║ 11x10        ║         369.6 ║         17.43 ║        11.46% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/5/iterations:1/manual_time       0.356 ms          730 ms            1 Best_Grid=1 Best_TFLOPs=18.0998 Best_Time_us=355.941

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_16384x96_x_96x384                                 ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         144.3 ║          8.37 ║         5.51% ║
║ 7x8          ║         139.4 ║          8.66 ║         5.70% ║
║ 8x8          ║         142.4 ║          8.48 ║         5.58% ║
║ 10x10        ║         144.4 ║          8.37 ║         5.50% ║
║ 11x10        ║         144.9 ║          8.34 ║         5.48% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/6/iterations:1/manual_time       0.139 ms         31.2 ms            1 Best_Grid=1 Best_TFLOPs=8.6627 Best_Time_us=139.444

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_16384x384_x_384x1536                              ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         529.0 ║         36.54 ║        24.03% ║
║ 7x8          ║         666.9 ║         28.98 ║        19.06% ║
║ 8x8          ║         620.7 ║         31.14 ║        20.48% ║
║ 10x10        ║         569.6 ║         33.93 ║        22.31% ║
║ 11x10        ║         550.6 ║         35.10 ║        23.08% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/7/iterations:1/manual_time       0.529 ms         87.1 ms            1 Best_Grid=0 Best_TFLOPs=36.5372 Best_Time_us=528.977

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_16384x1536_x_1536x384                             ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         370.9 ║         52.11 ║        34.27% ║
║ 7x8          ║         439.8 ║         43.94 ║        28.90% ║
║ 8x8          ║         386.4 ║         50.02 ║        32.89% ║
║ 10x10        ║         379.6 ║         50.92 ║        33.48% ║
║ 11x10        ║         370.5 ║         52.17 ║        34.31% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/8/iterations:1/manual_time       0.370 ms          383 ms            1 Best_Grid=4 Best_TFLOPs=52.1686 Best_Time_us=370.479

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_16384x384_x_384x384                               ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         199.9 ║         24.17 ║        15.90% ║
║ 7x8          ║         199.8 ║         24.18 ║        15.90% ║
║ 8x8          ║         193.2 ║         25.01 ║        16.45% ║
║ 10x10        ║         189.3 ║         25.53 ║        16.79% ║
║ 11x10        ║         188.7 ║         25.61 ║        16.84% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/9/iterations:1/manual_time       0.189 ms         91.1 ms            1 Best_Grid=4 Best_TFLOPs=25.6055 Best_Time_us=188.703

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_16384x1152_x_1152x384                             ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         306.5 ║         47.29 ║        31.10% ║
║ 7x8          ║         357.7 ║         40.52 ║        26.65% ║
║ 8x8          ║         317.0 ║         45.73 ║        30.07% ║
║ 10x10        ║         311.0 ║         46.61 ║        30.65% ║
║ 11x10        ║         306.7 ║         47.27 ║        31.08% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/10/iterations:1/manual_time      0.307 ms          290 ms            1 Best_Grid=0 Best_TFLOPs=47.2916 Best_Time_us=306.513

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_4096x96_x_96x768                                  ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║          82.4 ║          7.33 ║         4.82% ║
║ 7x8          ║          79.2 ║          7.63 ║         5.02% ║
║ 8x8          ║          80.1 ║          7.54 ║         4.96% ║
║ 10x10        ║          78.5 ║          7.69 ║         5.06% ║
║ 11x10        ║          78.4 ║          7.70 ║         5.07% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/11/iterations:1/manual_time      0.078 ms         25.6 ms            1 Best_Grid=4 Best_TFLOPs=7.70409 Best_Time_us=78.3973

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_4096x768_x_768x3072                               ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         306.6 ║         63.04 ║        41.46% ║
║ 7x8          ║         394.9 ║         48.94 ║        32.18% ║
║ 8x8          ║         367.9 ║         52.53 ║        34.54% ║
║ 10x10        ║         301.7 ║         64.05 ║        42.12% ║
║ 11x10        ║         278.0 ║         69.53 ║        45.72% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/12/iterations:1/manual_time      0.278 ms         54.7 ms            1 Best_Grid=4 Best_TFLOPs=69.527 Best_Time_us=277.984

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_4096x3072_x_3072x768                              ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         299.5 ║         64.54 ║        42.44% ║
║ 7x8          ║         389.2 ║         49.66 ║        32.65% ║
║ 8x8          ║         317.7 ║         60.84 ║        40.01% ║
║ 10x10        ║         267.8 ║         72.17 ║        47.46% ║
║ 11x10        ║         282.3 ║         68.46 ║        45.02% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/13/iterations:1/manual_time      0.268 ms          193 ms            1 Best_Grid=3 Best_TFLOPs=72.1736 Best_Time_us=267.79

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_4096x768_x_768x768                                ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         133.9 ║         36.08 ║        23.72% ║
║ 7x8          ║         146.6 ║         32.96 ║        21.68% ║
║ 8x8          ║         132.1 ║         36.57 ║        24.05% ║
║ 10x10        ║         120.6 ║         40.08 ║        26.36% ║
║ 11x10        ║         120.1 ║         40.23 ║        26.46% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/14/iterations:1/manual_time      0.120 ms         43.4 ms            1 Best_Grid=4 Best_TFLOPs=40.2291 Best_Time_us=120.108

╔══════════════════════════════════════════════════════════════╗
║ Shape: fwd_4096x2304_x_2304x768                              ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         243.8 ║         59.45 ║        39.09% ║
║ 7x8          ║         311.7 ║         46.50 ║        30.58% ║
║ 8x8          ║         255.3 ║         56.77 ║        37.34% ║
║ 10x10        ║         220.9 ║         65.62 ║        43.15% ║
║ 11x10        ║         222.1 ║         65.27 ║        42.92% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/15/iterations:1/manual_time      0.221 ms          154 ms            1 Best_Grid=3 Best_TFLOPs=65.62 Best_Time_us=220.901

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_16384x96_x_16384x384_Ta                           ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         336.3 ║          3.59 ║         2.36% ║
║ 7x8          ║         175.8 ║          6.87 ║         4.52% ║
║ 8x8          ║         176.5 ║          6.84 ║         4.50% ║
║ 10x10        ║         178.1 ║          6.78 ║         4.46% ║
║ 11x10        ║         176.9 ║          6.83 ║         4.49% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/16/iterations:1/manual_time      0.176 ms         96.1 ms            1 Best_Grid=1 Best_TFLOPs=6.87288 Best_Time_us=175.757

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_16384x384_x_16384x1536_Ta                         ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         554.7 ║         34.84 ║        22.91% ║
║ 7x8          ║         510.0 ║         37.90 ║        24.92% ║
║ 8x8          ║         449.9 ║         42.96 ║        28.25% ║
║ 10x10        ║         406.4 ║         47.56 ║        31.28% ║
║ 11x10        ║         406.3 ║         47.57 ║        31.28% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/17/iterations:1/manual_time      0.406 ms          437 ms            1 Best_Grid=4 Best_TFLOPs=47.571 Best_Time_us=406.284

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_16384x1536_x_16384x384_Ta                         ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         632.2 ║         30.57 ║        20.11% ║
║ 7x8          ║         537.8 ║         35.94 ║        23.63% ║
║ 8x8          ║         538.4 ║         35.90 ║        23.61% ║
║ 10x10        ║         455.1 ║         42.47 ║        27.93% ║
║ 11x10        ║         457.5 ║         42.24 ║        27.78% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/18/iterations:1/manual_time      0.455 ms          441 ms            1 Best_Grid=3 Best_TFLOPs=42.4678 Best_Time_us=455.106

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_16384x384_x_16384x384_Ta                          ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         438.6 ║         11.02 ║         7.24% ║
║ 7x8          ║         252.0 ║         19.17 ║        12.61% ║
║ 8x8          ║         256.1 ║         18.86 ║        12.41% ║
║ 10x10        ║         252.1 ║         19.16 ║        12.60% ║
║ 11x10        ║         252.1 ║         19.17 ║        12.60% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/19/iterations:1/manual_time      0.252 ms          170 ms            1 Best_Grid=1 Best_TFLOPs=19.1726 Best_Time_us=252.018

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_16384x1152_x_16384x384_Ta                         ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         584.3 ║         24.81 ║        16.32% ║
║ 7x8          ║         459.7 ║         31.53 ║        20.74% ║
║ 8x8          ║         456.9 ║         31.73 ║        20.86% ║
║ 10x10        ║         394.2 ║         36.78 ║        24.18% ║
║ 11x10        ║         394.9 ║         36.71 ║        24.14% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/20/iterations:1/manual_time      0.394 ms          368 ms            1 Best_Grid=3 Best_TFLOPs=36.7751 Best_Time_us=394.166

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_4096x96_x_4096x768_Ta                             ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         123.3 ║          4.90 ║         3.22% ║
║ 7x8          ║          96.3 ║          6.27 ║         4.12% ║
║ 8x8          ║          89.3 ║          6.77 ║         4.45% ║
║ 10x10        ║          89.8 ║          6.73 ║         4.42% ║
║ 11x10        ║          90.8 ║          6.65 ║         4.38% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/21/iterations:1/manual_time      0.089 ms         42.6 ms            1 Best_Grid=2 Best_TFLOPs=6.76628 Best_Time_us=89.2632

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_4096x768_x_4096x3072_Ta                           ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         321.1 ║         60.19 ║        39.58% ║
║ 7x8          ║         367.7 ║         52.56 ║        34.57% ║
║ 8x8          ║         324.5 ║         59.57 ║        39.17% ║
║ 10x10        ║         292.3 ║         66.11 ║        43.48% ║
║ 11x10        ║         265.5 ║         72.78 ║        47.86% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/22/iterations:1/manual_time      0.266 ms          205 ms            1 Best_Grid=4 Best_TFLOPs=72.7838 Best_Time_us=265.545

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_4096x3072_x_4096x768_Ta                           ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         377.3 ║         51.22 ║        33.69% ║
║ 7x8          ║         443.9 ║         43.54 ║        28.63% ║
║ 8x8          ║         373.9 ║         51.69 ║        33.99% ║
║ 10x10        ║         318.3 ║         60.73 ║        39.94% ║
║ 11x10        ║         318.9 ║         60.61 ║        39.86% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/23/iterations:1/manual_time      0.318 ms          198 ms            1 Best_Grid=3 Best_TFLOPs=60.7295 Best_Time_us=318.253

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_4096x768_x_4096x768_Ta                            ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         177.5 ║         27.22 ║        17.90% ║
║ 7x8          ║         153.0 ║         31.58 ║        20.77% ║
║ 8x8          ║         134.1 ║         36.03 ║        23.69% ║
║ 10x10        ║         133.5 ║         36.19 ║        23.80% ║
║ 11x10        ║         134.1 ║         36.04 ║        23.70% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/24/iterations:1/manual_time      0.134 ms         64.9 ms            1 Best_Grid=3 Best_TFLOPs=36.1895 Best_Time_us=133.515

╔══════════════════════════════════════════════════════════════╗
║ Shape: bwd_4096x2304_x_4096x768_Ta                           ║
╠══════════════╦═══════════════╦═══════════════╦═══════════════╣
║   CoreGrid   ║   Time (us)   ║    TFLOPs     ║  Utilization  ║
╠══════════════╬═══════════════╬═══════════════╬═══════════════╣
║ std::nullopt ║         321.3 ║         45.12 ║        29.67% ║
║ 7x8          ║         346.2 ║         41.87 ║        27.53% ║
║ 8x8          ║         295.8 ║         49.01 ║        32.23% ║
║ 10x10        ║         270.5 ║         53.58 ║        35.24% ║
║ 11x10        ║         270.7 ║         53.55 ║        35.22% ║
║ 12x10        ║          SKIP ║             - ║             - ║
║ 13x10        ║          SKIP ║             - ║             - ║
╚══════════════╩═══════════════╩═══════════════╩═══════════════╝
TTTrainMatmul/25/iterations:1/manual_time      0.271 ms          163 ms            1 Best_Grid=3 Best_TFLOPs=53.5844 Best_Time_us=270.518
```

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=zbaczewski/tt-train-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:zbaczewski/tt-train-matmul)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=zbaczewski/tt-train-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:zbaczewski/tt-train-matmul)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/tt-train-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/tt-train-matmul)