### PR TITLE
[tt-train] Revert test skip in NIGHTLY_UnusedParametersInModuleSGD

### DIFF
--- a/tt-train/tests/autograd/module_base_parameters_test.cpp
+++ b/tt-train/tests/autograd/module_base_parameters_test.cpp
@@ -85,7 +85,6 @@ TEST_F(ModuleBaseParametersTest, AllParametersIncluded) {
 };
 
 TEST_F(ModuleBaseParametersTest, NIGHTLY_UnusedParametersInModuleSGD) {
-    GTEST_SKIP() << "Skipping due to segmentation fault - see GitHub issue 35082";
     auto* device = &ttml::autograd::ctx().get_device();
 
     ModelUnusedLayer model;


### PR DESCRIPTION
### Ticket
#35082 

### Problem description
`NIGHTLY_UnusedParametersInModuleSGD` test has been failing due to segfault caused by SIMD RNG enabled by default. This change has been since then reverted [here](https://github.com/tenstorrent/tt-metal/pull/35144).

### What's changed
Reverted test skip.

### Checklist

- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/revert-autograd-test-skip)](https://github.com/tenstorrent/tt-metal/actions/runs/20917790100)