### PR TITLE
#35526: Use noc_async_writes_flushed before cb_pop_front in matmul/fused/reduce

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -191,11 +191,12 @@ void kernel_main() {
                             out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                         }
 
-                        noc_async_write_barrier();
+                        noc_async_writes_flushed();
 
                         cb_pop_front(cb_id_out0, out_subblock_tile_count);
                         out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                     }
+                    noc_async_write_barrier();
                     // Pop fully padded subblocks along the row
                     if (bw == num_blocks_w_dim_ - 1) {
                         cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -530,10 +530,11 @@ void kernel_main() {
                                 out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                             }
 
-                            noc_async_write_barrier();
+                            noc_async_writes_flushed();
                             cb_pop_front(cb_id_out0, out_subblock_tile_count);
                             out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
                         }
+                        noc_async_write_barrier();
                         // Pop fully padded subblocks along the row
                         if (bw == num_blocks_w_dim_ - 1) {
                             cb_wait_front(cb_id_out0, padded_block_tiles_w_skip);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -148,10 +148,11 @@ void kernel_main() {
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                 }
 
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_id_out0, out_subblock_tile_count);
                 out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
             }
+            noc_async_write_barrier();
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
         }
         out_tensor_start_tile_id += MtNt;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -54,10 +54,11 @@ void kernel_main() {
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                 }
 
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_id_out0, out_subblock_tile_count);
                 out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
             }
+            noc_async_write_barrier();
             out_tensor_sbh_start_tile_id += out_tensor_next_subblock_stride_h;
         }
         out_tensor_start_tile_id += MtNt;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -108,9 +108,10 @@ void kernel_main() {
                 cb_wait_front(cb_id_dst, onetile);
                 uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
                 noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_id_dst, onetile);
             }
+            noc_async_write_barrier();
             tile_offset += c_stride;
         }
         tile_offset += next_batch_shift;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -83,7 +83,7 @@ void kernel_main() {
                     cb_wait_front(cb_id_updated_running_mean, onetile);
                     uint32_t l1_write_updated_mean_addr = get_read_ptr(cb_id_updated_running_mean);
                     noc_async_write_tile(tile_offset, old_running_mean, l1_write_updated_mean_addr);
-                    noc_async_write_barrier();
+                    noc_async_writes_flushed();
                     cb_pop_front(cb_id_updated_running_mean, onetile);
                 }
 
@@ -100,7 +100,7 @@ void kernel_main() {
                     cb_wait_front(cb_id_updated_running_var, onetile);
                     uint32_t l1_write_updated_var_addr = get_read_ptr(cb_id_updated_running_var);
                     noc_async_write_tile(tile_offset, old_running_var, l1_write_updated_var_addr);
-                    noc_async_write_barrier();
+                    noc_async_writes_flushed();
                     cb_pop_front(cb_id_updated_running_var, onetile);
                 }
                 ++tile_offset;
@@ -109,9 +109,10 @@ void kernel_main() {
                 cb_wait_front(cb_id_dst, onetile);
                 uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
                 noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_id_dst, onetile);
             }
+            noc_async_write_barrier();
             tile_offset += next_channel_shift;
         }
         tile_offset += next_batch_shift;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -466,9 +466,10 @@ void kernel_main() {
                                     num_mcast_cores_last_group,
                                     false);
                             }
-                            noc_async_write_barrier();
+                            noc_async_writes_flushed();
                             cb_pop_front(cb_mcast, 1);
                         }
+                        noc_async_write_barrier();
                     }
                 }
                 if constexpr (GROUP_SIZE_IS_POWER_OF_2) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -248,9 +248,10 @@ void kernel_main() {
                         num_mcast_cores_last_group,
                         false);
                 }
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_ex, 1);
             }
+            noc_async_write_barrier();
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -209,9 +209,10 @@ void kernel_main() {
                     const uint32_t l1_read_addr = get_read_ptr(cb_out);
                     noc_async_write_tile(
                         out_start_id + index_b_offset + out_block_index_offset + mt_offset + nt, dst_a, l1_read_addr);
-                    noc_async_write_barrier();
+                    noc_async_writes_flushed();
                     cb_pop_front(cb_out, 1);
                 }
+                noc_async_write_barrier();
                 mt_offset += num_channels_tiles;
             }
             out_block_index_offset += out_block_h_actual * num_channels_tiles;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -244,9 +244,10 @@ void kernel_main() {
                     // l1_read_addr += (single_tile_size_bytes * (block_w-block_w_curr));
                 }
                 out_block_start_id_offset += out_block_h_actual * num_channels_tiles;
-                noc_async_write_barrier();
+                noc_async_writes_flushed();
                 cb_pop_front(cb_out, out_block_hw_normal);
             }
+            noc_async_write_barrier();
 
             if constexpr (GROUP_SIZE_IS_POWER_OF_2) {
                 if (row_offset == TILE_WIDTH) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -32,8 +32,9 @@ void kernel_main() {
                 tile_id++;
                 l1_read_addr += tile_bytes;
             }
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(cb_id_out0, block.full_block_size());
         }
+        noc_async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -31,7 +31,8 @@ void kernel_main() {
             tile_id++;
             l1_read_addr += tile_bytes;
         }
-        noc_async_write_barrier();
+        noc_async_writes_flushed();
         cb_pop_front(cb_out, blk);
     }
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -53,7 +53,8 @@ void kernel_main() {
             tile_id++;
             l1_read_addr += tile_bytes;
         }
-        noc_async_write_barrier();
+        noc_async_writes_flushed();
         cb_pop_front(cb_id_out0, blk);
     }
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/kernels/dataflow/accumulation_writer.cpp
@@ -35,9 +35,10 @@ void kernel_main() {
             cb_wait_front(cb_out, ONE_TILE);
             uint32_t l1_read_addr = get_read_ptr(cb_out);
             noc_async_write_tile(write_tile_id, output_addrg, l1_read_addr);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(cb_out, ONE_TILE);
         }
+        noc_async_write_barrier();
         ++high_rank_offset;
         if (high_rank_offset >= input_tile_offset) {
             high_rank_offset = 0;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/kernels/dataflow/ema_writer.cpp
@@ -36,7 +36,8 @@ void kernel_main() {
         const uint32_t l1_read_addr = get_read_ptr(dst_cb);
         const uint64_t dst_noc_addr = dst_accessor.get_noc_addr(tile_id);
         noc_async_write(l1_read_addr, dst_noc_addr, dst_tile_size);
-        noc_async_write_barrier();
+        noc_async_writes_flushed();
         cb_pop_front(dst_cb, 1);
     }
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -34,17 +34,19 @@ void kernel_main() {
             cb_wait_front(values_cb_index, onetile);
             uint32_t l1_read_addr = get_read_ptr(values_cb_index);
             noc_async_write_tile(j * Kt + i, interleaved_accessor0, l1_read_addr);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(values_cb_index, onetile);
         }
+        noc_async_write_barrier();
 
         // topk indices
         for (uint32_t i = 0; i < Kt; ++i) {
             cb_wait_front(output_ind_cb_index, onetile);
             uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
             noc_async_write_tile(j * Kt + i, interleaved_accessor1, l1_read_addr);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(output_ind_cb_index, onetile);
         }
+        noc_async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
@@ -34,17 +34,19 @@ void kernel_main() {
             cb_wait_front(values_cb_index, onetile);
             uint32_t l1_read_addr = get_read_ptr(values_cb_index);
             noc_async_write_tile(j * Kt + i, interleaved_accessor0, l1_read_addr);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(values_cb_index, onetile);
         }
+        noc_async_write_barrier();
 
         // topk indices
         for (uint32_t i = 0; i < Kt; ++i) {
             cb_wait_front(output_ind_cb_index, onetile);
             uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
             noc_async_write_tile(j * Kt + i, interleaved_accessor1, l1_read_addr);
-            noc_async_write_barrier();
+            noc_async_writes_flushed();
             cb_pop_front(output_ind_cb_index, onetile);
         }
+        noc_async_write_barrier();
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue #35526

### Problem description
Using flushed before cb_pop_front should be faster than a full barrier. However, many kernels don't do that.

### What's changed
Use flushed before cb_pop_front

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-35526_flush)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-35526_flush)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-35526_flush)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-35526_flush)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-35526_flush)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-35526_flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-35526_flush)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs