### PR TITLE
Remove '_no_pack' Tilize Variants

### DIFF
--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -28,22 +28,6 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb) {
     MATH((llk_math_hw_configure(icb, icb)));
 }
 
-// clang-format off
-/**
- * no_pack variant of unary_op_init_common, to be used with tilize_*_no_pack variants.
- *
- * Note: This function does not configure PACK thread, use with caution.
- */
-// clang-format on
-ALWI void unary_op_init_common_no_pack(uint32_t icb) {
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
-        false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
-
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
-    MATH((llk_math_hw_configure(icb, icb)));
-}
-
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb) { unary_op_init_common(icb, ocb); }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Ticket
N/A

### Problem description
'_no_pack' tilize variants were added as a bandaid during implementation of MPWI.  MPWI now operates on row major data so these functions are no longer needed.

### What's changed
'_no_pack' tilize variants have been removed.

### Checklist
All Post Commit:
https://github.com/tenstorrent/tt-metal/actions/runs/20863777920

Nightly L2:
https://github.com/tenstorrent/tt-metal/actions/runs/20863789932

Frequent Model:
https://github.com/tenstorrent/tt-metal/actions/runs/20863801025

Blackhole Post Commit (unrelated failure)
https://github.com/tenstorrent/tt-metal/actions/runs/20863781612

Blackhole Nightly (unrelated failure)
https://github.com/tenstorrent/tt-metal/actions/runs/20863796463