### PR TITLE
Replace Eth::SENDER, Eth::RECEIVER with Eth::ACTIVE

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -311,7 +311,7 @@ TEST_F(MeshDispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
             for (uint32_t erisc_idx = 0; erisc_idx < erisc_count; ++erisc_idx) {
                 log_info(tt::LogTest, "Active Eth DM{} Loopback. Logical core {}", erisc_idx, active_eth_core.str());
                 dram_test_config.kernel_cfg = tt_metal::EthernetConfig{
-                    .eth_mode = Eth::RECEIVER,
+                    .eth_mode = Eth::ACTIVE,
                     .noc = static_cast<tt_metal::NOC>(erisc_idx),
                     .processor = static_cast<DataMovementProcessor>(erisc_idx)};
                 ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, mesh_device, dram_test_config));

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -599,7 +599,7 @@ void run_local_noc_stream_reg_inc(
             MetalContext::instance().hal().get_dev_addr(hal_programmable_core_type, HalL1MemAddrType::UNRESERVED);
         tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0};
         if (hal_programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) {
-            config.eth_mode = Eth::SENDER;
+            config.eth_mode = Eth::ACTIVE;
         } else if (hal_programmable_core_type == HalProgrammableCoreType::IDLE_ETH) {
             config.eth_mode = Eth::IDLE;
         }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -642,7 +642,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
             program,
             "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
             eth_core_range,
-            tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0});
+            tt_metal::EthernetConfig{.eth_mode = Eth::ACTIVE, .noc = tt_metal::NOC::NOC_0});
 
         workload.add_program(device_range, std::move(program));
         auto& program_ref = workload.get_programs().at(device_range);
@@ -664,7 +664,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
             program_common_test,
             "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
             eth_core_range,
-            tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0});
+            tt_metal::EthernetConfig{.eth_mode = Eth::ACTIVE, .noc = tt_metal::NOC::NOC_0});
 
         auto device_range_common_test = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload_common_test;
@@ -682,7 +682,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
             program2,
             "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
             eth_core_range,
-            tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0});
+            tt_metal::EthernetConfig{.eth_mode = Eth::ACTIVE, .noc = tt_metal::NOC::NOC_0});
 
         auto device_range2 = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         distributed::MeshWorkload workload2;

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -63,7 +63,7 @@ void RunTest(
     tt_metal::EthernetConfig config = {.noc = static_cast<tt_metal::NOC>(processor), .processor = processor};
     if (active) {
         test_cores = device->get_active_ethernet_cores(true);
-        config.eth_mode = Eth::SENDER;
+        config.eth_mode = Eth::ACTIVE;
     } else {
         test_cores = device->get_inactive_ethernet_cores();
         config.eth_mode = Eth::IDLE;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -139,7 +139,7 @@ KernelHandle create_kernel(
                 kernel_path,
                 cr_set,
                 tt::tt_metal::EthernetConfig{
-                    .eth_mode = core_type == HalProgrammableCoreType::IDLE_ETH ? Eth::IDLE : Eth::RECEIVER,
+                    .eth_mode = core_type == HalProgrammableCoreType::IDLE_ETH ? Eth::IDLE : Eth::ACTIVE,
                     .noc = static_cast<NOC>(processor_id),
                     .processor = static_cast<DataMovementProcessor>(processor_id),
                     .compile_args = compile_args,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -99,7 +99,7 @@ static void test_sems_across_core_types(
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_across_core_types.cpp",
                 eth_core,
                 tt::tt_metal::EthernetConfig{
-                    .eth_mode = active_eth ? tt::tt_metal::Eth::RECEIVER : tt::tt_metal::Eth::IDLE,
+                    .eth_mode = active_eth ? tt::tt_metal::Eth::ACTIVE : tt::tt_metal::Eth::IDLE,
                     .noc = static_cast<tt_metal::NOC>(dm_processor),
                     .processor = dm_processor,
                     .compile_args = compile_args,
@@ -176,7 +176,7 @@ TEST_F(MeshDispatchFixture, EthTestBlank) {
                 "tt_metal/kernels/dataflow/blank.cpp",
                 eth_core,
                 tt::tt_metal::EthernetConfig{
-                    .eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER,
+                    .eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::ACTIVE,
                     .noc = static_cast<NOC>(erisc_idx),
                     .processor = dm_processor,
                 });
@@ -257,7 +257,10 @@ TEST_F(MeshDispatchFixture, EthTestInitLocalMemory) {
             program,
             "tests/tt_metal/tt_metal/test_kernels/misc/local_mem.cpp",
             eth_core,
-            tt::tt_metal::EthernetConfig{.eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::RECEIVER, .noc = static_cast<NOC>(erisc_idx), .processor = dm_processor});
+            tt::tt_metal::EthernetConfig{
+                .eth_mode = this->slow_dispatch_ ? Eth::IDLE : Eth::ACTIVE,
+                .noc = static_cast<NOC>(erisc_idx),
+                .processor = dm_processor});
 
         workload.add_program(device_range, std::move(program));
         this->RunProgram(mesh_device, workload);
@@ -341,7 +344,7 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
                 program,
                 "tt_metal/kernels/dataflow/blank.cpp",
                 core_coord,
-                EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = static_cast<NOC>(erisc_idx), .processor = dm_processor});
+                EthernetConfig{.eth_mode = Eth::ACTIVE, .noc = static_cast<NOC>(erisc_idx), .processor = dm_processor});
 
             workload.add_program(device_range, std::move(program));
             this->RunProgram(mesh_device, workload);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -387,7 +387,7 @@ bool initialize_program(
                 "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/pgm_dispatch_perf.cpp",
                 *erisc_core,
                 tt::tt_metal::EthernetConfig{
-                    .eth_mode = Eth::RECEIVER,
+                    .eth_mode = Eth::ACTIVE,
                     .noc = NOC::NOC_0,
                     .defines = defines,
                 });

--- a/tt_metal/api/tt-metalium/data_types.hpp
+++ b/tt_metal/api/tt-metalium/data_types.hpp
@@ -45,9 +45,8 @@ enum NOC_MODE : uint8_t {
 };
 
 enum Eth : uint8_t {
-    SENDER = 0,
-    RECEIVER = 1,
-    IDLE = 2,
+    ACTIVE = 0,
+    IDLE = 1,
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -98,7 +98,7 @@ struct ComputeConfig {
 };
 
 struct EthernetConfig {
-    Eth eth_mode = Eth::SENDER;
+    Eth eth_mode = Eth::ACTIVE;
     NOC noc = NOC::NOC_0;
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0;
     std::vector<uint32_t> compile_args;

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -91,7 +91,7 @@ struct ComputeConfigDescriptor {
     bool math_approx_mode = false;
 };
 struct EthernetConfigDescriptor {
-    Eth eth_mode = Eth::SENDER;
+    Eth eth_mode = Eth::ACTIVE;
     NOC noc = NOC::NOC_0;
     DataMovementProcessor processor = DataMovementProcessor::RISCV_0;
 };

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -182,7 +182,7 @@ KernelHandle FDKernel::configure_kernel_variant(
             path,
             logical_core_,
             tt::tt_metal::EthernetConfig{
-                .eth_mode = is_active_eth_core ? Eth::SENDER : Eth::IDLE,
+                .eth_mode = is_active_eth_core ? Eth::ACTIVE : Eth::IDLE,
                 .noc = noc_selection_.non_dispatch_noc,
                 .compile_args = compile_args,
                 .defines = defines,

--- a/tt_metal/impl/flatbuffer/base_types.fbs
+++ b/tt_metal/impl/flatbuffer/base_types.fbs
@@ -23,9 +23,8 @@ enum NOC_MODE : byte {
 }
 
 enum EthMode : ubyte {
-  SENDER = 0,
-  RECEIVER = 1,
-  IDLE = 2
+  ACTIVE = 0,
+  IDLE = 1
 }
 
 enum MathFidelity : ubyte {

--- a/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
@@ -33,8 +33,7 @@ NOC_MODE from_flatbuffer(flatbuffer::NOC_MODE in) {
 
 Eth from_flatbuffer(flatbuffer::EthMode in) {
     switch (in) {
-        case flatbuffer::EthMode::SENDER: return Eth::SENDER;
-        case flatbuffer::EthMode::RECEIVER: return Eth::RECEIVER;
+        case flatbuffer::EthMode::ACTIVE: return Eth::ACTIVE;
         case flatbuffer::EthMode::IDLE: return Eth::IDLE;
     }
     TT_THROW("Unsupported EthMode from flatbuffer.");

--- a/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
@@ -34,8 +34,7 @@ flatbuffer::NOC_MODE to_flatbuffer(NOC_MODE in) {
 
 flatbuffer::EthMode to_flatbuffer(Eth in) {
     switch (in) {
-        case Eth::SENDER: return flatbuffer::EthMode::SENDER;
-        case Eth::RECEIVER: return flatbuffer::EthMode::RECEIVER;
+        case Eth::ACTIVE: return flatbuffer::EthMode::ACTIVE;
         case Eth::IDLE: return flatbuffer::EthMode::IDLE;
     }
     TT_THROW("Unsupported Eth to flatbuffer.");


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We don't have any distinction between `Eth::SENDER` and `Eth::RECEIVER`. This is a source of confusion as there's no difference when using CreateKernel. An ethernet core is either Active or Idle.

### What's changed
- Replace `Eth::SENDER` and `Eth::RECEIVER` with `Eth::ACTIVE` which is better aligned with our terminology of Active and Idle ethernet.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/eth-types)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/eth-types)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/eth-types)
- [ ] New/Existing tests provide coverage for changes

APC debug run
https://github.com/tenstorrent/tt-metal/actions/runs/20863933173

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/eth-types)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/eth-types)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/eth-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/eth-types)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs