### PR TITLE
use subordinate_sync correctly

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -157,7 +157,7 @@ static void RunTest(
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
     std::string expected;
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        const uint32_t line_num = 67;
+        const uint32_t line_num = 66;
         expected = fmt::format(
             "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. "
             "Note that file name reporting is not yet implemented, and the reported line number for the assert may be "

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -57,9 +57,8 @@ void MAIN {
     }
 #else
 #if defined(TRISC0) or defined(TRISC1) or defined(TRISC2)
-#define GET_TRISC_RUN_EVAL(x, t) x##t
-#define GET_TRISC_RUN(x, t) GET_TRISC_RUN_EVAL(x, t)
-    volatile tt_l1_ptr uint8_t * const trisc_run = &GET_TRISC_RUN(((tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE))->subordinate_sync.trisc, COMPILE_FOR_TRISC);
+    volatile tt_l1_ptr uint8_t * const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))
+        ->subordinate_sync.map[COMPILE_FOR_TRISC + 1];  // first entry is for NCRISC
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif
 #endif


### PR DESCRIPTION
### Ticket
none

### Problem description
test was using old style `subordinate_sync_t`

### What's changed
changed the test to use new structure. NOTE this only works for WH/BH, we'll need a new way to verify this on Quasar 

### Checklist
Change only touches test code, so no reason to run all post commit
- [x] Verified test is passing locally.