### PR TITLE
Make bank to DRAM tables unique per core for Wormhole

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1135,11 +1135,9 @@ void MetalContext::generate_device_bank_to_noc_tables(ChipId device_id) {
         for (unsigned int bank_id = 0; bank_id < num_dram_banks; bank_id++) {
             uint16_t noc_x, noc_y;
             CoreCoord dram_noc_coord;
-            if (!bank_id_to_dram_view_[device_id].empty()) {
-                dram_noc_coord = soc_d.get_preferred_worker_core_for_dram_view(bank_id_to_dram_view_[device_id][bank_id], noc);
-            } else {
-                dram_noc_coord = soc_d.get_preferred_worker_core_for_dram_view(allocator.get_dram_channel_from_bank_id(bank_id), noc);
-            }
+            // Always use cached bank_id_to_dram_view since we populate it above
+            dram_noc_coord =
+                soc_d.get_preferred_worker_core_for_dram_view(bank_id_to_dram_view_[device_id][bank_id], noc);
             if (dram_is_virtualized) {
                 noc_x = dram_noc_coord.x;
                 noc_y = dram_noc_coord.y;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1274,6 +1274,11 @@ void MetalContext::initialize_device_bank_to_noc_tables(
     const HalProgrammableCoreType& core_type,
     CoreCoord virtual_core,
     std::optional<CoreCoord> end_core) {
+    // Skip for Mock devices as they don't need NOC tables written to cores
+    if (cluster_->get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     const uint32_t dram_to_noc_sz_in_bytes = dram_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
     const uint32_t l1_to_noc_sz_in_bytes = l1_bank_to_noc_xy_[device_id].size() * sizeof(uint16_t);
     const uint32_t dram_offset_sz_in_bytes = dram_bank_offset_map_[device_id].size() * sizeof(int32_t);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1088,6 +1088,11 @@ CoreCoord MetalContext::virtual_noc0_coordinate(ChipId device_id, uint8_t noc_in
 }
 
 void MetalContext::generate_device_bank_to_noc_tables(ChipId device_id) {
+    // Skip for Mock devices as they don't have real device coordinates or need NOC tables
+    if (cluster_->get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     // Create a dummp allocator to generatoe the bank/noc tables. Specifically, these depend on l1_bank_remap.
     auto config = L1BankingAllocator::generate_config(
         device_id,
@@ -1165,6 +1170,11 @@ void MetalContext::generate_device_bank_to_noc_tables(ChipId device_id) {
 }
 
 void MetalContext::generate_worker_logical_to_virtual_map(ChipId device_id) {
+    // Skip for Mock devices as they don't have real device coordinates
+    if (cluster_->get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
     // Generate logical to virtual map for DRAM and L1 banks
     const auto& soc_desc = cluster_->get_soc_desc(device_id);
     auto tensix_grid_size = soc_desc.get_grid_size(CoreType::TENSIX);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1215,8 +1215,7 @@ std::vector<uint16_t> MetalContext::generate_dram_bank_to_noc_table_by_proximity
         "generate_dram_bank_to_noc_table_by_proximity should only be called for Silicon devices");
 
     // Check cache first
-    if (dram_bank_to_noc_xy_by_proximity_[device_id].find(virtual_core) !=
-        dram_bank_to_noc_xy_by_proximity_[device_id].end()) {
+    if (dram_bank_to_noc_xy_by_proximity_[device_id].contains(virtual_core)) {
         return dram_bank_to_noc_xy_by_proximity_[device_id].at(virtual_core);
     }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -172,6 +172,7 @@ private:
     CoreCoord virtual_noc0_coordinate(ChipId device_id, uint8_t noc_index, CoreCoord coord);
     void generate_device_bank_to_noc_tables(ChipId device_id);
     void generate_worker_logical_to_virtual_map(ChipId device_id);
+    std::vector<uint16_t> generate_dram_bank_to_noc_table_for_core(ChipId device_id, CoreCoord virtual_core);
     void initialize_device_bank_to_noc_tables(
         ChipId device_id,
         const HalProgrammableCoreType& core_type,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -173,6 +173,9 @@ private:
     void generate_device_bank_to_noc_tables(ChipId device_id);
     void generate_worker_logical_to_virtual_map(ChipId device_id);
     std::vector<uint16_t> generate_dram_bank_to_noc_table_by_proximity(ChipId device_id, CoreCoord virtual_core);
+    // Helper function to find rectangular core ranges that share the same DRAM table
+    std::vector<std::pair<CoreRange, std::vector<uint16_t>>> find_rectangular_ranges_with_same_table(
+        ChipId device_id, CoreCoord start_core, CoreCoord end_core);
     void initialize_device_bank_to_noc_tables(
         ChipId device_id,
         const HalProgrammableCoreType& core_type,
@@ -223,6 +226,8 @@ private:
     std::unordered_map<ChipId, std::vector<uint16_t>> l1_bank_to_noc_xy_;
     // Cached bank_id to DRAM view mapping (used for WH proximity-based routing)
     std::unordered_map<ChipId, std::vector<size_t>> bank_id_to_dram_view_;
+    // Cached per-core proximity-based DRAM tables (used for WH)
+    std::unordered_map<ChipId, std::map<CoreCoord, std::vector<uint16_t>>> dram_bank_to_noc_xy_by_proximity_;
 
     std::unordered_map<ChipId, std::vector<uint8_t>> worker_logical_col_to_virtual_col_;
     std::unordered_map<ChipId, std::vector<uint8_t>> worker_logical_row_to_virtual_row_;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -172,7 +172,7 @@ private:
     CoreCoord virtual_noc0_coordinate(ChipId device_id, uint8_t noc_index, CoreCoord coord);
     void generate_device_bank_to_noc_tables(ChipId device_id);
     void generate_worker_logical_to_virtual_map(ChipId device_id);
-    std::vector<uint16_t> generate_dram_bank_to_noc_table_for_core(ChipId device_id, CoreCoord virtual_core);
+    std::vector<uint16_t> generate_dram_bank_to_noc_table_by_proximity(ChipId device_id, CoreCoord virtual_core);
     void initialize_device_bank_to_noc_tables(
         ChipId device_id,
         const HalProgrammableCoreType& core_type,
@@ -221,6 +221,8 @@ private:
     std::unordered_map<ChipId, std::vector<int32_t>> l1_bank_offset_map_;
     std::unordered_map<ChipId, std::vector<uint16_t>> dram_bank_to_noc_xy_;
     std::unordered_map<ChipId, std::vector<uint16_t>> l1_bank_to_noc_xy_;
+    // Cached bank_id to DRAM view mapping (used for WH proximity-based routing)
+    std::unordered_map<ChipId, std::vector<size_t>> bank_id_to_dram_view_;
 
     std::unordered_map<ChipId, std::vector<uint8_t>> worker_logical_col_to_virtual_col_;
     std::unordered_map<ChipId, std::vector<uint8_t>> worker_logical_row_to_virtual_row_;


### PR DESCRIPTION
## Description

Fixes #15729

Wormhole has multiple DRAM NOC endpoints per DRAM bank (3 ports per channel). Previously, all worker cores used the same DRAM endpoint regardless of their position on the chip, which was suboptimal for cores far from the selected endpoint.

This change generates per-core DRAM bank tables for Wormhole that pick the closest NOC endpoint for each DRAM channel based on the distance.

## Changes

- Add `generate_dram_bank_to_noc_table_for_core()` function to compute per-core DRAM tables
- Modify `initialize_device_bank_to_noc_tables()` to use per-core tables for Wormhole
- Blackhole continues to use the existing device-wide table (unchanged)

## How It Works

For each worker core, the algorithm:
1. Gets the worker's NOC0 coordinate
2. For each DRAM channel, iterates through all 3 NOC endpoints
3. Calculates distance to each endpoint
4. Selects the closest endpoint for that core's table

### Example

For Channel 0 with endpoints at (0,0), (0,1), (0,11):

| Worker Position | Before (Fixed) | After (Closest) | Distance Reduction |
|-----------------|----------------|-----------------|-------------------|
| (1, 11)         | (0, 0)         | (0, 11)         | 12 → 1            |
| (1, 1)          | (0, 0)         | (0, 1)          | 2 → 1             |
| (9, 11)         | (0, 0)         | (0, 11)         | 20 → 9            |

## Testing

- [x] Build passes
- [x] Requires testing on WH hardware
- Passing CI runs: Nightly tt-metal L2 tests : https://github.com/tenstorrent/tt-metal/actions/runs/21458475199

## Impact

This optimization reduces NOC traffic distance for DRAM accesses on Wormhole, potentially improving performance for DRAM-intensive workloads.