### PR TITLE
Fix parameter shadowing bug in BlockRep constructor

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -324,12 +324,12 @@ struct BlockRep {
 
     BlockRep(uint32_t n_data, uint32_t n_mixed, uint32_t n_pads, uint32_t times) :
         n_data(n_data), n_mixed(n_mixed), n_pads(n_pads), times(times) {
-        if (n_data == 0 && n_mixed == 0) {
-            n_pads *= times;
-            times = 1;
-        } else if (n_pads == 0 && n_mixed == 0) {
-            n_data *= times;
-            times = 1;
+        if (this->n_data == 0 && this->n_mixed == 0) {
+            this->n_pads *= this->times;
+            this->times = 1;
+        } else if (this->n_pads == 0 && this->n_mixed == 0) {
+            this->n_data *= this->times;
+            this->times = 1;
         }
     }
 


### PR DESCRIPTION
### Ticket
N/A - Found via clang static analyzer warning

https://blozano-tt.github.io/clangsa-results/tilize_with_val_padding_multi_core_interleaved_program_factory.cpp_clangsa_2b7310a32285a8091b4bc1b372e05e03.plist.html#reportHash=c2dfa21a6129131b28febd92f3926ed6

### Problem description
The `BlockRep` constructor in `work_split_tilize.hpp` had a parameter shadowing bug. The constructor parameters (`n_data`, `n_mixed`, `n_pads`, `times`) shadow the member variables of the same name. While the member initializer list correctly initializes the members, the logic in the constructor body was modifying the local parameter copies instead of the member variables.

This meant the optimization logic that collapses `times` into `n_pads` (when `n_data == 0 && n_mixed == 0`) or into `n_data` (when `n_pads == 0 && n_mixed == 0`) had no effect - the member variables remained unchanged.

### What's changed
Added explicit `this->` prefix to all member variable references in the constructor body to ensure the actual member variables are modified, not the shadowed parameters.

Before:
```cpp
if (n_data == 0 && n_mixed == 0) {
    n_pads *= times;  // modifies parameter, not member!
    times = 1;
}
```

After:
```cpp
if (this->n_data == 0 && this->n_mixed == 0) {
    this->n_pads *= this->times;  // correctly modifies member
    this->times = 1;
}
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/blockrep-parameter-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/blockrep-parameter-shadowing)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/blockrep-parameter-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/blockrep-parameter-shadowing)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/blockrep-parameter-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/blockrep-parameter-shadowing)
- [ ] New/Existing tests provide coverage for changes