### PR TITLE
fix-matmul-wrong-clang-tidy-fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -139,9 +139,9 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
         if (in0_block_w % per_core_factor_k != 0) {
             continue;
         }
-        for (const auto& [multiple, factor] : factors | std::views::reverse) {
-            uint32_t per_core_factor_m = std::get<0>(factor);
-            uint32_t per_core_factor_n = std::get<1>(factor);
+        for (const auto& factor : std::ranges::reverse_view(factors)) {
+            uint32_t per_core_factor_m = std::get<0>(factor.second);
+            uint32_t per_core_factor_n = std::get<1>(factor.second);
 
             size = utilities::get_estimated_size_of_cbs(
                 per_core_factor_m,

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/types.hpp"
+#include <ranges>
 
 namespace ttnn::operations::matmul {
 
@@ -138,7 +139,7 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
         if (in0_block_w % per_core_factor_k != 0) {
             continue;
         }
-        for (const auto& [multiple, factor] : factors) {
+        for (const auto& [multiple, factor] : factors | std::views::reverse) {
             uint32_t per_core_factor_m = std::get<0>(factor);
             uint32_t per_core_factor_n = std::get<1>(factor);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asala/fix-matmul-wrong-clang-tidy-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asala/fix-matmul-wrong-clang-tidy-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs