### PR TITLE
Fix dead store warnings in ternary_program_factory.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1304,14 +1304,14 @@ void TernaryDeviceOperation::TernaryProgramFactory::override_runtime_arguments(
         auto* args = GetCommonRuntimeArgs(program, reader_kernel_id).data();
         if (operation_attributes.ternary_variant == TernaryVariant::TTS) {
             args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*predicate_buffer, args);
-            args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_true_tensor.value().buffer(), args);
+            CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_true_tensor.value().buffer(), args);
         } else if (operation_attributes.ternary_variant == TernaryVariant::TST) {
             args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*predicate_buffer, args);
-            args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_false_tensor.value().buffer(), args);
+            CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_false_tensor.value().buffer(), args);
         } else {  // TTT
             args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*predicate_buffer, args);
             args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_true_tensor.value().buffer(), args);
-            args = CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_false_tensor.value().buffer(), args);
+            CMAKE_UNIQUE_NAMESPACE::copy_common_runtime_args(*value_false_tensor.value().buffer(), args);
         }
 
         // Update common runtime args for writer kernel


### PR DESCRIPTION
### Ticket
N/A - Static analysis cleanup

https://blozano-tt.github.io/clangsa-results/ternary_program_factory.cpp_clangsa_b5a37bd82fe278d101ee57a387e7364b.plist.html#reportHash=cf00a5ee8dda6971a54b6f2fd3b42732

### Problem description
Static analysis flagged three dead store warnings in `ternary_program_factory.cpp`:
- Line 1307: Value stored to 'args' is never read
- Line 1310: Value stored to 'args' is never read
- Line 1314: Value stored to 'args' is never read

The `copy_common_runtime_args()` function returns a pointer to the next position in the buffer (for chaining multiple calls), but on the **last call** of each branch in `override_runtime_arguments()`, the return value was being stored to `args` but never read - it was immediately overwritten when setting up the writer kernel args.

### What's changed
Removed the unnecessary `args =` assignment on the final call of each branch:
- TTS branch: Last call no longer assigns to `args`
- TST branch: Last call no longer assigns to `args`
- TTT branch: Last call no longer assigns to `args`

The intermediate assignments that are needed for chaining are preserved. This is a purely cosmetic change that silences static analysis warnings without affecting behavior.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix-dead-stores-ternary-program-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix-dead-stores-ternary-program-factory)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-dead-stores-ternary-program-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-dead-stores-ternary-program-factory)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-dead-stores-ternary-program-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-dead-stores-ternary-program-factory)
- [x] New/Existing tests provide coverage for changes (no functional change - static analysis fix only)