### PR TITLE
[Fabric] Disable 80B header for 2D

### DIFF
--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -127,8 +127,9 @@ private:
         uint32_t buffer_size;
     };
     static constexpr Routing2DBufferTier ROUTING_2D_BUFFER_TIERS[] = {
-        {19, 19},  // 80B header - max capacity
-        {35, 35}   // 96B header - max capacity
+        // NOTE: 80B header size de-stabilized some Mesh benchmarks for 8X4 mesh, so disabling for now
+        //{19, 19},  // 80B header - max capacity
+        {35, 35}  // 96B header - max capacity
     };
 
     // ============ Private Implementation ============

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -869,7 +869,7 @@ struct LowLatencyMeshRoutingFields {
 
 // TODO: https://github.com/tenstorrent/tt-metal/issues/32237
 // Primary template for 2D routing headers with variable route buffer size
-template <int RouteBufferSize = 32>
+template <int RouteBufferSize = 35>
 struct HybridMeshPacketHeaderT : PacketHeaderBase<HybridMeshPacketHeaderT<RouteBufferSize>> {
     LowLatencyMeshRoutingFields routing_fields;
     uint8_t route_buffer[RouteBufferSize];
@@ -903,8 +903,8 @@ static_assert(sizeof(HybridMeshPacketHeaderT<35>) == 96, "35B buffer must result
 #ifdef FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE
 using HybridMeshPacketHeader = HybridMeshPacketHeaderT<FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE>;
 #else
-// Default: backward compatibility (96B header with 32B route buffer)
-using HybridMeshPacketHeader = HybridMeshPacketHeaderT<32>;
+// Default: backward compatibility (96B header with 35B route buffer)
+using HybridMeshPacketHeader = HybridMeshPacketHeaderT<35>;
 #endif
 
 struct UDMHybridMeshPacketHeader : public HybridMeshPacketHeader {

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -142,8 +142,8 @@ struct FabricHeaderConfig {
 #ifdef FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE
     static constexpr uint32_t MESH_ROUTE_BUFFER_SIZE = FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE;
 #else
-    // Default: 32 bytes (96B header)
-    static constexpr uint32_t MESH_ROUTE_BUFFER_SIZE = 32;
+    // Default: 35 bytes (96B header)
+    static constexpr uint32_t MESH_ROUTE_BUFFER_SIZE = 35;
 #endif
 
     // Validation (Fail fast)


### PR DESCRIPTION
### Ticket
NA

### Problem description
With the recent dynamic pkt hdr changes, the smallest 2D pkt hdr size was shrunk down to 80B from 96B. Looks like 80B hdr de-stabilized some of the 2D benchmarks on galaxy causing noisy pipelines.

### What's changed
Disabled the 80B pkt hdr (19B route buffer tier) for 2D for now. Also updated some default values.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
- [x] [Galaxy model perf] (https://github.com/tenstorrent/tt-metal/actions/runs/20888133418)
- [x] [Multi-host] (https://github.com/tenstorrent/tt-metal/actions/runs/20903380934)
- [x] [Galaxy quick] (https://github.com/tenstorrent/tt-metal/actions/runs/20870845187)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/fabric-fix-2d-hdr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/fabric-fix-2d-hdr)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs