### PR TITLE
Replace assert/TT_ASSERT with gtest macros in test_basic_1d_fabric.cpp

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1664,7 +1664,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     // Check topology and fabric config
     const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
-    assert(
+    ASSERT_TRUE(
         (topology == Topology::Linear || topology == Topology::Ring) &&
         (fabric_config == tt_fabric::FabricConfig::FABRIC_1D ||
          fabric_config == tt_fabric::FabricConfig::FABRIC_1D_RING));
@@ -1874,7 +1874,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) { RunTestUnicastRaw(this, 1, RoutingDire
 
 TEST_F(Galaxy1x32Fabric1DFixture, TestUnicastRaw_AllHops) {
     const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
-    TT_ASSERT(num_devices == 32, "1x32 mesh required for this test");
+    ASSERT_EQ(num_devices, 32) << "1x32 mesh required for this test";
     for (uint32_t hops = 1; hops < num_devices; hops++) {
         RunTestUnicastRaw(this, hops, RoutingDirection::E);
     }


### PR DESCRIPTION
### Ticket
N/A - Code quality fix

### Problem description
In `test_basic_1d_fabric.cpp`, two assertions use `assert()` and `TT_ASSERT()` which do not fire in Release mode. This could allow tests to pass with invalid preconditions, masking potential issues.

### What's changed
Replaced the problematic assertions with gtest macros that work in all build configurations:

1. **Line 1667**: Changed `assert(...)` to `ASSERT_TRUE(...)` for the topology and fabric config check
2. **Line 1877**: Changed `TT_ASSERT(num_devices == 32, "...")` to `ASSERT_EQ(num_devices, 32) << "..."` for device count validation

Using gtest macros ensures:
- Assertions fire in Release mode
- Better failure diagnostics (especially `ASSERT_EQ` which shows expected vs actual)
- Consistent test behavior across build configurations

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/replace-asserts-with-gtest-macros)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/replace-asserts-with-gtest-macros)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/replace-asserts-with-gtest-macros)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/replace-asserts-with-gtest-macros)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/replace-asserts-with-gtest-macros)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/replace-asserts-with-gtest-macros)
- [x] New/Existing tests provide coverage for changes