### PR TITLE
Fix static analyzer false positive in device_operation.hpp

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -539,14 +539,14 @@ typename device_operation_t::tensor_return_value_t launch(
                 tensor_return_value);
         } else {
             // Fall back to default topology imputation
-            auto [output_topology_placements, output_topology_shape] =
+            auto output_topology_result =
                 detail::get_output_placements_and_shape<device_operation_t>(tensor_args, first_tensor.value());
 
             tensor_return_value = tt::stl::reflection::transform_object_of_type<Tensor>(
-                [&output_topology_placements, &output_topology_shape](const Tensor& output_tensor) {
+                [&output_topology_result](const Tensor& output_tensor) {
                     auto topology = tt::tt_metal::TensorTopology(
-                        output_topology_shape,
-                        output_topology_placements,
+                        output_topology_result.second,
+                        output_topology_result.first,
                         output_tensor.tensor_topology().mesh_coords());
                     return output_tensor.with_tensor_topology(topology);
                 },


### PR DESCRIPTION
### Ticket
N/A - Static analyzer false positive fix

### Problem description
The clang static analyzer reports many many `core.CallAndMessage` warnings in `device_operation.hpp` at line 548:

```
1st function call argument is an uninitialized value [core.CallAndMessage]
```

This is a **false positive** caused by the analyzer's inability to properly track variable initialization through C++ structured bindings (`auto [a, b] = ...`) when those variables are subsequently captured by reference in a lambda.

The variables ARE properly initialized by the `get_output_placements_and_shape` function call, but the analyzer loses track of this when they're captured in the lambda.

### What's changed
Refactored from structured bindings to explicit pair access:

```cpp
// Before: structured binding with two captures
auto [output_topology_placements, output_topology_shape] = get_output_placements_and_shape<...>(...);
[&output_topology_placements, &output_topology_shape](...)

// After: single result with pair access  
auto output_topology_result = get_output_placements_and_shape<...>(...);
[&output_topology_result](...)
```

**Benefits:**
- Eliminates many many false positive warnings, making the static analysis report usable for finding real issues
- Captures one object instead of two (marginally simpler lambda capture)
- No functional change - code behaves identically

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/device-operation-uninitialized-value-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/device-operation-uninitialized-value-warning)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/device-operation-uninitialized-value-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/device-operation-uninitialized-value-warning)
- [x] New/Existing tests provide coverage for changes (no new tests needed - this is a refactor with no behavioral change)