### PR TITLE
Enable -Wunused-parameter for ttnn to catch issues upstream

### DIFF
--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -120,7 +120,7 @@ public:
 
     template <typename ArrType, std::enable_if_t<tensor_accessor::detail::has_subscript_operator_v<ArrType>, int> = 0>
     FORCE_INLINE std::uint64_t get_shard_noc_addr(
-        const ArrType shard_coord, const uint32_t offset = 0, uint8_t noc = noc_index) const {
+        [[maybe_unused]] const ArrType shard_coord, const uint32_t offset = 0, uint8_t noc = noc_index) const {
         uint32_t shard_id = 0;
         for (uint32_t i = 0; i < dspec().rank(); ++i) {
             // Check that shard_coord is within bounds

--- a/tt_metal/hw/inc/internal/tensor/helpers.h
+++ b/tt_metal/hw/inc/internal/tensor/helpers.h
@@ -39,12 +39,14 @@ struct ConditionalField {
 template <typename T>
 struct ConditionalField<false, T> {
     // Constructor that ignores a single argument
+    // NOLINTNEXTLINE(misc-unused-parameters)
     template <typename T_, std::enable_if_t<!std::is_same_v<std::decay_t<T_>, ConditionalField>, int> = 0>
-    ConditionalField(T_&& val) {}  // Ignore value if passed to constructor
+    ConditionalField(T_&& /*val*/) {}  // Ignore value if passed to constructor
 
     // Variadic constructor that ignores all arguments
+    // NOLINTNEXTLINE(misc-unused-parameters)
     template <typename... Args, std::enable_if_t<sizeof...(Args) != 1, int> = 0>
-    ConditionalField(Args&&... args) {}  // Ignore all arguments if passed to constructor
+    ConditionalField(Args&&... /*args*/) {}  // Ignore all arguments if passed to constructor
 
     ConditionalField() = default;
 };

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Build TTNN and TTNNCPP
 ####################################################################################################
 
+add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wunused-parameter>")
+
 # FIXME: Many lambda functions in ttnn capture variables and don't use them.
 add_compile_options("$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>")
 

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -169,7 +169,10 @@ private:
 inline ProgramHashToOpName program_hash_to_opname_{};
 
 inline void start_tracy_zone(
-    const std::string& source, const std::string& functName, uint32_t lineNum, uint32_t color = 0) {
+    [[maybe_unused]] const std::string& source,
+    [[maybe_unused]] const std::string& functName,
+    [[maybe_unused]] uint32_t lineNum,
+    [[maybe_unused]] uint32_t color = 0) {
 #if defined(TRACY_ENABLE)
     auto tracySrcLoc =
         ___tracy_alloc_srcloc(lineNum, source.c_str(), source.length(), functName.c_str(), functName.length());
@@ -182,7 +185,7 @@ inline void start_tracy_zone(
 #endif
 }
 
-inline bool stop_tracy_zone(const std::string& name = "", uint32_t color = 0) {
+inline bool stop_tracy_zone([[maybe_unused]] const std::string& name = "", [[maybe_unused]] uint32_t color = 0) {
     bool callStackWasEmpty = true;
 #if defined(TRACY_ENABLE)
     if (!call_stack.empty()) {
@@ -204,7 +207,7 @@ inline bool stop_tracy_zone(const std::string& name = "", uint32_t color = 0) {
 constexpr auto tracy_max_message_length =
     static_cast<size_t>(std::numeric_limits<uint16_t>::max());  // Tracy hard limit is 64KiB including null terminator
 
-inline void tracy_message(const std::string& source, uint32_t color = 0xf0f8ff) {
+inline void tracy_message([[maybe_unused]] const std::string& source, [[maybe_unused]] uint32_t color = 0xf0f8ff) {
 #if defined(TRACY_ENABLE)
     const auto truncated_size = std::min(source.size(), tracy_max_message_length - 1);
     if (source.size() > truncated_size) {

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -175,19 +175,19 @@ inline void log_operation(
 
 template <typename device_operation_t>
 inline void log_operation(
-    std::size_t device_id,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args,
-    tt::stl::hash::hash_t program_hash,
-    bool program_cache_hit) {}
+    std::size_t /*device_id*/,
+    const typename device_operation_t::operation_attributes_t& /*operation_attributes*/,
+    const typename device_operation_t::tensor_args_t& /*tensor_args*/,
+    tt::stl::hash::hash_t /*program_hash*/,
+    bool /*program_cache_hit*/) {}
 
 #endif
 
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void enqueue_mesh_workload(
-    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
-    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
-    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    [[maybe_unused]] const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    [[maybe_unused]] const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    [[maybe_unused]] typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     distributed::MeshDevice* mesh_device,
     tt::tt_metal::distributed::MeshWorkload& workload) {
     mesh_device_operation_utils::set_runtime_id(workload);

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -80,7 +80,8 @@ void log_external_operation(const operation::ExternalOperation& operation, const
 }
 #else
 
-void log_external_operation(const operation::ExternalOperation& operation, const std::vector<Tensor>& input_tensors) {}
+void log_external_operation(
+    const operation::ExternalOperation& /*operation*/, const std::vector<Tensor>& /*input_tensors*/) {}
 
 #endif
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -112,7 +112,7 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
 }
 
 void AllToAllCombineDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -78,7 +78,7 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
 }
 
 void AllToAllDispatchDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -219,7 +219,7 @@ bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(Tensor const& t) {
     return shard_grid_transposed;
 }
 
-void ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(Tensor const& t, std::string const& prefix) {
+void ShardedAddrGenArgBuilder::log_sharded_tensor_kernel_args(const Tensor& t, const std::string& prefix) {
     auto const& [pages_per_shard_y, pages_per_shard_x] = t.buffer()->shard_spec().shape_in_pages();
     [[maybe_unused]] const auto& [shard_grid_start, shard_grid_end] =
         shard_grid_from_shard_spec(t.shard_spec().value());

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -68,7 +68,7 @@ void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
 }
 
 void MeshPartitionDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 MeshPartitionDeviceOperation::spec_return_value_t MeshPartitionDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.cpp
@@ -20,12 +20,12 @@ MoveDeviceOperation::program_factory_t MoveDeviceOperation::select_program_facto
 }
 
 void MoveDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
     // TODO: #33357
 }
 
 void MoveDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
     // TODO: #33357
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::data_movement::pad::program {
 
 namespace {
 inline void log_rt_args(const CoreCoord& core, std::vector<uint32_t>& args) {
-    for ([[maybe_unused]] auto v : args) {
+    for (auto v : args) {
         log_debug(tt::LogOp, "{},{} :: {}", core.x, core.y, v);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -43,7 +43,7 @@ void PermuteDeviceOperation::validate_on_program_cache_miss(
 }
 
 void PermuteDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 PermuteDeviceOperation::spec_return_value_t PermuteDeviceOperation::compute_output_specs(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp
@@ -47,7 +47,7 @@ void ApplyDeviceDelayDeviceOperation::validate_on_program_cache_miss(
 }
 
 void ApplyDeviceDelayDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
     // No additional validation needed on cache hit
 }
 
@@ -99,10 +99,10 @@ ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::create_at(
 }
 
 void ApplyDeviceDelayDeviceOperation::ApplyDeviceDelayMeshWorkload::override_runtime_arguments(
-    cached_mesh_workload_t& cached_workload,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    cached_mesh_workload_t& /*cached_workload*/,
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
     // No runtime arguments to override for this operation since delay cycles are compile-time
 }
 

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -17,10 +17,10 @@ ExampleDeviceOperation::program_factory_t ExampleDeviceOperation::select_program
 }
 
 void ExampleDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 void ExampleDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 ExampleDeviceOperation::spec_return_value_t ExampleDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
@@ -59,7 +59,7 @@ void LlamaReduceScatterDeviceOperation::validate_on_program_cache_miss(
 }
 
 void LlamaReduceScatterDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 LlamaReduceScatterDeviceOperation::spec_return_value_t LlamaReduceScatterDeviceOperation::compute_output_specs(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
@@ -54,7 +54,7 @@ void LlamaReduceScatterCreateHeadsDeviceOperation::validate_on_program_cache_mis
 }
 
 void LlamaReduceScatterCreateHeadsDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 LlamaReduceScatterCreateHeadsDeviceOperation::spec_return_value_t
 LlamaReduceScatterCreateHeadsDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.cpp
@@ -23,7 +23,7 @@ void StridedAllGatherAsync::validate_on_program_cache_hit(
 }
 
 void StridedAllGatherAsync::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensors_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensors_args*/) {}
 
 StridedAllGatherAsync::spec_return_value_t StridedAllGatherAsync::compute_output_specs(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
@@ -16,10 +16,10 @@ ExecuteTestHangDeviceOperation::program_factory_t ExecuteTestHangDeviceOperation
 }
 
 void ExecuteTestHangDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t&, const tensor_args_t& /*tensor_args*/) {}
 
 void ExecuteTestHangDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t&, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t&, const tensor_args_t& /*tensor_args*/) {}
 
 ExecuteTestHangDeviceOperation::spec_return_value_t ExecuteTestHangDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_program_factory.cpp
@@ -33,9 +33,9 @@ ExecuteTestHangDeviceOperation::SingleCore::cached_program_t ExecuteTestHangDevi
 }
 
 void ExecuteTestHangDeviceOperation::SingleCore::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {}
+    cached_program_t& /*cached_program*/,
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {}
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -152,7 +152,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(
 }
 
 void NlpCreateHeadsDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 NlpCreateHeadsDeviceOperation::spec_return_value_t NlpCreateHeadsDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.cpp
@@ -149,7 +149,7 @@ void NlpCreateHeadsBoltzDeviceOperation::validate_on_program_cache_miss(
 }
 
 void NlpCreateHeadsBoltzDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 NlpCreateHeadsBoltzDeviceOperation::spec_return_value_t NlpCreateHeadsBoltzDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -16,10 +16,10 @@ GenericOpDeviceOperation::program_factory_t GenericOpDeviceOperation::select_pro
 }
 
 void GenericOpDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 void GenericOpDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 GenericOpDeviceOperation::spec_return_value_t GenericOpDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
 void MorehLayerNormBackwardGammaBetaGradOperation::validate_inputs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 MorehLayerNormBackwardGammaBetaGradOperation::program_factory_t
 MorehLayerNormBackwardGammaBetaGradOperation::select_program_factory(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
@@ -10,7 +10,7 @@
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {
 void MorehLayerNormBackwardInputGradOperation::validate_inputs(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
 MorehLayerNormBackwardInputGradOperation::program_factory_t
 MorehLayerNormBackwardInputGradOperation::select_program_factory(


### PR DESCRIPTION
### Ticket
N/A - Code quality improvement

### Problem description
Unused function parameters in ttnn code can indicate dead code paths, incomplete implementations, or accidental omissions. Without compile-time enforcement, these issues go undetected until they cause problems downstream in merge gate.

The goal is to **block unused parameters before they get checked in**, catching issues as far upstream as possible during the build process rather than in code review or production.

### What's changed
This PR enables the `-Wunused-parameter` compiler warning for the ttnn codebase (Clang builds only) and fixes all existing violations.

**Key changes:**
1. **CMakeLists.txt**: Added `-Wunused-parameter` warning flag for Clang in `ttnn/CMakeLists.txt`
2. **Fixed existing warnings**: All unused parameters are now either:
   - Commented out with `/*param_name*/` syntax (when truly unused)
   - Marked with `[[maybe_unused]]` attribute (when conditionally used, e.g., in debug logging)

**Files affected:**
- Device operations (CCL, data movement, matmul, moreh, pool, etc.)
- Test infrastructure (`test_launch_operation.cpp`)
- Core headers (`device_operation.hpp`, `tensor_accessor.h`, `helpers.h`)
- Python bindings (`pytensor.cpp`)

**Benefits:**
- Catches dead code and incomplete implementations at compile time
- Prevents accidental parameter omissions in new implementations  
- Makes function signatures clearer about which parameters are actually used
- All changes are semantically equivalent - no runtime behavior changes in debug or release modes

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=enable-wunused-parameter-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:enable-wunused-parameter-ttnn)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=enable-wunused-parameter-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:enable-wunused-parameter-ttnn)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=enable-wunused-parameter-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:enable-wunused-parameter-ttnn)
- [x] New/Existing tests provide coverage for changes (build system change - existing tests cover all modified code)