### PR TITLE
[skip ci] Enhance run_conv2d_short_sweep function to accept additional params

### DIFF
--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -180,6 +180,8 @@ def run_conv2d_short_sweep(
     input_specs,
     device,
     config_tensors_in_dram=False,
+    output_dtype=None,  # ttnn dtype object (e.g., ttnn.bfloat8_b)
+    compute_kernel_config=None,  # ttnn compute config object
 ) -> list:
     # for tt-forge suite, extra arguments are tensor configs
     is_forge_suite = False
@@ -262,7 +264,12 @@ def run_conv2d_short_sweep(
     # Set config_tensors_in_dram if requested (helps avoid L1 OOM for memory-intensive configs)
     if config_tensors_in_dram:
         conv_config.config_tensors_in_dram = True
-    conv_output_dtype = ttnn.bfloat16
+
+    # Use provided dtype or default to bfloat16
+    conv_output_dtype = output_dtype if output_dtype is not None else ttnn.bfloat16
+
+    # Use provided compute_config or None (will use default)
+    compute_config = compute_kernel_config
 
     if is_forge_suite:
         input_layout = ttnn.Layout(input_layout)
@@ -288,26 +295,34 @@ def run_conv2d_short_sweep(
 
         tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16, device=device)
     start_time = start_measuring_time()
-    [tt_output_tensor_on_device, [out_height, out_width], [weights_device, bias_device]] = ttnn.conv2d(
-        input_tensor=tt_input_tensor,
-        weight_tensor=tt_weight_tensor,
-        in_channels=input_channels,
-        out_channels=output_channels,
-        device=device,
-        bias_tensor=tt_bias_tensor,
-        kernel_size=(kernel_height, kernel_width),
-        stride=(stride_h, stride_w),
-        padding=(pad_h, pad_w),
-        dilation=(dilation_h, dilation_w),
-        batch_size=batch_size,
-        input_height=input_height,
-        input_width=input_width,
-        groups=groups,
-        conv_config=conv_config,
-        return_output_dim=True,
-        return_weights_and_bias=True,
-        dtype=conv_output_dtype,
-    )
+
+    # Build conv2d call arguments
+    conv2d_args = {
+        "input_tensor": tt_input_tensor,
+        "weight_tensor": tt_weight_tensor,
+        "in_channels": input_channels,
+        "out_channels": output_channels,
+        "device": device,
+        "bias_tensor": tt_bias_tensor,
+        "kernel_size": (kernel_height, kernel_width),
+        "stride": (stride_h, stride_w),
+        "padding": (pad_h, pad_w),
+        "dilation": (dilation_h, dilation_w),
+        "batch_size": batch_size,
+        "input_height": input_height,
+        "input_width": input_width,
+        "groups": groups,
+        "conv_config": conv_config,
+        "return_output_dim": True,
+        "return_weights_and_bias": True,
+        "dtype": conv_output_dtype,
+    }
+
+    # Add compute_config if provided
+    if compute_config is not None:
+        conv2d_args["compute_config"] = compute_config
+
+    [tt_output_tensor_on_device, [out_height, out_width], [weights_device, bias_device]] = ttnn.conv2d(**conv2d_args)
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
     torch_output_tensor = ttnn.to_torch(tt_output_tensor)

--- a/tests/sweep_framework/sweep_utils/conv2d_common.py
+++ b/tests/sweep_framework/sweep_utils/conv2d_common.py
@@ -264,7 +264,7 @@ def run_conv2d_short_sweep(
     # Set config_tensors_in_dram if requested (helps avoid L1 OOM for memory-intensive configs)
     if config_tensors_in_dram:
         conv_config.config_tensors_in_dram = True
-    
+
     # Use provided dtype or default to bfloat16
     conv_output_dtype = output_dtype if output_dtype is not None else ttnn.bfloat16
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
run_conv2d_short_sweep is not accepting all kw params

### What's changed
Add additional optional params that needed in the follow up PR

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/update_conv2d_sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/update_conv2d_sweep)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs