### PR TITLE
Improving error messages across owned scripts

### DIFF
--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -92,7 +92,12 @@ def dump_risc_debug_signals(
                     # Verifying that the original data was restored
                     assert read_words_from_device(location, firmware_text_address, word_count=4) == original_data
 
-        log_check_risc(risc_name, location, False, f"Failed to halt core {risc_name} at {location.to_user_str()}")
+        log_check_risc(
+            risc_name,
+            location,
+            False,
+            f"Failed to halt core {risc_name} at {location.to_user_str()} on device {location.device.id}.",
+        )
 
         # Return the collected debug bus signals
         return DumpDebugBusSignals(

--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -96,7 +96,7 @@ def dump_risc_debug_signals(
             risc_name,
             location,
             False,
-            f"Failed to halt core {risc_name} at {location.to_user_str()} on device {location.device.id}.",
+            f"Failed to halt core.",
         )
 
         # Return the collected debug bus signals

--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -96,7 +96,7 @@ def dump_risc_debug_signals(
             risc_name,
             location,
             False,
-            f"Failed to halt core {risc_name} at {location.to_user_str()} on device {location.device.id}.",
+            f"Failed to halt core {risc_name} at {location.to_user_str()}.",
         )
 
         # Return the collected debug bus signals

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -150,7 +150,7 @@ def _convert_metal_device_ids_to_device_ids(
                 break
         log_check(
             found,
-            f"Device with unique_id {unique_id} (metal_device_id {metal_device_id}) not found in context.devices",
+            f"Device {metal_device_id} [{unique_id}] not found. There is a mismatch between metal and exalens device IDs, most likely due to use of TT_VISIBLE_DEVICES. Please contact script owner.",
         )
     return device_ids
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-exalens/issues/800

Improved error messaging in `run_checks` and `dump_risc_debug_bus` scripts.