### PR TITLE
[skip ci] Fix mismatched model name in T3K unit pipeline

### DIFF
--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -172,7 +172,7 @@
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
   timeout: 10
-  model-name: deepseekv3
+  model-name: deepseek
 
 - name: t3k_tttv2_modules_tests
   cmd: run_t3000_tttv2_modules_tests


### PR DESCRIPTION
T3K unit tests run here: https://github.com/tenstorrent/tt-metal/actions/runs/20928745145