### PR TITLE
Increased timeout for t3k integration llama3 test

### DIFF
--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -65,7 +65,7 @@
   sku: wh_llmbox
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
-  timeout: 45
+  timeout: 47
 
 - name: t3k_llama3_accuracy_tests
   cmd: run_t3000_llama3_accuracy_tests


### PR DESCRIPTION
A copy of https://github.com/tenstorrent/tt-metal/pull/35454

### Problem description
t3000-frequent-tests / t3k llama3 tests where failing on test_chunked_generation test.
See more [in slack](https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1767388894548839?thread_ts=1767388877.405339&cid=C05GRJC4J4A).

### What's changed
Increased timeout for t3k frequent llama3 test by 2 minutes (since now it's very tight and 10-20% of runs can fail because of <1 minute is needed to complete the tests)

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20823591684) - CI passes

#### Model tests

- [x] [T3K frequent llama3 tests](https://github.com/tenstorrent/tt-metal/actions/runs/20822975910) - CI passes