### PR TITLE
Improve triage debug messages

### DIFF
--- a/tools/triage/check_core_magic.py
+++ b/tools/triage/check_core_magic.py
@@ -30,6 +30,8 @@ script_config = ScriptConfig(
     depends=["run_checks", "dispatcher_data", "elfs_cache"],
 )
 
+MAILBOX_CORRUPTED_MESSAGE = "Mailbox is likely corrupted, potentially due to NoC writes to an invalid location."
+
 
 class CoreMagicValues:
     """
@@ -156,14 +158,14 @@ def check_core_magic(
             False,
             f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
             f"but found {found_type} firmware at {found_type} mailbox location. "
-            f"Value at expected location: 0x{actual_magic:08X}",
+            f"Value at expected location: 0x{actual_magic:08X}. Triage may have incorrectly identified the firmware type.",
         )
     else:
         log_check_location(
             location,
             False,
             f"{risc_name}: core_magic_number mismatch! Expected {expected_type} (0x{expected_magic:08X}), "
-            f"found unknown value 0x{actual_magic:08X}. Could not identify firmware type at other locations.",
+            f"found unknown value 0x{actual_magic:08X}. Could not identify firmware type at other locations. {MAILBOX_CORRUPTED_MESSAGE}",
         )
 
 

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -8,8 +8,8 @@ Usage:
     check_noc_status.py
 
 Description:
-    This script checks if there are any mismatches between values of number of NOC transactions
-    stored in global variables from risc firmware and NOC status registers.
+    This script checks if there are any mismatches between values of number of NOC transactions stored in global
+    variables from risc firmware and NOC status registers. These values should be in sync when the NoC is idle.
 
 Owner:
     jbaumanTT
@@ -97,7 +97,11 @@ def check_noc_status(
             message += f"    {reg} {var} {reg_val} {var_val}\n"
             passed = False
     if not passed:
-        message = "Mismatched state: \n" + message
+        message = (
+            "Mismatched state: \n"
+            + message
+            + "\n. Either the device is not idle and is currently processing transactions, the kernel has incorrectly modified the NOC transaction counters, or the NoC is hung."
+        )
 
     log_check_location(location, passed, message)
 

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -100,7 +100,7 @@ def check_noc_status(
         message = (
             "Mismatched state: \n"
             + message
-            + "\n. Either the device is not idle and is currently processing transactions, the kernel has incorrectly modified the NOC transaction counters, or the NoC is hung."
+            + "\nEither the device is not idle and is currently processing transactions, the kernel has incorrectly modified the NOC transaction counters, or the NoC is hung."
         )
 
     log_check_location(location, passed, message)

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -36,6 +36,8 @@ script_config = ScriptConfig(
     depends=["inspector_data", "elfs_cache", "run_checks", "metal_device_id_mapping"],
 )
 
+MAILBOX_CORRUPTED_MESSAGE = "Mailbox is likely corrupted, potentially due to NoC writes to an invalid location."
+
 
 @dataclass
 class DispatcherCoreData:
@@ -269,7 +271,7 @@ class DispatcherData:
         log_check_location(
             location,
             launch_msg_rd_ptr < self._launch_msg_buffer_num_entries,
-            f"launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}.",
+            f"launch message read pointer {launch_msg_rd_ptr} >= {self._launch_msg_buffer_num_entries}. {MAILBOX_CORRUPTED_MESSAGE}",
         )
 
         previous_launch_msg_rd_ptr = (launch_msg_rd_ptr - 1) % self._launch_msg_buffer_num_entries

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -10,7 +10,8 @@ Usage:
 Options:
 
 Description:
-    Read important variables from fast dispatch kernels.
+    Read important variables from fast dispatch kernels. These can help identify the state the dispatcher is in, to help
+    determine the cause of any hangs.
 
 Owner:
     jbaumanTT
@@ -231,7 +232,7 @@ def read_wait_globals(
         if is_dispatcher_kernel:
             log_check(
                 wait_stream_value is not None,
-                f"Failed to read wait_stream_value for kernel {dispatcher_core_data.kernel_name}",
+                f"Failed to read wait_stream_value for kernel {dispatcher_core_data.kernel_name}. There may be a problem with the dispatcher kernel.",
             )
 
     if last_wait_count is not None and stream_width is not None:
@@ -254,7 +255,10 @@ def read_wait_globals(
             delta = (int(sem_value) - int(local_count)) & 0xFFFFFFFF
             sem_minus_local = delta - 0x100000000 if (delta & 0x80000000) else delta
     except Exception:
-        log_check(False, f"Failed to read sem_minus_local for kernel {dispatcher_core_data.kernel_name}")
+        log_check(
+            False,
+            f"Failed to read sem_minus_local for kernel {dispatcher_core_data.kernel_name}. There may be a problem with the dispatcher kernel.",
+        )
         # Leave as None if any lookups fail
         sem_minus_local = None
 

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -8,7 +8,8 @@ Usage:
     dump_watcher_ringbuffer
 
 Description:
-    Dump watcher ring buffer contents for all cores, skipping cores with empty buffers.
+    Dump watcher ring buffer contents for all cores, skipping cores with empty buffers. This ringbuffer can be written
+    into by using the WATCHER_RING_BUFFER_PUSH macro in a kernel.
 
 Owner:
     jbaumanTT


### PR DESCRIPTION
### Ticket
[#](https://github.com/tenstorrent/tt-exalens/issues/801)

### Problem description
Currently it can be difficult for users to interpret some triage errors.

### What's changed
Add longer descriptions of possible causes to some errors. This can help users with debugging the cause.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/improvetriagedebugmessages)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/improvetriagedebugmessages)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/improvetriagedebugmessages)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/improvetriagedebugmessages)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/improvetriagedebugmessages)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/improvetriagedebugmessages)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/improvetriagedebugmessages)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs