### PR TITLE
Added Fabric Benchmark Upload Guards

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,7 +31,8 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            cmd: "ls -la generated/fabric",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,
@@ -127,7 +128,7 @@ jobs:
         if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
         shell: bash
         run: |
-          if [ -d "generated/fabric" ]; then
+          if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
           else

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,8 +31,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
-            cmd: "ls -la generated/fabric",
+            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,
@@ -125,7 +124,7 @@ jobs:
           prefix: "test_reports_"
       - name: Check for benchmark data
         id: check-benchmark-data
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         shell: bash
         run: |
           if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
@@ -137,15 +136,12 @@ jobs:
           fi
       - name: Upload benchmark data
         ## Only upload benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
-        shell: bash
-        run:
-          echo "Uploading benchmark data"
-        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        # with:
-        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-        #   path: /work
+        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,7 +31,8 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            cmd: "ls -l",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,
@@ -122,14 +123,29 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Check for benchmark data
+        id: check-benchmark-data
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        shell: bash
+        run: |
+          if [ -d "generated/fabric" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            echo "Benchmark files found, will upload to database"
+          else
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            echo "Benchmark files not found, database upload will be skipped"
+          fi
       - name: Upload benchmark data
         ## Only upload benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') }}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-          path: /work
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        shell: bash
+        run:
+          echo "Uploading benchmark data"
+        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        # with:
+        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+        #   path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,8 +31,8 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
-            cmd: "ls -la generated/fabric",
+            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            # cmd: "ls -la generated/fabric",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,8 +31,7 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
-            cmd: "ls -l",
+            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -31,8 +31,8 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["arch-wormhole_b0", "pipeline-perf", "config-t3000", "in-service"],
             name: "T3K ubench - Fabric BW & Latency",
-            cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
-            # cmd: "ls -la generated/fabric",
+            # cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
+            cmd: "ls -la generated/fabric",
           }, # Sean Nijjar
           {
             arch: wormhole_b0,

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
-          # source tests/scripts/t3000/run_t3000_unit_tests.sh
-          # run_t3000_ttfabric_tests
+          source tests/scripts/t3000/run_t3000_unit_tests.sh
+          run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:
@@ -129,7 +129,7 @@ jobs:
           prefix: "test_reports_"
       - name: Check for benchmark data
         id: check-benchmark-data
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         shell: bash
         run: |
           if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
@@ -141,17 +141,14 @@ jobs:
           fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
-        shell: bash
-        run:
-          echo "Uploading benchmark data"
-        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        # with:
-        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-        #   path: /work
+        if: ${{ !cancelled() && github.ref_name == 'main' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
-          # source tests/scripts/t3000/run_t3000_unit_tests.sh
-          # run_t3000_ttfabric_tests
+          source tests/scripts/t3000/run_t3000_unit_tests.sh
+          run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
-          source tests/scripts/t3000/run_t3000_unit_tests.sh
-          run_t3000_ttfabric_tests
+          # source tests/scripts/t3000/run_t3000_unit_tests.sh
+          # run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
-          source tests/scripts/t3000/run_t3000_unit_tests.sh
-          run_t3000_ttfabric_tests
+          # source tests/scripts/t3000/run_t3000_unit_tests.sh
+          # run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:
@@ -127,16 +127,31 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Check for benchmark data
+        id: check-benchmark-data
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        shell: bash
+        run: |
+          if [ -d "generated/fabric" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            echo "Benchmark files found, will upload to database"
+          else
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            echo "Benchmark files not found, database upload will be skipped"
+          fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main'}}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-          path: /work
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        shell: bash
+        run:
+          echo "Uploading benchmark data"
+        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        # with:
+        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+        #   path: /work
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{ inputs.run-fabric-tests == 'true' }}
         run: |
           mkdir -p generated/test_reports
-          source tests/scripts/t3000/run_t3000_unit_tests.sh
-          run_t3000_ttfabric_tests
+          # source tests/scripts/t3000/run_t3000_unit_tests.sh
+          # run_t3000_ttfabric_tests
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
         with:
@@ -132,7 +132,7 @@ jobs:
         if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
         shell: bash
         run: |
-          if [ -d "generated/fabric" ]; then
+          if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
           else

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -150,13 +150,14 @@ jobs:
         if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
         shell: bash
         run: |
-          if [ -d "generated/fabric" ]; then
+          if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
             ls -la generated/fabric
           else
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
             echo "Benchmark files not found, database upload will be skipped"
+            ls -la generated/fabric
           fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -139,7 +139,7 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -139,22 +139,37 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Check for benchmark data
+        id: check-benchmark-data
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        shell: bash
+        run: |
+          if [ -d "generated/fabric" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            echo "Benchmark files found, will upload to database"
+          else
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            echo "Benchmark files not found, database upload will be skipped"
+          fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' }}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-          path: /work
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        shell: bash
+        run:
+          echo "Uploading benchmark data"
+        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        # with:
+        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+        #   path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -139,7 +139,7 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -147,31 +147,26 @@ jobs:
           prefix: "test_reports_"
       - name: Check for benchmark data
         id: check-benchmark-data
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         shell: bash
         run: |
           if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
-            ls -la generated/fabric
           else
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
             echo "Benchmark files not found, database upload will be skipped"
-            ls -la generated/fabric
           fi
       - name: Upload benchmark data
         ## Only upload fabric benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
-        shell: bash
-        run:
-          echo "Uploading benchmark data"
-        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        # with:
-        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-        #   path: /work
+        if: ${{ !cancelled() && github.ref_name == 'main' && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -139,7 +139,7 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -139,7 +139,7 @@ jobs:
           TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
-          TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
+          # TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -153,6 +153,7 @@ jobs:
           if [ -d "generated/fabric" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
+            ls -la generated/fabric
           else
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
             echo "Benchmark files not found, database upload will be skipped"

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,7 +36,8 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then
@@ -117,7 +118,7 @@ jobs:
         if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
         shell: bash
         run: |
-          if [ -d "generated/fabric" ]; then
+          if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
             echo "Benchmark files found, will upload to database"
           else

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,7 +36,8 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -l"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then
@@ -112,14 +113,29 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: Check for benchmark data
+        id: check-benchmark-data
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        shell: bash
+        run: |
+          if [ -d "generated/fabric" ]; then
+            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
+            echo "Benchmark files found, will upload to database"
+          else
+            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
+            echo "Benchmark files not found, database upload will be skipped"
+          fi
       - name: Upload benchmark data
         ## Only upload benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') }}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-          path: /work
+        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        shell: bash
+        run:
+          echo "Uploading benchmark data"
+        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        # with:
+        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+        #   path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,8 +36,7 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -l"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,8 +36,7 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then
@@ -115,7 +114,7 @@ jobs:
           prefix: "test_reports_"
       - name: Check for benchmark data
         id: check-benchmark-data
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' }}
         shell: bash
         run: |
           if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
@@ -127,15 +126,12 @@ jobs:
           fi
       - name: Upload benchmark data
         ## Only upload benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'jhaiTT/34732-add-benchmark-upload-guards' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
-        shell: bash
-        run:
-          echo "Uploading benchmark data"
-        # uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
-        # with:
-        #   ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
-        #   sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
-        #   username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
-        #   hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
-        #   path: /work
+        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_bandwidth_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,8 +36,8 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -36,8 +36,8 @@ jobs:
 
           # Check which test groups should be included
           if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
-            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
+            # matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
+            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"ls -la"}')
           fi
 
           if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34732

### Problem description
In a previous issue (https://github.com/tenstorrent/tt-metal/issues/34521), `galaxy-quick` would fail when trying to upload fabric ubench data via SFTP from a skipped/commented out fabric test, because the file it was trying to upload was not created/did not exist. This led to false negatives, where users would believe the `galaxy-quick` workflow had failed even though other tests had passed. This was fixed in https://github.com/tenstorrent/tt-metal/pull/34730, which added a guard to `galaxy-quick` that checks for the existence of ubench data before trying to upload it. 

This PR adds the guard to all other CI workflows that upload fabric ubench data via SFTP, to hopefully prevent this from occurring again in the future. These workflows are:
- `tm-fabric-tests-impl.yaml`
- `t3000-fast-tests-impl.yaml`
- `tm-fabric-tests-perf-impl.yaml`
- `metal-run-microbenchmarks-impl.yaml`

### What's changed
- Added a guard that checks for the presence of `generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv`, then enables/skips upload via SFTP based on the file's existence
- NOTE: In all of these files, we check explicitly for `bandwidth_summary_results_wormhole_b0_upload.csv`, so if the tests are modified or copied to be run on Blackhole machines, this filename must be updated. 

### Checklist
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jhaiTT/34732-add-benchmark-upload-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jhaiTT/34732-add-benchmark-upload-guards) (https://github.com/tenstorrent/tt-metal/actions/runs/20929804514)
- [x] tm-fabric-tests-impl.yaml (whole test) https://github.com/tenstorrent/tt-metal/actions/runs/20789511906 (fails like main)
- [x] tm-fabric-tests-impl.yaml (wh-6u) (https://github.com/tenstorrent/tt-metal/actions/runs/20929812360/job/60138930812)
- [x] t3000-fast-tests-impl.yaml (https://github.com/tenstorrent/tt-metal/actions/runs/20929812360/job/60138930932)
- [x] tm-fabric-tests-perf-impl.yaml (https://github.com/tenstorrent/tt-metal/actions/runs/20929812360/job/60138939126) (Fails like main)
- [x] metal-run-microbenchmarks-impl.yaml (https://github.com/tenstorrent/tt-metal/actions/runs/20929828625/job/60176636853) (fails but none of the failures are related to this change)

Per-test validation:
`tm-fabric-tests-impl.yaml`:
- Benchmark upload when data detected: https://github.com/tenstorrent/tt-metal/actions/runs/20923299268/job/60115594142
- Upload skipped when no data: https://github.com/tenstorrent/tt-metal/actions/runs/20923396531/job/60115964102

`t3000-fast-tests-impl.yaml`:
- Benchmark upload when data detected: https://github.com/tenstorrent/tt-metal/actions/runs/20923299268/job/60115594293
- Upload skipped when no data: https://github.com/tenstorrent/tt-metal/actions/runs/20923396531/job/60115964146

`tm-fabric-tests-perf-impl.yaml`:
- Benchmark upload when data detected: https://github.com/tenstorrent/tt-metal/actions/runs/20923299268/job/60115604787
- Upload skipped when no data: https://github.com/tenstorrent/tt-metal/actions/runs/20923396531/job/60115984152

`metal-run-microbenchmarks-impl.yaml`:
- Benchmark upload when data detected: https://github.com/tenstorrent/tt-metal/actions/runs/20923266729/job/60115621873
- Upload skipped when no data: https://github.com/tenstorrent/tt-metal/actions/runs/20923165806/job/60115100713