### PR TITLE
Capture src/dst addr and useful NoC counters in NoC Debug Packets

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -438,6 +438,7 @@ def test_device_api_debugger_non_dropping():
 
     # There is a read/write barrier after each noc_async_read/write call.
     # Verify that the noc counters are being tracked properly
+    NOC_COUNTER_BITS = 12
     prev_counters = {}  # (proc, noc, type) -> previous counter value
     read_event_count = 0
     write_event_count = 0
@@ -463,10 +464,11 @@ def test_device_api_debugger_non_dropping():
 
             if counter_key in prev_counters:
                 prev_counter = prev_counters[counter_key]
-                assert noc_status_counter == prev_counter + 1, (
+                expected_counter = (prev_counter + 1) % (2**NOC_COUNTER_BITS)
+                assert noc_status_counter == expected_counter, (
                     f"noc_status_counter should increment by 1 for consecutive {event_type} events "
-                    f"for {proc} {noc}. Previous counter: {prev_counter}, current counter: {noc_status_counter} "
-                    f"at timestamp {event.get('timestamp')}"
+                    f"for {proc} {noc}. Previous counter: {prev_counter}, current counter: {noc_status_counter}, "
+                    f"expected: {expected_counter} at timestamp {event.get('timestamp')}"
                 )
 
             prev_counters[counter_key] = noc_status_counter

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -436,6 +436,48 @@ def test_device_api_debugger_non_dropping():
         write_barrier_end_count == expected_barrier_count
     ), f"Expected {expected_barrier_count} WRITE_BARRIER_END events, found {write_barrier_end_count}"
 
+    # There is a read/write barrier after each noc_async_read/write call.
+    # Verify that the noc counters are being tracked properly
+    prev_counters = {}  # (proc, noc, type) -> previous counter value
+    read_event_count = 0
+    write_event_count = 0
+
+    for event in noc_trace_data:
+        event_type = event.get("type")
+        if event_type in ["READ", "WRITE_"]:
+            assert (
+                "noc_status_counter" in event
+            ), f"noc_status_counter missing in {event_type} event at timestamp {event.get('timestamp')}"
+            assert "proc" in event, f"proc missing in {event_type} event at timestamp {event.get('timestamp')}"
+            assert "noc" in event, f"noc missing in {event_type} event at timestamp {event.get('timestamp')}"
+
+            noc_status_counter = event.get("noc_status_counter")
+            proc = event.get("proc")
+            noc = event.get("noc")
+
+            assert isinstance(
+                noc_status_counter, int
+            ), f"noc_status_counter must be an integer, found {type(noc_status_counter)} in {event_type} event"
+
+            counter_key = (proc, noc, event_type)
+
+            if counter_key in prev_counters:
+                prev_counter = prev_counters[counter_key]
+                assert noc_status_counter == prev_counter + 1, (
+                    f"noc_status_counter should increment by 1 for consecutive {event_type} events "
+                    f"for {proc} {noc}. Previous counter: {prev_counter}, current counter: {noc_status_counter} "
+                    f"at timestamp {event.get('timestamp')}"
+                )
+
+            prev_counters[counter_key] = noc_status_counter
+
+            if event_type == "READ":
+                read_event_count += 1
+            else:
+                write_event_count += 1
+
+    assert read_event_count > 0 or write_event_count > 0, "No READ or WRITE_ events found to verify noc_status_counter"
+
 
 def wildcard_match(pattern, words):
     if not pattern.endswith("*"):

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -495,7 +495,7 @@ FORCE_INLINE void noc_async_read_one_packet(
         Read responses - assigned VCs dynamically
     */
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, src_noc_addr, size, -1, false);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false);
     }
 
     WAYPOINT("RP2W");
@@ -540,7 +540,7 @@ inline void noc_async_read(
         Read responses - assigned VCs dynamically
     */
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, src_noc_addr, size, -1, false);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false);
     }
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
@@ -579,7 +579,7 @@ FORCE_INLINE void noc_async_read_one_packet_set_state(
     */
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ_SET_STATE, src_noc_addr, size, (use_vc) ? static_cast<int8_t>(vc) : -1, false);
+        NocEventType::READ_SET_STATE, 0, src_noc_addr, size, (use_vc) ? static_cast<int8_t>(vc) : -1, false);
 
     WAYPOINT("NASW");
     ncrisc_noc_read_set_state<noc_mode, true /* one_packet */, use_vc>(noc, read_cmd_buf, src_noc_addr, size, vc);
@@ -612,6 +612,7 @@ FORCE_INLINE void noc_async_read_one_packet_with_state(
     */
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::READ_WITH_STATE,
+        dst_local_l1_addr,
         static_cast<uint64_t>(src_local_l1_addr),
         0,
         (use_vc) ? static_cast<int8_t>(vc) : -1,
@@ -654,7 +655,7 @@ void noc_async_read_set_state(uint64_t src_noc_addr, uint8_t noc = noc_index) {
         Read responses - assigned VCs dynamically
     */
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, src_noc_addr, 0, -1, false);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, 0, src_noc_addr, 0, -1, false);
 
     WAYPOINT("NAUW");
     ncrisc_noc_read_set_state<noc_mode>(noc, read_cmd_buf, src_noc_addr);
@@ -690,7 +691,7 @@ FORCE_INLINE void noc_async_read_with_state(
         Read responses - assigned VCs dynamically
     */
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ_WITH_STATE, static_cast<uint64_t>(src_local_l1_addr), size, -1, false);
+        NocEventType::READ_WITH_STATE, dst_local_l1_addr, static_cast<uint64_t>(src_local_l1_addr), size, -1, false);
 
     WAYPOINT("NAVW");
 
@@ -750,7 +751,7 @@ FORCE_INLINE void noc_async_write_one_packet(
     uint8_t noc = noc_index,
     uint32_t vc = NOC_UNICAST_WRITE_VC) {
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted);
     }
 
     WAYPOINT("NWPW");
@@ -804,7 +805,7 @@ inline void noc_async_write(
     uint8_t noc = noc_index,
     uint32_t vc = NOC_UNICAST_WRITE_VC) {
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted);
     }
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
@@ -835,7 +836,12 @@ FORCE_INLINE void noc_async_write_multicast_one_packet(
     if constexpr (enable_noc_tracing) {
         NOC_TRACE_QUICK_PUSH_IF_LINKED(write_cmd_buf, linked);
         RECORD_NOC_EVENT_WITH_ADDR(
-            NocEventType::WRITE_MULTICAST, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
+            NocEventType::WRITE_MULTICAST,
+            src_local_l1_addr,
+            dst_noc_addr_multicast,
+            size,
+            NOC_MULTICAST_WRITE_VC,
+            false);
     }
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
@@ -900,7 +906,7 @@ inline void noc_async_write_multicast(
     bool linked = false,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::WRITE_MULTICAST, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
+        NocEventType::WRITE_MULTICAST, src_local_l1_addr, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
         noc_async_write_multicast_one_packet<false>(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked);
@@ -949,7 +955,7 @@ template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
     uint64_t dst_noc_addr, uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size, vc, posted);
 
     WAYPOINT("NWPW");
     ncrisc_noc_write_set_state<posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
@@ -978,7 +984,7 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
 template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
     uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_local_l1_addr, 0ull, 0, -1, posted);
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_l1_addr, src_local_l1_addr);
@@ -1028,7 +1034,7 @@ FORCE_INLINE void noc_async_read_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, page_size, -1);
+        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, page_size, -1);
     }
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, page_size, noc);
@@ -1051,7 +1057,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1072,7 +1078,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<TensorAccessor<DSpec>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1093,7 +1099,7 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1120,7 +1126,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
     noc_async_read_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1141,7 +1147,8 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1);
     noc_async_read_page<InterleavedPow2AddrGenFast<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1189,7 +1196,13 @@ FORCE_INLINE void noc_async_write_page(
     }
     if constexpr (enable_noc_tracing) {
         RECORD_NOC_EVENT_WITH_ID(
-            NocEventType::WRITE_, id, addrgen, offset, size ? size : page_size, NOC_UNICAST_WRITE_VC);
+            NocEventType::WRITE_,
+            src_local_l1_addr,
+            id,
+            addrgen,
+            offset,
+            size ? size : page_size,
+            NOC_UNICAST_WRITE_VC);
     }
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
         src_local_l1_addr, addrgen.get_noc_addr(id, offset, noc), size ? size : page_size, noc);
@@ -1219,7 +1232,8 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t write_size_bytes,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1236,7 +1250,7 @@ template <bool DRAM>
 [[deprecated("Use <typename AddrGen> noc_async_write_page instead.")]]
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const InterleavedAddrGen<DRAM>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1262,7 +1276,7 @@ FORCE_INLINE void noc_async_write_tile(
     const InterleavedAddrGenFast<DRAM, tile_hw>& addrgen,
     uint32_t src_local_l1_addr,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1281,7 +1295,7 @@ template <typename DSpec>
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const TensorAccessor<DSpec>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<TensorAccessor<DSpec>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1311,7 +1325,8 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t write_size_bytes,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
     noc_async_write_page<InterleavedPow2AddrGenFast<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1337,7 +1352,12 @@ FORCE_INLINE void noc_async_read_shard(
     const uint32_t shard_id, const TensorAccessor<DSpec>& s, std::uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
     auto shard_volume = s.dspec().shard_volume();
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ, s.get_shard_noc_addr(shard_id, noc), s.page_size * shard_volume, -1, false);
+        NocEventType::READ,
+        dst_local_l1_addr,
+        s.get_shard_noc_addr(shard_id, noc),
+        s.page_size * shard_volume,
+        -1,
+        false);
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         s.get_shard_noc_addr(shard_id, noc), dst_local_l1_addr, s.page_size * shard_volume, noc);
 }
@@ -1366,6 +1386,7 @@ FORCE_INLINE void noc_async_write_shard(
     auto shard_volume = s.dspec().shard_volume();
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::WRITE_,
+        src_local_l1_addr,
         s.get_shard_noc_addr(shard_id, noc),
         s.page_size * shard_volume,
         NOC_UNICAST_WRITE_VC,
@@ -1554,7 +1575,7 @@ inline void noc_async_write_multicast_loopback_src(
 
     NOC_TRACE_QUICK_PUSH_IF_LINKED(write_cmd_buf, linked);
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::WRITE_MULTICAST, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
+        NocEventType::WRITE_MULTICAST, src_local_l1_addr, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
 
     WAYPOINT("NMLW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
@@ -2026,7 +2047,7 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
 template <bool posted = false>
 FORCE_INLINE void noc_semaphore_inc(
     uint64_t addr, uint32_t incr, uint8_t noc_id = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC, addr, 0, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC, 0, addr, 0, vc, posted);
 
     WAYPOINT("NSIW");
     DEBUG_SANITIZE_NOC_ADDR(noc_id, addr, 4);
@@ -2176,7 +2197,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, src_local_l1_addr, dst_noc_addr, size, -1, posted);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
 
@@ -2235,7 +2256,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, dst_noc_addr, 0, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, 0, dst_noc_addr, 0, vc, posted);
 
     ncrisc_noc_write_set_state<posted, false /* one_packet */>(noc, cmd_buf, dst_noc_addr, 0 /* len_bytes */, vc);
     WAYPOINT("NAWD");
@@ -2272,7 +2293,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, 0ull, size, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, src_local_l1_addr, 0ull, size, -1, posted);
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_local_l1_addr, src_local_l1_addr, size);

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1034,7 +1034,7 @@ FORCE_INLINE void noc_async_read_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, page_size, -1);
+        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, page_size, -1, false);
     }
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, page_size, noc);
@@ -1057,7 +1057,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1078,7 +1078,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
     noc_async_read_page<TensorAccessor<DSpec>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1099,7 +1099,7 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1126,7 +1126,7 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
     noc_async_read_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1148,7 +1148,7 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1);
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1, false);
     noc_async_read_page<InterleavedPow2AddrGenFast<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1202,7 +1202,8 @@ FORCE_INLINE void noc_async_write_page(
             addrgen,
             offset,
             size ? size : page_size,
-            NOC_UNICAST_WRITE_VC);
+            NOC_UNICAST_WRITE_VC,
+            posted);
     }
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
         src_local_l1_addr, addrgen.get_noc_addr(id, offset, noc), size ? size : page_size, noc);
@@ -1233,7 +1234,7 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
+        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC, false);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1250,7 +1251,7 @@ template <bool DRAM>
 [[deprecated("Use <typename AddrGen> noc_async_write_page instead.")]]
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const InterleavedAddrGen<DRAM>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1276,7 +1277,7 @@ FORCE_INLINE void noc_async_write_tile(
     const InterleavedAddrGenFast<DRAM, tile_hw>& addrgen,
     uint32_t src_local_l1_addr,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false);
     noc_async_write_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1295,7 +1296,14 @@ template <typename DSpec>
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const TensorAccessor<DSpec>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC);
+        NocEventType::WRITE_,
+        src_local_l1_addr,
+        id,
+        addrgen,
+        0 /* offset */,
+        addrgen.page_size,
+        NOC_UNICAST_WRITE_VC,
+        false);
     noc_async_write_page<TensorAccessor<DSpec>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1326,7 +1334,7 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC);
+        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC, false);
     noc_async_write_page<InterleavedPow2AddrGenFast<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1606,7 +1614,7 @@ inline void noc_async_write_multicast_loopback_src(
  * | noc      | Which NOC to query on                | uint8_t  | 0 or 1      | False    |
  */
 void noc_async_read_barrier(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_START);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_START, false);
 
     WAYPOINT("NRBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1619,7 +1627,7 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
     invalidate_l1_cache();
     WAYPOINT("NRBD");
 
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_END);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_END, false);
 }
 
 /**
@@ -1636,7 +1644,7 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_write_barrier(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_START);
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_START, false);
 
     WAYPOINT("NWBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1649,7 +1657,7 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
     invalidate_l1_cache();
     WAYPOINT("NWBD");
 
-    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_END);
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_END, false);
 }
 
 /**
@@ -1665,7 +1673,7 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_writes_flushed(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH);
+    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH, false);
 
     WAYPOINT("NWFW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1718,7 +1726,7 @@ void noc_async_posted_writes_flushed(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::ATOMIC_BARRIER);
+    RECORD_NOC_EVENT(NocEventType::ATOMIC_BARRIER, false);
 
     WAYPOINT("NABW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1743,7 +1751,7 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 FORCE_INLINE
 void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
     invalidate_l1_cache();
-    RECORD_NOC_EVENT(NocEventType::FULL_BARRIER);
+    RECORD_NOC_EVENT(NocEventType::FULL_BARRIER, false);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         WAYPOINT("NFBW");
         while (!ncrisc_dynamic_noc_reads_flushed(noc_idx)) {
@@ -1798,7 +1806,7 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false);
 
     WAYPOINT("NSW");
     do {
@@ -1824,7 +1832,7 @@ void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false);
 
     WAYPOINT("NSMW");
     do {
@@ -1850,7 +1858,7 @@ void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val)
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET, false);
 
     // set semaphore value to val
     (*sem_addr) = val;
@@ -2096,7 +2104,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
 template <bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID);
+    RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID, false);
 
     WAYPOINT("NRDW");
     ncrisc_noc_fast_read_with_transaction_id<noc_mode, skip_ptr_update, skip_cmdbuf_chk>(
@@ -2118,7 +2126,7 @@ FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
 // clang-format on
 FORCE_INLINE
 void noc_async_read_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_SET_TRID);
+    RECORD_NOC_EVENT(NocEventType::READ_SET_TRID, false);
 
     WAYPOINT("NSTW");
     ncrisc_noc_set_transaction_id(noc, read_cmd_buf, trid);
@@ -2139,7 +2147,7 @@ void noc_async_read_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_async_write_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_SET_TRID);
+    RECORD_NOC_EVENT(NocEventType::WRITE_SET_TRID, false);
     WAYPOINT("NWSW");
     ncrisc_noc_set_transaction_id(noc, write_cmd_buf, trid);
     WAYPOINT("NWSD");
@@ -2163,7 +2171,7 @@ void noc_async_write_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
 FORCE_INLINE
 void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTW");
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_WITH_TRID);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_WITH_TRID, false);
     while (!ncrisc_noc_read_with_transaction_id_flushed(noc, trid)) {
         continue;
     }
@@ -2355,7 +2363,7 @@ void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_async_write_flushed_with_trid(uint32_t trid, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH_WITH_TRID);
+    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH_WITH_TRID, false);
     WAYPOINT("NFTW");
     while (!ncrisc_noc_nonposted_write_with_transaction_id_sent(noc, trid)) {
         continue;

--- a/tt_metal/hw/inc/experimental/noc.h
+++ b/tt_metal/hw/inc/experimental/noc.h
@@ -161,6 +161,7 @@ public:
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         RECORD_NOC_EVENT_WITH_ADDR(
             NocEventType::READ_SET_STATE,
+            0,
             src_noc_addr,
             size_bytes,
             (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1,
@@ -260,7 +261,8 @@ public:
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
             if constexpr (enable_noc_tracing) {
-                RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size_bytes, -1, posted);
+                RECORD_NOC_EVENT_WITH_ADDR(
+                    NocEventType::WRITE_WITH_TRID, src_addr, dst_noc_addr, size_bytes, -1, posted);
             }
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, size_bytes);
             constexpr bool one_packet = max_page_size <= NOC_MAX_BURST_SIZE;
@@ -365,7 +367,7 @@ public:
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
         constexpr bool posted = response_mode == ResponseMode::POSTED;
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size_bytes, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size_bytes, vc, posted);
 
         WAYPOINT("NWPW");
         ncrisc_noc_write_set_state<posted, max_page_size <= NOC_MAX_BURST_SIZE>(
@@ -411,11 +413,11 @@ public:
                 (uint32_t)get_dst_ptr<AddressType::NOC>(dst, dst_args),
                 noc_id_);
         } else {
-            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1, posted);
             // In order to sanitize, need to grab full noc addr + xfer size from state.
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_addr =
                 get_dst_ptr<AddressType::NOC>(dst, dst_args);  // NoC target was programmed in set_async_write_state
+            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_addr, 0ull, 0, -1, posted);
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id_, dst_addr, src_addr);
 
             WAYPOINT("NWPW");

--- a/tt_metal/hw/inc/experimental/noc.h
+++ b/tt_metal/hw/inc/experimental/noc.h
@@ -163,7 +163,8 @@ public:
             NocEventType::READ_SET_STATE,
             src_noc_addr,
             size_bytes,
-            (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1);
+            (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1,
+            false);
 
         WAYPOINT("NASW");
         ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, vc_selection == VcSelection::CUSTOM>(
@@ -249,6 +250,8 @@ public:
         const dst_args_t<Dst>& dst_args,
         uint32_t vc = NOC_UNICAST_WRITE_VC,
         uint32_t trid = INVALID_TXN_ID) const {
+        constexpr bool posted = response_mode == ResponseMode::POSTED;
+
         if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
             // TODO (#31535): Need to add check in ncrisc_noc_fast_write_any_len to ensure outstanding transaction
             // register does not overflow
@@ -257,7 +260,7 @@ public:
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
             if constexpr (enable_noc_tracing) {
-                RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size_bytes, -1);
+                RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, dst_noc_addr, size_bytes, -1, posted);
             }
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, size_bytes);
             constexpr bool one_packet = max_page_size <= NOC_MAX_BURST_SIZE;
@@ -272,11 +275,11 @@ public:
                 false,  // linked
                 1,      // num_dests
                 true,   // multicast_path_reserve
-                response_mode == ResponseMode::POSTED,
+                posted,
                 trid);
             WAYPOINT("NWPD");
         } else {
-            noc_async_write<max_page_size, enable_noc_tracing, response_mode == ResponseMode::POSTED>(
+            noc_async_write<max_page_size, enable_noc_tracing, posted>(
                 get_src_ptr<AddressType::LOCAL_L1>(src, src_args),
                 get_dst_ptr<AddressType::NOC>(dst, dst_args),
                 size_bytes,
@@ -361,10 +364,11 @@ public:
         const Dst& dst, uint32_t size_bytes, const dst_args_t<Dst>& dst_args, uint8_t vc = NOC_UNICAST_WRITE_VC) const {
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size_bytes, vc);
+        constexpr bool posted = response_mode == ResponseMode::POSTED;
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size_bytes, vc, posted);
 
         WAYPOINT("NWPW");
-        ncrisc_noc_write_set_state<response_mode == ResponseMode::POSTED, max_page_size <= NOC_MAX_BURST_SIZE>(
+        ncrisc_noc_write_set_state<posted, max_page_size <= NOC_MAX_BURST_SIZE>(
             noc_id_, write_cmd_buf, dst_noc_addr, size_bytes, vc);
         WAYPOINT("NWPD");
     }
@@ -399,13 +403,15 @@ public:
         const src_args_t<Src>& src_args,
         const dst_args_t<Dst>& dst_args,
         uint8_t vc = NOC_UNICAST_WRITE_VC) const {
+        constexpr bool posted = response_mode == ResponseMode::POSTED;
+
         if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-            noc_async_write_one_packet_with_state<response_mode == ResponseMode::POSTED>(
+            noc_async_write_one_packet_with_state<posted>(
                 get_src_ptr<AddressType::LOCAL_L1>(src, src_args),
                 (uint32_t)get_dst_ptr<AddressType::NOC>(dst, dst_args),
                 noc_id_);
         } else {
-            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
+            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1, posted);
             // In order to sanitize, need to grab full noc addr + xfer size from state.
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_addr =
@@ -413,7 +419,7 @@ public:
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id_, dst_addr, src_addr);
 
             WAYPOINT("NWPW");
-            ncrisc_noc_write_any_len_with_state<noc_mode, response_mode == ResponseMode::POSTED>(
+            ncrisc_noc_write_any_len_with_state<noc_mode, posted>(
                 noc_id_,
                 write_cmd_buf,
                 get_src_ptr<AddressType::LOCAL_L1>(src, src_args),

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1724,3 +1724,18 @@ inline __attribute__((always_inline)) void ncrisc_dynamic_noc_full_sync() {
         }
     }
 }
+
+template <bool write, bool posted>
+inline __attribute__((always_inline)) uint32_t get_noc_counter_for_debug(uint32_t noc) {
+    if constexpr (write) {
+        if constexpr (posted) {
+            return NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+        } else {
+            return NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        }
+    } else {
+        // Read
+        static_assert(posted == false, "There is no such thing as posted reads");
+        return NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    }
+}

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -1598,3 +1598,18 @@ inline __attribute__((always_inline)) void ncrisc_dynamic_noc_full_sync() {
         }
     }
 }
+
+template <bool write, bool posted>
+inline __attribute__((always_inline)) uint32_t get_noc_counter_for_debug(uint32_t noc) {
+    if constexpr (write) {
+        if constexpr (posted) {
+            return NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+        } else {
+            return NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        }
+    } else {
+        // Read
+        static_assert(posted == false, "There is no such thing as posted reads");
+        return NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    }
+}

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -750,6 +750,8 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                     // Additional metadata from trailer data
                     if (device_marker.meta_data.contains("dst_addr")) {
                         data["dst_addr"] = device_marker.meta_data["dst_addr"];
+                        data["src_addr"] = device_marker.meta_data["src_addr"];
+                        data["posted"] = device_marker.meta_data["posted"];
                         data["noc_status_counter"] = device_marker.meta_data["noc_status_counter"];
                     }
 
@@ -1738,7 +1740,8 @@ void DeviceProfiler::readTsData16BMarkerData(
         }
 
         EMD trailer_metadata(trailer_data[0]);
-        meta_data["dst_addr"] = trailer_metadata.getLocalNocEventDstTrailer().dst_addr;
+        meta_data["dst_addr"] = trailer_metadata.getLocalNocEventDstTrailer().getDstAddr();
+        meta_data["src_addr"] = trailer_metadata.getLocalNocEventDstTrailer().getSrcAddr();
         meta_data["noc_status_counter"] = trailer_metadata.getLocalNocEventDstTrailer().counter_value;
     } else {
         TT_THROW("TS_DATA_16B marker contains unexpected event contents {:#X}", event_metadata.asU64());

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -750,6 +750,7 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                     // Additional metadata from trailer data
                     if (device_marker.meta_data.contains("dst_addr")) {
                         data["dst_addr"] = device_marker.meta_data["dst_addr"];
+                        data["noc_status_counter"] = device_marker.meta_data["noc_status_counter"];
                     }
 
                     json_events_by_op[program_execution_uid].push_back(data);
@@ -1738,6 +1739,7 @@ void DeviceProfiler::readTsData16BMarkerData(
 
         EMD trailer_metadata(trailer_data[0]);
         meta_data["dst_addr"] = trailer_metadata.getLocalNocEventDstTrailer().dst_addr;
+        meta_data["noc_status_counter"] = trailer_metadata.getLocalNocEventDstTrailer().counter_value;
     } else {
         TT_THROW("TS_DATA_16B marker contains unexpected event contents {:#X}", event_metadata.asU64());
     }

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -88,9 +88,24 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
 
     // Expected to come after a LocalNocEvent when NoC Debug Mode is enabled.
     struct LocalNocEventDstTrailer {
-        uint32_t dst_addr;
-        uint32_t counter_value;
-    } __attribute__((packed));
+        uint64_t dst_addr_4b : 22;     // Destination address / 4 (4-byte aligned base)
+        uint64_t dst_addr_offset : 4;  // Byte offset within 4-byte chunk (0-15)
+        uint64_t src_addr_4b : 22;     // Source address / 4 (4-byte aligned base)
+        uint64_t src_addr_offset : 4;  // Byte offset within 4-byte chunk (0-15)
+        uint64_t counter_value : 12;   // Counter value
+
+        void setDstAddr(uint32_t addr) {
+            dst_addr_4b = addr >> 2;
+            dst_addr_offset = addr & 0x3;
+        }
+        uint32_t getDstAddr() const { return (dst_addr_4b << 2) | (dst_addr_offset & 0x3); }
+
+        void setSrcAddr(uint32_t addr) {
+            src_addr_4b = addr >> 2;
+            src_addr_offset = addr & 0x3;
+        }
+        uint32_t getSrcAddr() const { return (src_addr_4b << 2) | (src_addr_offset & 0x3); }
+    };
 
     // represents a fabric NOC event
     enum class FabricPacketType : unsigned char { REGULAR, LOW_LATENCY, LOW_LATENCY_MESH, DYNAMIC_MESH };

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -75,10 +75,13 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         NocType noc_type : 4;
         NocVirtualChannel noc_vc : 4;
         uint8_t payload_chunks;
+        uint8_t posted : 1;
+        uint8_t reserved : 7;
 
-        void setNumBytes(uint32_t num_bytes) {
+        void setAttributes(uint32_t num_bytes, bool p) {
             uint32_t bytes_rounded_up = (num_bytes + PAYLOAD_CHUNK_SIZE - 1) / PAYLOAD_CHUNK_SIZE;
             payload_chunks = std::min(uint32_t(std::numeric_limits<uint8_t>::max()), bytes_rounded_up);
+            posted = p;
         }
         uint32_t getNumBytes() const { return payload_chunks * PAYLOAD_CHUNK_SIZE; }
     };
@@ -86,7 +89,7 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
     // Expected to come after a LocalNocEvent when NoC Debug Mode is enabled.
     struct LocalNocEventDstTrailer {
         uint32_t dst_addr;
-        uint32_t padding;
+        uint32_t counter_value;
     } __attribute__((packed));
 
     // represents a fabric NOC event

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -795,8 +795,8 @@ __attribute__((noinline)) void trace_only_init() {
 #define DeviceIncrementTraceCount()
 
 // null macros when noc tracing is disabled
-#define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, offset, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted)
+#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -795,7 +795,7 @@ __attribute__((noinline)) void trace_only_init() {
 #define DeviceIncrementTraceCount()
 
 // null macros when noc tracing is disabled
-#define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc)
+#define RECORD_NOC_EVENT_WITH_ADDR(type, noc_addr, num_bytes, vc, posted)
 #define RECORD_NOC_EVENT_WITH_ID(type, noc_id, addrgen, offset, num_bytes, vc)
 #define RECORD_NOC_EVENT(type)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -796,8 +796,8 @@ __attribute__((noinline)) void trace_only_init() {
 
 // null macros when noc tracing is disabled
 #define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc)
-#define RECORD_NOC_EVENT(type)
+#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted)
+#define RECORD_NOC_EVENT(type, posted)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 
 // null macros when perf counters are disabled


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35681

### Problem description
If we capture the relevant NoC counters in the NoC Debugging packets we can use them to detect missing barriers and also some other potential non deterministic bugs.

### What's changed
Extra data is captured using TS_DATA_16B when device debugging is enabled. Normal NoC tracing is not changed.
- Add `posted` bit to `LocalNocEvent`
- Add `counter_value` to `LocalNocEventDstTrailer`. Depending on if the NoC access was a read/write / posted the relevant counter value is placed here. For example, Non Posted Write will have the value of nonposted_write_reqs_sent
- Add a `src` local address to `LocalNocEventDstTrailer`. This is used to track the Write source addr and Read destination address. It stores the address in units of 4B.
- Update unit tests to verify this functionality

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/capture-noc-counters)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/capture-noc-counters)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/capture-noc-counters)
- [ ] New/Existing tests provide coverage for changes

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/21005156846


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/capture-noc-counters)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/capture-noc-counters)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/capture-noc-counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/capture-noc-counters)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs