### PR TITLE
fix tracy .str conversion for when special_parent_text col is empty

### DIFF
--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -341,6 +341,9 @@ def import_tracy_op_logs(
         df = pd.read_csv(tracyOpTimesLog)
 
     # Filter and update host_time for TT_DNN/TT_METAL ops
+    # Ensure name is string type before using .str accessor
+    # (pandas may infer as numeric if all values are null)
+    df["name"] = df["name"].astype(str)
     tt_mask = df["name"].str.contains("TT_DNN|TT_METAL", regex=True, na=False)
     if tt_mask.any():
         tt_df = df[tt_mask]
@@ -349,6 +352,8 @@ def import_tracy_op_logs(
             assert opID in ops, f"Op time for op {opID} must present. OpID: {opID}, Name: {op['name']}"
             ops[opID]["host_time"] = op
 
+    # Similar to df["name"], ensure special_parent_text is string type before using .str accessor.
+    df["special_parent_text"] = df["special_parent_text"].astype(str)
     parent_mask = df["special_parent_text"].str.contains("id:", na=False)
     if parent_mask.any():
         child_df = df[parent_mask].copy()


### PR DESCRIPTION
### Problem description
- `AttributeError` in `ttrt` when using `tracy` (occurred when using the `.str` accessor on some cols that might be null).
- This error was initially introduced in [this PR](https://github.com/tenstorrent/tt-metal/pull/35310).
- See the failing CI job in `tt-mlir`: [Link](https://github.com/tenstorrent/tt-mlir/actions/runs/20930722091/job/60143128830?pr=6557#step:15:157)
- This bug blocked `mlir`'s uplift. So this hot fix was created.
- Created a branch in `mlir` that uplifts to this fix to make sure that it fixes the issue. See the successful CI job in `tt-mlir` after this fix: [Link](https://github.com/tenstorrent/tt-mlir/actions/runs/20932855034/job/60150300784?pr=6558#step:15:141)

### What's changed
This PR fixes a pandas `AttributeError` that occurs when using the .str accessor on DataFrame columns that may be inferred as numeric types when all values are null. The fix ensures that name and special_parent_text columns are explicitly converted to string type before using string methods.

### Changes:
- Added `astype(str)` conversion for `df["name"]` column before filtering `TT_DNN/TT_METAL` operations
- Added `astype(str)` conversion for `df["special_parent_text"]` column before extracting parent operation IDs



### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sgholami/tracy-hot-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sgholami/tracy-hot-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/tracy-hot-fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/tracy-hot-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/tracy-hot-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/tracy-hot-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/tracy-hot-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs