### PR TITLE
[skip ci] Fix dead store warning in topology_mapper.cpp

### DIFF
--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -896,7 +896,6 @@ void TopologyMapper::receive_mapping_from_host(int rank) {
         if (hostname_len > 0) {
             TT_FATAL(idx + hostname_len <= record.size(), "Deserializer overflow reading hostname");
             std::string hostname_str(reinterpret_cast<const char*>(record.data() + idx), hostname_len);
-            idx += hostname_len;
             info.hostname = hostname_str;
         }
 


### PR DESCRIPTION
### Ticket
N/A - Static analysis fix

### Problem description
Clang Static Analyzer reports a dead store warning in `tt_metal/fabric/topology_mapper.cpp`. The variable `idx` is incremented after reading the hostname string, but this value is never used since hostname is the last field being deserialized and `idx` goes out of scope at the end of the loop iteration.

### What's changed
Removed the unused assignment `idx += hostname_len;` on line 899 in the `receive_mapping_from_host()` function. The bounds check (`TT_FATAL`) is preserved to ensure we don't read past the buffer, but we no longer update `idx` after reading the hostname string since it's the last field and the variable is never used afterward.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/remove-dead-store-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/remove-dead-store-topology-mapper)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/remove-dead-store-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/remove-dead-store-topology-mapper)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/remove-dead-store-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/remove-dead-store-topology-mapper)
- [x] New/Existing tests provide coverage for changes (no behavioral change - dead code removal only)