### PR TITLE
Skip Tracy third-party library from clang static analysis

### DIFF
--- a/.codechecker.skiplist
+++ b/.codechecker.skiplist
@@ -3,6 +3,7 @@
 
 # External third-party dependencies (not Tenstorrent code)
 -*/.cpmcache/*
+-*/third_party/tracy/*
 
 # NOTE: tt_metal/third_party/umd IS scanned - it's Tenstorrent code
 # UMD simulation is disabled via TT_UMD_BUILD_SIMULATION=FALSE in the preset


### PR DESCRIPTION
### Ticket
N/A - Minor tooling improvement

### Problem description
Clang static analyzer reports are being generated for Tracy profiling library code (e.g., `TracyCallstack.cpp @ Line 781`). Tracy is third-party code that we don't maintain, so these reports are noise that clutters the analysis output.

### What's changed
Added `-*/third_party/tracy/*` pattern to `.codechecker.skiplist` to exclude Tracy library files from static analysis reports.

This is consistent with how other third-party dependencies (like `.cpmcache`) are already excluded.

### Checklist

- [x] New/Existing tests provide coverage for changes

No tests needed - this is a tooling configuration change that doesn't affect runtime behavior.