### PR TITLE
Fix variable shadowing and improve error handling in pad RM multi-core

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -23,8 +23,6 @@ inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint
 split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint32_t ntiles_w) {
     uint32_t ncores, ncores_h, ncores_w, ntiles_per_core_h, ntiles_per_core_w, nbatch_per_core_h, ncores_per_batch_h;
 
-    ncores_h = 1;
-
     // each batch needs to be padded independently
     switch (nbatch) {
         case 1:
@@ -91,13 +89,13 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
             break;
 
         default:
-            TT_ASSERT(false, "unhandled nbatch. TODO");
+            TT_THROW("Unsupported nbatch value {} for pad operation. Supported values are 1, 2, and 8.", nbatch);
 
             // generic case -- TODO
 
             // one of the following will be 0 when grid_size.y != nbatch
-            uint32_t nbatch_per_core_h = nbatch / grid_size.y;   // floor
-            uint32_t ncores_per_batch_h = grid_size.y / nbatch;  // floor
+            nbatch_per_core_h = nbatch / grid_size.y;   // floor
+            ncores_per_batch_h = grid_size.y / nbatch;  // floor
             if (nbatch == grid_size.y) {
                 nbatch_per_core_h = 1;
                 ncores_per_batch_h = 1;
@@ -115,16 +113,19 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
                 nbatch_per_core_h = 1;
             } else if (ncores_per_batch_h == 0) {
                 // unsupported case. TODO.
-                TT_ASSERT(false);
+                TT_THROW(
+                    "Unsupported configuration: multiple batches per core along height dimension "
+                    "(nbatch={}, grid_size.y={})",
+                    nbatch,
+                    grid_size.y);
                 // there are multiple batch per core along h
                 // ncores_per_batch_h = 1;
             } else {
-                TT_THROW("Something went terribly wrong in splitting acrtoss cores");
+                TT_THROW("Something went terribly wrong in splitting across cores");
             }
             break;
     }
 
-    ncores_w = 1;
     switch (ntiles_w) {
         case 2: ncores_w = 2; break;
         case 4: ncores_w = 4; break;


### PR DESCRIPTION
### Ticket
N/A - Found via clang static analysis (deadcode.DeadStores checker)

### Problem description
The `split_across_cores()` function in the pad RM reader/writer multi-core program factory had multiple issues identified by static analysis:

1. **Variable shadowing bug**: In the `default` switch case, local declarations of `nbatch_per_core_h` and `ncores_per_batch_h` (with `uint32_t` type specifier) were shadowing the outer scope variables declared at the top of the function. This meant the outer variables remained uninitialized and would be returned in the tuple with garbage values if the default case was executed.

2. **Dead stores**: `ncores_h` and `ncores_w` were initialized before their respective switch statements, but every branch of those switches either assigns a new value or throws, making the initial assignments dead stores.

3. **Weak error handling**: The code used `TT_ASSERT` which may be disabled in release builds, potentially allowing invalid code paths to execute silently.

### What's changed
1. **Fixed variable shadowing**: Removed the `uint32_t` type specifiers so that assignments modify the outer scope variables that are actually returned
2. **Removed dead stores**: Eliminated unnecessary initialization of `ncores_h` and `ncores_w` before their switch statements
3. **Improved error handling**: Changed `TT_ASSERT(false, ...)` to `TT_THROW(...)` to ensure errors are raised in both debug and release builds
4. **Better error messages**: Added descriptive error messages with relevant parameter values (nbatch, grid_size.y) for easier debugging
5. **Typo fix**: Corrected 'acrtoss' to 'across' in an error message

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/pad-rm-variable-shadowing-and-error-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/pad-rm-variable-shadowing-and-error-handling)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/pad-rm-variable-shadowing-and-error-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/pad-rm-variable-shadowing-and-error-handling)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/pad-rm-variable-shadowing-and-error-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/pad-rm-variable-shadowing-and-error-handling)
- [x] New/Existing tests provide coverage for changes (error paths - no new tests needed)