### PR TITLE
[skip ci] Improve error handling for ORG_READ_GITHUB_TOKEN authentication failures

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -94,12 +94,12 @@ jobs:
             if [ "$MEMBERSHIP_HTTP_CODE" = "401" ]; then
               echo "❌ CRITICAL: ORG_READ_GITHUB_TOKEN is invalid or expired (HTTP 401)"
               echo "The token must be regenerated with 'read:org' scope and updated in repository secrets."
-              
+
               # Verify token is completely invalid by testing against a basic endpoint
               TOKEN_TEST_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
                                      -H "Accept: application/vnd.github.v3+json" \
                                      "https://api.github.com/user")
-              
+
               if [ "$TOKEN_TEST_CODE" = "401" ]; then
                 echo "Token validation failed (HTTP 401). Token is invalid, expired, or revoked."
                 # Fail the workflow to force attention to the token issue
@@ -116,9 +116,10 @@ jobs:
               RATE_LIMIT_INFO=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
                                      -H "Accept: application/vnd.github.v3+json" \
                                      "https://api.github.com/rate_limit")
-              
+
               CORE_REMAINING=$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.remaining // -1' 2>/dev/null)
-              
+
+
               if [ "$CORE_REMAINING" = "0" ]; then
                 RESET_TIME=$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.reset // ""' 2>/dev/null)
                 echo "⚠️  WARNING: GitHub API rate limit exceeded (HTTP 403)"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -102,27 +102,34 @@ jobs:
               
               if [ "$TOKEN_TEST_CODE" = "401" ]; then
                 echo "Token validation failed (HTTP 401). Token is invalid, expired, or revoked."
+                # Fail the workflow to force attention to the token issue
+                echo "::error::ORG_READ_GITHUB_TOKEN secret is invalid or expired. Please regenerate the token with 'read:org' scope."
               else
                 echo "Token validates (HTTP $TOKEN_TEST_CODE) but lacks organization access. Check token scopes include 'read:org'."
+                # Fail the workflow to force attention to the token scope issue
+                echo "::error::ORG_READ_GITHUB_TOKEN secret is valid but lacks required 'read:org' organization scope. Please update the token scopes or regenerate the token with 'read:org' scope."
               fi
-              
-              # Fail the workflow to force attention to the token issue
-              echo "::error::ORG_READ_GITHUB_TOKEN secret is invalid or expired. Please regenerate the token with 'read:org' scope."
               exit 1
             elif [ "$MEMBERSHIP_HTTP_CODE" = "403" ]; then
-              # Check if this is rate limiting or permission issue
-              RATE_LIMIT_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
-                                         -H "Accept: application/vnd.github.v3+json" \
-                                         "$MEMBERSHIP_API")
+              # Check if this is rate limiting or permission issue by examining the rate limit endpoint
+              # This endpoint doesn't count against the quota and provides definitive rate limit info
+              RATE_LIMIT_INFO=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "https://api.github.com/rate_limit")
               
-              if echo "$RATE_LIMIT_RESPONSE" | grep -q "rate limit"; then
+              CORE_REMAINING=$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.remaining // -1' 2>/dev/null)
+              
+              if [ "$CORE_REMAINING" = "0" ]; then
+                RESET_TIME=$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.reset // ""' 2>/dev/null)
                 echo "⚠️  WARNING: GitHub API rate limit exceeded (HTTP 403)"
-                echo "::warning::GitHub API rate limit exceeded. The workflow will retry automatically."
-                # Don't fail, let it retry
+                echo "Rate limit will reset at: $(date -r "$RESET_TIME" 2>/dev/null || echo "$RESET_TIME")"
+                echo "::warning::GitHub API rate limit exceeded. Subsequent jobs will be skipped (should-run=false). Please re-run this workflow after the rate limit resets."
+                # Don't fail; mark should-run=false so subsequent jobs are skipped. Manual re-run is required.
                 echo "should-run=false" >> $GITHUB_OUTPUT
               else
                 echo "❌ CRITICAL: ORG_READ_GITHUB_TOKEN lacks required permissions (HTTP 403)"
                 echo "The token must have 'read:org' scope to check organization membership."
+                echo "Rate limit remaining: $CORE_REMAINING (not rate limited)"
                 echo "::error::ORG_READ_GITHUB_TOKEN lacks 'read:org' permission. Please regenerate the token with proper scopes."
                 exit 1
               fi

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -86,8 +86,47 @@ jobs:
 
             echo "Membership check for $COMMENT_AUTHOR: HTTP $MEMBERSHIP_HTTP_CODE"
 
-            # HTTP 204 = member, HTTP 404 = not a member or private membership, HTTP 302 = public member
-            if [ "$MEMBERSHIP_HTTP_CODE" = "204" ] || [ "$MEMBERSHIP_HTTP_CODE" = "302" ]; then
+            # Handle different HTTP response codes
+            # 204 = member, 302 = public member
+            # 404 = not a member or private membership
+            # 401 = authentication failed (invalid/expired token)
+            # 403 = forbidden (token lacks read:org permission or rate limited)
+            if [ "$MEMBERSHIP_HTTP_CODE" = "401" ]; then
+              echo "❌ CRITICAL: ORG_READ_GITHUB_TOKEN is invalid or expired (HTTP 401)"
+              echo "The token must be regenerated with 'read:org' scope and updated in repository secrets."
+              
+              # Verify token is completely invalid by testing against a basic endpoint
+              TOKEN_TEST_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "https://api.github.com/user")
+              
+              if [ "$TOKEN_TEST_CODE" = "401" ]; then
+                echo "Token validation failed (HTTP 401). Token is invalid, expired, or revoked."
+              else
+                echo "Token validates (HTTP $TOKEN_TEST_CODE) but lacks organization access. Check token scopes include 'read:org'."
+              fi
+              
+              # Fail the workflow to force attention to the token issue
+              echo "::error::ORG_READ_GITHUB_TOKEN secret is invalid or expired. Please regenerate the token with 'read:org' scope."
+              exit 1
+            elif [ "$MEMBERSHIP_HTTP_CODE" = "403" ]; then
+              # Check if this is rate limiting or permission issue
+              RATE_LIMIT_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" \
+                                         -H "Accept: application/vnd.github.v3+json" \
+                                         "$MEMBERSHIP_API")
+              
+              if echo "$RATE_LIMIT_RESPONSE" | grep -q "rate limit"; then
+                echo "⚠️  WARNING: GitHub API rate limit exceeded (HTTP 403)"
+                echo "::warning::GitHub API rate limit exceeded. The workflow will retry automatically."
+                # Don't fail, let it retry
+                echo "should-run=false" >> $GITHUB_OUTPUT
+              else
+                echo "❌ CRITICAL: ORG_READ_GITHUB_TOKEN lacks required permissions (HTTP 403)"
+                echo "The token must have 'read:org' scope to check organization membership."
+                echo "::error::ORG_READ_GITHUB_TOKEN lacks 'read:org' permission. Please regenerate the token with proper scopes."
+                exit 1
+              fi
+            elif [ "$MEMBERSHIP_HTTP_CODE" = "204" ] || [ "$MEMBERSHIP_HTTP_CODE" = "302" ]; then
               echo "✅ User $COMMENT_AUTHOR is a member of tenstorrent organization"
               echo "should-run=true" >> $GITHUB_OUTPUT
               echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
@@ -215,8 +254,9 @@ jobs:
                 -d '{"content": "rocket"}' \
                 "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
 
-            else
-              echo "❌ User $COMMENT_AUTHOR is not a member of tenstorrent organization (HTTP $MEMBERSHIP_HTTP_CODE)"
+            elif [ "$MEMBERSHIP_HTTP_CODE" = "404" ]; then
+              # User is not a member of the organization
+              echo "❌ User $COMMENT_AUTHOR is not a member of tenstorrent organization (HTTP 404)"
               echo "should-run=false" >> $GITHUB_OUTPUT
 
               # Add unauthorized reaction
@@ -242,6 +282,11 @@ jobs:
                 "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
 
               rm -f "$TEMP_JSON_FILE"
+            else
+              # Unexpected HTTP code
+              echo "⚠️  WARNING: Unexpected HTTP code $MEMBERSHIP_HTTP_CODE when checking organization membership for $COMMENT_AUTHOR"
+              echo "::warning::Unexpected HTTP $MEMBERSHIP_HTTP_CODE from GitHub API. Expected 204/302 (member), 404 (not member), 401 (invalid token), or 403 (rate limit/permission)."
+              echo "should-run=false" >> $GITHUB_OUTPUT
             fi
           else
             echo "should-run=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The CodeOwners workflow uses `ORG_READ_GITHUB_TOKEN` to check organization membership. When this token expires or becomes invalid, the workflow returns HTTP 401 but continues silently, leading to confusing behavior where valid organization members are denied access.

**Example:** Run [20933336511](https://github.com/tenstorrent/tt-metal/actions/runs/20933336511) showed `blozano-tt` denied with HTTP 401, even though they are a valid member.

## Root Cause

The workflow only checked for HTTP 204/302 (member) or 404 (not member), treating all other codes (including 401) as "not a member." This meant token expiration was not detected, and no actionable error was raised.

## Solution

Added comprehensive error handling to distinguish between different API response codes:

### Changes

1. **HTTP 401 (Invalid/Expired Token)** - NEW
   - Detects when `ORG_READ_GITHUB_TOKEN` is invalid, expired, or revoked
   - Validates token against `/user` endpoint to distinguish invalid token vs missing scopes
   - **Fails the workflow** with clear error message
   - Provides actionable guidance: "regenerate the token with 'read:org' scope"

2. **HTTP 403 (Forbidden)** - NEW
   - Checks response body for "rate limit" to distinguish:
     - **Rate limiting**: Logs warning, doesn't fail (allows retry)
     - **Permission issues**: Fails with guidance to add 'read:org' scope

3. **HTTP 404 (Not a Member)** - IMPROVED
   - Explicitly handles this as expected "user is not a member" case
   - Posts appropriate denial message to PR

4. **HTTP 204/302 (Success)** - UNCHANGED
   - Continues to work as before for valid members

5. **Unexpected Codes** - NEW
   - Logs warning for any other HTTP codes
   - Doesn't fail but logs for investigation

### Benefits

- ✅ **Immediate Detection**: Token expiration detected immediately instead of silently failing
- ✅ **Clear Diagnostics**: Distinguishes between different types of auth failures
- ✅ **Actionable Errors**: Uses GitHub Actions annotations (`::error::`, `::warning::`) for UI visibility
- ✅ **Rate Limit Friendly**: Doesn't fail on rate limits, allowing automatic retries
- ✅ **Better Logging**: Each error type has specific diagnostic output

## Testing

The changes have been tested against the failing run scenario. When HTTP 401 is encountered:
- Token validation runs against `/user` endpoint
- Workflow fails with: `::error::ORG_READ_GITHUB_TOKEN secret is invalid or expired`
- Clear guidance provided for fixing the issue