### PR TITLE
Fix dropout to use output_tensor parameter for in-place operation

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -35,3 +35,25 @@ def test_dopout(device):
     # current dropout has pretty high variance so we just checking with some reasonable nubmers
     assert np.allclose(mean, prob, rtol=0.02)
     assert std < prob
+
+
+def test_dropout_output_tensor(device):
+    """Test that dropout correctly uses the output_tensor parameter for in-place operation.
+
+    This is a regression test for https://github.com/tenstorrent/tt-metal/issues/30284
+    """
+    t = torch.ones((1, 1, 32, 64))
+    tensor = ttnn.from_torch(t, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    # Call dropout with output_tensor=tensor (in-place)
+    output = ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=12345, output_tensor=tensor)
+
+    # Both tensor and output should reference the same underlying data
+    # After the operation, the original tensor should be modified
+    tensor_torch = ttnn.to_torch(tensor)
+    output_torch = ttnn.to_torch(output)
+
+    # The tensors should have the same values (both should show the dropout result)
+    assert torch.allclose(
+        tensor_torch, output_torch
+    ), "output_tensor parameter not working: input tensor was not modified in place"

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -138,13 +138,17 @@ ttnn::operations::experimental::dropout::DropoutDeviceOperation::tensor_return_v
     uint32_t seed,
     bool use_per_device_seed,
     DataType output_dtype,
-    const MemoryConfig& output_memory_config,
+    const std::optional<MemoryConfig>& output_memory_config,
     const std::optional<Tensor>& preallocated_output) {
     using OperationType = ttnn::operations::experimental::dropout::DropoutDeviceOperation;
 
+    auto resolved_memory_config = preallocated_output.has_value()
+                                      ? preallocated_output.value().memory_config()
+                                      : output_memory_config.value_or(input.memory_config());
+
     auto operation_attributes = OperationType::operation_attributes_t{
         .output_dtype = output_dtype,
-        .output_memory_config = output_memory_config,
+        .output_memory_config = resolved_memory_config,
         .seed = seed,
         .use_per_device_seed = use_per_device_seed,
         .prob = prob,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -48,7 +48,7 @@ ttnn::operations::experimental::dropout::DropoutDeviceOperation::tensor_return_v
     uint32_t seed,
     bool use_per_device_seed,
     DataType output_dtype,
-    const MemoryConfig& output_memory_config = MemoryConfig(),
+    const std::optional<MemoryConfig>& output_memory_config = std::nullopt,
     const std::optional<Tensor>& preallocated_output = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -16,10 +16,6 @@ Tensor DropoutOperation::invoke(
     bool use_per_device_seed,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    auto output_memory_config = optional_output_tensor.has_value()
-                                    ? optional_output_tensor.value().memory_config()
-                                    : memory_config.value_or(input_tensor.memory_config());
-
     return ttnn::prim::dropout(
         input_tensor,
         prob,
@@ -27,7 +23,7 @@ Tensor DropoutOperation::invoke(
         seed,
         use_per_device_seed,
         DataType::BFLOAT16,
-        output_memory_config,
+        memory_config,
         optional_output_tensor);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -9,8 +9,26 @@
 namespace ttnn::operations::experimental {
 
 Tensor DropoutOperation::invoke(
-    const Tensor& input_tensor, float prob, float scale, uint32_t seed, bool use_per_device_seed) {
-    return ttnn::prim::dropout(input_tensor, prob, scale, seed, use_per_device_seed, DataType::BFLOAT16);
+    const Tensor& input_tensor,
+    float prob,
+    float scale,
+    uint32_t seed,
+    bool use_per_device_seed,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    auto output_memory_config = optional_output_tensor.has_value()
+                                    ? optional_output_tensor.value().memory_config()
+                                    : memory_config.value_or(input_tensor.memory_config());
+
+    return ttnn::prim::dropout(
+        input_tensor,
+        prob,
+        scale,
+        seed,
+        use_per_device_seed,
+        DataType::BFLOAT16,
+        output_memory_config,
+        optional_output_tensor);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.hpp
@@ -5,14 +5,23 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/decorators.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::experimental {
 
 struct DropoutOperation {
     static Tensor invoke(
-        const Tensor& input_tensor, float prob, float scale, uint32_t seed, bool use_per_device_seed = true);
+        const Tensor& input_tensor,
+        float prob,
+        float scale,
+        uint32_t seed,
+        bool use_per_device_seed = true,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 }  // namespace ttnn::operations::experimental
 namespace ttnn::experimental {

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout_nanobind.cpp
@@ -70,8 +70,10 @@ void bind_experimental_dropout_operation(nb::module_& mod) {
                const float probability,
                const float scale,
                const uint32_t seed,
-               const std::optional<MemoryConfig>& /*memory_config*/,
-               const std::optional<Tensor>& /*output_tensor*/) { return self(input, probability, scale, seed); },
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<Tensor>& output_tensor) {
+                return self(input, probability, scale, seed, true, memory_config, output_tensor);
+            },
             nb::arg("input_tensor"),
             nb::arg("probability"),
             nb::arg("scale"),


### PR DESCRIPTION
## Summary

- Fix `ttnn.experimental.dropout` to properly use the `output_tensor` parameter for in-place operation
- The parameter was being accepted but silently ignored in the nanobind binding
- Add regression test to verify in-place functionality works correctly

Fixes #30284

## Details

The `output_tensor` and `memory_config` parameters were captured in the nanobind lambda but never forwarded to the underlying operation:

```cpp
// Before (broken):
const std::optional<MemoryConfig>& /*memory_config*/,
const std::optional<Tensor>& /*output_tensor*/) { return self(input, probability, scale, seed); }

// After (fixed):
const std::optional<MemoryConfig>& memory_config,
const std::optional<Tensor>& output_tensor) {
    return self(input, probability, scale, seed, true, memory_config, output_tensor);
}
```

## Test plan

- [x] Existing `test_dopout` test passes (dropout probability distribution)
- [x] New `test_dropout_output_tensor` test passes (verifies in-place operation works)