### PR TITLE
[skip ci] Add check-prs cursor command for PR status monitoring

### DIFF
--- a/.cursor/commands/git/check-prs.md
+++ b/.cursor/commands/git/check-prs.md
@@ -1,0 +1,25 @@
+# Check PR Status
+
+## Overview
+Check the status of all your open pull requests, including review status and CI checks.
+
+## Steps
+1. **Get open PRs**
+   - Run `gh pr list --author @me --state open` to find all your open PRs
+   - If no PRs found, report that and stop
+
+2. **For each PR, check review status**
+   - Run `gh pr view <PR_NUMBER> --json reviews,reviewRequests,reviewDecision`
+   - Report if PR has required approvals
+   - Report if any reviewer has requested changes
+   - Report if reviews are still pending
+
+3. **For each PR, check CI status**
+   - Run `gh pr checks <PR_NUMBER>`
+   - Report if all checks are passing
+   - Report any failing or pending checks
+
+4. **Summarize findings**
+   - List PRs that are ready to merge (approved + checks passing)
+   - List PRs that need attention (changes requested or checks failing)
+   - List PRs waiting on reviews


### PR DESCRIPTION
### Ticket
N/A - Developer tooling improvement

### Problem description
When working with multiple open PRs, it's tedious to manually check the status of each one to see which are ready to merge, which need attention due to failing CI, and which are still waiting on reviews.

### What's changed
Added a new Cursor command `/git/check-prs` that provides a quick overview of all open PRs for the current user. The command:

- Lists all open PRs using `gh pr list --author @me --state open`
- Checks review status for each PR (approvals, change requests, pending reviews)
- Checks CI status for each PR (passing, failing, pending checks)
- Provides a summary categorizing PRs into:
  - ✅ Ready to merge (approved + checks passing)
  - ⚠️ Needs attention (changes requested or checks failing)
  - ⏳ Waiting on reviews

This follows the same pattern as the existing `/git/create-pr` command.

### Example Output
I'll check the status of all your open PRs. Let me start by finding them.

[1 tool called]

You have 12 open PRs. Let me check the review status and CI checks for each one.

[2 tools called]

Now let me check the CI status for each PR:

[4 tools called]

## 📊 PR Status Report

Here's a summary of your **12 open PRs**:

---

### ✅ Ready to Merge (Approved + Checks Passing)

| PR | Title | Status |
|----|-------|--------|
| [#35574](https://github.com/tenstorrent/tt-metal/pull/35574) | Fix static analyzer VirtualCall warnings in MeshDevice | ✅ Approved by @ayerofieiev-tt, all checks pass |
| [#34754](https://github.com/tenstorrent/tt-metal/pull/34754) | Use AVX2 for `convert_layout_row_major_to_tile_nfaces` | ✅ Approved by @nvelickovicTT, all checks pass |

---

### ⚠️ Needs Attention (CI Failing)

| PR | Title | Issue |
|----|-------|-------|
| [#35483](https://github.com/tenstorrent/tt-metal/pull/35483) | Use ASan-built wheel for ttsim Python tests in PR Gate | ❌ Build failures (Release build, docs) - needs review |
| [#35045](https://github.com/tenstorrent/tt-metal/pull/35045) | Add Pytest Smoke Tests to PR Gate with ASan Support | ✅ Approved by @nsextonTT, @jbaumanTT but ❌ Build/wheel failures |
| [#29080](https://github.com/tenstorrent/tt-metal/pull/29080) | Add ttnn pytests coverage for TTSim CI | ❌ ttsim-integration-tests failing (TTNN Pytests), needs review |

---

### ⏳ Waiting on Reviews (Checks Passing)

| PR | Title | Approvals | Reviewers Requested |
|----|-------|-----------|---------------------|
| [#35703](https://github.com/tenstorrent/tt-metal/pull/35703) | Remove dead store for num_cores in embeddings | 0 | @TT-BrianLiu, metalium-developers-ops-data-movement |
| [#35700](https://github.com/tenstorrent/tt-metal/pull/35700) | Fix variable shadowing in pad RM multi-core | 0 | metalium-developers-ops-data-movement |
| [#35694](https://github.com/tenstorrent/tt-metal/pull/35694) | Skip Tracy from clang static analysis | 0 | metalium-developers-infra |
| [#35693](https://github.com/tenstorrent/tt-metal/pull/35693) | Fix dead store in topology_mapper.cpp | 0 | @ubcheema, @aliuTT, @aagarwalTT, @tt-aho, @SeanNijjar, @yugaoTT, @Riddy21 |
| [#35680](https://github.com/tenstorrent/tt-metal/pull/35680) | Migrate legacy tt_metal tests to gtest | 1 ✓ (@iwangTT) | @aagarwalTT, @jbaumanTT, @tt-asaigal, @nhuang-tt, @tt-aho, @cfjchu |
| [#35665](https://github.com/tenstorrent/tt-metal/pull/35665) | Replace assert()/TT_ASSERT() with reliable checks | 4 ✓ (@atatuzunerTT, @jvegaTT, @aliuTT, @tt-rkim) | @yugaoTT, @ubcheema + others |
| [#35553](https://github.com/tenstorrent/tt-metal/pull/35553) | Clean up CMakeLists.txt messages and flags | 2 ✓ (@ayerofieiev-tt, @afuller-TT) | @akerteszTT, @ubcheema + others |

---

### 📋 Summary

- **2 PRs** ready to merge 🚀
- **3 PRs** have failing CI and need fixes ⚠️  
- **7 PRs** waiting on reviews ⏳

**Top Priority:** Fix the build failures on **#35483** and **#35045** (they appear to need a rebase against main). The oldest stale PR is **#29080** from September 2025.

### Checklist

- [x] New/Existing tests provide coverage for changes (N/A - documentation/tooling only)