### PR TITLE
Revert changes to `create_arange_vector_of_bfloat16`

### DIFF
--- a/tt_metal/impl/data_format/bfloat16_utils.cpp
+++ b/tt_metal/impl/data_format/bfloat16_utils.cpp
@@ -18,14 +18,8 @@ std::pair<bfloat16, bfloat16> unpack_two_bfloat16_from_uint32(uint32_t uint32_da
     return two_bfloats;
 }
 
-std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bfloat16_values, bool print) {
-    if (num_bfloat16_values % 2 != 0) {
-        throw std::invalid_argument("num_bfloat16_values must be even (packed in pairs)");
-    }
-
-    const size_t num_pairs = num_bfloat16_values / 2;
-    std::vector<std::uint32_t> vec(num_pairs, 0);
-
+std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bool print) {
+    std::vector<std::uint32_t> vec(num_bytes / sizeof(std::uint32_t), 0);
     for (size_t i = 0; i < vec.size(); i++) {
         float num_1_float = i * 2;
         float num_2_float = (i * 2) + 1;
@@ -41,7 +35,7 @@ std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bfloat16_
         }
 
         // pack 2 uint16 into uint32
-        vec[i] = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
+        vec.at(i) = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(num_1_bfloat16, num_2_bfloat16));
     }
 
     return vec;

--- a/tt_metal/impl/data_format/bfloat16_utils.hpp
+++ b/tt_metal/impl/data_format/bfloat16_utils.hpp
@@ -12,7 +12,7 @@
 
 std::pair<bfloat16, bfloat16> unpack_two_bfloat16_from_uint32(uint32_t uint32_data);
 
-std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bfloat16_values, bool print = true);
+std::vector<std::uint32_t> create_arange_vector_of_bfloat16(size_t num_bytes, bool print = true);
 
 std::vector<uint16_t> u16_from_u32_vector(const std::vector<uint32_t>& in);
 


### PR DESCRIPTION
### Ticket
Closes #35711 

### Problem description
#34364 broke nightly as it included a semantic refactoring relating to `create_arange_vector_of_bfloat16` that was not updated on use sites.

### What's changed
Reverted the semantic change.

### Verification

L2 is failing for other tests.

Verified this partial revert fies:
1. MeshDeviceFixture.TensixComputeUnpackTilize
2. MeshDeviceFixture.TensixComputeFastTilize
3. MeshDeviceFixture.TensixComputeUnpackTilizeA_B
4. MeshDeviceFixture.TensixComputeUnpackUntilize
5. MeshDeviceFixture.TensixComputePackUntilize
6. MeshDeviceFixture.TensixComputePackUntilizeDst
7. MeshDeviceFixture.TensixComputePackUntilizeDstTinyTile
8. MeshDeviceFixture.TensixComputePackUntilizeDst
9. MeshDeviceFixture.TensixComputePackUntilizeDstTinyTile
10. tests/tt_metal/tt_metal/test_interleaved_layouts.cpp

### Checklist

- [x] [![APC](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=riverwu/revert-bfloat)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:riverwu/revert-bfloat)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/revert-bfloat)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/revert-bfloat)
    L2 is failing due to other issues.