### PR TITLE
Add stability test suite for BH GLX 2D Torus (1D and 2D)

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -235,7 +235,7 @@ jobs:
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
           ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
-          ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
+          ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -235,6 +235,7 @@ jobs:
         # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
         run: |
           ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
+          ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
@@ -20,7 +20,7 @@ Tests:
 
     patterns:
       - type: all_to_all
-        iterations: 10
+        iterations: 1
 
   - name: "AllToAll2DTorus"
     enable_flow_control: true
@@ -39,7 +39,7 @@ Tests:
 
     patterns:
       - type: all_to_all
-        iterations: 10
+        iterations: 1
 
 # ================================================
 # Fabric 1D Tests (Line and Ring)
@@ -61,7 +61,7 @@ Tests:
 
     patterns:
       - type: all_to_all
-        iterations: 10
+        iterations: 1
 
   - name: "AllToAllRing"
     enable_flow_control: true
@@ -79,4 +79,4 @@ Tests:
 
     patterns:
       - type: all_to_all
-        iterations: 10
+        iterations: 1

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
@@ -1,0 +1,82 @@
+Tests:
+
+# ================================================
+# Fabric 2D Tests (Mesh and Torus)
+# ================================================
+
+  - name: "AllToAllMesh"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Mesh
+      num_links: 2
+
+    parametrization_params:
+      ftype: [unicast, mcast]
+      ntype: [unicast_write, atomic_inc, unicast_scatter_write]
+      size: [2048, 4096]
+
+    defaults:
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 1
+
+  - name: "AllToAll2DTorus"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Torus
+      torus_config: XY
+      num_links: 2
+
+    parametrization_params:
+      ftype: [unicast, mcast]
+      ntype: [unicast_write, atomic_inc, unicast_scatter_write]
+      size: [2048, 4096]
+
+    defaults:
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 1
+
+# ================================================
+# Fabric 1D Tests (Line and Ring)
+# ================================================
+
+  - name: "AllToAllLinear"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Linear
+      num_links: 2
+
+    parametrization_params:
+      ftype: [unicast, mcast]
+      ntype: [unicast_write, atomic_inc, unicast_scatter_write]
+      size: [2048, 4096]
+
+    defaults:
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 1
+
+  - name: "AllToAllRing"
+    enable_flow_control: true
+    fabric_setup:
+      topology: Ring
+      num_links: 2
+
+    parametrization_params:
+      ftype: [mcast]
+      ntype: [unicast_write, atomic_inc, unicast_scatter_write]
+      size: [2048, 4096]
+
+    defaults:
+      num_packets: 20000
+
+    patterns:
+      - type: all_to_all
+        iterations: 1


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35596

### Problem description
- We want a unified fabric test suite for qualifying BH Galaxy Quads
- This will allow us to upstream & productize the cluster bringup infra

### What's changed
- Add test config YAML file that will be used to validate Fabric functionality on BH Exabox clusters
- Use this in BH GLX Quick Health Tests (adds 1 extra minute)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/bh_glx_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/bh_glx_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/bh_glx_tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/bh_glx_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/bh_glx_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/bh_glx_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/bh_glx_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs