### PR TITLE
Add multi-host support to deepseek op unit tests

### DIFF
--- a/models/demos/deepseek_v3/tests/unit/test_fill_pad.py
+++ b/models/demos/deepseek_v3/tests/unit/test_fill_pad.py
@@ -60,6 +60,10 @@ def test_fill_pad_deepseek(mesh_device, shape_dtype_fill, mem_config, enable_tra
 
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
-    for t in ttnn.get_device_tensors(tt_out_tensors):
+    coords = list(tt_out_tensors.tensor_topology().mesh_coords())
+    view = mesh_device.get_view()
+    for coord, t in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
+        if not view.is_local(coord):
+            continue
         padded_torch_output_tensor = ttnn.from_device(t).to_torch_with_padded_shape()
         assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)

--- a/models/demos/deepseek_v3/tests/unit/test_gather.py
+++ b/models/demos/deepseek_v3/tests/unit/test_gather.py
@@ -54,6 +54,10 @@ def test_gather_deepseek(mesh_device, shapes_dtypes, dim, layout, mem_config, en
 
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
-    for ttnn_gather in ttnn.get_device_tensors(tt_out_tensors):
+    coords = list(tt_out_tensors.tensor_topology().mesh_coords())
+    view = mesh_device.get_view()
+    for coord, ttnn_gather in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
+        if not view.is_local(coord):
+            continue
         assert ttnn_gather.shape == torch_index.shape
         assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/models/demos/deepseek_v3/tests/unit/test_permute.py
+++ b/models/demos/deepseek_v3/tests/unit/test_permute.py
@@ -53,6 +53,10 @@ def test_permute_deepseek(mesh_device, test_config, dtype, enable_trace):
     tt_output_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     torch_ref = torch.permute(torch_input, perm)
-    for tt_out_tensor in ttnn.get_device_tensors(tt_output_tensors):
+    coords = list(tt_output_tensors.tensor_topology().mesh_coords())
+    view = mesh_device.get_view()
+    for coord, tt_out_tensor in zip(coords, ttnn.get_device_tensors(tt_output_tensors)):
+        if not view.is_local(coord):
+            continue
         torch_out = ttnn.to_torch(tt_out_tensor)
         assert_equal(torch_ref, torch_out)

--- a/models/demos/deepseek_v3/tests/unit/test_scatter.py
+++ b/models/demos/deepseek_v3/tests/unit/test_scatter.py
@@ -39,6 +39,7 @@ def test_scatter(
     index_mem_config,
     enable_trace,
 ):
+    torch.manual_seed(0)
     # Index tensor generation is somewhat hardcoded
     index_dtype = ttnn.uint16
     index_torch_dtype = torch.int64  # torch.scatter expects int64 for index tensor

--- a/models/demos/deepseek_v3/tests/unit/utils.py
+++ b/models/demos/deepseek_v3/tests/unit/utils.py
@@ -35,7 +35,11 @@ def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
 
         # Every device executes the same op, check that each device returned the
         # same result
-        for tt_output in ttnn.get_device_tensors(tt_outputs):
+        view = mesh_device.get_view()
+        coords = list(tt_outputs.tensor_topology().mesh_coords())
+        for coord, tt_output in zip(coords, ttnn.get_device_tensors(tt_outputs)):
+            if not view.is_local(coord):
+                continue
             tt_output = ttnn.to_torch(tt_output)
             check_op_proc(tt_output)
     else:
@@ -62,6 +66,10 @@ def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
 
         # Every device executes the same op, check that each device returned the
         # same result
-        for tt_output in ttnn.get_device_tensors(tt_outputs):
+        view = mesh_device.get_view()
+        coords = list(tt_outputs.tensor_topology().mesh_coords())
+        for coord, tt_output in zip(coords, ttnn.get_device_tensors(tt_outputs)):
+            if not view.is_local(coord):
+                continue
             tt_output = ttnn.to_torch(tt_output)
             check_op_proc(tt_output)


### PR DESCRIPTION
### Ticket
#35442 

### Problem description
The original op unit tests didn't have multi-host support and most of them failed.

### What's changed
Add manual seeds and use this pattern instead to iterate over host-local devices when reading data back:

```diff
-        for tt_out in ttnn.get_device_tensors(tt_out_tensor):
+        coords = list(tt_out_tensor.tensor_topology().mesh_coords())
+        for coord, tt_out in zip(coords, ttnn.get_device_tensors(tt_out_tensor)):
+            if not mesh_device.get_view().is_local(coord):
+                continue
```

<img width="1679" height="367" alt="image" src="https://github.com/user-attachments/assets/d982b952-d3d5-46f6-bf77-508d7070e48e" />

### Checklist

[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)

[![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml)

[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml)