### PR TITLE
Update conv2d performance targets and threshold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -232,8 +232,6 @@ tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py @t
 tests/ttnn/**/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/ttnn/**/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 /tests/ttnn/notebook_tests/ @tenstorrent/metalium-developers-external-experience @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/sweep_framework/ @stevendae @bbradelTT @ntarafdar @pavlejosipovic @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/matmul/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/eltwise/ @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,13 +224,13 @@ tests/ttnn/unit_tests/gtests/ccl/ @tenstorrent/metalium-developers-ops-data-move
 tests/ttnn/unit_tests/operations/ccl/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/eltwise/ @sjameelTT @ntarafdar @dchenTT @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/gtests/udm/ @yugaoTT @tenstorrent/codeowner-bypass
-tests/ttnn/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
-tests/ttnn/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/matmul/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/data_movement/ @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py @tenstorrent/metalium-developers-convolutions @tenstorrent/metalium-developers-ops-data-movement @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/fused/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 /tests/ttnn/**/unit_tests/operations/reduce/ @tenstorrent/metalium-developers-external-experience @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
+tests/ttnn/**/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
+tests/ttnn/**/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 /tests/ttnn/notebook_tests/ @tenstorrent/metalium-developers-external-experience @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/conv/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/pool/ @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass

--- a/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
+++ b/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
@@ -29,7 +29,7 @@ CONV_PERF_CONFIGS = [
         "act_block_h_override": 0, "act_block_w_div": 1,
         "enable_activation_reuse": False, "enable_act_double_buffer": False,
         "enable_weights_double_buffer": False, "fp32_accum": False,
-        "perf_targets": {"wh": 67, "bh_p150": 24},
+        "perf_targets": {"wh": 67, "bh_p150": 25},
     },
     # HEIGHT SHARDED, Unet - dm bound (activation reuse)
     {
@@ -80,7 +80,7 @@ CONV_PERF_CONFIGS = [
 # fmt: on
 
 # Applied to both upper and lower bounds
-THRESHOLD_PERCENT = 0.03
+THRESHOLD_PERCENT = 0.05
 
 # Build performance targets per architecture (in us) from global config
 PERF_TARGETS_WH = {config["test_name"]: config["perf_targets"]["wh"] for config in CONV_PERF_CONFIGS}


### PR DESCRIPTION
### Problem description
Ops perf tests stared failing on blackhole device perf pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/20910987964/job/60074133373#step:30:270

There was a small perf regression (https://github.com/tenstorrent/tt-metal/commit/b3492219b08e405d2dac63a24ad8bca660f4511e), however, the test was unstable even before then.

### What's changed
- Updated the target after the regression and relaxed the threshold to account for instabillity.
- Updated CODEOWNERS to give ownership to conv team over conv perf tests

### Checklist
Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/20952548457 ✅ 