### PR TITLE
Add support for paged KV cache and chunked prefill to ring distributed sdpa

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
@@ -277,7 +277,7 @@ def run_test_ring_distributed_sdpa_with_prefix_and_paged_kv(
 
     # Log timing information
     logger.info(
-        f"Timing (seq_len={s}, prefix_len={prefix_len}, page_block_size={page_block_size}, q_chunk={q_chunk_size}, k_chunk={k_chunk_size}): "
+        f"Timing (New tokens seq_len={s-prefix_len}, prefix_len={prefix_len}, page_block_size={page_block_size}, q_chunk={q_chunk_size}, k_chunk={k_chunk_size}): "
         f"ring_distributed={ring_time*1000:.2f}ms"
     )
 
@@ -285,17 +285,17 @@ def run_test_ring_distributed_sdpa_with_prefix_and_paged_kv(
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize(
     "s",
-    [256, 512, 1024, 1536, 2048, 2560, 3072, 3584, 4096],
-    ids=["s256", "s512", "s1k", "s1.5k", "s2k", "s2.5k", "s3k", "s3.5k", "s4k"],
+    [1024, 2048, 4096, 8192, 16384, 32768],
+    ids=["s1k", "s2k", "s4k", "s8k", "s16k", "s32k"],
 )
 @pytest.mark.parametrize(
     "prefix_len",
-    [0, 32, 64, 96, 128, 256, 480, 512, 544],
-    ids=["p0", "p32", "p64", "p96", "p128", "p256", "p480", "p512", "p544"],
+    [0, 64, 128, 256, 512],
+    ids=["p0", "p32", "p128", "p512"],
 )
-@pytest.mark.parametrize("page_block_size", [32, 64], ids=["b32", "b64"])
-@pytest.mark.parametrize("q_chunk_size", [64, 128, 256], ids=["q64", "q128", "q256"])
-@pytest.mark.parametrize("k_chunk_size", [64, 128, 256, 512], ids=["k64", "k128", "k256", "k512"])
+@pytest.mark.parametrize("page_block_size", [64], ids=["b64"])
+@pytest.mark.parametrize("q_chunk_size", [64, 256], ids=["q64", "q256"])
+@pytest.mark.parametrize("k_chunk_size", [64, 512], ids=["k64", "k512"])
 def test_ring_distributed_sdpa_prefix_and_paged_kv(device, s, prefix_len, page_block_size, q_chunk_size, k_chunk_size):
     """Test ring-distributed SDPA with both prefix caching and paged KV cache."""
     b, ring_size = 1, 4

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ring_distributed_sdpa.py
@@ -285,13 +285,13 @@ def run_test_ring_distributed_sdpa_with_prefix_and_paged_kv(
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize(
     "s",
-    [1024, 2048, 4096, 8192, 16384, 32768],
-    ids=["s1k", "s2k", "s4k", "s8k", "s16k", "s32k"],
+    [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+    ids=["s1k", "s2k", "s4k", "s8k", "s16k", "s32k", "s64k", "s128k"],
 )
 @pytest.mark.parametrize(
     "prefix_len",
     [0, 64, 128, 256, 512],
-    ids=["p0", "p32", "p128", "p512"],
+    ids=["p0", "p64", "p128", "p256", "p512"],
 )
 @pytest.mark.parametrize("page_block_size", [64], ids=["b64"])
 @pytest.mark.parametrize("q_chunk_size", [64, 256], ids=["q64", "q256"])

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -93,22 +93,108 @@ void RingDistributedSdpaDeviceOperation::validate_on_program_cache_miss(
     const auto DH = q_shape[3];
     const auto Sk = k_shape[2];
 
-    // Ring-distributed SDPA is causal-only
-    TT_FATAL(
-        Sq == Sk,
-        "Ring-distributed SDPA is causal and requires Q and K to have the same sequence length. Got Q: {}, K: {}",
-        Sq,
-        Sk);
+    // Validate chunk_start_idx and page_table
+    bool is_chunked = operation_attributes.chunk_start_idx.has_value();
+    bool has_page_table = tensor_args.page_table.has_value();
 
-    // Basic Q,K,V shape validation
-    TT_FATAL(
-        k_shape[0] == B && v_shape[0] == B,
-        "Batch sizes must match. Got Q: {}, K: {}, V: {}",
-        B,
-        k_shape[0],
-        v_shape[0]);
+    // Validate page_table if provided
+    if (has_page_table) {
+        const auto& page_table_tensor = tensor_args.page_table.value();
+        TT_FATAL(page_table_tensor.storage_type() == StorageType::DEVICE, "page_table tensor must be on device");
+        TT_FATAL(page_table_tensor.buffer() != nullptr, "page_table tensor must be allocated in a buffer on device");
+        TT_FATAL(
+            page_table_tensor.dtype() == DataType::INT32,
+            "page_table tensor must have INT32 dtype. Got {}",
+            page_table_tensor.dtype());
+        const auto& page_table_shape = page_table_tensor.logical_shape();
+        TT_FATAL(
+            page_table_shape.size() == 2,
+            "page_table must be 2D tensor [batch_size x num_pages]. Got shape: {}",
+            page_table_shape);
+        TT_FATAL(
+            page_table_shape[0] == B,
+            "page_table batch size must match input batch size. Got page_table batch: {}, input batch: {}",
+            page_table_shape[0],
+            B);
+    }
+
+    if (is_chunked) {
+        TT_FATAL(
+            has_page_table,
+            "page_table must be provided when chunk_start_idx is set. chunk_start_idx: {}",
+            operation_attributes.chunk_start_idx.value());
+        TT_FATAL(
+            operation_attributes.chunk_start_idx.value() >= 0,
+            "chunk_start_idx must be non-negative. Got chunk_start_idx: {}",
+            operation_attributes.chunk_start_idx.value());
+
+        const auto q_chunk_size =
+            operation_attributes.program_config ? operation_attributes.program_config->q_chunk_size : 32;
+        TT_FATAL(
+            operation_attributes.chunk_start_idx.value() % q_chunk_size == 0,
+            "chunk_start_idx must be a multiple of q_chunk_size. Got chunk_start_idx: {}, q_chunk_size: {}",
+            operation_attributes.chunk_start_idx.value(),
+            q_chunk_size);
+
+        // In chunked mode with paged KV, k_shape[2] represents block_size, not full sequence length
+        // The actual KV cache length is determined by the page_table and block_size
+        // For ring distributed SDPA with paged KV, we validate that K and V have matching shapes
+        // The page_table will map to the appropriate blocks in the paged cache
+        const auto block_size = k_shape[2];
+        TT_FATAL(
+            block_size > 0,
+            "block_size (K's sequence dimension in paged mode) must be positive. Got block_size: {}",
+            block_size);
+        // Note: Full KV cache length validation is done via page_table, not K/V tensor shapes directly
+
+        TT_FATAL(
+            Sq % block_size == 0,
+            "Sequence length must be a multiple of block_size. Got sequence length: {}, block_size: {}",
+            Sq,
+            block_size);
+
+        TT_FATAL(
+            operation_attributes.chunk_start_idx.value() % block_size == 0,
+            "chunk_start_idx must be a multiple of block_size. Got chunk_start_idx: {}, block_size: {}",
+            operation_attributes.chunk_start_idx.value(),
+            block_size);
+
+        TT_FATAL(
+            (Sq + operation_attributes.chunk_start_idx.value()) % k_chunk_size == 0,
+            "sequence length + chunk_start_idx must be divisible by k_chunk_size. Got sequence length: {}, "
+            "chunk_start_idx: {}, k_chunk_size: {}",
+            Sq,
+            operation_attributes.chunk_start_idx.value(),
+            k_chunk_size);
+    }
+
+    if (!is_chunked) {
+        // Ring-distributed SDPA is causal-only
+        TT_FATAL(
+            Sq == Sk,
+            "Ring-distributed SDPA is causal and requires Q and K to have the same sequence length when not using "
+            "prefix caching. Got Q: {}, K: {}",
+            Sq,
+            Sk);
+
+        // Basic Q,K,V shape validation
+        TT_FATAL(
+            k_shape[0] == B && v_shape[0] == B,
+            "Batch sizes must match. Got Q: {}, K: {}, V: {}",
+            B,
+            k_shape[0],
+            v_shape[0]);
+
+        TT_FATAL(v_shape[2] == Sk, "K and V sequence length must match. Got K: {}, V: {}", k_shape[2], v_shape[2]);
+    } else {
+        // In paged KV mode, k_shape[2] and v_shape[2] represent block_size and should match
+        TT_FATAL(
+            v_shape[2] == k_shape[2],
+            "K and V block_size (sequence dimension in paged mode) must match. Got K: {}, V: {}",
+            k_shape[2],
+            v_shape[2]);
+    }
     TT_FATAL(v_shape[1] == nkv, "K and V num_heads must match. Got K: {}, V: {}", k_shape[1], v_shape[1]);
-    TT_FATAL(v_shape[2] == Sk, "K and V sequence length must match. Got K: {}, V: {}", k_shape[2], v_shape[2]);
     TT_FATAL(
         k_shape[3] == DH && v_shape[3] == DH,
         "Head dimensions must match. Got Q: {}, K: {}, V: {}",
@@ -150,12 +236,20 @@ void RingDistributedSdpaDeviceOperation::validate_on_program_cache_miss(
         tt::constants::TILE_WIDTH);
 
     TT_FATAL(
-        q_chunk_size < Sq / operation_attributes.ring_size,
-        "q_chunk_size must be less than sequence length tiles divided by ring size. Got q_chunk_size: {}, sequence "
-        "length tiles: {}, ring size: {}",
+        q_chunk_size <= Sq / (2 * operation_attributes.ring_size),
+        "q_chunk_size must be less than or equal to per-device sequence length. Got q_chunk_size: {}, per-device "
+        "sequence length: {}, global sequence length: {}, ring size: {}",
         q_chunk_size,
-        Sq / operation_attributes.ring_size,
+        Sq / (2 * operation_attributes.ring_size),
+        Sq,
         operation_attributes.ring_size);
+
+    TT_FATAL(
+        (Sq / (2 * operation_attributes.ring_size)) % q_chunk_size == 0,
+        "per-device sequence length must be divisible by q_chunk_size. Got per-device sequence length: {}, "
+        "q_chunk_size: {}",
+        Sq / (2 * operation_attributes.ring_size),
+        q_chunk_size);
 
     // Validate padding: Only the sequence dimension may be padded
     auto validate_padding = [](const Tensor& tensor) {
@@ -209,7 +303,9 @@ ring_distributed_sdpa(
     std::optional<float> scale,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
-    ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    const std::optional<ttnn::Tensor>& page_table,
+    std::optional<int64_t> chunk_start_idx) {
     using OperationType =
         ttnn::operations::transformer::ring_distributed_sdpa::RingDistributedSdpaDeviceOperation;
 
@@ -223,12 +319,14 @@ ring_distributed_sdpa(
         .output_mem_config = output_mem_config,
         .program_config = program_config,
         .compute_kernel_config = compute_kernel_config,
+        .chunk_start_idx = chunk_start_idx,
     };
 
     auto tensor_args = OperationType::tensor_args_t{
         .q = input_tensor_q,
         .k = input_tensor_k,
         .v = input_tensor_v,
+        .page_table = page_table,
     };
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.cpp
@@ -92,6 +92,10 @@ void RingDistributedSdpaDeviceOperation::validate_on_program_cache_miss(
     const auto Sq = q_shape[2];
     const auto DH = q_shape[3];
     const auto Sk = k_shape[2];
+    const auto q_chunk_size =
+        operation_attributes.program_config ? operation_attributes.program_config->q_chunk_size : 32;
+    const auto k_chunk_size =
+        operation_attributes.program_config ? operation_attributes.program_config->k_chunk_size : 32;
 
     // Validate chunk_start_idx and page_table
     bool is_chunked = operation_attributes.chunk_start_idx.has_value();
@@ -220,10 +224,6 @@ void RingDistributedSdpaDeviceOperation::validate_on_program_cache_miss(
         operation_attributes.ring_size);
 
     // Chunk size compatibility
-    const auto q_chunk_size =
-        operation_attributes.program_config ? operation_attributes.program_config->q_chunk_size : 32;
-    const auto k_chunk_size =
-        operation_attributes.program_config ? operation_attributes.program_config->k_chunk_size : 32;
     TT_FATAL(
         q_chunk_size % tt::constants::TILE_WIDTH == 0,
         "q_chunk_size must be divisible by TILE_WIDTH. Got q_chunk_size: {}, TILE_WIDTH: {}",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
@@ -53,6 +53,8 @@ ring_distributed_sdpa(
     std::optional<float> scale,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const std::optional<ttnn::operations::transformer::SDPAProgramConfig>& program_config,
-    ttnn::DeviceComputeKernelConfig compute_kernel_config);
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    const std::optional<ttnn::Tensor>& page_table = std::nullopt,
+    std::optional<int64_t> chunk_start_idx = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation_types.hpp
@@ -19,12 +19,14 @@ struct operation_attributes_t {
     tt::tt_metal::MemoryConfig output_mem_config;
     std::optional<SDPAProgramConfig> program_config;
     DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<int64_t> chunk_start_idx;
 };
 
 struct tensor_args_t {
     ttnn::Tensor q;
     ttnn::Tensor k;
     ttnn::Tensor v;
+    std::optional<ttnn::Tensor> page_table;
 };
 
 using spec_return_value_t = ttnn::TensorSpec;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -78,7 +78,6 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     const uint32_t chunk_1 = ring_id;
     const uint32_t chunk_2 = (2 * ring_size) - ring_id - 1;
 
-    // In chunked prefill mode, the offset of Q in terms of Q chunks
     bool is_chunked = chunk_start_idx.has_value();
 
     // Extract paged KV cache parameters first, before calculating Sk

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -32,7 +32,9 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     std::size_t q_chunk_size,
     std::size_t k_chunk_size,
     DeviceComputeKernelConfig compute_kernel_config,
-    std::optional<SDPAProgramConfig> program_config) {
+    std::optional<SDPAProgramConfig> program_config,
+    const std::optional<Tensor>& page_table,
+    std::optional<int64_t> chunk_start_idx) {
     /*
     Q: B x NQH x S*ring_size x DH
     K: B x NKH x DH x S
@@ -76,7 +78,37 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     const uint32_t chunk_1 = ring_id;
     const uint32_t chunk_2 = (2 * ring_size) - ring_id - 1;
 
-    const uint32_t Sk = k_shape[2];
+    // In chunked prefill mode, the offset of Q in terms of Q chunks
+    bool is_chunked = chunk_start_idx.has_value();
+
+    // Extract paged KV cache parameters first, before calculating Sk
+    uint32_t block_size = 0;
+    uint32_t block_size_t = 0;
+    [[maybe_unused]] uint32_t max_blocks_per_seq = 0;
+    uint32_t page_table_stick_size = 0;
+    tt::DataFormat page_table_df = tt::DataFormat::Int32;
+
+    // Calculate KV sequence length: when using paged KV, k_shape[2] is block_size, not sequence length
+    // The full KV sequence length is: chunk_start_idx + full_Q_seq_len
+    // In ring distributed, q_shape[2] is the full Q sequence length (before ring distribution)
+    // So full_Q_seq_len = q_shape[2] = Sq * 2 * ring_size
+    uint32_t Sk;
+    if (is_chunked) {
+        const auto& page_table_tensor = page_table.value();
+        block_size = k_shape[2];  // K's sequence dimension represents block size
+        block_size_t = block_size / TILE_HEIGHT;
+        max_blocks_per_seq = page_table_tensor.padded_shape()[1];
+        page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
+        TT_FATAL(
+            page_table_stick_size % 32 == 0,
+            "page table page size in bytes must be a multiple of 32 due to address alignment");
+
+        // Full KV sequence length = chunk_start_idx + full_Q_seq_len
+        // q_shape[2] is the full Q sequence length (before ring distribution)
+        Sk = chunk_start_idx.value() + q_shape[2];
+    } else {
+        Sk = k_shape[2];
+    }
 
     // Calculate padded sequence length
     const uint32_t padded_Sq = std::ceil((float)Sq / q_chunk_size) * q_chunk_size;
@@ -95,9 +127,16 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     const uint32_t q_num_chunks = padded_Sq / q_chunk_size;
     const uint32_t k_num_chunks = padded_Sk / k_chunk_size;
 
-    // In chunked prefill mode, the offset of Q in terms of Q chunks
+    // Calculate chunk offsets for ring distribution
     uint32_t chunked_q_chunk_offset_phase_1 = (chunk_1 * Sq) / q_chunk_size;
     uint32_t chunked_q_chunk_offset_phase_2 = (chunk_2 * Sq) / q_chunk_size;
+
+    // Add chunk_start_idx offset for prefix caching
+    // The offset should be relative to the full Q sequence, so we add chunk_start_idx / q_chunk_size
+    if (is_chunked) {
+        chunked_q_chunk_offset_phase_1 += chunk_start_idx.value() / q_chunk_size;
+        chunked_q_chunk_offset_phase_2 += chunk_start_idx.value() / q_chunk_size;
+    }
 
     // Parallelization scheme
     // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order
@@ -209,22 +248,35 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
 
     std::vector<uint32_t> reader_compile_time_args = {
         // interleaved accessor args
-        B,          NQH,          NKH,        Sqt,          Skt,       valid_Sqt * 2 * ring_size, valid_Skt, DHt, vDHt,
-        Sq_chunk_t, q_num_chunks, Sk_chunk_t, k_num_chunks, num_cores,
-        true,   //(std::uint32_t)is_causal,
-        false,  //(std::uint32_t)use_provided_mask,
-        false,  //(std::uint32_t)broadcast_provided_mask_heads,
-        false,  //(std::uint32_t)use_padded_mask,
-        false,  //(uint32_t)is_chunked,
-        0,      // block_size_t,
-        0,      // page_table_stick_size
-        0       // use_attention_sink
+        B,
+        NQH,
+        NKH,
+        Sqt,
+        Skt,
+        valid_Sqt * 2 * ring_size,
+        valid_Skt,
+        DHt,
+        vDHt,
+        Sq_chunk_t,
+        q_num_chunks,
+        Sk_chunk_t,
+        k_num_chunks,
+        num_cores,
+        true,                  //(std::uint32_t)is_causal,
+        false,                 //(std::uint32_t)use_provided_mask,
+        false,                 //(std::uint32_t)broadcast_provided_mask_heads,
+        false,                 //(std::uint32_t)use_padded_mask,
+        (uint32_t)is_chunked,  //(uint32_t)is_chunked,
+        block_size_t,
+        page_table_stick_size,
+        0  // use_attention_sink
     };
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs().append_to(reader_compile_time_args);  // mask tensor (not used in ring)
-    TensorAccessorArgs().append_to(reader_compile_time_args);  // page table (not used in ring)
+    TensorAccessorArgs(page_table.has_value() ? page_table->buffer() : nullptr)
+        .append_to(reader_compile_time_args);                  // page table
     TensorAccessorArgs().append_to(reader_compile_time_args);  // attention sink (not used in ring)
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -377,6 +429,13 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
                             .set_page_size(tt::CBIndex::c_7, scalar_tile_size);
     CreateCircularBuffer(program, core_grid, c_in7_config);
 
+    // page table circular buffer (only when using paged KV)
+    if (is_chunked) {
+        auto c_in6_config = CircularBufferConfig(page_table_stick_size, {{tt::CBIndex::c_6, page_table_df}})
+                                .set_page_size(tt::CBIndex::c_6, page_table_stick_size);
+        CreateCircularBuffer(program, core_grid, c_in6_config);
+    }
+
     // cb_qk_im
     auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{tt::CBIndex::c_24, im_df}})
                                   .set_page_size(tt::CBIndex::c_24, im_tile_size);
@@ -453,6 +512,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         local_q_start = std::min(local_q_start, q_num_chunks);
         local_q_end = std::min(local_q_end, q_num_chunks);
 
+        uint32_t page_table_addr = page_table.has_value() ? page_table->buffer()->address() : 0;
         SetRuntimeArgs(
             program,
             reader_kernels_id,
@@ -461,7 +521,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
              k_addr,
              v_addr,
              0,  // mask_addr,
-             0,
+             page_table_addr,
              0,  // attention sink addr,
              i,
              local_batch_start,
@@ -591,7 +651,9 @@ RingDistributedSdpaMeshWorkloadFactory::create_mesh_workload(
                 q_chunk_size,
                 k_chunk_size,
                 operation_attributes.compute_kernel_config,
-                operation_attributes.program_config);
+                operation_attributes.program_config,
+                tensor_args.page_table,
+                operation_attributes.chunk_start_idx);
             shared_variables[single_coord_range] = cached_program.shared_variables;
             mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
         }
@@ -623,6 +685,7 @@ void RingDistributedSdpaMeshWorkloadFactory::override_runtime_arguments(
         uint32_t k_addr = k_buffer->address();
         uint32_t v_addr = v_buffer->address();
         uint32_t out_addr = out0_buffer->address();
+        uint32_t page_table_addr = tensor_args.page_table.has_value() ? tensor_args.page_table->buffer()->address() : 0;
 
         auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
         auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
@@ -636,6 +699,7 @@ void RingDistributedSdpaMeshWorkloadFactory::override_runtime_arguments(
             reader_args[0] = q_addr;
             reader_args[1] = k_addr;
             reader_args[2] = v_addr;
+            reader_args[4] = page_table_addr;  // Update page_table_addr (index 4 is after mask_addr)
 
             writer_args[0] = out_addr;
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.hpp
@@ -50,7 +50,9 @@ private:
         std::size_t q_chunk_size,
         std::size_t k_chunk_size,
         DeviceComputeKernelConfig compute_kernel_config,
-        std::optional<SDPAProgramConfig> program_config);
+        std::optional<SDPAProgramConfig> program_config,
+        const std::optional<Tensor>& page_table = std::nullopt,
+        std::optional<int64_t> chunk_start_idx = std::nullopt);
 };
 
 }  // namespace ttnn::operations::transformer::ring_distributed_sdpa::program

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -235,7 +235,9 @@ ttnn::Tensor ExecuteRingDistributedScaledDotProductAttention::invoke(
     std::optional<float> scale,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<SDPAProgramConfig>& program_config,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::Tensor>& page_table,
+    std::optional<int64_t> chunk_start_idx) {
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
@@ -251,7 +253,9 @@ ttnn::Tensor ExecuteRingDistributedScaledDotProductAttention::invoke(
         scale,
         memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
         program_config,
-        kernel_config_val);
+        kernel_config_val,
+        page_table,
+        chunk_start_idx);
 }
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -116,7 +116,9 @@ struct ExecuteRingDistributedScaledDotProductAttention {
         std::optional<float> scale = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<SDPAProgramConfig>& program_config = std::nullopt,
-        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<ttnn::Tensor>& page_table = std::nullopt,
+        std::optional<int64_t> chunk_start_idx = std::nullopt);
 };
 
 }  // namespace operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -495,8 +495,14 @@ void bind_sdpa(nb::module_& mod) {
 
         Args:
             input_tensor_q (ttnn.Tensor): the input tensor.          [b x nqh x s x dh]
+                The sequence length 's' must be divisible by 2*ring_size. Additionally, for proper tile alignment,
+                's' should be divisible by TILE_HEIGHT * 2 * ring_size (typically 256 for ring_size=4).
             input_tensor_k (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+                When using paged KV cache (page_table is provided), this represents paged KV cache blocks with shape
+                [max_num_blocks x nkv x block_size x dh], where block_size is the page block size.
             input_tensor_v (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
+                When using paged KV cache (page_table is provided), this represents paged KV cache blocks with shape
+                [max_num_blocks x nkv x block_size x dh], where block_size is the page block size.
             ring_size (uint32_t): Number of devices in the ring topology.
             ring_id (uint32_t, optional): This device's position in the ring (0 to ring_size-1).
                                          If None, automatically infers from device coordinate. Defaults to `None`.
@@ -506,6 +512,9 @@ void bind_sdpa(nb::module_& mod) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             program_config (SDPAProgramConfig, optional): Program configuration. Defaults to `None`.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration. Defaults to `None`.
+            page_table (ttnn.Tensor, optional): Page table tensor for paged KV cache access [b x num_pages]. Defaults to `None`.
+            chunk_start_idx (int, optional): Absolute position in the sequence where this chunk starts (for prefix caching).
+                Must be a multiple of program_config.q_chunk_size. Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to `0`.
 
         Returns:
@@ -528,7 +537,9 @@ void bind_sdpa(nb::module_& mod) {
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                std::optional<SDPAProgramConfig> program_config,
-               std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+               std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+               const std::optional<ttnn::Tensor>& page_table,
+               std::optional<int64_t> chunk_start_idx) {
                 return self(
                     input_tensor_q,
                     input_tensor_k,
@@ -538,7 +549,9 @@ void bind_sdpa(nb::module_& mod) {
                     scale,
                     memory_config,
                     program_config,
-                    compute_kernel_config);
+                    compute_kernel_config,
+                    page_table,
+                    chunk_start_idx);
             },
             nb::arg("input_tensor_q").noconvert(),
             nb::arg("input_tensor_k").noconvert(),
@@ -549,6 +562,8 @@ void bind_sdpa(nb::module_& mod) {
             nb::arg("scale") = nb::none(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("program_config") = nb::none(),
-            nb::arg("compute_kernel_config") = nb::none()});
+            nb::arg("compute_kernel_config") = nb::none(),
+            nb::arg("page_table") = nb::none(),
+            nb::arg("chunk_start_idx") = nb::none()});
 }
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Ticket
Step towards prefix caching in Llama70B-Galaxy in https://github.com/tenstorrent/vllm/issues/268

### Problem description
Some optimization techniques, such as chunked prefill and prefix caching, require prefill to run in chunks. Specifically, for all chunks except the first one, Q will be shorter than K and V. And since inference engines such as VLLM use paged KV cache, now also the SDPA must be able to load K/V from the paged storage.

### What's changed
* Added support for `chunk_start_idx` and `page_table` inputs.
* Extended `test_ring_distributed_sdpa.py` with chunked+paged test.

### Tests
Conformance:
* From the large number of possible input parameters: 372 passed, 1572 skipped, 0 failed
* Nightly tt-metal L2: https://github.com/tenstorrent/tt-metal/actions/runs/20989301300
* Galaxy demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/20990539543
* Galaxy unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/20990568907
* VLLM nightly: https://github.com/tenstorrent/tt-metal/actions/runs/21023521777

Performance:
<img width="840" height="882" alt="image" src="https://github.com/user-attachments/assets/3d7da053-004c-4240-89df-7e5a8481d3ae" />

Rows in green are the non-chunked runs, rows in orange are from main. Time2 is the 2nd run of the same test - shows variability in the results.

Conclusions:
* Performance within measurement error margin.
* Having 512 older tokens to attend to has minimal impact on performance.
* Increasing q_chunk_size and k_chunk_size generally helps performance, except in 4k seq length case, when q_chunk_size=64 seems to have the best results.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:viktorpus/ring-sdpa-chunked)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/ring-sdpa-chunked)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/ring-sdpa-chunked)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/ring-sdpa-chunked)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/ring-sdpa-chunked)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/ring-sdpa-chunked)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/ring-sdpa-chunked)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs