### PR TITLE
Fix t3k deepseek unit test regression

### DIFF
--- a/models/demos/deepseek_v3/tests/unit/test_all_broadcast.py
+++ b/models/demos/deepseek_v3/tests/unit/test_all_broadcast.py
@@ -65,10 +65,11 @@ def test_all_broadcast_deepseek(
 
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for tt_out_tensor in tt_out_tensors:
         coords = list(tt_out_tensor.tensor_topology().mesh_coords())
         for coord, tt_out in zip(coords, ttnn.get_device_tensors(tt_out_tensor)):
-            if not mesh_device.get_view().is_local(coord):
+            if view is not None and not view.is_local(coord):
                 continue
             torch_out = ttnn.to_torch(tt_out)
             eq, output = comp_equal(torch_out, torch_reference)

--- a/models/demos/deepseek_v3/tests/unit/test_all_gather.py
+++ b/models/demos/deepseek_v3/tests/unit/test_all_gather.py
@@ -93,11 +93,17 @@ def test_deepseek(mesh_device, shape_dtype_buffer_type_shard_spec, layout, dim, 
 
     tt_output_tensor = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
     coords = list(tt_output_tensor.tensor_topology().mesh_coords())
+    coord_to_index = {coord: idx for idx, coord in enumerate(coords)}
     view = mesh_device.get_view() if ttnn.using_distributed_env() else None
+    device_tensors = ttnn.get_device_tensors(tt_output_tensor)
+    coord_iter = coords
+    if view is not None and len(device_tensors) != len(coords):
+        coord_iter = [coord for coord in coords if view.is_local(coord)]
     per_device_batch = torch_reference.shape[0] // math.prod(mesh_device.shape)
     torch_reference_slices = torch_reference.split(per_device_batch, dim=0)
-    for device_idx, (coord, tt_out) in enumerate(zip(coords, ttnn.get_device_tensors(tt_output_tensor))):
+    for coord, tt_out in zip(coord_iter, device_tensors):
         if view is not None and not view.is_local(coord):
             continue
+        device_idx = coord_to_index[coord]
         eq, mess = comp_equal(torch_reference_slices[device_idx], ttnn.to_torch(tt_out))
         assert eq, mess

--- a/models/demos/deepseek_v3/tests/unit/test_concat.py
+++ b/models/demos/deepseek_v3/tests/unit/test_concat.py
@@ -87,9 +87,9 @@ def test_concat_deepseek(mesh_device, shape_list, dim, dtype, mem_config, layout
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     coords = list(tt_out_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, tt_out_tensor in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         torch_out = ttnn.to_torch(tt_out_tensor)
         eq, output = comp_equal(torch_out, torch_reference)

--- a/models/demos/deepseek_v3/tests/unit/test_fill_pad.py
+++ b/models/demos/deepseek_v3/tests/unit/test_fill_pad.py
@@ -61,9 +61,9 @@ def test_fill_pad_deepseek(mesh_device, shape_dtype_fill, mem_config, enable_tra
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     coords = list(tt_out_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, t in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         padded_torch_output_tensor = ttnn.from_device(t).to_torch_with_padded_shape()
         assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)

--- a/models/demos/deepseek_v3/tests/unit/test_gather.py
+++ b/models/demos/deepseek_v3/tests/unit/test_gather.py
@@ -55,9 +55,9 @@ def test_gather_deepseek(mesh_device, shapes_dtypes, dim, layout, mem_config, en
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     coords = list(tt_out_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, ttnn_gather in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         assert ttnn_gather.shape == torch_index.shape
         assert_allclose(torch_gather, ttnn.to_torch(ttnn_gather))

--- a/models/demos/deepseek_v3/tests/unit/test_interleaved_to_sharded.py
+++ b/models/demos/deepseek_v3/tests/unit/test_interleaved_to_sharded.py
@@ -139,9 +139,9 @@ def test_interleaved_to_sharded_deepseek(mesh_device, test_config, layout, enabl
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     coords = list(tt_out_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, tt_out_tensor in zip(coords, ttnn.get_device_tensors(tt_out_tensors)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         torch_out = ttnn.to_torch(tt_out_tensor)
         eq, output = comp_equal(torch_out, torch_input)

--- a/models/demos/deepseek_v3/tests/unit/test_mesh_partition.py
+++ b/models/demos/deepseek_v3/tests/unit/test_mesh_partition.py
@@ -72,9 +72,9 @@ def test_mesh_partition_deepseek(mesh_device, shape, dim, dtype, mem_config, lay
     tt_out_tensors = maybe_trace(run_op, enable_trace=enable_trace, device=mesh_device)
 
     coords = list(tt_out_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, tt_out, torch_ref in zip(coords, ttnn.get_device_tensors(tt_out_tensors), torch_references):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         torch_out = ttnn.to_torch(tt_out)
         eq, output = comp_equal(torch_out, torch_ref)

--- a/models/demos/deepseek_v3/tests/unit/test_pad.py
+++ b/models/demos/deepseek_v3/tests/unit/test_pad.py
@@ -58,9 +58,9 @@ def test_pad_deepseek(mesh_device, test_config, dtype, layout, enable_trace):
     torch_ref = torch.nn.functional.pad(torch_input, sum([[0, pd] for pd in reversed(shape_diff)], []), value=pad_value)
 
     coords = list(tt_outputs.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, tt_out in zip(coords, ttnn.get_device_tensors(tt_outputs)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         torch_out = ttnn.to_torch(tt_out)
         eq, output = comp_equal(torch_out, torch_ref)

--- a/models/demos/deepseek_v3/tests/unit/test_permute.py
+++ b/models/demos/deepseek_v3/tests/unit/test_permute.py
@@ -54,9 +54,9 @@ def test_permute_deepseek(mesh_device, test_config, dtype, enable_trace):
 
     torch_ref = torch.permute(torch_input, perm)
     coords = list(tt_output_tensors.tensor_topology().mesh_coords())
-    view = mesh_device.get_view()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
     for coord, tt_out_tensor in zip(coords, ttnn.get_device_tensors(tt_output_tensors)):
-        if not view.is_local(coord):
+        if view is not None and not view.is_local(coord):
             continue
         torch_out = ttnn.to_torch(tt_out_tensor)
         assert_equal(torch_ref, torch_out)

--- a/models/demos/deepseek_v3/tests/unit/test_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reduce_scatter.py
@@ -130,11 +130,11 @@ def test_nd(
         )
 
         coords = list(tt_out_tensor.tensor_topology().mesh_coords())
-        view = mesh_device.get_view()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
         torch_outputs = []
         torch_references = []
         for coord, tt_out, torch_ref in zip(coords, ttnn.get_device_tensors(tt_out_tensor), torch_reference_slices):
-            if not view.is_local(coord):
+            if view is not None and not view.is_local(coord):
                 continue
             torch_outputs.append(ttnn.to_torch(tt_out))
             torch_references.append(torch_ref)

--- a/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
+++ b/models/demos/deepseek_v3/tests/unit/test_rmsnorm.py
@@ -502,12 +502,12 @@ def test_rmsnorm_distributed_mesh_device(mesh_device, enable_trace, device_param
     def check_outputs(tt_output):
         # tt_output is sharded across devices, each device has its chunk
         coords = list(tt_output.tensor_topology().mesh_coords())
-        view = mesh_device.get_view()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
         device_tensors = ttnn.get_device_tensors(tt_output)
 
         # Compare each local device's output with its corresponding chunk of reference.
         for coord, tt_device_out in zip(coords, device_tensors):
-            if not view.is_local(coord):
+            if view is not None and not view.is_local(coord):
                 continue
             col_idx = coord[1]  # Column index in mesh (cluster_axis=1)
             tt_output_torch = ttnn.to_torch(tt_device_out)

--- a/models/demos/deepseek_v3/tests/unit/utils.py
+++ b/models/demos/deepseek_v3/tests/unit/utils.py
@@ -35,10 +35,10 @@ def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
 
         # Every device executes the same op, check that each device returned the
         # same result
-        view = mesh_device.get_view()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
         coords = list(tt_outputs.tensor_topology().mesh_coords())
         for coord, tt_output in zip(coords, ttnn.get_device_tensors(tt_outputs)):
-            if not view.is_local(coord):
+            if view is not None and not view.is_local(coord):
                 continue
             tt_output = ttnn.to_torch(tt_output)
             check_op_proc(tt_output)
@@ -66,10 +66,10 @@ def run_test(mesh_device, run_op_proc, check_op_proc, enable_trace):
 
         # Every device executes the same op, check that each device returned the
         # same result
-        view = mesh_device.get_view()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
         coords = list(tt_outputs.tensor_topology().mesh_coords())
         for coord, tt_output in zip(coords, ttnn.get_device_tensors(tt_outputs)):
-            if not view.is_local(coord):
+            if view is not None and not view.is_local(coord):
                 continue
             tt_output = ttnn.to_torch(tt_output)
             check_op_proc(tt_output)


### PR DESCRIPTION
### Problem description
Previous commit fixing these tests for multihost but it turns out that, surprisingly, calling `mesh_device.get_view()` crashes on a t3000.

### What's changed
Guard these calls with a `ttnn.using_distributed_env`

### Checklist
[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
[![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml)
[![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=yieldthought%2Ffix-ds-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml)
✅ All above fails are on unrelated tests