### PR TITLE
Fix addcdiv

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -181,6 +181,8 @@ def test_ternary_addcdiv_float32_full_range(input_shapes, value, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     ARCH_NAME = ttnn.get_arch_name()
+
+    # Retest and fix BH assert once #33726 is done
     if "blackhole" in ARCH_NAME:
         assert torch.allclose(output_tensor, torch_output_tensor, atol=1e-6, rtol=1e-5)
     elif "wormhole" in ARCH_NAME:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -83,8 +83,7 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
 )
 @pytest.mark.parametrize("value", [1.0, 2.75, 5.0, -10.0])
 def test_ternary_addcdiv_float32_full_range(input_shapes, value, device):
-    """Test addcdiv with float32 covering a wide range of input values."""
-    # Maximum range capped at [-1e15, 1e15]
+    """Test addcdiv with float32 inputs spanning the range of [-1e15, 1e15]."""
     value_ranges_a = [
         (-100, 100),
         (-300, 300),
@@ -95,50 +94,50 @@ def test_ternary_addcdiv_float32_full_range(input_shapes, value, device):
         (-1e7, 1e7),
         (-1e10, 1e10),
         (-1e15, 1e15),
-        (1e8, 1e10),  # large positive input
-        (1e12, 1e15),  # very large positive input
-        (-1e10, -1e8),  # large negative input
-        (-1e15, -1e12),  # very large negative input
-        (-1e-5, 1e-5),  # small input
-        (-1e-10, 1e-10),  # very small input
+        (1e8, 1e10),
+        (1e12, 1e15),
+        (-1e10, -1e8),
+        (-1e15, -1e12),
+        (-1e-5, 1e-5),
+        (-1e-10, 1e-10),
     ]
 
     value_ranges_b = [
-        (-250, 250),
-        (-750, 750),
-        (-500, 1000),
-        (-5e3, 5e3),
-        (-5e4, 5e4),
-        (-1e6, 1e6),
-        (-1e8, 1e8),
-        (-1e10, 1e10),
-        (-1e15, 1e15),
-        (1.5e7, 1e9),  # large positive input
-        (1e12, 1e15),  # very large positive input
-        (-1e9, -1e7),  # large negative input
-        (-1e15, -1e12),  # very large negative input
-        (-1e-5, 1e-5),  # small input
-        (-1e-10, 1e-10),  # very small input
-        (-1e8, 1e8),  # mixed range
+        (-50, 200),
+        (-400, 600),
+        (-2000, 3000),
+        (-2e4, 2e4),
+        (-3e5, 3e5),
+        (-5e6, 5e6),
+        (-2e8, 2e8),
+        (-8e9, 8e9),
+        (-1e14, 1e14),
+        (2e8, 5e9),
+        (8e11, 8e14),
+        (-5e8, -2e7),
+        (-8e14, -8e11),
+        (-2e-4, 2e-4),
+        (-2e-8, 2e-8),
+        (-3e7, 3e7),
     ]
 
     value_ranges_c = [
-        (-250, 250),
-        (-750, 750),
-        (-500, 1000),
-        (-5e3, 5e3),
-        (-5e4, 5e4),
-        (-1e6, 1e6),
-        (-1e8, 1e8),
-        (-1e10, 1e10),
-        (-1e15, 1e15),
-        (1.5e7, 1e9),  # large positive input
-        (1e12, 1e15),  # very large positive input
-        (-1e9, -1e7),  # large negative input
-        (-1e15, -1e12),  # very large negative input
-        (-1e-5, 1e-5),  # small input
-        (-1e-10, 1e-10),  # very small input
-        (-1e8, 1e8),  # mixed range
+        (-200, 50),
+        (-800, 200),
+        (-5000, 2000),
+        (-1e3, 1e4),
+        (-1e4, 1e5),
+        (-2e5, 2e6),
+        (-1e7, 1e8),
+        (-1e9, 1e10),
+        (-5e13, 5e14),
+        (5e7, 2e9),
+        (1e11, 2e14),
+        (-3e7, -5e6),
+        (-2e13, -2e11),
+        (-5e-6, 5e-6),
+        (-1e-7, 1e-7),
+        (-1e6, 1e7),
     ]
 
     torch_input_tensor_a = create_full_range_tensor(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -13,6 +13,44 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
+def ulp_distance_fp32(expected: torch.Tensor, actual: torch.Tensor) -> torch.Tensor:
+    """
+    Compute elementwise ULP distance for float32 tensors.
+
+    - For finite values: uses ordered-int representation distance
+    - If both are the same non-finite (NaN/Inf of same sign): distance = 0
+    - Otherwise: distance = max int64 (flags mismatch)
+    """
+    expected = expected.to(torch.float32).contiguous()
+    actual = actual.to(torch.float32).contiguous()
+
+    expected_finite = torch.isfinite(expected)
+    actual_finite = torch.isfinite(actual)
+    both_finite = expected_finite & actual_finite
+
+    same_nan = torch.isnan(expected) & torch.isnan(actual)
+    same_posinf = torch.isposinf(expected) & torch.isposinf(actual)
+    same_neginf = torch.isneginf(expected) & torch.isneginf(actual)
+    same_nonfinite = same_nan | same_posinf | same_neginf
+
+    # Bitwise ULP distance for finite values
+    expected_bits_u = expected.view(torch.int32).to(torch.int64) & 0xFFFFFFFF
+    actual_bits_u = actual.view(torch.int32).to(torch.int64) & 0xFFFFFFFF
+
+    expected_sign = (expected_bits_u >> 31) & 1
+    actual_sign = (actual_bits_u >> 31) & 1
+
+    # Convert to ordered representation: monotonic with float ordering
+    expected_ord = torch.where(expected_sign == 0, expected_bits_u + 0x80000000, 0x80000000 - expected_bits_u)
+    actual_ord = torch.where(actual_sign == 0, actual_bits_u + 0x80000000, 0x80000000 - actual_bits_u)
+
+    ulp_dist = torch.full_like(expected_ord, fill_value=torch.iinfo(torch.int64).max, dtype=torch.int64)
+    ulp_dist[both_finite] = (expected_ord[both_finite] - actual_ord[both_finite]).abs()
+    ulp_dist[same_nonfinite] = 0
+
+    return ulp_dist
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -81,7 +119,7 @@ def create_full_range_tensor(input_shape, dtype, value_ranges):
     "input_shapes",
     ((torch.Size([1, 2, 32, 128])),),
 )
-@pytest.mark.parametrize("value", [1.0, 2.75, 5.0, -10.0])
+@pytest.mark.parametrize("value", [2.75])
 def test_ternary_addcdiv_float32_full_range(input_shapes, value, device):
     """Test addcdiv with float32 inputs spanning the range of [-1e15, 1e15]."""
     value_ranges_a = [
@@ -178,7 +216,10 @@ def test_ternary_addcdiv_float32_full_range(input_shapes, value, device):
     )
 
     output_tensor = ttnn.addcdiv(input_tensor_a, input_tensor_b, input_tensor_c, value=value)
-    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=32, allow_nonfinite=True)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.allclose(output_tensor, torch_output_tensor, atol=1e-6, rtol=1e-5)
+    assert_with_ulp(output_tensor, torch_output_tensor, ulp_threshold=64, allow_nonfinite=True)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -47,12 +47,16 @@ Tensor _addcdiv(
         return result;
     }
 
-    // For non-FP32: 0.5 * inf != inf but 1.7014e+3 and 0/0 = 0 for non-fp32
-    Tensor t_inf = ttnn::multiply(
-        ttnn::sign(t_factor, output_mem_config),
-        std::numeric_limits<float>::infinity(),
-        std::nullopt,
-        output_mem_config);
+    // For non-FP32: 0.5 * inf != inf but 1.7014e+3 and 0/0 = 0
+    // To match Torch behavior after golden normalization, we explicitly
+    // inject an "infinite term" whenever input_c == 0:
+    //   (value * input_b) / 0  ->  sign(input_b) * (value * inf)
+    // If input_b == 0 and input_c ==0: force sign = +1 so the result becomes (value * inf)
+    // Note: We intentionally avoid using sign(t_factor) here, since (value * input_b) can underflow to 0 in BF16.
+    const float signed_inf = value * std::numeric_limits<float>::infinity();  // value * torch.tensor(float("inf"))
+    Tensor sign_b = ttnn::sign(input_b, output_mem_config);
+    Tensor sign_or_one = ttnn::where(ttnn::eqz(input_b, output_mem_config), 1.0f, sign_b, output_mem_config);
+    Tensor t_inf = ttnn::multiply(sign_or_one, signed_inf, std::nullopt, output_mem_config);
     result = ttnn::where(ttnn::eqz(input_c, output_mem_config), t_inf, result, output_mem_config);
     return result;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -27,7 +27,7 @@ Tensor _addcmul(
     return result;
 }
 
-// addcdiv(input,tensor1,tensor2,value)=input+value×tensor1/tensor2
+// addcdiv(input,tensor1,tensor2,value)=input+(value×tensor1)/tensor2
 Tensor _addcdiv(
     const Tensor& input_a,
     const Tensor& input_b,
@@ -39,10 +39,9 @@ Tensor _addcdiv(
             input_c.storage_type() == StorageType::DEVICE,
         "Ternary operation requires input tensors to be on Device.");
 
-    Tensor t_div = ttnn::div(input_b, input_c, false, std::nullopt, std::nullopt, output_mem_config);
-    Tensor t_factor = ttnn::multiply(t_div, value, std::nullopt, output_mem_config);
-    t_div.deallocate();
-    Tensor result = ttnn::add(input_a, t_factor, std::nullopt, output_mem_config);
+    Tensor t_factor = ttnn::multiply(input_b, value, std::nullopt, output_mem_config);
+    Tensor t_div = ttnn::div(t_factor, input_c, false, std::nullopt, std::nullopt, output_mem_config);
+    Tensor result = ttnn::add(input_a, t_div, std::nullopt, output_mem_config);
 
     if (result.dtype() == DataType::FLOAT32) {
         return result;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -390,7 +390,10 @@ void py_module(nb::module_& mod) {
     bind_ternary_composite_float(
         mod,
         ttnn::addcdiv,
-        R"doc(Computes Addcdiv on :attr:`input_tensor_a`, :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+        R"doc(Multiplies :attr:`input_tensor_b` by a scalar, divides the result
+        element-wise by :attr:`input_tensor_c`, and adds it to
+        :attr:`input_tensor_a`.
+        Returns a tensor with the same layout as :attr:`input_tensor_a`.)doc");
 
     bind_ternary_where(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -27,42 +27,45 @@ void bind_ternary_composite_float(
     nb::module_& mod,
     const ternary_operation_t& operation,
     const std::string& description,
+    const std::string& math,
     const std::string& supported_dtype = "BFLOAT16") {
     auto doc = fmt::format(
         R"doc(
         {2}
 
+        .. math::
+            {3}
+
         Args:
-            input_tensor_a (ttnn.Tensor): the input tensor.
-            input_tensor_b (ttnn.Tensor): the input tensor.
-            input_tensor_c (ttnn.Tensor or Number): the input tensor.
+            input_tensor_a (ttnn.Tensor): the input tensor to be added.
+            input_tensor_b (ttnn.Tensor): the input numerator tensor.
+            input_tensor_c (ttnn.Tensor or Number): the input denominator tensor.
 
 
         Keyword Args:
-            value (float, optional): scalar value to be multiplied.
+            value (float, optional): scalar value to be multiplied with input_tensor_b.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
 
         Note:
-            Supported dtypes, layouts, and ranks:
+            Supported dtypes and layouts:
 
             .. list-table::
                :header-rows: 1
 
                * - Dtypes
                  - Layouts
-                 - Ranks
-               * - {3}
+               * - {4}
                  - TILE
-                 - 2, 3, 4
 
             bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
         description,
+        math,
         supported_dtype);
 
     bind_registered_operation(
@@ -393,7 +396,9 @@ void py_module(nb::module_& mod) {
         R"doc(Multiplies :attr:`input_tensor_b` by a scalar, divides the result
         element-wise by :attr:`input_tensor_c`, and adds it to
         :attr:`input_tensor_a`.
-        Returns a tensor with the same layout as :attr:`input_tensor_a`.)doc");
+        Returns a tensor with the same layout as :attr:`input_tensor_a`.)doc",
+        R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i + \frac{(value * \mathrm{input\_tensor\_b}_i)}{\mathrm{input\_tensor\_c}_i})doc",
+        "FLOAT32, BFLOAT16, BFLOAT8_B");
 
     bind_ternary_where(
         mod,


### PR DESCRIPTION
### Ticket
#33758

### Problem description
The order of operations is incorrect. Multiplication and division have the same precedence and are therefore evaluated from left to right. 

According to Torch documentation, the formula is:
`tensor_a + scalar * (tensor_b / tensor_c)`
and this is the behavior followed by TT.

However, based on evaluation, Torch applies the following formula instead:
`tensor_a + (scalar * tensor_b) / tensor_c`

### What's changed
Changed order of operations to match Torch behavior.

## Accuracy Improvement
### Test Config

| Item | New Impl | Old Impl |
|--------|----------|----------|
| Scalars tested | 0.5, 1.0, 2.75, 10.0 | 0.5, 1.0, 2.75, 10.0 |
| Tensor a range | [-3.316e+38, 3.403e+38] | [-3.316e+38, 3.403e+38] |
| Tensor b range | [-3.347e+38, 3.347e+38] | [-3.347e+38, 3.347e+38] |
| Tensor c range | [-3.289e+38, 3.289e+38] | [-3.289e+38, 3.289e+38] |
| Total triplets tested | 4,000,000,000 (4.00B) |  4,000,000,000 (4.00B) |
| Skipped (subnormal/inf/nan) | 426,047,167 (10.65%) | 428,168,806 (10.70%) |
| Validated (normal outputs) | 3,573,952,833 | 3,571,831,194 |

### ULP Summary in WH_B0
| ULP | New Impl | Old Impl |
|--------|----------|----------|
| Global max ULP | 2,130,698,510 | 2,130,698,510 |
| ULP = 0 | 3,175,524,610 (88.8519%) | 3,077,482,899 (86.1598%) |
| ULP = 1 | 371,702,480 (10.4003%) | 455,130,804 (12.7422%) |
| ULP = 2 | 4,476,325 (0.1252%) | 16,704,727 (0.4677%) |
| ULP 3–10 | 2,529,434 (0.0708%) | 2,965,390 (0.0830%) |
| ULP 11–100 | 1,962,832 (0.0549%) | 2,086,319 (0.0584%) |
| ULP > 100 | 17,757,152 (0.4968%) | 17,461,055 (0.4889%) |
| Total mismatches (ULP > 0) | 398,428,223 (11.1481%) | 494,047,295 (13.8402%) |

### ULP Summary in BH
| ULP | New Impl | Old Impl |
|-----|----------|----------|
| Global max ULP | 2,130,698,510 | 2,130,698,510 |
| ULP = 0 | 2,986,913,446 (83.5745%) | 2,928,062,953 (81.9765%) |
| ULP = 1 | 546,562,117 (15.2929%) | 580,084,009 (16.2405%) |
| ULP = 2 | 17,291,939 (0.4838%) | 39,806,834 (1.1145%) |
| ULP 3–10 | 3,249,579 (0.0909%) | 4,154,006 (0.1163%) |
| ULP 11–100 | 2,158,765 (0.0604%) | 2,259,691 (0.0633%) |
| ULP > 100 | 17,776,987 (0.4974%) | 17,463,701 (0.4889%) |
| Total mismatches (ULP > 0) | 587,039,387 (16.4255%) | 643,768,241 (18.0235%) |



### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=anasuya/addcdiv_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:anasuya/addcdiv_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anasuya/addcdiv_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anasuya/addcdiv_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/addcdiv_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/addcdiv_fix)
- [x] New/Existing tests provide coverage for changes