### PR TITLE
Fix qwen25_vl unit tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -359,7 +359,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -359,7 +359,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/models/demos/qwen25_vl/tests/test_model.py
+++ b/models/demos/qwen25_vl/tests/test_model.py
@@ -92,7 +92,7 @@ def test_vision_model_inference(
     # reference_model.load_state_dict(model_args.reference_vision_model().state_dict(), strict=False)
     # FIXME: state_dict = model_args.load_state_dict()
     state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
-    state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
+    state_dict = convert_hf_to_meta(state_dict, model_args.vision_head_dim)
     state_dict_prefix = model_args.get_state_dict_prefix("VisionTransformer")
     state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}
 
@@ -108,7 +108,7 @@ def test_vision_model_inference(
     cu_seqlens, cu_window_seqlens, position_embeddings, window_index = qwen2_5_vision_transformer_preprocess(
         seq_len=ref_seq_len,
         grid_thw=image_grid_thw,
-        head_dim=model_args.head_dim,
+        head_dim=model_args.vision_head_dim,
         spatial_merge_size=model_args.hf_config.vision_config.spatial_merge_size,
         window_size=model_args.hf_config.vision_config.window_size,
         patch_size=model_args.hf_config.vision_config.patch_size,

--- a/models/demos/qwen25_vl/tests/test_rms_norm.py
+++ b/models/demos/qwen25_vl/tests/test_rms_norm.py
@@ -57,7 +57,7 @@ def test_rms_norm_inference(
     tt_ccl = TT_CCL(mesh_device)
     tt_inner_norm = RMSNorm(
         device=mesh_device,
-        dim=model_args.dim,
+        dim=model_args.vision_dim,
         eps=1e-6,  # Qwen2_5_VLVisionBlock hard-codes this
         state_dict=state_dict,
         state_dict_prefix="",
@@ -69,7 +69,7 @@ def test_rms_norm_inference(
     # Wrap it in DistributedNorm
     tt_model = DistributedNorm(tt_inner_norm, model_args, tt_ccl=tt_ccl, TG=model_args.is_galaxy)
 
-    input = torch.rand(1, 1, max_seq_len, model_args.dim)
+    input = torch.rand(1, 1, max_seq_len, model_args.vision_dim)
     reference_output = reference_model(input)
 
     # DistributedNorm inputs are fractured across devices and interleaved in DRAM (for prefill) and L1 (for decode)

--- a/models/demos/qwen25_vl/tests/test_vision_attention.py
+++ b/models/demos/qwen25_vl/tests/test_vision_attention.py
@@ -57,17 +57,17 @@ def test_vision_attention_inference(
     # reference_model.load_state_dict(model_args.reference_attention().state_dict())
 
     state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
-    state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
+    state_dict = convert_hf_to_meta(state_dict, model_args.vision_head_dim)
     state_dict_prefix = model_args.get_state_dict_prefix("VisionAttention", 0)
     state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}
 
     # Example inputs and preprocessing
-    pt_attention_input = torch.randn(1, 1, ref_seq_len, model_args.dim)
+    pt_attention_input = torch.randn(1, 1, ref_seq_len, model_args.vision_dim)
     # pt_attention_input = torch.load("ref_1_attn_norm.pt").unsqueeze(0).unsqueeze(0)
     cu_seqlens, cu_window_seqlens, position_embeddings, window_index = qwen2_5_vision_transformer_preprocess(
         seq_len=ref_seq_len,
         grid_thw=image_grid_thw,
-        head_dim=model_args.head_dim,
+        head_dim=model_args.vision_head_dim,
         spatial_merge_size=model_args.hf_config.vision_config.spatial_merge_size,
         window_size=model_args.hf_config.vision_config.window_size,
         patch_size=model_args.hf_config.vision_config.patch_size,
@@ -102,7 +102,7 @@ def test_vision_attention_inference(
 
     rot_mats = [cos, sin]
 
-    transformation_mat_torch = get_rot_transformation_mat(model_args.head_dim)
+    transformation_mat_torch = get_rot_transformation_mat(model_args.vision_head_dim)
 
     transformation_mats_prefill = ttnn.as_tensor(
         transformation_mat_torch,
@@ -140,7 +140,9 @@ def test_vision_attention_inference(
         tt_out,
         mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1),
     )
-    tt_output_torch = tt_out[:, 0:1, :, : model_args.dim].view(batch_size, seq_len, -1)  # [ batch, seq, hidden_dim]
+    tt_output_torch = tt_out[:, 0:1, :, : model_args.vision_dim].view(
+        batch_size, seq_len, -1
+    )  # [ batch, seq, hidden_dim]
 
     # Remove sequence padding
     tt_output_torch = tt_output_torch[0, :ref_seq_len, :]

--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -181,7 +181,7 @@ class DropInVisionTransformer(torch.nn.Module):
         self.debug = debug
 
         state_dict = standardize_hf_keys_multimodal(reference_model.state_dict())
-        state_dict = convert_hf_to_meta(state_dict, model_args.head_dim)
+        state_dict = convert_hf_to_meta(state_dict, model_args.vision_head_dim)
         state_dict_prefix = model_args.get_state_dict_prefix("VisionTransformer")
         state_dict = {f"{state_dict_prefix}.{k}": v for k, v in state_dict.items()}
 


### PR DESCRIPTION
### Problem description
qwen25_vl unit tests tests are failing (e.g. [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20945497760/job/60188021865))

### What's changed
Added `vision_` prefix to some of the model_args parameters in the tests directory

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20962379474) - CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/20962278926) - CI passes
- [x] [(Single-card) Demo tests (with perf runs)](https://github.com/tenstorrent/tt-metal/actions/runs/20961853285) - CI passes
- [x] [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/20961991914) - CI passes
- [x] [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/20961982338) - CI passes
- [x] [vLLM nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/20963335958/job/60247243668) - CI passes