### PR TITLE
#0: Remove exp+approx from exp

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -288,15 +288,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp_improved_<true>(sfpi::vFloat val) {
 
 template <
     bool APPROXIMATION_MODE,
-    bool FAST_APPROX,
     bool is_fp32_dest_acc_en,
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
 void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
-            exp_base_scale_factor);
+        _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>(exp_base_scale_factor);
     } else {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -310,9 +308,9 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
+template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000>
 void exp_init() {
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, scale>();
+    _init_exponential_<APPROXIMATION_MODE, scale>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -313,5 +313,15 @@ void exp_init() {
     _init_exponential_<APPROXIMATION_MODE, scale>();
 }
 
+template <bool APPROXIMATION_MODE>
+void exp_piecewise_init() {
+    _init_exponential_piecewise_<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+void exp_sdpa_first_column_init() {
+    _init_exponential_sdpa_first_column_<APPROXIMATION_MODE>();
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -92,22 +92,12 @@
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
-#define SFPU_TEMPLATE_PARAMS_KERNEL(                                                                                   \
-    OP,                                                                                                                \
-    APPROXIMATE,                                                                                                       \
-    FAST_APPROX,                                                                                                       \
-    IS_FP32_DEST_ACC_EN,                                                                                               \
-    SCALE_EN,                                                                                                          \
-    SKIP_POSITIVE_CHECK,                                                                                               \
-    ITERATIONS,                                                                                                        \
-    DST_IDX,                                                                                                           \
-    VECTOR_MODE,                                                                                                       \
-    SCALE)                                                                                                             \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                                \
-        ckernel::sfpu::                                                                                               \
-            calculate_##OP<APPROXIMATE, FAST_APPROX, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>, \
-        DST_IDX,                                                                                                      \
-        VECTOR_MODE,                                                                                                  \
+#define SFPU_TEMPLATE_PARAMS_KERNEL(                                                                                \
+    OP, APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, SKIP_POSITIVE_CHECK, ITERATIONS, DST_IDX, VECTOR_MODE, SCALE)   \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+        ckernel::sfpu::calculate_##OP<APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>, \
+        DST_IDX,                                                                                                    \
+        VECTOR_MODE,                                                                                                \
         SCALE)
 
 // For kernels with one template parameter and one extra runtime argument.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -311,5 +311,15 @@ void exp_init() {
     _init_exponential_<APPROXIMATION_MODE, scale>();
 }
 
+template <bool APPROXIMATION_MODE>
+void exp_piecewise_init() {
+    _init_exponential_piecewise_<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+void exp_sdpa_first_column_init() {
+    _init_exponential_sdpa_first_column_<APPROXIMATION_MODE>();
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -285,15 +285,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp_improved_<true>(sfpi::vFloat val) {
 
 template <
     bool APPROXIMATION_MODE,
-    bool FAST_APPROX,
     bool is_fp32_dest_acc_en,
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool SKIP_POSITIVE_CHECK = false>
 void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (APPROXIMATION_MODE) {
-        _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, FAST_APPROX, SKIP_POSITIVE_CHECK>(
-            exp_base_scale_factor);
+        _calculate_exponential_<APPROXIMATION_MODE, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>(exp_base_scale_factor);
     } else {
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -308,9 +306,9 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
     }
 }
 
-template <bool APPROXIMATION_MODE, bool FAST_APPROX, uint32_t scale = 0x3F800000>
+template <bool APPROXIMATION_MODE, uint32_t scale = 0x3F800000>
 void exp_init() {
-    _init_exponential_<APPROXIMATION_MODE, FAST_APPROX, scale>();
+    _init_exponential_<APPROXIMATION_MODE, scale>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -92,22 +92,12 @@
         ckernel::sfpu::FN<APPROXIMATE>, DST_IDX, (int)VectorMode::MODE, PARAM0, PARAM1);
 
 // For ops with multiple template parameters and one runtime parameter (e.g., scale)
-#define SFPU_TEMPLATE_PARAMS_KERNEL(                                                                                   \
-    OP,                                                                                                                \
-    APPROXIMATE,                                                                                                       \
-    FAST_APPROX,                                                                                                       \
-    IS_FP32_DEST_ACC_EN,                                                                                               \
-    SCALE_EN,                                                                                                          \
-    SKIP_POSITIVE_CHECK,                                                                                               \
-    ITERATIONS,                                                                                                        \
-    DST_IDX,                                                                                                           \
-    VECTOR_MODE,                                                                                                       \
-    SCALE)                                                                                                             \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                                \
-        ckernel::sfpu::                                                                                               \
-            calculate_##OP<APPROXIMATE, FAST_APPROX, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>, \
-        DST_IDX,                                                                                                      \
-        VECTOR_MODE,                                                                                                  \
+#define SFPU_TEMPLATE_PARAMS_KERNEL(                                                                                \
+    OP, APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, SKIP_POSITIVE_CHECK, ITERATIONS, DST_IDX, VECTOR_MODE, SCALE)   \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+        ckernel::sfpu::calculate_##OP<APPROXIMATE, IS_FP32_DEST_ACC_EN, SCALE_EN, ITERATIONS, SKIP_POSITIVE_CHECK>, \
+        DST_IDX,                                                                                                    \
+        VECTOR_MODE,                                                                                                \
         SCALE)
 
 // For kernels with one template parameter and one extra runtime argument.

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
@@ -53,4 +53,26 @@ ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_
         exponential, approx, DST_ACCUM_MODE, scale_en, skip_positive_check, iterations, idst, vector_mode, scale));
 }
 
+/**
+ * Please refer to documentation for any_init.
+ *
+ * This init function is used for exponentialpiecewise approximation mode.
+ *
+ */
+template <bool approx = false>
+ALWI void exp_tile_piecewise_init() {
+    MATH(SFPU_INIT_KERNEL_CALL(exponential, sfpu::exp_piecewise_init, approx));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ *
+ * This init function is used for SDPA first column computation.
+ *
+ */
+template <bool approx = false>
+ALWI void exp_tile_sdpa_first_column_init() {
+    MATH(SFPU_INIT_KERNEL_CALL(exponential, sfpu::exp_sdpa_first_column_init, approx));
+}
+
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/exp.h
@@ -15,13 +15,13 @@ namespace ckernel {
 /**
  * Please refer to documentation for any_init.
  *
- * Template scale parameter is used when aprox and fast_and_approx are true and exp_tile is called with scale_en set to
+ * Template scale parameter is used when aprox is true and exp_tile is called with scale_en set to
  * true.
  *
  */
-template <bool approx = false, bool fast_and_approx = true, uint32_t scale = 0x3F800000>
+template <bool approx = false, uint32_t scale = 0x3F800000>
 ALWI void exp_tile_init() {
-    MATH(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, approx, fast_and_approx, scale));
+    MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(exponential, sfpu::exp_init, approx, scale));
 }
 
 // clang-format off
@@ -36,7 +36,6 @@ ALWI void exp_tile_init() {
  * | Template Parameter      | Description                                                    | Type     | Valid Range      | Default |
  * |-------------------------|----------------------------------------------------------------|----------|------------------|---------|
  * | approx                  | Enable approximate mode.                                       | bool     | true, false      | false   |
- * | fast_and_approx         | If approx is true, enable fast approximation.                  | bool     | true, false      | true   |
  * | scale_en                | Enable input scaling by a constant factor in approximate or non-approximate mode | bool     | true, false      | false   |
  * | skip_positive_check     | Skip large-positive input check                                | bool     | true, false      | false   |
  * | iterations              | Number of iterations over 32-SFPU lanes to run                 | int      | Positive integer | 8       |
@@ -48,15 +47,10 @@ ALWI void exp_tile_init() {
  * | scale       | Scale factor to apply in approximate or non-approximate mode if scale_en is true (default: 0x3F80, 1.0f in FP16b) | uint16_t | Valid FP16b representation                            | False    |
  */
 // clang-format on
-template <
-    bool approx = false,
-    bool fast_and_approx = true,
-    bool scale_en = false,
-    bool skip_positive_check = false,
-    int iterations = 8>
+template <bool approx = false, bool scale_en = false, bool skip_positive_check = false, int iterations = 8>
 ALWI void exp_tile(uint32_t idst, int vector_mode = (int)VectorMode::RC, uint16_t scale = p_sfpu::kCONST_1_FP16B) {
     MATH(SFPU_TEMPLATE_PARAMS_KERNEL(
-        exponential, approx, fast_and_approx, DST_ACCUM_MODE, scale_en, skip_positive_check, iterations, idst, vector_mode, scale));
+        exponential, approx, DST_ACCUM_MODE, scale_en, skip_positive_check, iterations, idst, vector_mode, scale));
 }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
@@ -41,8 +41,8 @@ void MAIN {
             negative_tile(1);
 
             // Apply exp with fast+approx mode to DST[1]: exp(-x)
-            exp_tile_init<true, true>();  // Fast+approx exp
-            exp_tile<true, true>(1);
+            exp_tile_init<true>();  // Fast+approx exp
+            exp_tile<true>(1);
 
             // Apply logsigmoid SFPU: logsigmoid(x) = -softplus(-x)
             logsigmoid_tile_init();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -463,7 +463,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     // Postcondition: in0_cb and in1_cb has num_tiles produced
 
     sub_tiles_init(in0_cb, in1_cb);
-    exp_tile_init<EXP_APPROX_MODE, false>();
+    exp_tile_sdpa_first_column_init<EXP_APPROX_MODE>();
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
@@ -533,7 +533,7 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
     cb_wait_front(in1_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
-    exp_tile_init<false, false>();
+    exp_tile_sdpa_first_column_init<false>();
     // recip_tile_init<false>(); // Can omit this because accurate exp_tile_init performs reduce_tile_init
 
     for (uint32_t i = 0; i < num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -397,7 +397,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     // Postcondition: out_cb has num_tiles produced
     // Postcondition: in0_cb and in1_cb has num_tiles produced
     sub_tiles_init(in0_cb, in1_cb);
-    exp_tile_init<EXP_APPROX_MODE, false>();
+    exp_tile_sdpa_first_column_init<EXP_APPROX_MODE>();
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     cb_reserve_back(out_cb, num_tiles);
@@ -515,7 +515,7 @@ void correction_block(
     for (uint32_t i = 0; i < num_head_tiles; i++) {
         acquire_dst();
         copy_tile_to_dst_init_short(cb_worker_max);
-        exp_tile_init<EXP_APPROX_MODE, false>();
+        exp_tile_piecewise_init<EXP_APPROX_MODE>();
         max_tile_init();
         copy_tile(cb_prev_max, i, dst_reg_0);
         copy_tile(cb_worker_max, i, dst_reg_1);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34061

### Problem description
From [here](https://github.com/tenstorrent/tt-metal/issues/34061#issue-3709192909), exp+fast+approx is better compared to exp+approx .

### What's changed
<img width="940" height="135" alt="Image" src="https://github.com/user-attachments/assets/d6d57299-0bab-433a-8a15-a9f02cc5b18b" />

- Removed fast_and_approx flag as exp+approx is unlinked from exp
- Created seperate init function specific to exp+approx(exp_tile_piecewise_init) that is used for sdpa and other ops using the same
- exp_tile_sdpa_first_column_init(_init_exponential_sdpa_first_column_) is specific for sdpa/ when we the user wnat to have 21f/61f appraoch  and piecewise approach

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and
      [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml)
      and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs:
      [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset
      (runs:
      the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and
      [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs