### PR TITLE
#34755: Add Fused Implementation of Deepseek MOE Gate for Deepseek B1

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+#include "sfpu/ckernel_sfpu_load_config.h"
+#include "sfpu/ckernel_sfpu_topk.h"
+#include "lltt.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_recip.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// TODO: Initial evaluation of using replay buffers here did not show any performance improvement
+// Try re-evaluating with latest op sequence and record larger sequences
+
+constexpr uint32_t dst_tile_offset = 64;  // 1 tile x 64 rows per tile
+constexpr uint32_t scores_offset = 0;
+constexpr uint32_t indices_offset = scores_offset + dst_tile_offset;
+constexpr uint32_t bias_offset = indices_offset + dst_tile_offset;
+constexpr uint32_t interm_offset = bias_offset + dst_tile_offset;
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_load16_single_face() {
+    // Load 16 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_offset + 12);
+}
+
+template <bool is_fp32_dest_acc_en, uint32_t offset = 0>
+inline void bitonic_topk_load16_concat_indices_single_face() {
+    // Load 16 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12 + offset);
+
+    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 12 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 12 + offset);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_load16_concatted_indices_single_face() {
+    // Load 16 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+
+    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 12);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store16_concatted_indices_single_face() {
+    // Store 16 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 12);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store16_single_face() {
+    // Store 16 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_offset + 12);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_load8_even_cols_single_face() {
+    // Load 8 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_load8_even_cols_concatted_indices_single_face() {
+    // Load 8 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store8_even_cols_single_face() {
+    // Store 8 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+
+    constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store8_even_cols_split_indices_single_face() {
+    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be true");
+    // Store 8 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store8_even_cols_concatted_indices_single_face() {
+    // Store 8 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_load8_odd_cols_concatted_indices_single_face() {
+    // Load 8 consecutive numbers
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 6);
+
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 6);
+}
+
+template <bool is_fp32_dest_acc_en>
+inline void bitonic_topk_store8_odd_cols_concatted_indices_single_face() {
+    // Store 8 consecutive numbers
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 2);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 6);
+
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 2);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 6);
+}
+
+template <bool start_transpose, bool end_transpose>
+inline void bitonic_topk_ph0_st1_to_1_single_face() {
+    if constexpr (start_transpose) {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+
+    // Step 1
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    if constexpr (end_transpose) {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+}
+
+template <bool start_transpose, bool end_transpose>
+inline void bitonic_topk_ph1_st2_to_1_single_face() {
+    if constexpr (start_transpose) {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+
+    // Step 2
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ROWS_02_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ROWS_02_MAX);
+
+    // Step 1
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ROWS_02_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ROWS_02_MAX);
+
+    if constexpr (end_transpose) {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+}
+
+template <bool end_transpose, bool bitonic = true>
+inline void bitonic_topk_ph2_st3_to_1_single_face() {
+    // Step 3
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    if constexpr (bitonic) {
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    } else {
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    }
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    constexpr int swap_mode = bitonic ? p_sfpswap::ROWS_01_MAX : p_sfpswap::ALL_ROWS_MAX;
+
+    // Step 2
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, swap_mode);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, swap_mode);
+
+    // Step 1
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, swap_mode);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, swap_mode);
+
+    if constexpr (end_transpose) {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+}
+
+template <bool dir, bool end_transpose>
+inline void bitonic_top8_ph3_st4_to_1() {
+    // TODO: Use replay buffer for these instructions
+    if constexpr (dir == (bool)SortDir::ArgMax) {
+        // Step 4
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 3
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Step 2
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 1
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+        if constexpr (end_transpose) {
+            TTI_SFPTRANSP(0, 0, 0, 0);
+        }
+    } else {
+        // Step 4
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 3
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Step 2
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 1
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+        if constexpr (end_transpose) {
+            TTI_SFPTRANSP(0, 0, 0, 0);
+        }
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool idir>
+inline void bitonic_top8_ph0_to_ph3() {
+    // Phase 0
+    {
+        constexpr bool start_transpose = true;
+        constexpr bool end_transpose = false;
+        constexpr int phase_replay_count = 2 + (int)start_transpose + (int)end_transpose;
+        bitonic_topk_ph0_st1_to_1_single_face<start_transpose, end_transpose>();
+    }
+    // Phase 1
+    {
+        constexpr bool start_transpose = false;
+        constexpr bool end_transpose = true;
+        constexpr int phase_replay_count = 4 + (int)start_transpose + (int)end_transpose;
+        // Odd Columns
+        bitonic_topk_ph1_st2_to_1_single_face<start_transpose, end_transpose>();
+    }
+    // Phase 2
+    {
+        constexpr bool end_transpose = true;
+        constexpr int phase_replay_count = 7 + (int)end_transpose;
+        // Even Columns
+        bitonic_topk_ph2_st3_to_1_single_face<end_transpose>();
+    }
+    // Modified Phase 3 for top8
+    {
+        constexpr bool end_transpose = true;
+        constexpr int phase_replay_count = 8 + (int)end_transpose;
+        bitonic_top8_ph3_st4_to_1<idir, end_transpose>();
+    }
+}
+
+void reverse_sort_order() {
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG3, p_sfpswap::UNCONDITIONALLY);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpswap::UNCONDITIONALLY);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void _deepseek_moe_gate_sum_top2() {
+    constexpr bool idir = false;  // Sort descending order
+    constexpr int load_store_replay_count = 8;
+    constexpr int load_replay_offset = 0;
+    constexpr int store_replay_offset = load_replay_offset + load_store_replay_count;
+    constexpr int phase_replay_offset = store_replay_offset + load_store_replay_count;
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Phase 0-3 Even Columns
+    bitonic_topk_load16_concat_indices_single_face<is_fp32_dest_acc_en, 0>();
+    bitonic_top8_ph0_to_ph3<APPROXIMATION_MODE, is_fp32_dest_acc_en, idir>();
+    bitonic_topk_store8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
+
+    // Phase 0-3 Odd Columns
+    bitonic_topk_load16_concat_indices_single_face<is_fp32_dest_acc_en, 2>();
+    bitonic_top8_ph0_to_ph3<APPROXIMATION_MODE, is_fp32_dest_acc_en, !idir>();
+
+    // Instead of a full phase 4, we rerun phase 3 since we are only comparing top8 values
+    bitonic_topk_load8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
+    bitonic_top8_ph3_st4_to_1<idir, true>();
+    bitonic_topk_store8_even_cols_split_indices_single_face<is_fp32_dest_acc_en>();
+
+    // Sum top2
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Replicate the top2 sum down the column
+    // This is needed for the subsequent top4 sort
+    // TODO: Evaluate compared to broadcast using MOVB2D in FPU
+    TTI_SFPCONFIG(0, p_sfpu::LREG14, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG14, p_sfpu::LREG0, 0);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset + 4);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void _deepseek_moe_gate_sort_top4_groups() {
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    // Sort top4
+    // Load the top2 sums and concat indices
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+
+    // Load the top2 sums (again) and bias scores
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
+    TTI_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_7, bias_offset + 4);
+
+    // Sort 8 groups (not bitonic)
+    bitonic_topk_ph0_st1_to_1_single_face<true, false>();
+    bitonic_topk_ph1_st2_to_1_single_face<false, true>();
+    bitonic_topk_ph2_st3_to_1_single_face<true, false>();
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_7, bias_offset + 0);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+    constexpr bool idir = false;  // Sort descending order
+
+    // Combine and sort 4 groups of 8 values to 2 groups of 8 values
+    // Even Columns sorted Top8 in LREG0 and LREG1
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Reverse order of sort for top8 values in odd columns
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 2);
+    reverse_sort_order();
+
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+    bitonic_top8_ph3_st4_to_1<idir, true>();
+
+    bitonic_topk_store8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
+
+    // Move and reverse the other column of 8 values
+    // Disable index tracking while we shift values
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    // There is a hardware bug that affects operations on LREG4-7 while this is enabled
+    // Note this overwrites LREG0
+    _sfpu_load_config32_(0xF, 0x0, 0x0);
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    // Re-enable index tracking
+    _sfpu_load_config32_(0xF, 0x0, 0x4);
+    reverse_sort_order();
+    bitonic_topk_load8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
+
+    // Step 4 Only, we need top8 but it doesn't have to be sorted
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+
+    // Reduce the top8 values to 1 value
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+
+    // Calculate 1 / (sum + eps) * scale
+    sfpi::vFloat l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vFloat eps_value = Converter::as_float(eps);
+    l0 = l0 + eps_value;
+    l0 = sfpu_reciprocal<APPROXIMATION_MODE>(l0);
+    sfpi::vFloat scale_value = Converter::as_float(scale);
+    l0 = l0 * scale_value;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    TTI_SFPNOP;
+
+    // Broadcast to all rows and multiply by the top8 values
+    TTI_SFPCONFIG(0, p_sfpu::LREG14, 0);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void _init_deepseek_moe_gate_topk() {
+    _sfpu_load_config32_(0xF, 0x0, 0x4);  // Set bit [2] of the SFPU_CONTROL_REG to enable index tracking mode
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+enum class DeepseekMoeGateEltwiseBinaryMode {
+    COPY,
+    RELOAD,
+};
+
+// local function declarations
+template <EltwiseBinaryType eltwise_binary_type>
+inline void deepseek_moe_gate_eltwise_binary_configure_addrmod() {
+    // Use srcA for data movement
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        addr_mod_t{
+            .srca = {.incr = 8},
+            .srcb = {.incr = 8},
+            .dest = {.incr = 8},
+        }
+            .set(ADDR_MOD_0);
+        addr_mod_t{
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_1);
+    }
+}
+
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src() {
+    if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCA_VLD);  // MOVD2A for a whole face assumes unpacker will set a dummy
+                                                      // data_valid, so we want to wait on that
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 4);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 8);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 12, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 12);
+    } else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB) {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCB_VLD);  // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                      // data_valid, so we want to wait on that
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DstSync Dst, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_(
+    const std::uint32_t num_faces, uint dst_index, const bool clear_fp32_dst_acc) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    static_assert(!(eltwise_binary_type == ELWMUL && high_fidelity), "High fidelity is not supported for ELWMUL");
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        ckernel_template::run();
+    }
+    math::clear_dst_reg_addr();
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+inline void deepseek_moe_gate_eltwise_binary_configure_mop(
+    const std::uint32_t acc_to_dest = 0, const std::uint32_t num_faces = 4) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    const uint addr_mod = ADDR_MOD_0;
+    constexpr uint innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
+    uint outerloop = num_faces;
+    auto broadcast_type = p_elwise::SRCB_NO_BCAST;
+
+    constexpr uint32_t dst_tile_offset = 64;  // 1 tile x 64 rows per tile
+    constexpr uint32_t dst_math_offset = 2 * dst_tile_offset;
+
+    uint math_op;
+
+    // TODO: Probably not worth it to use a replay buffer/mop for this
+    // Just hardcode the math ops in _llk_math_deepseek_moe_gate_eltwise_binary_ since we only have 1 face
+    if constexpr (eltwise_binary_type == ELWADD) {
+        math_op = TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+
+    } else if constexpr (eltwise_binary_type == ELWSUB) {
+        math_op = TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+    } else if constexpr (eltwise_binary_type == ELWMUL) {
+        static_assert(!high_fidelity, "High fidelity is not supported for ELWMUL");
+        math_op = TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, dst_math_offset);
+    }
+    if constexpr (mode == DeepseekMoeGateEltwiseBinaryMode::RELOAD) {
+        load_replay_buf(
+            ckernel::math::replay_buf_offset,  // replay buffer offset
+            5,
+            [] { deepseek_moe_gate_eltwise_binary_reuse_dest_as_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(); });
+        uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 5);
+        ckernel_template tmp(outerloop, innerloop, math_op);
+        tmp.set_start_op(replay_instr);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    } else {
+        ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 0), math_op);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int MATH_FIDELITY_DESC = 0>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_init_(
+    const std::uint32_t num_faces, const std::uint32_t acc_to_dest) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+
+    deepseek_moe_gate_eltwise_binary_configure_addrmod<eltwise_binary_type>();
+
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        deepseek_moe_gate_eltwise_binary_configure_mop<eltwise_binary_type, mode, MATH_FIDELITY_PHASES>(
+            acc_to_dest, num_faces);
+    }
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_globals.h"
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+namespace ckernel {
+
+constexpr uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
+
+// Configure address modifiers for single face transpose
+template <bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_configure_addrmod() {
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = transpose_dest_tile_offset},
+    }
+        .set(ADDR_MOD_2);
+
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_3);
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    // For 16-bit data, simple single-pass transpose
+    // Load replay buffer with the transpose sequence for one 16x16 face (face 0: rows 0-15)
+    load_replay_buf(
+        ckernel::math::replay_buf_offset,  // replay buffer offset
+        16,                                // 16 instructions: 8x MOVD2B + 8x MOVB2D
+        [] {
+            // Move 8 rows from DEST to SrcB interleaved (1 row at a time)
+            TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0);
+            TTI_MOVD2B(0, 18, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 1);
+            TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 2);
+            TTI_MOVD2B(0, 22, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 3);
+            TTI_MOVD2B(0, 24, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 4);
+            TTI_MOVD2B(0, 26, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 5);
+            TTI_MOVD2B(0, 28, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 6);
+            TTI_MOVD2B(0, 30, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 7);
+
+            // Move 8 rows from SrcB back to DEST interleaved (1 row at a time)
+            TTI_MOVB2D(0, 16, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 0);
+            TTI_MOVB2D(0, 18, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 1);
+            TTI_MOVB2D(0, 20, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 2);
+            TTI_MOVB2D(0, 22, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 3);
+            TTI_MOVB2D(0, 24, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 4);
+            TTI_MOVB2D(0, 26, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 5);
+            TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
+            TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
+        });
+    uint d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
+    uint b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
+
+    ckernel_template tmp(num_tiles, 1, d2b_instr, TT_OP_TRNSPSRCB);
+    tmp.set_end_op(b2d_instr);
+    tmp.program();
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    // For 16-bit data, simple single-pass transpose
+    // Load replay buffer with the transpose sequence for one 16x16 face (face 0: rows 0-15)
+    load_replay_buf(
+        ckernel::math::replay_buf_offset,  // replay buffer offset
+        11,                                // 11 instructions: 2x MOVD2B + TRNSPSRCB + 8x MOVB2D
+        [] {
+            // Move 4 rows from DEST to SrcB (4 rows at a time)
+            // This will place the first 2 rows in the first 2 columns, and the last 2 rows in the last 2 columns
+            TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+            TTI_MOVD2B(0, 28, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+
+            TTI_TRNSPSRCB;
+
+            // Move 8 rows from SrcB back to DEST interleaved (1 row at a time)
+            TTI_MOVB2D(0, 16, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 0);
+            TTI_MOVB2D(0, 18, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 1);
+            TTI_MOVB2D(0, 20, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 2);
+            TTI_MOVB2D(0, 22, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 3);
+            TTI_MOVB2D(0, 24, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 4);
+            TTI_MOVB2D(0, 26, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 5);
+            TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
+            TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
+        });
+    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
+
+    ckernel_template tmp(num_tiles, 1, replay_instr);
+    tmp.program();
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    load_replay_buf(
+        ckernel::math::replay_buf_offset,  // replay buffer offset
+        4,                                 // 4 instructions: 2x MOVD2B + TRNSPSRCB + 1x MOVB2D
+        [] {
+            // Move 8 rows from DEST to SrcB (4 rows at a time)
+            TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+            TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 4);
+
+            TTI_TRNSPSRCB;
+
+            // Move 1 row from SrcB back to DEST
+            TTI_MOVB2D(0, 16, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 0);
+        });
+    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
+
+    ckernel_template tmp(num_tiles, 1, replay_instr);
+    tmp.program();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_configure_addrmod<is_32bit>();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop<4, is_32bit>();
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    // TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop<3, is_32bit>();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop<2, is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    // Run the 16-bit single-face transpose MOP
+    ckernel_template::run();
+}
+
+// Perform in-place transpose on face 0 (rows 0-15) of a single tile in DEST
+// dst_index: The tile index in DEST register buffer (0, 1, 2, ...)
+//            The function transposes face 0 of the specified tile
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    // Run the 16-bit single-face transpose MOP
+    ckernel_template::run();
+}
+
+// Perform in-place transpose on face 0 (rows 0-15) of a single tile in DEST
+// dst_index: The tile index in DEST register buffer (0, 1, 2, ...)
+//            The function transposes face 0 of the specified tile
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    ckernel_template::run();
+
+    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "../../../../../../tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY
+ *************************************************************************/
+
+// Version with operands
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, NUM_FIDELITY_PHASES>(
+        num_faces, acc_to_dest);
+}
+
+template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_deepseek_moe_gate_eltwise_binary(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_<
+        eltwise_binary_type,
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        NUM_FIDELITY_PHASES>(num_faces, dst_index, clear_fp32_dst_acc);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_common_api.h"
+#include "../../../../../../tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h"
+
+namespace ckernel {
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init_<is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step0() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step1() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step2() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "../../../../../../../tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_sum_top2() {
+    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_sort_top4_groups() {
+    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_topk_init() {
+    _init_deepseek_moe_gate_topk<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_deepseek_moe_gate_topk_single_face.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
+    // Don't need the second addrmod so set type to unused
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+        sfpu::deepseek_moe_gate_topk_init<APPROXIMATE, is_fp32_dest_acc_en>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
+    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_top8(
+    uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/transpose_wh.h"
+#ifdef TRISC_MATH
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h"
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h"
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h"
+#endif
+
+namespace ckernel {
+
+template <bool enable_sigmoid = false, bool is_32bit = false>
+ALWI void deepseek_moe_gate_init(uint32_t icb0, uint32_t icb1) {
+    if constexpr (enable_sigmoid) {
+        // Init sigmoid (SFPU)
+        sigmoid_tile_init<false>();
+        // Init transpose wh (FPU)
+        transpose_wh_init_short(icb0);
+    } else {
+        // Init copy add (FPU)
+        UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1, 1)));
+        MATH((llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands<
+              ELWADD,
+              DeepseekMoeGateEltwiseBinaryMode::COPY,
+              MATH_FIDELITY>(icb0, icb1, false)));
+        // Init transpose dest addrmods (does not conflict with copy add)
+        MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init<is_32bit>()));
+        // Init topk (SFPU)
+        MATH((llk_math_sfpu_deepseek_moe_gate_topk_init<APPROX, DST_ACCUM_MODE>()));
+    }
+}
+
+template <bool enable_sigmoid = false, bool is_32bit = false>
+ALWI void deepseek_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t scale) {
+    if constexpr (enable_sigmoid) {
+        // Transpose wh (FPU)
+        transpose_wh_tile(icb0, 0, 0);
+        // Sigmoid (SFPU)
+        sigmoid_tile<VectorMode::RC_custom, false>(0);
+        // Init add binary reuse (FPU)
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+            false, false, icb1)));
+        MATH((llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands<
+              ELWADD,
+              DeepseekMoeGateEltwiseBinaryMode::RELOAD,
+              MATH_FIDELITY>(icb1, icb1, false)));
+        // Add binary reuse (FPU)
+        UNPACK((llk_unpack_A<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(icb1, 0)));
+        MATH((llk_math_deepseek_moe_gate_eltwise_binary<ELWADD, DST_ACCUM_MODE, MATH_FIDELITY>(icb1, icb1, 0, true)));
+        // Init transpose dest addrmods (does not conflict with add binary reuse)
+        MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init<is_32bit>()));
+        // Init topk (SFPU)
+        MATH((llk_math_sfpu_deepseek_moe_gate_topk_init<APPROX, DST_ACCUM_MODE>()));
+    } else {
+        // Copy add (FPU)
+        UNPACK((llk_unpack_AB(icb0, icb1, 0, 0)));
+        MATH((llk_math_deepseek_moe_gate_eltwise_binary<ELWADD, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1, 0, true)));
+    }
+    // Set srcb dummy valid for transpose wh (FPU)
+    UNPACK((llk_unpack_set_srcb_dummy_valid()));
+    // Sum top2 (SFPU)
+    MATH((llk_math_sfpu_deepseek_moe_gate_sum_top2<APPROX, DST_ACCUM_MODE>(0)));
+    // Transpose dest step 0 (FPU)
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init<is_32bit>()));
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step0<DST_ACCUM_MODE, is_32bit>()));
+    // Sort top4 groups (SFPU)
+    MATH((llk_math_sfpu_deepseek_moe_gate_sort_top4_groups<APPROX, DST_ACCUM_MODE>(0)));
+    // Transpose dest step 1 (FPU)
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init<is_32bit>()));
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step1<DST_ACCUM_MODE, is_32bit>()));
+    // Top8 (SFPU)
+    MATH((llk_math_sfpu_deepseek_moe_gate_top8<APPROX, DST_ACCUM_MODE>(0, eps, scale)));
+    // Transpose dest step 2 (FPU)
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init<is_32bit>()));
+    MATH((llk_math_deepseek_moe_gate_transpose_dest_single_face_step2<DST_ACCUM_MODE, is_32bit>()));
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_compute.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#define REDUCE_OP PoolType::SUM
+#define REDUCE_DIM ReduceDim::REDUCE_ROW
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/reconfig_data_format.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "../../../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h"
+
+namespace NAMESPACE {
+
+void MAIN {
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t input_indices_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t output_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t output_indices_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t eps = get_compile_time_arg_val(5);
+    constexpr uint32_t scaling_factor = get_compile_time_arg_val(6);
+    constexpr uint32_t enable_sigmoid = get_compile_time_arg_val(7);
+
+    // Init portion, only done once
+    binary_op_init_common(input_cb, bias_cb, output_cb);
+    cb_wait_front(input_indices_cb, 1);
+    cb_wait_front(bias_cb, 1);
+
+    // Compute portion, to be looped in fused op
+    copy_tile_to_dst_init_short(input_indices_cb);
+    reconfig_data_format_srca(input_indices_cb);
+
+    tile_regs_acquire();
+
+    // Copy indices (already transposed to cols)
+    copy_tile(input_indices_cb, 0, 1);
+
+    reconfig_data_format_srca(input_cb);
+    deepseek_moe_gate_init<enable_sigmoid>(input_cb, bias_cb);
+    cb_wait_front(input_cb, 1);
+    deepseek_moe_gate<enable_sigmoid>(input_cb, bias_cb, eps, scaling_factor);
+    // Pop input tile
+    cb_pop_front(input_cb, 1);
+
+    tile_regs_commit();
+
+    pack_reconfig_data_format(output_cb);
+    cb_reserve_back(output_cb, 1);
+    cb_reserve_back(output_indices_cb, 1);
+
+    tile_regs_wait();
+
+    pack_tile(0, output_cb);
+    cb_push_back(output_cb, 1);
+
+    pack_reconfig_data_format(output_indices_cb);
+    pack_tile(1, output_indices_cb);
+    cb_push_back(output_indices_cb, 1);
+
+    tile_regs_release();
+}
+}  // namespace NAMESPACE

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_reader.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_reader.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t bias_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t indices_cb = get_compile_time_arg_val(2);
+
+    // Signal that input buffer is ready (backed by L1 shards)
+    cb_reserve_back(bias_cb, 1);
+    cb_push_back(bias_cb, 1);
+    cb_reserve_back(indices_cb, 1);
+    cb_push_back(indices_cb, 1);
+    cb_reserve_back(input_cb, 1);
+    cb_push_back(input_cb, 1);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_writer.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_writer.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t output_indices_cb = get_compile_time_arg_val(1);
+    cb_wait_front(output_indices_cb, 1);
+    cb_wait_front(output_cb, 1);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.utils import float_to_uint32
+
+
+class DeepseekMoeGateSingleCore:
+    """
+    Single-core Deepseek Moe Gate implementation using ttnn.generic_op.
+
+    This class implements the Deepseek Moe Gate operation on a single face (16x16) of data.
+    The operation is a combination of sigmoid activation, element-wise addition with bias,
+    and sorting of top 8 values per group.
+    """
+
+    @staticmethod
+    def golden(input_tensor, bias_tensor, eps=1e-20, scaling_factor=2.5, enable_sigmoid=False):
+        """
+        PyTorch reference implementation of Deepseek Moe Gate for validation.
+
+        Args:
+            input_tensor: Input tensor (torch.Tensor) of shape [16, 16]
+            bias_tensor: Bias tensor (torch.Tensor) of shape [16, 16]
+            eps: Epsilon value for normalization
+            scaling_factor: Scaling factor for normalization
+            enable_sigmoid: Whether to enable sigmoid activation
+
+        Returns:
+            Top8 normalized scores tensor (torch.Tensor) of shape [1, 8]
+            Top8 indices tensor (torch.Tensor) of shape [1, 8]
+        """
+        scores = torch.sigmoid(input_tensor) if enable_sigmoid else input_tensor
+        bias_scores = scores + bias_tensor
+        sorted_bias, sorted_indices = torch.sort(bias_scores, dim=-1, descending=True)
+        sorted_scores = scores.clone()
+        for i in range(sorted_indices.shape[0]):
+            sorted_scores[i] = scores[i][sorted_indices[i]]
+            sorted_indices[i] += i * sorted_indices.shape[1]
+        top2_sum = sorted_bias[:, 0] + sorted_bias[:, 1]
+        sorted_top2_sum, sorted_top2_indices = torch.sort(top2_sum, descending=True)
+        top4_values = sorted_bias[sorted_top2_indices[:4]].flatten()
+        sorted_scores = sorted_scores[sorted_top2_indices[:4]].flatten()
+        sorted_indices = sorted_indices[sorted_top2_indices[:4]].flatten()
+        top8_values, top8_indices = torch.topk(top4_values, 8, dim=-1, sorted=True)
+        top8_values = sorted_scores[top8_indices]
+        top8_indices = sorted_indices[top8_indices]
+        denominator = torch.sum(top8_values, dim=-1) + eps
+        normalized_scores = top8_values / denominator * scaling_factor
+        return normalized_scores, top8_indices
+
+    @staticmethod
+    def op(
+        input_tensor,
+        bias_tensor,
+        output_tensor,
+        input_indices_tensor,
+        output_indices_tensor,
+        eps=1e-20,
+        scaling_factor=2.5,
+        enable_sigmoid=False,
+    ):
+        """
+        Execute Deepseek Moe Gate operation using generic_op.
+
+        Args:
+            input_tensor: Input tensor with values to sort (must be sharded, shape [16, 16])
+            bias_tensor: Transposed bias tensor with values to add (must be sharded, shape [16, 16])
+            output_tensor: Pre-allocated output tensor for top8 normalized scores (must be sharded, shape [16, 16])
+            input_indices_tensor: Input tensor with transposed indices to sort (must be sharded, shape [16, 16])
+            output_indices_tensor: Pre-allocated output tensor for top8 indices (must be sharded, shape [16, 16])
+            eps: Epsilon value for normalization
+            scaling_factor: Scaling factor for normalization
+            enable_sigmoid: Whether to enable sigmoid activation
+
+        Returns:
+            output_tensor with top8 normalized scores (must be sharded, shape [16, 16])
+            output_indices_tensor with top8 indices (must be sharded, shape [16, 16])
+            Note: Only the first 8 values are relevant
+        """
+        # Get tensor properties
+        input_shape = input_tensor.shape
+        bias_shape = bias_tensor.shape
+        output_shape = output_tensor.shape
+        input_indices_shape = input_indices_tensor.shape
+        output_indices_shape = output_indices_tensor.shape
+
+        assert input_shape == output_shape, "Input and output tensors must have the same shape"
+        assert bias_shape == input_shape, "Bias and input tensors must have the same shape"
+        assert input_indices_shape == input_shape, "Input indices and input tensors must have the same shape"
+        assert output_indices_shape == input_shape, "Output indices and input tensors must have the same shape"
+        assert input_shape[0] == 16, f"Height must be 16 for Deepseek Moe Gate, got {input_shape[0]}"
+        assert input_shape[1] == 16, f"Width must be 16 for Deepseek Moe Gate, got {input_shape[1]}"
+
+        # Get tile info from input tensor
+        input_tile = input_tensor.tile
+        input_tile_height, input_tile_width = input_tile.tile_shape
+        input_tile_size = input_tile.get_tile_size(input_tensor.dtype)
+        assert input_tile_height == 16, f"Height must be 16 for Deepseek Moe Gate, got {input_tile_height}"
+        assert input_tile_width == 16, f"Width must be 16 for Deepseek Moe Gate, got {input_tile_width}"
+
+        # Get tile info from bias tensor
+        bias_tile = bias_tensor.tile
+        bias_tile_size = bias_tile.get_tile_size(bias_tensor.dtype)
+
+        # Get tile info from output tensor
+        output_tile = output_tensor.tile
+        output_tile_size = output_tile.get_tile_size(output_tensor.dtype)
+
+        # Get tile info from input indices tensor
+        input_indices_tile = input_indices_tensor.tile
+        input_indices_tile_size = input_indices_tile.get_tile_size(input_indices_tensor.dtype)
+
+        # Get tile info from output indices tensor
+        output_indices_tile = output_indices_tensor.tile
+        output_indices_tile_size = output_indices_tile.get_tile_size(output_indices_tensor.dtype)
+
+        # Get core grid from input tensor (single core)
+        all_cores = input_tensor.memory_config().shard_spec.grid
+        assert all_cores.num_cores() == 1, f"Only single core is supported"
+        assert all_cores == bias_tensor.memory_config().shard_spec.grid
+        assert all_cores == output_tensor.memory_config().shard_spec.grid
+        assert all_cores == input_indices_tensor.memory_config().shard_spec.grid
+        assert all_cores == output_indices_tensor.memory_config().shard_spec.grid
+
+        # CB indices
+        cb_index = 0
+        input_cb = cb_index
+        cb_index += 1
+        bias_cb = cb_index
+        cb_index += 1
+        output_cb = cb_index
+        cb_index += 1
+        input_indices_cb = cb_index
+        cb_index += 1
+        output_indices_cb = cb_index
+        cb_index += 1
+
+        # Create tile descriptors
+        input_tile_descriptor = ttnn.TileDescriptor(input_tile)
+        bias_tile_descriptor = ttnn.TileDescriptor(bias_tile)
+        output_tile_descriptor = ttnn.TileDescriptor(output_tile)
+        input_indices_tile_descriptor = ttnn.TileDescriptor(input_indices_tile)
+        output_indices_tile_descriptor = ttnn.TileDescriptor(output_indices_tile)
+
+        # CB: Input values (created from sharded tensor)
+        in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, input_tensor)
+        in_cb_descriptor.format_descriptors[0].tile = input_tile_descriptor
+        in_cb_descriptor.format_descriptors[0].page_size = input_tile_size
+
+        # CB: Bias values (created from sharded tensor)
+        bias_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bias_cb, bias_tensor)
+        bias_cb_descriptor.format_descriptors[0].tile = bias_tile_descriptor
+        bias_cb_descriptor.format_descriptors[0].page_size = bias_tile_size
+
+        # CB: Output values (created from sharded tensor)
+        out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(output_cb, output_tensor)
+        out_cb_descriptor.format_descriptors[0].tile = output_tile_descriptor
+        out_cb_descriptor.format_descriptors[0].page_size = output_tile_size
+
+        # CB: Input indices (created from sharded tensor)
+        in_indices_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_indices_cb, input_indices_tensor)
+        in_indices_cb_descriptor.format_descriptors[0].tile = input_indices_tile_descriptor
+        in_indices_cb_descriptor.format_descriptors[0].page_size = input_indices_tile_size
+
+        # CB: Output indices (created from sharded tensor)
+        out_indices_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(output_indices_cb, output_indices_tensor)
+        out_indices_cb_descriptor.format_descriptors[0].tile = output_indices_tile_descriptor
+        out_indices_cb_descriptor.format_descriptors[0].page_size = output_indices_tile_size
+
+        # Reader kernel
+        reader_compile_time_args = [
+            input_cb,
+            bias_cb,
+            input_indices_cb,
+        ]
+
+        reader_kernel_descriptor = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_reader.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=all_cores,
+            compile_time_args=reader_compile_time_args,
+            config=ttnn.ReaderConfigDescriptor(),
+        )
+
+        # Writer kernel
+        writer_compile_time_args = [
+            output_cb,
+            output_indices_cb,
+        ]
+
+        writer_kernel_descriptor = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_writer.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=all_cores,
+            compile_time_args=writer_compile_time_args,
+            config=ttnn.WriterConfigDescriptor(),
+        )
+
+        # Compute kernel
+        compute_compile_time_args = [
+            input_cb,
+            bias_cb,
+            input_indices_cb,
+            output_cb,
+            output_indices_cb,
+            float_to_uint32(eps),
+            float_to_uint32(scaling_factor),
+            enable_sigmoid,
+        ]
+
+        compute_kernel_descriptor = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_compute.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=all_cores,
+            compile_time_args=compute_compile_time_args,
+            config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.HiFi4,  # Makes no difference for this operation
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+        )
+
+        # Create program descriptor
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=[reader_kernel_descriptor, writer_kernel_descriptor, compute_kernel_descriptor],
+            cbs=[
+                in_cb_descriptor,
+                bias_cb_descriptor,
+                out_cb_descriptor,
+                in_indices_cb_descriptor,
+                out_indices_cb_descriptor,
+            ],
+        )
+
+        # Execute generic op
+        io_tensors = [input_tensor, bias_tensor, input_indices_tensor, output_tensor, output_indices_tensor]
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output_tensor, output_indices_tensor

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.deepseek_moe_gate.op import DeepseekMoeGateSingleCore
+
+
+@pytest.mark.parametrize("enable_sigmoid", [True, False])
+@pytest.mark.parametrize("seed", [42, 201, 512])
+def test_deepseek_moe_gate(device, enable_sigmoid, seed):
+    """Test TTNN Deepseek Moe Gate operation on a 16x16 tile"""
+
+    # Tensor dimensions - full 32x32 tile
+    input_shape = (8, 32)
+    reshaped_input_shape = (16, 16)
+    tile = ttnn.Tile([16, 16])
+
+    logger.info(f"Testing Deepseek Moe Gate with input shape {input_shape}")
+    logger.info(f"Tile size: {tile.tile_shape}")
+
+    # Create input PyTorch tensor with random values
+    torch.manual_seed(seed)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    if not enable_sigmoid:
+        torch_input = torch.sigmoid(torch_input)
+    torch_bias = torch.randn(input_shape, dtype=torch.bfloat16)
+    eps = 1e-20
+    scaling_factor = 2.5
+
+    # Compute reference output using PyTorch
+    top8_scores, top8_indices = DeepseekMoeGateSingleCore.golden(
+        torch_input, torch_bias, eps, scaling_factor, enable_sigmoid
+    )
+
+    # Shard spec: single core
+    shard_shape = reshaped_input_shape
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    # Create input values tensor sharded on single core
+    reshaped_input = torch.reshape(torch_input, reshaped_input_shape)
+    ttnn_input = ttnn.from_torch(
+        reshaped_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=tile,
+    )
+
+    reshaped_bias = torch.transpose(torch.reshape(torch_bias, reshaped_input_shape), 0, 1)
+    ttnn_bias = ttnn.from_torch(
+        reshaped_bias,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=tile,
+    )
+
+    torch_input_indices = torch.arange(reshaped_input_shape[0] * reshaped_input_shape[1], dtype=torch.int32)
+    torch_input_indices = torch_input_indices.reshape(reshaped_input_shape)
+    torch_input_indices = torch.transpose(torch_input_indices, 0, 1).to(torch.uint16)
+
+    ttnn_input_indices = ttnn.from_torch(
+        torch_input_indices,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=tile,
+    )
+
+    # Create output tensor sharded on same core
+    torch_output = torch.zeros(reshaped_input_shape, dtype=torch.bfloat16)
+    ttnn_output = ttnn.from_torch(
+        torch_output,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=tile,
+    )
+
+    torch_output_indices = torch.zeros(reshaped_input_shape, dtype=torch.uint16)
+    ttnn_output_indices = ttnn.from_torch(
+        torch_output_indices,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        tile=tile,
+    )
+
+    logger.info(f"Created tensors sharded on single core with shard shape {shard_shape}")
+
+    # Run Deepseek Moe Gate operation
+    logger.info("Running Deepseek Moe Gate operation...")
+    ttnn_result, ttnn_result_indices = DeepseekMoeGateSingleCore.op(
+        ttnn_input,
+        ttnn_bias,
+        ttnn_output,
+        ttnn_input_indices,
+        ttnn_output_indices,
+        eps,
+        scaling_factor,
+        enable_sigmoid,
+    )
+
+    # Convert back to torch for verification
+    output_torch = ttnn.to_torch(ttnn_result)
+    output_indices_torch = ttnn.to_torch(ttnn_result_indices)
+
+    output_torch = output_torch[0, :8]
+    output_indices_torch = output_indices_torch[0, :8]
+
+    sorted_output_indices_torch, i = torch.sort(output_indices_torch, dim=-1)
+    sorted_output_torch = output_torch[i]
+
+    top8_indices, i = torch.sort(top8_indices, dim=-1)
+    top8_scores = top8_scores[i]
+
+    assert torch.equal(sorted_output_indices_torch, top8_indices), "Output indices do not match"
+    assert torch.allclose(sorted_output_torch, top8_scores, atol=1e-2, rtol=1e-4), "Output scores do not match"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34755

### Problem description
The original `deepseek_grouped_gate` op takes over 50us. We need a performant version that works with tiny tiles.

### What's changed
Implement a fused sfpu/fpu llk for deepseek grouped gate. This runs entirely in trisc and does not spill/reload/use noc.
New implementation is ~1.2us with sigmoid, and ~900ns without. In the final fused megakernel for deepseek, sigmoid should be fused with the preceeding matmul instead of gate for performance.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/gate)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/gate)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/gate)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/gate)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/gate)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/gate)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs