### PR TITLE
ci: Change pr-gate default build-type from ASanCoverage to ASan

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -23,7 +23,7 @@ on:
     inputs:
       build-type:
         required: false
-        default: ASanCoverage
+        default: ASan
         type: choice
         options:
           - Release
@@ -77,7 +77,7 @@ jobs:
     with:
       version: "22.04"
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
-      build-type: ${{ inputs.build-type || 'ASanCoverage' }}
+      build-type: ${{ inputs.build-type || 'ASan' }}
       publish-artifact: false
       skip-tt-train: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}


### PR DESCRIPTION
### Ticket
N/A - CI configuration improvement

### Problem description
The PR gate workflow currently defaults to `ASanCoverage` build type, which includes coverage instrumentation overhead. For standard PR validation, using plain `ASan` (AddressSanitizer without coverage) provides faster builds while still catching memory issues.

### What's changed
- Changed the default `build-type` input from `ASanCoverage` to `ASan` in the workflow dispatch
- Updated the fallback default in the build job from `ASanCoverage` to `ASan`

This reduces PR gate build times by removing unnecessary coverage instrumentation while maintaining memory safety checks.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ci/pr-gate-default-build-type-asan)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ci/pr-gate-default-build-type-asan)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci/pr-gate-default-build-type-asan)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci/pr-gate-default-build-type-asan)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/pr-gate-default-build-type-asan)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/pr-gate-default-build-type-asan)
- [x] New/Existing tests provide coverage for changes (CI workflow change, validated by CI itself)