### PR TITLE
[skip ci] Add suite-level device fixture to reduce CI overhead

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -80,7 +80,7 @@ struct CreateTensorParams {
 
 }  // namespace
 
-class CreateTensorTest : public ttnn::TTNNFixtureWithDevice,
+class CreateTensorTest : public ttnn::TTNNFixtureWithSuiteDevice<CreateTensorTest>,
                          public ::testing::WithParamInterface<CreateTensorParams> {};
 
 TEST_P(CreateTensorTest, Tile) {
@@ -105,7 +105,7 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& value) 
 
 using CombinationInputParams =
     std::tuple<ttnn::Shape, tt::tt_metal::DataType, tt::tt_metal::Layout, tt::tt_metal::MemoryConfig>;
-class EmptyTensorTest : public ttnn::TTNNFixtureWithDevice,
+class EmptyTensorTest : public ttnn::TTNNFixtureWithSuiteDevice<EmptyTensorTest>,
                         public ::testing::WithParamInterface<CombinationInputParams> {};
 
 TEST_P(EmptyTensorTest, Combinations) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
@@ -35,7 +35,7 @@ struct CreateTensorParams {
 
 }  // namespace
 
-class CreateTensorWithLayoutTest : public ttnn::TTNNFixtureWithDevice,
+class CreateTensorWithLayoutTest : public ttnn::TTNNFixtureWithSuiteDevice<CreateTensorWithLayoutTest>,
                                    public ::testing::WithParamInterface<CreateTensorParams> {};
 
 TEST_P(CreateTensorWithLayoutTest, Tile) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -96,7 +96,7 @@ TensorSpec get_nd_sharding_tensor_spec(
 }  // namespace
 
 class NDShardingTests
-    : public ttnn::TTNNFixtureWithDevice,
+    : public ttnn::TTNNFixtureWithSuiteDevice<NDShardingTests>,
       public ::testing::WithParamInterface<std::tuple<NDShardingParams, BufferType, ShardOrientation>> {};
 
 TEST_P(NDShardingTests, LoopbackTest) {
@@ -211,7 +211,7 @@ TEST_P(NdToLegacyShardingTests, NdToLegacySharding) {
     }
 }
 
-class NdShardingOpCompatTests : public ttnn::TTNNFixtureWithDevice,
+class NdShardingOpCompatTests : public ttnn::TTNNFixtureWithSuiteDevice<NdShardingOpCompatTests>,
                                 public ::testing::WithParamInterface<NDShardingOpCompatParams> {};
 
 TEST_P(NdShardingOpCompatTests, TestAdd) {
@@ -298,7 +298,7 @@ TEST_F(NDShardingPerfTests, TestBatchShardingPerf) {
     EXPECT_TRUE(small_shards_nd_sharding_time_ns < block_2d_sharding_time_ns * 6);
 }
 
-class NDShardingBufferSizeTests : public ttnn::TTNNFixtureWithDevice,
+class NDShardingBufferSizeTests : public ttnn::TTNNFixtureWithSuiteDevice<NDShardingBufferSizeTests>,
                                   public ::testing::WithParamInterface<NDShardingBufferSizeParams> {};
 
 TEST_P(NDShardingBufferSizeTests, TestBufferSize) {

--- a/tests/ttnn/unit_tests/gtests/test_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_add.cpp
@@ -47,7 +47,6 @@ TEST_P(Add1DTensorAndScalarFixture, AddsScalarCorrectly) {
         TT_FATAL(
             ttnn::allclose<::bfloat16>(ttnn::from_device(expected_tensor), ttnn::from_device(output_tensor)), "Error");
     }
-    ttnn::close_device(device);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/ttnn/unit_tests/gtests/test_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_add.cpp
@@ -31,7 +31,7 @@ struct Add1DTensorAndScalarParam {
     uint32_t w;
 };
 
-class Add1DTensorAndScalarFixture : public TTNNFixtureWithDevice,
+class Add1DTensorAndScalarFixture : public TTNNFixtureWithSuiteDevice<Add1DTensorAndScalarFixture>,
                                     public testing::WithParamInterface<Add1DTensorAndScalarParam> {};
 
 TEST_P(Add1DTensorAndScalarFixture, AddsScalarCorrectly) {

--- a/tests/ttnn/unit_tests/gtests/test_add_int.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_add_int.cpp
@@ -32,7 +32,8 @@ struct AddUnaryParam {
     uint32_t w;
 };
 
-class AddUnaryFixture : public TTNNFixtureWithDevice, public testing::WithParamInterface<AddUnaryParam> {};
+class AddUnaryFixture : public TTNNFixtureWithSuiteDevice<AddUnaryFixture>,
+                        public testing::WithParamInterface<AddUnaryParam> {};
 
 TEST_P(AddUnaryFixture, CompareWithTorchReference) {
     auto param = GetParam();

--- a/tests/ttnn/unit_tests/gtests/test_broadcast_to.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_broadcast_to.cpp
@@ -36,8 +36,6 @@ TEST_P(Broadcast_toFixture, Broadcast_to) {
     auto output_tensor = ttnn::experimental::broadcast_to(input_tensor, output_shape, memory_config, output);
     const auto expected_tensor = ttnn::full(output_shape, 1, DataType::BFLOAT16, ttnn::TILE_LAYOUT, device);
     TT_FATAL(ttnn::allclose<::bfloat16>(ttnn::from_device(expected_tensor), ttnn::from_device(output_tensor)), "Error");
-
-    ttnn::close_device(device);
 }
 
 // Spatial dimension broadcasts (H and W)

--- a/tests/ttnn/unit_tests/gtests/test_broadcast_to.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_broadcast_to.cpp
@@ -19,7 +19,8 @@ struct BroadcastParam {
     std::vector<uint32_t> broadcast_shape;
 };
 
-class Broadcast_toFixture : public TTNNFixtureWithDevice, public testing::WithParamInterface<BroadcastParam> {};
+class Broadcast_toFixture : public TTNNFixtureWithSuiteDevice<Broadcast_toFixture>,
+                            public testing::WithParamInterface<BroadcastParam> {};
 
 TEST_P(Broadcast_toFixture, Broadcast_to) {
     auto param = GetParam();

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -52,7 +52,7 @@ struct AddOpGraphTestParam {
 };
 
 class AddOpGraphTestFixture
-    : public TTNNFixtureWithDevice,
+    : public TTNNFixtureWithSuiteDevice<AddOpGraphTestFixture>,
       public testing::WithParamInterface<std::tuple<AddOpGraphTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(AddOpGraphTestFixture, AddGraphTrace) {

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -49,7 +49,7 @@ struct BufferTestParam {
 };
 
 class BufferTestFixture
-    : public TTNNFixtureWithDevice,
+    : public TTNNFixtureWithSuiteDevice<BufferTestFixture>,
       public testing::WithParamInterface<std::tuple<BufferTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
 
 TEST_P(BufferTestFixture, BufferTest) {

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -192,7 +192,7 @@ const auto g_block_shard_1_1_1600_256_tiled_to_32_cores = ttnn::TensorSpec(
 // Unary tests
 // ============================================================================
 
-class EltwiseUnaryOpIfTest : public TTNNFixtureWithDevice,
+class EltwiseUnaryOpIfTest : public TTNNFixtureWithSuiteDevice<EltwiseUnaryOpIfTest>,
                              public testing::WithParamInterface<std::tuple<ttnn::TensorSpec>> {};
 
 TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
@@ -407,7 +407,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Softmax tests
 // ============================================================================
 
-class SoftmaxOpIfTest : public TTNNFixtureWithDevice,
+class SoftmaxOpIfTest : public TTNNFixtureWithSuiteDevice<SoftmaxOpIfTest>,
                         public testing::WithParamInterface<std::tuple<ttnn::TensorSpec, int>> {};
 
 TEST_P(SoftmaxOpIfTest, Softmax) {
@@ -462,7 +462,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Binary tests
 // ============================================================================
 
-class EltwiseBinaryOpIfTest : public TTNNFixtureWithDevice,
+class EltwiseBinaryOpIfTest : public TTNNFixtureWithSuiteDevice<EltwiseBinaryOpIfTest>,
                               public testing::WithParamInterface<std::tuple<ttnn::TensorSpec, ttnn::TensorSpec>> {};
 
 TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
@@ -689,7 +689,7 @@ INSTANTIATE_TEST_SUITE_P(
 // ============================================================================
 
 class MatmulOpIfTest
-    : public TTNNFixtureWithDevice,
+    : public TTNNFixtureWithSuiteDevice<MatmulOpIfTest>,
       public testing::WithParamInterface<
           std::
               tuple<ttnn::TensorSpec, ttnn::TensorSpec, std::optional<ttnn::operations::matmul::MatmulProgramConfig>>> {
@@ -791,7 +791,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .fused_activation = std::nullopt})));
 
 class Conv2dOpIfTest
-    : public ttnn::TTNNFixtureWithDevice,
+    : public ttnn::TTNNFixtureWithSuiteDevice<Conv2dOpIfTest>,
       public ::testing::WithParamInterface<std::optional<ttnn::operations::conv::conv2d::Conv2dConfig>> {};
 
 TEST_P(Conv2dOpIfTest, Conv2d) {

--- a/tests/ttnn/unit_tests/gtests/test_relational_int.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_relational_int.cpp
@@ -33,7 +33,7 @@ struct RelationalUnaryParam {
     uint32_t w;
 };
 
-class RelationalUnaryFixture : public TTNNFixtureWithDevice,
+class RelationalUnaryFixture : public TTNNFixtureWithSuiteDevice<RelationalUnaryFixture>,
                                public testing::WithParamInterface<RelationalUnaryParam> {};
 
 static ttnn::Tensor make_int_tensor(ttnn::MeshDevice& device, uint32_t h, uint32_t w, int32_t fill_value) {

--- a/tests/ttnn/unit_tests/gtests/test_rsub_int.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_rsub_int.cpp
@@ -32,7 +32,8 @@ struct RsubUnaryParam {
     uint32_t w;
 };
 
-class RsubUnaryFixture : public TTNNFixtureWithDevice, public testing::WithParamInterface<RsubUnaryParam> {};
+class RsubUnaryFixture : public TTNNFixtureWithSuiteDevice<RsubUnaryFixture>,
+                         public testing::WithParamInterface<RsubUnaryParam> {};
 
 TEST_P(RsubUnaryFixture, CompareWithTorchReference) {
     auto param = GetParam();

--- a/tests/ttnn/unit_tests/gtests/test_sub_int.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_sub_int.cpp
@@ -32,7 +32,8 @@ struct SubUnaryParam {
     uint32_t w;
 };
 
-class SubUnaryFixture : public TTNNFixtureWithDevice, public testing::WithParamInterface<SubUnaryParam> {};
+class SubUnaryFixture : public TTNNFixtureWithSuiteDevice<SubUnaryFixture>,
+                        public testing::WithParamInterface<SubUnaryParam> {};
 
 TEST_P(SubUnaryFixture, CompareWithTorchReference) {
     auto param = GetParam();

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -66,6 +66,41 @@ protected:
         TTNNFixtureBase(trace_region_size, l1_small_size) {}
 };
 
+// CRTP-based fixture that shares the device across all tests in a parameterized test suite.
+// Each derived class gets its own static device instance, providing isolation between suites
+// while avoiding repeated device init/teardown within a suite.
+//
+// Usage:
+//   class MyTests : public TTNNFixtureWithSuiteDevice<MyTests>,
+//                   public ::testing::WithParamInterface<MyParams> {};
+//
+template <typename Derived>
+class TTNNFixtureWithSuiteDevice : public TTNNFixtureBase {
+protected:
+    static tt::tt_metal::distributed::MeshDevice* device_;
+    static std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+
+public:
+    static void SetUpTestSuite() {
+        device_holder_ = ttnn::open_mesh_device(/*device_id=*/0, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE);
+        device_ = device_holder_.get();
+    }
+
+    static void TearDownTestSuite() {
+        if (device_holder_) {
+            device_holder_->close();
+            device_holder_.reset();
+            device_ = nullptr;
+        }
+    }
+};
+
+template <typename Derived>
+tt::tt_metal::distributed::MeshDevice* TTNNFixtureWithSuiteDevice<Derived>::device_ = nullptr;
+
+template <typename Derived>
+std::shared_ptr<tt::tt_metal::distributed::MeshDevice> TTNNFixtureWithSuiteDevice<Derived>::device_holder_ = nullptr;
+
 class MultiCommandQueueSingleDeviceFixture : public TTNNFixtureBase {
 protected:
     tt::tt_metal::distributed::MeshDevice* device_ = nullptr;

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -76,6 +76,10 @@ protected:
 //
 template <typename Derived>
 class TTNNFixtureWithSuiteDevice : public TTNNFixtureBase {
+    friend Derived;
+
+    TTNNFixtureWithSuiteDevice() = default;
+
 protected:
     static tt::tt_metal::distributed::MeshDevice* device_;
     static std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;


### PR DESCRIPTION
### Ticket
N/A - CI optimization

### Problem description
Parameterized gtests using `TTNNFixtureWithDevice` were reinitializing the device for **every single test case**, causing significant CI overhead. For example, `NDShardingTests` with 132 parameter combinations × 2 tests was triggering 264 complete device init/teardown cycles.

Each cycle included:
- Firmware bundle version establishment (~350ms overhead)
- Watcher attach/detach
- Auto-discovery mesh graph generation
- Control plane construction
- TopologyMapper initialization

This was visible in CI logs as repeated messages like:
```
[ RUN      ] TensorShardingTests/NDShardingTests.RegionWriteReadTest/34
2026-01-13 20:12:19.768 | info | UMD | Established firmware bundle version: 18.7.0
2026-01-13 20:12:19.798 | info | LLRuntime | Watcher thread stopped watching...
2026-01-13 20:12:19.810 | info | Distributed | Using auto discovery to generate mesh graph.
...
```

### What's changed
Added `TTNNFixtureWithSuiteDevice<T>` - a CRTP-based test fixture template that shares device initialization across all test cases in a parameterized test suite, rather than reinitializing for each test case.

**Key design decisions:**
- Uses CRTP pattern so each test class gets its own static device instance
- Provides isolation between different test suites (different suites still get separate devices)
- Uses `SetUpTestSuite()` / `TearDownTestSuite()` for suite-level lifecycle
- Drop-in replacement for `TTNNFixtureWithDevice` in parameterized tests

**Updated 17 parameterized test classes across 12 files:**

| File | Test Classes |
|------|-------------|
| `ttnn_test_fixtures.hpp` | Added `TTNNFixtureWithSuiteDevice<T>` template |
| `test_graph_query_op_constraints.cpp` | `EltwiseUnaryOpIfTest`, `SoftmaxOpIfTest`, `EltwiseBinaryOpIfTest`, `MatmulOpIfTest`, `Conv2dOpIfTest` |
| `test_graph_basic.cpp` | `BufferTestFixture` |
| `test_graph_add.cpp` | `AddOpGraphTestFixture` |
| `test_add.cpp` | `Add1DTensorAndScalarFixture` |
| `test_add_int.cpp` | `AddUnaryFixture` |
| `test_sub_int.cpp` | `SubUnaryFixture` |
| `test_rsub_int.cpp` | `RsubUnaryFixture` |
| `test_relational_int.cpp` | `RelationalUnaryFixture` |
| `test_broadcast_to.cpp` | `Broadcast_toFixture` |
| `tensor/test_create_tensor.cpp` | `CreateTensorTest`, `EmptyTensorTest` |
| `tensor/test_create_tensor_with_layout.cpp` | `CreateTensorWithLayoutTest` |
| `tensor/test_tensor_nd_sharding.cpp` | `NDShardingTests`, `NdShardingOpCompatTests`, `NDShardingBufferSizeTests` |

**Expected CI impact:**
- Before: Device init/teardown for each parameterized test case (hundreds of cycles)
- After: Device init once per test suite, teardown once at end
- Estimated savings: Several minutes per `ttnn-basic-tests` run in merge gate

### Measured CI Impact
- 2 minutes reduction in test time for every run of ttnn-basic-tests in merge gate

### Checklist

- [x] [Merge Gate](https://github.com/tenstorrent/tt-metal/actions/runs/20974213060) is faster
- [x] New/Existing tests provide coverage for changes