### PR TITLE
[DM]: Removing unused `mesh_device` parameter

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.cpp
@@ -35,7 +35,7 @@ L1AddressInfo get_l1_address_and_size(
     // return {HARDCODED_L1_MEMORY_BASE_ADDRESS, HARDCODED_L1_MEMORY_SIZE_BYTES};
 }
 
-DramAddressInfo get_dram_address_and_size(const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/) {
+DramAddressInfo get_dram_address_and_size() {
     // Obtaining DRAM address and size //
 
     auto dram_base_address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);

--- a/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/dm_common.hpp
@@ -31,7 +31,7 @@ struct DramAddressInfo {
 };
 
 // Function to get DRAM address and size
-DramAddressInfo get_dram_address_and_size(const std::shared_ptr<distributed::MeshDevice>& mesh_device);
+DramAddressInfo get_dram_address_and_size();
 
 // Function to compute physical constraints
 std::tuple<uint32_t, uint32_t, uint32_t> compute_physical_constraints(

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -45,7 +45,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramCo
     const size_t total_size_bytes = test_config.pages_per_transaction * test_config.bytes_per_page;
 
     // DRAM Address
-    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size(mesh_device);
+    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
 
     uint32_t input_dram_address = dram_info.base_address;
     uint32_t output_dram_address = input_dram_address + total_size_bytes;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35458)

### Problem description
`mesh_device` parameter is no longer used in the `get_dram_address_and_size` API in `tests/tt_metal/tt_metal/data_movement/dm_common.cpp`. It is being commented out by https://github.com/tenstorrent/tt-metal/pull/35433, but we can remove it altogether.

### What's changed
Removed `mesh_device` parameter from API declaration and in all calls to the API.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=atuzuner/DM_remove_parameter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:atuzuner/DM_remove_parameter)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=atuzuner/DM_remove_parameter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:atuzuner/DM_remove_parameter)
- [x] [![DM test suite](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-data-movement-wrapper.yaml/badge.svg?branch=atuzuner/DM_remove_parameter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-data-movement-wrapper.yaml?query=branch:atuzuner/DM_remove_parameter)