### PR TITLE
Fix N150 profiler

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -843,7 +843,7 @@ def test_dispatch_cores_extended_worker():
 
     verify_stats(
         run_device_profiler_test(
-            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py",
+            testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops -k DispatchCoreType.WORKER",
             setupAutoExtract=False,
             doDispatchCores=True,
         ),

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -813,8 +813,8 @@ def test_dispatch_cores_extended_worker():
     REF_COUNT_DICT = {
         "Tensix CQ Dispatch*": [9325],
         "Tensix CQ Prefetch": [9325],
-        "dispatch_total_cq_cmd_op_time": [223],
-        "dispatch_go_send_wait_time": [223],
+        "dispatch_total_cq_cmd_op_time": [87],
+        "dispatch_go_send_wait_time": [87],
     }
 
     verify_stats(


### PR DESCRIPTION
### Problem description
Dispatch profiler op count is not breaking

### Solution
Only look at op count

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mo/fix_n150_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mo/fix_n150_profiler)
- [x] [Profiler CI ](https://github.com/tenstorrent/tt-metal/actions/runs/20968717406)
- [x] [Profiler CI galaxy](https://github.com/tenstorrent/tt-metal/actions/runs/20972207409)