### PR TITLE
fix: Add [[maybe_unused]] to benchmark loop variables to silence clang static analyzer

### DIFF
--- a/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
+++ b/tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp
@@ -40,7 +40,7 @@ void BM_DistributedHostBufferSequentialTransform(benchmark::State& state) {
     auto buffer = create_distributed_host_buffer(state.range(0));
     auto transform_fn = get_transform_fn();
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto transformed_buffer =
             buffer.transform(transform_fn, DistributedHostBuffer::ProcessShardExecutionPolicy::SEQUENTIAL);
         benchmark::DoNotOptimize(transformed_buffer);
@@ -51,7 +51,7 @@ void BM_DistributedHostBufferParallelTransform(benchmark::State& state) {
     auto buffer = create_distributed_host_buffer(state.range(0));
     auto transform_fn = get_transform_fn();
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto transformed_buffer =
             buffer.transform(transform_fn, DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
         benchmark::DoNotOptimize(transformed_buffer);

--- a/tests/tt_metal/distributed/benchmark_thread_pool.cpp
+++ b/tests/tt_metal/distributed/benchmark_thread_pool.cpp
@@ -13,7 +13,7 @@ static void BM_ThreadPool(benchmark::State& state, ThreadPoolCreator create_thre
 
     auto thread_pool = create_thread_pool(num_threads);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         uint64_t NUM_ITERS = state.range(0);
 
         auto work = []() { std::this_thread::sleep_for(std::chrono::microseconds(20)); };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -89,7 +89,7 @@ static void BM_write(
         DeviceLocalBufferConfig{.page_size = page_size, .buffer_type = buffer_type},
         mesh_device.get());
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), device_buffer, host_buffer, true);
     }
 
@@ -116,7 +116,7 @@ static void BM_read(benchmark::State& state, const std::shared_ptr<MeshDevice>& 
         mesh_device.get());
     std::vector<ElementType> host_buffer;
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         // EnqueueReadMeshBuffer cannot read from a replicated buffer yet, have to use ReadShard
         ReadShard(mesh_device->mesh_command_queue(), host_buffer, device_buffer, MeshCoordinate(0, 0), true);
     }

--- a/tests/ttnn/benchmark/cpp/benchmark_host_alloc_on_tensor_readback.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_host_alloc_on_tensor_readback.cpp
@@ -27,7 +27,7 @@ void BM_host_alloc_on_tensor_readback(benchmark::State& state) {
         device);
 
     // Note we are reading garbage data from the device, but it is not important for this benchmark.
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto host_tensor = device_tensor.cpu(/*blocking=*/true);
         benchmark::DoNotOptimize(host_tensor);
     }

--- a/tests/ttnn/benchmark/cpp/benchmark_host_dtype_conversion.cpp
+++ b/tests/ttnn/benchmark/cpp/benchmark_host_dtype_conversion.cpp
@@ -37,7 +37,7 @@ void BM_host_bfloat8_conversion(benchmark::State& state) {
     }
     auto tensor = ttnn::distributed::from_host_shards(tensors, device->shape());
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto converted_tensor = ttnn::to_dtype(tensor, ttnn::DataType::BFLOAT8_B);
         benchmark::DoNotOptimize(converted_tensor);
     }

--- a/tests/ttnn/benchmark/cpp/host_tilizer_untilizer/tilizer_untilizer.cpp
+++ b/tests/ttnn/benchmark/cpp/host_tilizer_untilizer/tilizer_untilizer.cpp
@@ -32,7 +32,7 @@ const std::vector<float>& GetInputData() {
 // Benchmark for LIN_ROW_MAJOR -> TILED_SWIZZLED
 void BM_ConvertLayout_RowMajorToTiledSwizzled(benchmark::State& state) {
     const auto& input_data = GetInputData();
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(input_data),
             shape,
@@ -46,7 +46,7 @@ void BM_ConvertLayout_RowMajorToTiledSwizzled(benchmark::State& state) {
 // Benchmark for LIN_ROW_MAJOR -> TILED_NFACES
 void BM_ConvertLayout_RowMajorToTiledNfaces(benchmark::State& state) {
     const auto& input_data = GetInputData();
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(input_data),
             shape,
@@ -64,7 +64,7 @@ void BM_ConvertLayout_TiledSwizzledToRowMajor(benchmark::State& state) {
     static std::vector<float> tiled_data = convert_layout<float>(
         tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(tiled_data),
             shape,
@@ -82,7 +82,7 @@ void BM_ConvertLayout_TiledSwizzledToTiledNFaces(benchmark::State& state) {
     static std::vector<float> tiled_data = convert_layout<float>(
         tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(tiled_data),
             shape,
@@ -100,7 +100,7 @@ void BM_ConvertLayout_TiledNFacesToRowMajor(benchmark::State& state) {
     static std::vector<float> nfaces_data = convert_layout<float>(
         tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(nfaces_data),
             shape,
@@ -118,7 +118,7 @@ void BM_ConvertLayout_TiledNFacesToTiledSwizzled(benchmark::State& state) {
     static std::vector<float> nfaces_data = convert_layout<float>(
         tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = convert_layout<float>(
             tt::stl::make_const_span(nfaces_data),
             shape,

--- a/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
+++ b/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
@@ -552,7 +552,7 @@ void BM_Matmul_BFLOAT16(benchmark::State& state) {
     const auto device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id, /*l1_small_size=*/200000, /*trace_region_size=*/65536);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         RunMatmulBenchmark(state, test_config, matmul_shape, device, device_id);
     }
 
@@ -693,7 +693,7 @@ void BM_Matmul_BFLOAT8_B(benchmark::State& state) {
     const auto device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id, /*l1_small_size=*/200000, /*trace_region_size=*/65536);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         RunMatmulBenchmark(state, test_config, matmul_shape, device, device_id);
     }
 
@@ -840,7 +840,7 @@ void BM_Matmul_BFLOAT4_B(benchmark::State& state) {
     const auto device_id = 0;
     auto device = ttnn::device::open_mesh_device(device_id, /*l1_small_size=*/200000, /*trace_region_size=*/65536);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         RunMatmulBenchmark(state, test_config, matmul_shape, device, device_id);
     }
     // Close device

--- a/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
+++ b/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
@@ -62,7 +62,7 @@ void BM_where_experimental_bf16_ttt(benchmark::State& state) {
 
     auto output = ttnn::operations::experimental::ternary::where(cond_tensor, true_value_tensor, false_value_tensor);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = ttnn::operations::experimental::ternary::where(cond_tensor, true_value_tensor, false_value_tensor);
         tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
         benchmark::DoNotOptimize(out);
@@ -92,7 +92,7 @@ void BM_where_bf16_ttt(benchmark::State& state) {
 
     auto output = ttnn::where(cond_tensor, true_value_tensor, false_value_tensor);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = ttnn::where(cond_tensor, true_value_tensor, false_value_tensor);
         tt::tt_metal::distributed::Synchronize(dev_ptr, std::nullopt);
         benchmark::DoNotOptimize(out);

--- a/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
+++ b/tests/ttnn/benchmark/cpp/padding/pad_rm.cpp
@@ -40,7 +40,7 @@ void BM_pad_rm_2d_last_dim_right(benchmark::State& state) {
     ttnn::SmallVector<uint32_t> padded_shape = {8192, 8192};
     ttnn::SmallVector<uint32_t> tensor_start = {0, 0};
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
             ttnn::Shape(padded_shape),
             ttnn::Shape(tensor_start),
@@ -55,7 +55,7 @@ void BM_pad_rm_2d_last_dim_left_right(benchmark::State& state) {
     ttnn::SmallVector<uint32_t> padded_shape = {8192, 8192};
     ttnn::SmallVector<uint32_t> tensor_start = {0, 92};
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
             ttnn::Shape(padded_shape),
             ttnn::Shape(tensor_start),
@@ -70,7 +70,7 @@ void BM_pad_rm_4d_last_dim_left_right(benchmark::State& state) {
     ttnn::SmallVector<uint32_t> padded_shape = {16, 20 + 12, 512 + 30, 500 + 30};
     ttnn::SmallVector<uint32_t> tensor_start = {0, 1, 3, 4};
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
             ttnn::Shape(padded_shape),
             ttnn::Shape(tensor_start),
@@ -88,7 +88,7 @@ void BM_pad_rm_2d_scaling(benchmark::State& state) {
     ttnn::SmallVector<uint32_t> padded_shape = {8192, N_padded};
     ttnn::SmallVector<uint32_t> tensor_start = {0, 100};
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto out = input_tensor.pad(
             ttnn::Shape(padded_shape),
             ttnn::Shape(tensor_start),

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -96,7 +96,7 @@ TestResult mem_bench_page_sizing(benchmark::State& state) {
     auto hugepage_size = get_hugepage_size(device_id);
     bool cached = state.range(2);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         const double iteration_time =
             cached ? copy_to_hugepage(hugepage, hugepage_size, src_data, ctx.total_size, ctx.page_size, true)
                    : copy_to_hugepage(hugepage, hugepage_size, src_data, ctx.total_size, ctx.page_size, false);
@@ -132,7 +132,7 @@ TestResult mem_bench_copy_multithread(benchmark::State& state) {
     const auto bytes_per_thread = ((ctx.total_size / ctx.threads) + (MEMCPY_ALIGNMENT)-1) & -(MEMCPY_ALIGNMENT);
     const auto last_thread_bytes = ctx.total_size - (bytes_per_thread * (ctx.threads - 1));
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto iteration_time = execute_work_synced_start(
             ctx.threads,
             [&](int thread_idx) {
@@ -185,7 +185,7 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     auto* hugepage = get_hugepage(device->id(), 0);
     auto hugepage_size = get_hugepage_size(device->id());
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto pgm = CreateProgram();
         std::optional<CoreRange> configured_cores;
         if (ctx.number_reader_kernels) {
@@ -254,7 +254,7 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
     auto* host_hugepage = get_hugepage(device->id() + 1, 0);
     auto host_hugepage_size = get_hugepage_size(device->id() + 1);
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto pgm = CreateProgram();
         auto configured_cores =
             configure_kernels(device, pgm, ctx, 0, ctx.number_reader_kernels, false, device_hugepage_size).value();
@@ -295,7 +295,7 @@ TestResult mem_bench_multi_mmio_devices(
 
     // One thread to wait for program on each device
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         std::map<int, Program> programs;                  // device : programs
         std::map<int, CoreRange> configured_core_ranges;  // device : cores
         for (auto [device_id, device] : devices) {
@@ -412,7 +412,7 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
     // Writers will have 0 bytes read. Will not mix.
     TestResult results;
 
-    for (auto _ : state) {
+    for ([[maybe_unused]] auto _ : state) {
         auto pgm = CreateProgram();
         auto configured_read_cores =
             configure_kernels(device, pgm, ctx, 0, ctx.number_reader_kernels, false, hugepage_size / 2).value();


### PR DESCRIPTION
### Ticket
N/A - Code quality improvement

### Problem description
The clang static analyzer reports warnings for the pattern `for (auto _ : state)` used in Google Benchmark iteration loops. The analyzer correctly identifies that the loop variable `_` is unused, but this is intentional - benchmark loops use this pattern to iterate over the benchmark state without needing the iteration value.

### What's changed
Added `[[maybe_unused]]` attribute to all benchmark loop variables to suppress the clang static analyzer warnings:

```cpp
// Before:
for (auto _ : state)

// After:
for ([[maybe_unused]] auto _ : state)
```

**Files modified (10 files, 28 occurrences):**
- `tests/tt_metal/distributed/benchmark_distributed_host_buffer.cpp` (2)
- `tests/tt_metal/distributed/benchmark_thread_pool.cpp` (1)
- `tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp` (2)
- `tests/ttnn/benchmark/cpp/benchmark_host_alloc_on_tensor_readback.cpp` (1)
- `tests/ttnn/benchmark/cpp/benchmark_host_dtype_conversion.cpp` (1)
- `tests/ttnn/benchmark/cpp/host_tilizer_untilizer/tilizer_untilizer.cpp` (6)
- `tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp` (3)
- `tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp` (2)
- `tests/ttnn/benchmark/cpp/padding/pad_rm.cpp` (4)
- `tt_metal/tools/mem_bench/mem_bench.cpp` (6)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/add-maybe-unused-to-benchmark-loops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/add-maybe-unused-to-benchmark-loops)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/add-maybe-unused-to-benchmark-loops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/add-maybe-unused-to-benchmark-loops)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/add-maybe-unused-to-benchmark-loops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/add-maybe-unused-to-benchmark-loops)
- [x] New/Existing tests provide coverage for changes (no new tests needed - attribute-only change)