### PR TITLE
Test to reproduce matmul_tiles failing on i8 data type

### DIFF
--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -571,10 +571,13 @@ template std::vector<uint16_t> tilize_nfaces<uint16_t>(const std::vector<uint16_
 template std::vector<uint32_t> tilize_nfaces<uint32_t>(const std::vector<uint32_t>& input, uint32_t m, uint32_t n);
 template std::vector<bfloat16> tilize_nfaces<bfloat16>(const std::vector<bfloat16>& input, uint32_t m, uint32_t n);
 template std::vector<float> tilize_nfaces<float>(const std::vector<float>& input, uint32_t m, uint32_t n);
+template std::vector<int8_t> tilize_nfaces<int8_t>(const std::vector<int8_t>& input, uint32_t m, uint32_t n);
 
 template std::vector<uint16_t> untilize_nfaces<uint16_t>(const std::vector<uint16_t>& input, uint32_t m, uint32_t n);
 template std::vector<uint32_t> untilize_nfaces<uint32_t>(const std::vector<uint32_t>& input, uint32_t m, uint32_t n);
 template std::vector<bfloat16> untilize_nfaces<bfloat16>(const std::vector<bfloat16>& input, uint32_t m, uint32_t n);
 template std::vector<float> untilize_nfaces<float>(const std::vector<float>& input, uint32_t m, uint32_t n);
+template std::vector<int8_t> untilize_nfaces<int8_t>(const std::vector<int8_t>& input, uint32_t m, uint32_t n);
+template std::vector<int32_t> untilize_nfaces<int32_t>(const std::vector<int32_t>& input, uint32_t m, uint32_t n);
 
 // clang-format on

--- a/tt_metal/programming_examples/matmul/matmul_single_core/CMakeLists.txt
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(metal_example_matmul_single_core)
 target_sources(metal_example_matmul_single_core PRIVATE matmul_single_core.cpp)
+add_executable(metal_example_matmul_single_core_i8)
+target_sources(metal_example_matmul_single_core_i8 PRIVATE matmul_single_core_i8.cpp)
 
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
@@ -7,6 +9,12 @@ endif()
 
 target_link_libraries(
     metal_example_matmul_single_core
+    PRIVATE
+        TT::Metalium
+        Matmul::Common
+)
+target_link_libraries(
+    metal_example_matmul_single_core_i8
     PRIVATE
         TT::Metalium
         Matmul::Common

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core_i8.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core_i8.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <random>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <bmm_op.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "tt-metalium/core_coord.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt;
+using namespace tt::tt_metal;
+
+// Reference implementation of matrix multiplication.
+// Array A is of size MxK, Array B is of size KxN, and the output C is of size MxN.
+// The implementation is bare bones and does not include optimizations such as tiling or vectorization.
+// This is intended to be used as a golden reference for testing the Metalium implementation.
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+void golden_matmul(
+    const std::vector<int8_t>& a,
+    const std::vector<int8_t>& b,
+    std::vector<int32_t>& output,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K) {
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < N; j++) {
+            std::uint32_t idx_c = j + (i * N);
+            std::uint32_t idx_a = i * K;
+            std::uint32_t idx_b = j;
+            int32_t c_f = 0;
+            for (int k_m = 0; k_m < K; k_m++) {
+                c_f += static_cast<int32_t>(a[idx_a]) * static_cast<int32_t>(b[idx_b]);
+                idx_a += 1;
+                idx_b += N;
+            }
+            output.at(idx_c) = c_f;
+        }
+    }
+}
+
+// Matrix multiplication using the accelerator.
+// Input a and b as well as output are vectors of bfloat16. But in the tiled layout.
+// The input a is of size MxK, input b is of size KxN, and the output c is of size MxN.
+// For this function, M, N and N must be divisible by TILE_HEIGHT and TILE_WIDTH respectively as that is the native unit
+// of computation on the accelerator.
+void matmul_single_core(
+    const std::vector<int8_t>& a,
+    const std::vector<int8_t>& b,
+    std::vector<int32_t>& output,
+    bool /*bcast_batch*/,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    // Set up mesh command queue, workload, device range, and program. This is a single-core example using core {0,0}.
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    Program program{};
+    // Core range from x: [0, 0] to y: [0, 0] (single core at {0, 0})
+    CoreCoord core({0, 0});
+
+    // Calcaulate the number of tiles for each dimension.
+    uint32_t Mt = M / TILE_HEIGHT;
+    uint32_t Kt = K / TILE_WIDTH;
+    uint32_t Nt = N / TILE_WIDTH;
+
+    // Create DRAM buffers for the input and output data.
+    uint32_t single_tile_size_i8 = sizeof(int8_t) * TILE_HEIGHT * TILE_WIDTH;
+    uint32_t single_tile_size_i32 = sizeof(int32_t) * TILE_HEIGHT * TILE_WIDTH;
+
+    // We allocate DRAM buffers for the input and output data (replicated per device across the mesh).
+    // Setting page_size to single_tile_size is the most common configuration for memory buffers in Metalium
+    // as it is generic, works for most cases and achieves good performance.
+    distributed::DeviceLocalBufferConfig dram_config_i8{
+        .page_size = single_tile_size_i8, .buffer_type = tt_metal::BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config_i32{
+      .page_size = single_tile_size_i32, .buffer_type = tt_metal::BufferType::DRAM};
+
+    distributed::ReplicatedBufferConfig buffer_config_A{.size = sizeof(int8_t) * a.size()};
+    distributed::ReplicatedBufferConfig buffer_config_B{.size = sizeof(int8_t) * b.size()};
+    distributed::ReplicatedBufferConfig buffer_config_C{.size = sizeof(int32_t) * output.size()};
+
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config_A, dram_config_i8, mesh_device.get());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config_B, dram_config_i8, mesh_device.get());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config_C, dram_config_i32, mesh_device.get());
+
+    // Create circular buffers for the input and output data.
+    // Using 2 tiles per circular buffer to allow for double buffering (data movement can be reading from one tile while
+    // the compute kernel is using the other tile). This number can be adjusted based on the use case. But geberally
+    // diminishing returns observed after several tiles.
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+    uint32_t src0_cb_index = CBIndex::c_0;
+    uint32_t num_input_tiles = 2;
+    CircularBufferConfig cb_src0_config =
+      CircularBufferConfig(num_input_tiles * single_tile_size_i8, {{src0_cb_index, tt::DataFormat::Int8}})
+            .set_page_size(src0_cb_index, single_tile_size_i8);
+    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    uint32_t src1_cb_index = CBIndex::c_1;
+    CircularBufferConfig cb_src1_config =
+      CircularBufferConfig(num_input_tiles * single_tile_size_i8, {{src1_cb_index, tt::DataFormat::Int8}})
+            .set_page_size(src1_cb_index, single_tile_size_i8);
+    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_16;
+    uint32_t num_output_tiles = 2;
+    CircularBufferConfig cb_output_config =
+      CircularBufferConfig(num_output_tiles * single_tile_size_i32, {{output_cb_index, tt::DataFormat::Int32}})
+            .set_page_size(output_cb_index, single_tile_size_i32);
+    tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    // Create the data movement kernels and the compute kernel
+    std::vector<uint32_t> reader_compile_time_args;
+    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
+    auto reader_id = tt_metal::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
+
+    std::vector<uint32_t> writer_compile_time_args;
+    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
+    auto writer_id = tt_metal::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
+
+    // Compile time arguments for the kernels
+    // Note that these take effect at the kernel's compile time. Chaning these values will require recompilation of the
+    // kernel. Having arguments at compile time allows the compiler to optimize the kernel for the specific use case.
+    // Like applying loop unrolling, constant folding, etc.. resulting in a more efficient kernel.
+    std::vector<uint32_t> compute_compile_time_args = {
+        Mt,  // Mt
+        Kt,  // Kt
+        Nt   // Nt
+    };
+    tt_metal::CreateKernel(
+        program,
+        OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/compute/mm.cpp",
+        core,
+        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_compile_time_args});
+
+    // Set kernel arguments
+    uint32_t src0_addr = src0_dram_buffer->address();
+    uint32_t src1_addr = src1_dram_buffer->address();
+    uint32_t dst_addr = dst_dram_buffer->address();
+    tt_metal::SetRuntimeArgs(program, reader_id, core, {src0_addr, src1_addr, Mt, Kt, Nt});
+
+    tt_metal::SetRuntimeArgs(program, writer_id, core, {dst_addr, Mt, Kt, Nt});
+    // NOTE: Note that we never set the runtime arguments for the compute kernel. This is because everything needed has
+    // been set at compile time. The compute kernel does not need any runtime arguments to execute. And so we can skip
+    // this step.
+
+    // Upload the input data to the DRAM buffers, execute the kernels, wait for the result to be read into the output
+    // buffer
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+}
+
+///////////////////////////////////////
+
+int main() {
+    bool pass = true;
+
+    try {
+        // Open device
+        constexpr int device_id = 0;
+        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+
+        // parameters for the matrix multiplication
+        constexpr uint32_t M = 64;  // user-defined
+        constexpr uint32_t N = 64;  // user-defined
+        constexpr uint32_t K = 64;  // user-defined
+
+        static_assert(M % TILE_HEIGHT == 0, "M must be divisible by TILE_HEIGHT");
+        static_assert(N % TILE_WIDTH == 0, "N must be divisible by TILE_WIDTH");
+        static_assert(K % TILE_WIDTH == 0, "K must be divisible by TILE_WIDTH");
+
+        // input vectors with various ranges of values
+        std::mt19937 rng(std::random_device{}());
+        std::uniform_real_distribution<float> dist(0.f, 1.0f);
+        std::vector<int8_t> src0_vec(M * K);
+        std::vector<int8_t> src1_vec(K * N);
+
+        for (int8_t& v : src0_vec) {
+            v = static_cast<int8_t>(dist(rng)*256 - 127);
+        }
+        for (int8_t& v : src1_vec) {
+            v = static_cast<int8_t>(dist(rng)*256 - 127);
+        }
+
+        // Golden Matmul running on CPU so we can compare later
+        std::vector<int32_t> golden_vec(M * N, 0);
+        golden_matmul(src0_vec, src1_vec, golden_vec, M, N, K);
+
+        // Tilize the input vectors to match the expected tiled layout for the device
+        // The Tenstorrent hardware operates on data in 32x32 tiles rather than standard row-major format.
+        // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by the device.
+        // This transformation groups elements into 32x32 blocks and reorders them in memory so that each tile
+        // (32x32 elements) is stored contiguously. This matches the native data access patterns of the matrix engine
+        // and enables efficient operations on the accelerator.
+        src0_vec = tilize_nfaces(src0_vec, M, K);
+        src1_vec = tilize_nfaces(src1_vec, K, N);
+
+        // Invoke the matrix multiplication on the device
+        std::vector<int32_t> result_vec(M * N, 0);
+        matmul_single_core(src0_vec, src1_vec, result_vec, false, M, N, K, mesh_device);
+        // Reverse the tilization to get the result in the row-major format that the CPU expects
+        result_vec = untilize_nfaces(result_vec, M, N);
+        for (size_t i = 0; i < M*N; i++) {
+          TT_FATAL(result_vec[i] == golden_vec[i], "Values do not match.");
+        }
+        pass &= mesh_device->close();
+
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Test failed with exception!\n");
+        fmt::print(stderr, "{}\n", e.what());
+
+        throw;
+    }
+
+    if (pass) {
+        fmt::print("Test Passed\n");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    TT_ASSERT(pass);
+
+    return 0;
+}


### PR DESCRIPTION
### Problem description
` matmul_tiles` operation fails for i8 datatype.

### Step to reproduce
- `./build_metal.sh --build-programming-examples`
- `./build/programming_examples/metal_example_matmul_single_core_i8`
