### PR TITLE
Remove redundant return-type usings from device ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.cpp
@@ -47,7 +47,7 @@ void BroadcastDeviceOperation::validate_on_program_cache_miss(
         input_tensor.memory_config().memory_layout());
 }
 
-spec_return_value_t BroadcastDeviceOperation::compute_output_specs(
+TensorSpec BroadcastDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& shape = input_tensor.logical_shape();
@@ -57,7 +57,7 @@ spec_return_value_t BroadcastDeviceOperation::compute_output_specs(
             input_tensor.dtype(), input_tensor.tensor_spec().page_config(), operation_attributes.output_mem_config));
 }
 
-tensor_return_value_t BroadcastDeviceOperation::create_output_tensors(
+Tensor BroadcastDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto spec = compute_output_specs(operation_attributes, tensor_args);
     return create_device_tensor(spec, tensor_args.input_tensor.device());

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation.hpp
@@ -23,8 +23,8 @@ namespace ttnn::operations::ccl::broadcast {
 struct BroadcastDeviceOperation {
     using operation_attributes_t = broadcast::operation_attributes_t;
     using tensor_args_t = broadcast::tensor_args_t;
-    using spec_return_value_t = broadcast::spec_return_value_t;
-    using tensor_return_value_t = broadcast::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::BroadcastProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
@@ -55,7 +55,4 @@ struct tensor_args_t {
     Tensor input_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::ccl::broadcast

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
@@ -25,7 +25,7 @@ BroadcastProgramFactory::cached_mesh_workload_t BroadcastProgramFactory::create_
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -59,7 +59,7 @@ BroadcastProgramFactory::cached_program_t BroadcastProgramFactory::create_at(
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& coord,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
+    Tensor& tensor_return_value,
     const tt::tt_metal::GlobalSemaphore& semaphore,
     const tt::tt_metal::GlobalSemaphore& barrier_semaphore) {
     const auto& input_tensor = tensor_args.input_tensor;
@@ -323,7 +323,7 @@ void BroadcastProgramFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& input = tensor_args.input_tensor;
 
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.hpp
@@ -26,13 +26,13 @@ struct BroadcastProgramFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -41,7 +41,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& coord,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value,
+        Tensor& tensor_return_value,
         const tt::tt_metal::GlobalSemaphore& semaphore,
         const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
 };

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -670,7 +670,7 @@ void post_conv2d_op_memory_checks(
     tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     const auto& input_tensor_a = tensor_args.a;
     const auto& input_tensor_b = tensor_args.b;
     const auto& input_tensor_bias = tensor_args.bias;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -114,6 +114,6 @@ void post_conv2d_op_memory_checks(
     tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor);
+    Tensor& output_tensor);
 
 }  // namespace ttnn::operations::conv::conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -36,7 +36,7 @@ Conv2dDeviceOperation::program_factory_t Conv2dDeviceOperation::select_program_f
     return program::Conv2dShardedProgramFactory{};
 }
 
-spec_return_value_t Conv2dDeviceOperation::compute_output_specs(
+TensorSpec Conv2dDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& /*tensor_args*/) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;
     uint32_t batch_size = input_tensor_a_shape[0];
@@ -85,7 +85,7 @@ spec_return_value_t Conv2dDeviceOperation::compute_output_specs(
             padded_output_shape));
 }
 
-tensor_return_value_t Conv2dDeviceOperation::create_output_tensors(
+Tensor Conv2dDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.a.device());
 }
@@ -161,8 +161,7 @@ tt::stl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
     return tt::stl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
-Conv2dDeviceOperation::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;
     uint32_t batch_size = input_tensor_a_shape[0];

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
@@ -28,8 +28,8 @@ struct Conv2dDeviceOperation {
     using operation_attributes_t = conv2d::operation_attributes_t;
     using hashable_operation_attributes_t = conv2d::hashable_operation_attributes_t;
     using tensor_args_t = conv2d::tensor_args_t;
-    using spec_return_value_t = conv2d::spec_return_value_t;
-    using tensor_return_value_t = conv2d::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::Conv2dShardedProgramFactory, program::Conv2dWidthShardedProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -234,9 +234,6 @@ struct tensor_args_t {
     std::optional<Tensor> bias;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 // Both CB and tensor allocation sizes are per per tensix core and in bytes.
 struct conv_op_l1_usage {
     uint32_t tensor_allocation_size;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -164,9 +164,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
 }
 
 Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
@@ -1380,7 +1378,7 @@ void Conv2dShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto* src_buffer_a = tensor_args.a.buffer();
     auto* src_buffer_b = tensor_args.b.buffer();
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -23,15 +23,13 @@ struct Conv2dShardedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::conv::conv2d::program

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -41,9 +41,7 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
 }
 
 Conv2dWidthShardedProgramFactory::cached_program_t Conv2dWidthShardedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
@@ -657,7 +655,7 @@ void Conv2dWidthShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto* src_buffer_a = tensor_args.a.buffer();
     auto* src_buffer_b = tensor_args.b.buffer();
     auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -24,15 +24,13 @@ struct Conv2dWidthShardedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::conv::conv2d::program

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -181,7 +181,7 @@ void BcastDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t BcastDeviceOperation::compute_output_specs(
+TensorSpec BcastDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -217,7 +217,7 @@ spec_return_value_t BcastDeviceOperation::compute_output_specs(
             input_tensor.padded_shape()));
 }
 
-tensor_return_value_t BcastDeviceOperation::create_output_tensors(
+Tensor BcastDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();
@@ -245,8 +245,7 @@ tt::stl::hash::hash_t BcastDeviceOperation::compute_program_hash(
         operation_attributes.in_place);
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
-BcastDeviceOperation::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> BcastDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::data_movement::bcast {
 struct BcastDeviceOperation {
     using operation_attributes_t = bcast::operation_attributes_t;
     using tensor_args_t = bcast::tensor_args_t;
-    using spec_return_value_t = bcast::spec_return_value_t;
-    using tensor_return_value_t = bcast::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::BcastMultiCoreHProgramFactory,
         program::BcastShardedHProgramFactory,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation_types.hpp
@@ -22,7 +22,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::bcast

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.cpp
@@ -16,9 +16,7 @@ using namespace tt::tt_metal;
 using namespace tt::constants;
 
 BcastMultiCoreHProgramFactory::cached_program_t BcastMultiCoreHProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& a = tensor_args.input_a;
     const Tensor& b = tensor_args.input_b;
     Tensor& output = tensor_return_value;
@@ -195,7 +193,7 @@ void BcastMultiCoreHProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const uint32_t num_cores_x = cached_program.shared_variables.compute_with_storage_grid_size.x;
     const uint32_t num_cores_y = cached_program.shared_variables.compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_h_program_factory.hpp
@@ -25,13 +25,13 @@ struct BcastMultiCoreHProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast::program

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.cpp
@@ -16,9 +16,7 @@ using namespace tt::tt_metal;
 using namespace tt::constants;
 
 BcastMultiCoreHWProgramFactory::cached_program_t BcastMultiCoreHWProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& a = tensor_args.input_a;
     const Tensor& b = tensor_args.input_b;
     Tensor& output = tensor_return_value;
@@ -222,7 +220,7 @@ void BcastMultiCoreHWProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const uint32_t num_cores_x = cached_program.shared_variables.compute_with_storage_grid_size.x;
     const uint32_t num_cores_y = cached_program.shared_variables.compute_with_storage_grid_size.y;
     const auto& output_tensor = cached_program.shared_variables.inplace ? tensor_args.input_a : tensor_return_value;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_hw_program_factory.hpp
@@ -30,13 +30,13 @@ struct BcastMultiCoreHWProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast::program

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.cpp
@@ -16,9 +16,7 @@ using namespace tt::tt_metal;
 using namespace tt::constants;
 
 BcastMultiCoreWProgramFactory::cached_program_t BcastMultiCoreWProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& a = tensor_args.input_a;
     const Tensor& b = tensor_args.input_b;
     Tensor& output = tensor_return_value;
@@ -197,7 +195,7 @@ void BcastMultiCoreWProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const uint32_t num_cores_x = cached_program.shared_variables.compute_with_storage_grid_size.x;
     const uint32_t num_cores_y = cached_program.shared_variables.compute_with_storage_grid_size.y;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_multi_core_w_program_factory.hpp
@@ -25,13 +25,13 @@ struct BcastMultiCoreWProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast::program

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
@@ -16,9 +16,7 @@ using namespace tt::tt_metal;
 using namespace tt::constants;
 
 BcastShardedHOptimisedProgramFactory::cached_program_t BcastShardedHOptimisedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& a = tensor_args.input_a;
     const Tensor& b = tensor_args.input_b;
     Tensor& output = tensor_return_value;
@@ -194,7 +192,7 @@ void BcastShardedHOptimisedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     Buffer* src_buffer = tensor_args.input_a.buffer();
     Buffer* dst_buffer = tensor_return_value.buffer();
     UpdateDynamicCircularBufferAddress(cached_program.program, cached_program.shared_variables.cb_src0, *src_buffer);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.hpp
@@ -18,13 +18,13 @@ struct BcastShardedHOptimisedProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast::program

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.cpp
@@ -16,9 +16,7 @@ using namespace tt::tt_metal;
 using namespace tt::constants;
 
 BcastShardedHProgramFactory::cached_program_t BcastShardedHProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& a = tensor_args.input_a;
     const Tensor& b = tensor_args.input_b;
     Tensor& output = tensor_return_value;
@@ -185,7 +183,7 @@ void BcastShardedHProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     Buffer* src_buffer = tensor_args.input_a.buffer();
     Buffer* dst_buffer = tensor_return_value.buffer();
     UpdateDynamicCircularBufferAddress(cached_program.program, cached_program.shared_variables.cb_src0, *src_buffer);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_program_factory.hpp
@@ -26,13 +26,13 @@ struct BcastShardedHProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::bcast::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -144,7 +144,7 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t ConcatDeviceOperation::compute_output_specs(
+TensorSpec ConcatDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const Tensor& ref_in_tensor = tensor_args.input_tensors.at(0);
     ttnn::Shape shape_out = ref_in_tensor.logical_shape();
@@ -158,7 +158,7 @@ spec_return_value_t ConcatDeviceOperation::compute_output_specs(
         shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), args.output_mem_config));
 }
 
-tensor_return_value_t ConcatDeviceOperation::create_output_tensors(
+Tensor ConcatDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto output_spec = compute_output_specs(operation_attributes, tensor_args);
     return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -22,8 +22,8 @@ namespace ttnn::operations::data_movement::concat {
 struct ConcatDeviceOperation {
     using operation_attributes_t = concat::operation_attributes_t;
     using tensor_args_t = concat::tensor_args_t;
-    using spec_return_value_t = concat::spec_return_value_t;
-    using tensor_return_value_t = concat::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::ConcatProgramFactory,
         program::ConcatS2STiledProgramFactory,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation_types.hpp
@@ -18,7 +18,4 @@ struct tensor_args_t {
     std::vector<Tensor> input_tensors;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::concat

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -14,9 +14,7 @@
 namespace ttnn::operations::data_movement::concat::program {
 
 ConcatProgramFactory::cached_program_t ConcatProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -227,7 +225,7 @@ void ConcatProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.hpp
@@ -24,12 +24,12 @@ struct ConcatProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -16,7 +16,7 @@ namespace ttnn::operations::data_movement::concat::program {
 ConcatS2IProgramFactory::cached_program_t ConcatS2IProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -103,7 +103,7 @@ void ConcatS2IProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.hpp
@@ -24,12 +24,12 @@ struct ConcatS2IProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -29,9 +29,7 @@ uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint
 }  // namespace
 
 ConcatS2SMultiProgramFactory::cached_program_t ConcatS2SMultiProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -154,7 +152,7 @@ void ConcatS2SMultiProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.hpp
@@ -24,12 +24,12 @@ struct ConcatS2SMultiProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
@@ -34,9 +34,7 @@ static CoreRangeSet cores_to_corerangeset(const std::vector<CoreCoord>& cores) {
 }
 
 ConcatS2SRMProgramFactory::cached_program_t ConcatS2SRMProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -220,7 +218,7 @@ void ConcatS2SRMProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.hpp
@@ -24,12 +24,12 @@ struct ConcatS2SRMProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -14,9 +14,7 @@
 namespace ttnn::operations::data_movement::concat::program {
 
 ConcatS2STiledProgramFactory::cached_program_t ConcatS2STiledProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
 
@@ -217,7 +215,7 @@ void ConcatS2STiledProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.hpp
@@ -24,12 +24,12 @@ struct ConcatS2STiledProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::concat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.cpp
@@ -29,13 +29,13 @@ void FillPadDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(detail::data_type_to_size.contains(input_tensor.dtype()), "Unsupported datatype {}", input_tensor.dtype());
 }
 
-spec_return_value_t FillPadDeviceOperation::compute_output_specs(
+TensorSpec FillPadDeviceOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     return input_tensor.tensor_spec();
 }
 
-tensor_return_value_t FillPadDeviceOperation::create_output_tensors(
+Tensor FillPadDeviceOperation::create_output_tensors(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     return input_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation.hpp
@@ -17,8 +17,8 @@ namespace ttnn::operations::data_movement::fill_pad {
 struct FillPadDeviceOperation {
     using operation_attributes_t = fill_pad::operation_attributes_t;
     using tensor_args_t = fill_pad::tensor_args_t;
-    using spec_return_value_t = fill_pad::spec_return_value_t;
-    using tensor_return_value_t = fill_pad::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::FillPadProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_device_operation_types.hpp
@@ -17,8 +17,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::fill_pad

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.cpp
@@ -16,7 +16,7 @@ namespace ttnn::operations::data_movement::fill_pad::program {
 FillPadProgramFactory::cached_program_t FillPadProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     const Tensor& input_tensor = tensor_args.input;
     const float fill_value = operation_attributes.fill_value;
     tt::tt_metal::IDevice* device = input_tensor.device();
@@ -130,7 +130,7 @@ void FillPadProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     const Tensor& input_tensor = tensor_args.input;
     tt::tt_metal::Buffer* tens_buffer = input_tensor.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -34,13 +34,13 @@ struct FillPadProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::fill_pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.cpp
@@ -50,7 +50,7 @@ void FillRMDeviceOperation::validate_on_program_cache_miss(
         "FillRM does not currently support sharding");
 }
 
-spec_return_value_t FillRMDeviceOperation::compute_output_specs(
+TensorSpec FillRMDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     using namespace tt::tt_metal;
 
@@ -59,7 +59,7 @@ spec_return_value_t FillRMDeviceOperation::compute_output_specs(
     return TensorSpec(shape, TensorLayout(input_tensor.dtype(), PageConfig(Layout::ROW_MAJOR), args.output_mem_config));
 }
 
-tensor_return_value_t FillRMDeviceOperation::create_output_tensors(
+Tensor FillRMDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const Tensor& input_tensor = tensor_args.input;
     return create_device_tensor(compute_output_specs(args, tensor_args), input_tensor.device());

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation.hpp
@@ -17,8 +17,8 @@ namespace ttnn::operations::data_movement::fill_rm {
 struct FillRMDeviceOperation {
     using operation_attributes_t = fill_rm::operation_attributes_t;
     using tensor_args_t = fill_rm::tensor_args_t;
-    using spec_return_value_t = fill_rm::spec_return_value_t;
-    using tensor_return_value_t = fill_rm::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::FillRMProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_device_operation_types.hpp
@@ -24,8 +24,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::fill_rm

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.cpp
@@ -11,9 +11,7 @@
 namespace ttnn::operations::data_movement::fill_rm::program {
 
 FillRMProgramFactory::cached_program_t FillRMProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     const Tensor& input = tensor_args.input;
@@ -81,7 +79,7 @@ void FillRMProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     Buffer* dst_buffer = tensor_return_value.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_program_factory.hpp
@@ -20,13 +20,13 @@ struct FillRMProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::fill_rm::program

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation.hpp
@@ -13,8 +13,8 @@ namespace ttnn::operations::data_movement::indexed_fill {
 struct IndexedFillDeviceOperation {
     using operation_attributes_t = indexed_fill::operation_attributes_t;
     using tensor_args_t = indexed_fill::tensor_args_t;
-    using spec_return_value_t = indexed_fill::spec_return_value_t;
-    using tensor_return_value_t = indexed_fill::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<indexed_fill::program::IndexedFillProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_device_operation_types.hpp
@@ -19,7 +19,4 @@ struct tensor_args_t {
     Tensor input_tensor_b;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::data_movement::indexed_fill

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.cpp
@@ -13,9 +13,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement::indexed_fill::program {
 
 IndexedFillProgramFactory::cached_program_t IndexedFillProgramFactory::create(
-    const operation_attributes_t& /*operation_attributes*/,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& batch_ids = tensor_args.batch_id;
     const auto& input_a = tensor_args.input_tensor_a;
     const auto& input_b = tensor_args.input_tensor_b;
@@ -113,7 +111,7 @@ void IndexedFillProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const auto& batch_ids = tensor_args.batch_id;
     const auto& input_a = tensor_args.input_tensor_a;
     const auto& input_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_program_factory.hpp
@@ -21,15 +21,13 @@ struct IndexedFillProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::indexed_fill::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -19,7 +19,7 @@ struct MoveDeviceOperation {
     // Type aliases
     using operation_attributes_t = move::operation_attributes_t;
     using tensor_args_t = move::tensor_args_t;
-    using tensor_return_value_t = move::tensor_return_value_t;
+    using tensor_return_value_t = Tensor;
     using spec_return_value_t = ttnn::TensorSpec;
 
     using program_factory_t = std::

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation_types.hpp
@@ -25,6 +25,5 @@ struct tensor_args_t {
 };
 
 // Return types
-using tensor_return_value_t = Tensor;
 
 }  // namespace ttnn::operations::data_movement::move

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.cpp
@@ -60,11 +60,11 @@ std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, cons
 MoveOverlapProgramFactory::cached_program_t MoveOverlapProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::constants;
 
     const Tensor& input = tensor_args.input_tensor;
-    const tensor_return_value_t& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
@@ -182,12 +182,12 @@ void MoveOverlapProgramFactory::override_runtime_arguments(
     MoveOverlapProgramFactory::cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     auto& program = cached_program.program;
     const Tensor& input = tensor_args.input_tensor;
-    tensor_return_value_t& output = tensor_return_value;
+    Tensor& output = tensor_return_value;
 
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_overlap_program_factory.hpp
@@ -20,13 +20,13 @@ struct MoveOverlapProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -9,11 +9,9 @@
 namespace ttnn::operations::data_movement::move::program {
 
 MoveProgramFactory::cached_program_t MoveProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const Tensor& input = tensor_args.input_tensor;
-    const tensor_return_value_t& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
     using copy_attrs_t = ttnn::operations::data_movement::copy::operation_attributes_t;
     using copy_args_t = ttnn::operations::data_movement::copy::tensor_args_t;
 
@@ -29,11 +27,11 @@ void MoveProgramFactory::override_runtime_arguments(
     MoveProgramFactory::cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using copy_attrs_t = ttnn::operations::data_movement::copy::operation_attributes_t;
     using copy_args_t = ttnn::operations::data_movement::copy::tensor_args_t;
     const Tensor& input = tensor_args.input_tensor;
-    const tensor_return_value_t& output = tensor_return_value;
+    const Tensor& output = tensor_return_value;
 
     const copy_attrs_t copy_attrs{
         operation_attributes.output_mem_config, output.dtype(), operation_attributes.backwards};

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.hpp
@@ -18,13 +18,13 @@ struct MoveProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -17,11 +17,11 @@ namespace ttnn::operations::data_movement::move::program {
 MoveShardedProgramFactory::cached_program_t MoveShardedProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
     const Tensor& input = tensor_args.input_tensor;
-    tensor_return_value_t& output = tensor_return_value;
+    Tensor& output = tensor_return_value;
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -95,12 +95,12 @@ void MoveShardedProgramFactory::override_runtime_arguments(
     MoveShardedProgramFactory::cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     Program& program = cached_program.program;
     const Tensor& input = tensor_args.input_tensor;
-    tensor_return_value_t& output = tensor_return_value;
+    Tensor& output = tensor_return_value;
 
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.hpp
@@ -22,13 +22,13 @@ struct MoveShardedProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::move::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.hpp
@@ -26,8 +26,8 @@ namespace ttnn::operations::data_movement::pad {
 struct PadDeviceOperation {
     using operation_attributes_t = ttnn::operations::data_movement::pad::operation_attributes_t;
     using tensor_args_t = ttnn::operations::data_movement::pad::tensor_args_t;
-    using spec_return_value_t = ttnn::operations::data_movement::pad::spec_return_value_t;
-    using tensor_return_value_t = ttnn::operations::data_movement::pad::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::PadRmReaderWriterMultiCoreProgramFactory,
         program::PadRmReaderWriterMultiCoreV2ProgramFactory,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation_types.hpp
@@ -25,7 +25,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = ttnn::TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::pad

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -154,9 +154,7 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
 }  // namespace
 
 PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMultiCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
@@ -369,7 +367,7 @@ void PadRmReaderWriterMultiCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto* src_buffer = tensor_args.input.buffer();
     auto* dst_buffer = output.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
@@ -23,14 +23,12 @@ struct PadRmReaderWriterMultiCoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.cpp
@@ -113,9 +113,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 }  // namespace
 
 PadRmReaderWriterMultiCoreV2ProgramFactory::cached_program_t PadRmReaderWriterMultiCoreV2ProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
@@ -265,7 +263,7 @@ void PadRmReaderWriterMultiCoreV2ProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const auto& src_tensor = tensor_args.input;
 
     auto dst_tensor = output;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_v2_program_factory.hpp
@@ -23,14 +23,12 @@ struct PadRmReaderWriterMultiCoreV2ProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -11,9 +11,7 @@ using namespace tt::constants;
 
 namespace ttnn::operations::data_movement::pad::program {
 PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     Program program{};
@@ -144,7 +142,7 @@ void PadRmReaderWriterProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_buffer = tensor_args.input.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
     CoreCoord core = {0, 0};

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
@@ -23,14 +23,12 @@ struct PadRmReaderWriterProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -188,9 +188,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }  // namespace
 
 PadRmShardedHeightOnlyProgramFactory::cached_program_t PadRmShardedHeightOnlyProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
@@ -360,7 +358,7 @@ void PadRmShardedHeightOnlyProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_buffer_a = tensor_args.input.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -21,14 +21,12 @@ struct PadRmShardedHeightOnlyProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -12,9 +12,7 @@ using namespace tt::constants;
 
 namespace ttnn::operations::data_movement::pad::program {
 PadRmShardedWidthOnlyProgramFactory::cached_program_t PadRmShardedWidthOnlyProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input_tensor = tensor_args.input;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
@@ -142,7 +140,7 @@ void PadRmShardedWidthOnlyProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* input_buffer = tensor_args.input.buffer();
     auto* output_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
@@ -21,14 +21,12 @@ struct PadRmShardedWidthOnlyProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -26,9 +26,7 @@ static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::S
 }
 
 PadTileMulticoreProgramFactory::cached_program_t PadTileMulticoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
@@ -224,7 +222,7 @@ void PadTileMulticoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto* src_buffer = tensor_args.input.buffer();
     auto* dst_buffer = output.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
@@ -22,14 +22,12 @@ struct PadTileMulticoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -12,9 +12,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement::pad::program {
 PadTileCoreProgramFactory::cached_program_t PadTileCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
@@ -127,7 +125,7 @@ void PadTileCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_dram_buffer = tensor_args.input.buffer();
     auto* dst_dram_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
@@ -21,14 +21,12 @@ struct PadTileCoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 }  // namespace ttnn::operations::data_movement::pad::program

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -72,8 +72,7 @@ RepeatDeviceOperation::tensor_return_value_t RepeatDeviceOperation::create_outpu
         compute_output_specs(operation_attributes, input_tensors), input_tensors.input.device());
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
-RepeatDeviceOperation::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> RepeatDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -15,8 +15,8 @@ namespace ttnn::operations::data_movement::repeat {
 struct RepeatDeviceOperation {
     using operation_attributes_t = repeat::operation_attributes_t;
     using tensor_args_t = repeat::tensor_args_t;
-    using spec_return_value_t = repeat::spec_return_value_t;
-    using tensor_return_value_t = repeat::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::RepeatProgramFactoryLastDim, program::RepeatProgramFactoryHigherDim>;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
@@ -18,8 +18,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -23,9 +23,7 @@
 namespace ttnn::operations::data_movement::repeat::program {
 
 RepeatProgramFactoryHigherDim::cached_program_t RepeatProgramFactoryHigherDim::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const uint32_t num_repeats = operation_attributes.m_num_repeats;
@@ -144,7 +142,7 @@ void RepeatProgramFactoryHigherDim::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp
@@ -17,13 +17,13 @@ struct RepeatProgramFactoryHigherDim {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::repeat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -23,9 +23,7 @@
 namespace ttnn::operations::data_movement::repeat::program {
 
 RepeatProgramFactoryLastDim::cached_program_t RepeatProgramFactoryLastDim::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     // We are repeating the last dim on a 2D shape
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
@@ -111,7 +109,7 @@ void RepeatProgramFactoryLastDim::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp
@@ -17,13 +17,13 @@ struct RepeatProgramFactoryLastDim {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::repeat::program

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.hpp
@@ -14,8 +14,8 @@ namespace ttnn::operations::data_movement::reshape {
 struct ReshapeDeviceOperation {
     using operation_attributes_t = reshape::operation_attributes_t;
     using tensor_args_t = reshape::tensor_args_t;
-    using spec_return_value_t = reshape::spec_return_value_t;
-    using tensor_return_value_t = reshape::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<ReshapeRMProgramFactory, ReshapeTiledProgramFactory>;
 
     static program_factory_t select_program_factory(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation_types.hpp
@@ -23,7 +23,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -13,9 +13,7 @@
 namespace ttnn::operations::data_movement::reshape {
 
 ReshapeRMProgramFactory::cached_program_t ReshapeRMProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& sub_core_grid = operation_attributes.sub_core_grid;
@@ -188,7 +186,7 @@ void ReshapeRMProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& shared_variables = cached_program.shared_variables;
     const auto& reader_kernel_id = shared_variables.reader_kernel_id;
     const auto& reader_kernel_id2 = shared_variables.reader_kernel_id2;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp
@@ -22,13 +22,13 @@ struct ReshapeRMProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.cpp
@@ -272,9 +272,7 @@ Tensor compute_reshape_mapping_host_tensor(
 // the scratch page is copied to its output destination.
 
 ReshapeTiledProgramFactory::cached_program_t ReshapeTiledProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input;
     const auto& output_tensor = tensor_return_value;
 
@@ -414,7 +412,7 @@ void ReshapeTiledProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& shared_variables = cached_program.shared_variables;
     const auto& reader_kernel_id = shared_variables.reader_kernel_id;
     const auto& writer_kernel_id = shared_variables.writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_tiled_program_factory.hpp
@@ -21,13 +21,13 @@ struct ReshapeTiledProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::data_movement::reshape

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation.hpp
@@ -24,8 +24,8 @@ using namespace tt::tt_metal;
 struct ScatterDeviceOperation {
     using operation_attributes_t = scatter::operation_attributes_t;
     using tensor_args_t = scatter::tensor_args_t;
-    using spec_return_value_t = scatter::spec_return_value_t;
-    using tensor_return_value_t = scatter::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<scatter::ScatterProgramFactory, scatter::ScatterReduceBfloat16ProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_device_operation_types.hpp
@@ -27,7 +27,4 @@ struct tensor_args_t {
     const Tensor& src_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::data_movement::scatter

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 ScatterProgramFactory::cached_program_t ScatterProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     using namespace tt::tt_metal;
 
     Program program{};
@@ -174,7 +174,7 @@ void ScatterProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*args*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     const auto& program = cached_program.program;
     const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
     const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_program_factory.hpp
@@ -25,10 +25,10 @@ struct ScatterProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
 
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 }  // namespace ttnn::operations::data_movement::scatter

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.cpp
@@ -18,7 +18,7 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 ScatterReduceBfloat16ProgramFactory::cached_program_t ScatterReduceBfloat16ProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     using namespace tt::tt_metal;
 
     Program program{};
@@ -179,7 +179,7 @@ void ScatterReduceBfloat16ProgramFactory::override_runtime_arguments(
     ScatterReduceBfloat16ProgramFactory::cached_program_t& cached_program,
     const operation_attributes_t& /*args*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     const auto& program = cached_program.program;
     const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
     const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/scatter_reduce_bfloat16_program_factory.hpp
@@ -25,10 +25,10 @@ struct ScatterReduceBfloat16ProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
 
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 }  // namespace ttnn::operations::data_movement::scatter

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -223,7 +223,7 @@ SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_s
         tt::tt_metal::TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), args.output_mem_config));
 }
 
-tensor_return_value_t SliceDeviceOperation::create_output_tensors(
+Tensor SliceDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -28,8 +28,8 @@ namespace slice {
 struct SliceDeviceOperation {
     using operation_attributes_t = slice::operation_attributes_t;
     using tensor_args_t = slice::tensor_args_t;
-    using spec_return_value_t = slice::spec_return_value_t;
-    using tensor_return_value_t = slice::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::SliceRmProgramFactory,
         program::SliceRmShardedProgramFactory,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp
@@ -28,7 +28,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::data_movement::slice

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -191,7 +191,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
 
 namespace slice::program {
 SliceRmProgramFactory::cached_program_t SliceRmProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::tt_metal::IDevice* device = input.device();
@@ -267,7 +267,7 @@ void SliceRmProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const auto& src_tensor = tensor_args.input;
     const auto& slice_start = args.slice_start;
     uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
@@ -21,13 +21,13 @@ struct SliceRmProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::slice::program

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -189,7 +189,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 namespace slice::program {
 
 SliceRmShardedProgramFactory::cached_program_t SliceRmShardedProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -300,7 +300,7 @@ void SliceRmShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*args*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto* src_buffer_a = tensor_args.input.buffer();
     auto* dst_buffer = output.buffer();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
@@ -18,13 +18,13 @@ struct SliceRmShardedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::slice::program

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -17,7 +17,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement::slice::program {
 
 SliceRmStrideProgramFactory::cached_program_t SliceRmStrideProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input_tensor = tensor_args.input;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::tt_metal::IDevice* device = input_tensor.device();
@@ -195,7 +195,7 @@ void SliceRmStrideProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*args*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const auto& src_tensor = tensor_args.input;
     const auto& dst_tensor = output;
     const auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
@@ -19,13 +19,13 @@ struct SliceRmStrideProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::slice::program

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -165,7 +165,7 @@ namespace slice::program {
 
 // Slice Tile Program Factory implementation
 SliceTileProgramFactory::cached_program_t SliceTileProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::tt_metal::IDevice* device = input.device();
@@ -243,7 +243,7 @@ void SliceTileProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const Tensor& src_tensor = tensor_args.input;
     const Tensor& dst_tensor = output;
     const auto& slice_start = args.slice_start;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
@@ -21,13 +21,13 @@ struct SliceTileProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::slice::program

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -178,7 +178,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tensor_args(
 namespace slice::program {
 
 SliceTileTensorArgsProgramFactory::cached_program_t SliceTileTensorArgsProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input_tensor = tensor_args.input;
     const auto& start_tensor = tensor_args.start_tensor.value();
     const auto& end_tensor = tensor_args.end_tensor.value();
@@ -277,7 +277,7 @@ void SliceTileTensorArgsProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*args*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     const Tensor& src_tensor = tensor_args.input;
     const Tensor& start_tensor = tensor_args.start_tensor.value();
     const Tensor& end_tensor = tensor_args.end_tensor.value();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
@@ -21,13 +21,13 @@ struct SliceTileTensorArgsProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::data_movement::slice::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -125,7 +125,7 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t UnaryDeviceOperation::compute_output_specs(
+TensorSpec UnaryDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -144,7 +144,7 @@ spec_return_value_t UnaryDeviceOperation::compute_output_specs(
             tensor_args.input.padded_shape()));
 }
 
-tensor_return_value_t UnaryDeviceOperation::create_output_tensors(
+Tensor UnaryDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return *tensor_args.preallocated_output;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -24,8 +24,8 @@ struct UnaryDeviceOperation {
 
     using operation_attributes_t = unary::operation_attributes_t;
     using tensor_args_t = unary::tensor_args_t;
-    using spec_return_value_t = unary::spec_return_value_t;
-    using tensor_return_value_t = unary::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::UnaryProgramFactory, program::UnarySubCoreGridProgramFactory, program::UnaryShardedProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
@@ -27,8 +27,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 } // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -19,7 +19,7 @@ static const std::string compute_root = "ttnn/cpp/ttnn/operations/eltwise/unary/
 using namespace tt::constants;
 
 UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -215,7 +215,7 @@ void UnaryProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
     auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
     const uint32_t num_cores = cached_program.shared_variables.num_cores;
@@ -245,7 +245,7 @@ void UnaryProgramFactory::override_runtime_arguments(
 // Sub Core Grids : should be fused later with UnaryProgramFactory directing all_device_cores to use cores from
 // sub_core_grids and update the override args accordingly after adding cores as rtargs
 UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -418,7 +418,7 @@ void UnarySubCoreGridProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
     auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
     auto& cores_with_rtargs = cached_program.shared_variables.cores_with_rtargs;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.hpp
@@ -19,13 +19,13 @@ struct UnaryProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 struct UnarySubCoreGridProgramFactory {
@@ -37,13 +37,13 @@ struct UnarySubCoreGridProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -19,7 +19,7 @@ using namespace tt::constants;
 using namespace tt::tt_metal;
 
 UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -207,7 +207,7 @@ void UnaryShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& program = cached_program.program;
     const auto& cb_src0 = cached_program.shared_variables.cb_src0;
     const auto& out_cb = cached_program.shared_variables.out_cb;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.hpp
@@ -17,13 +17,13 @@ struct UnaryShardedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -18,7 +18,7 @@ DefaultMeshWorkloadFactory::cached_mesh_workload_t DefaultMeshWorkloadFactory::c
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
@@ -33,7 +33,7 @@ DefaultMeshWorkloadFactory::cached_program_t DefaultMeshWorkloadFactory::create_
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
 
     const auto& sender_device_coord = mesh_coordinate;  // coord
@@ -113,7 +113,7 @@ void DefaultMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     // Update runtime arguments for each program in the mesh workload
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.hpp
@@ -27,13 +27,13 @@ struct DefaultMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -42,7 +42,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::all_gather_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
@@ -16,8 +16,8 @@ namespace ttnn::operations::experimental::ccl::all_gather_async {
 struct AllGatherAsyncDeviceOperation {
     using operation_attributes_t = all_gather_async::operation_attributes_t;
     using tensor_args_t = all_gather_async::tensor_args_t;
-    using spec_return_value_t = all_gather_async::spec_return_value_t;
-    using tensor_return_value_t = all_gather_async::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<DefaultMeshWorkloadFactory, LlamaShardedMeshWorkloadFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -104,8 +104,4 @@ struct tensor_args_t {
     std::optional<Tensor> persistent_output_buffer;
 };
 
-using spec_return_value_t = TensorSpec;
-
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::ccl::all_gather_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
@@ -17,7 +17,7 @@ LlamaShardedMeshWorkloadFactory::cached_mesh_workload_t LlamaShardedMeshWorkload
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
@@ -32,7 +32,7 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
 
     const auto& sender_device_coord = mesh_coordinate;  // coord
@@ -325,7 +325,7 @@ void LlamaShardedMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     // Update runtime arguments for each program in the mesh workload
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.hpp
@@ -21,13 +21,13 @@ struct LlamaShardedMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -36,7 +36,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::all_gather_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::experimental::ccl::all_gather_concat_heads_fused {
 struct AllGatherConcatDeviceOperation {
     using operation_attributes_t = all_gather_concat_heads_fused::operation_attributes_t;
     using tensor_args_t = all_gather_concat_heads_fused::tensor_args_t;
-    using spec_return_value_t = all_gather_concat_heads_fused::spec_return_value_t;
-    using tensor_return_value_t = all_gather_concat_heads_fused::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::AllGatherConcatMeshWorkloadFactory>;
     using shared_variables_t = program::AllGatherConcatMeshWorkloadFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
@@ -69,7 +69,4 @@ struct tensor_args_t {
     Tensor buffer_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::ccl::all_gather_concat_heads_fused

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.cpp
@@ -46,7 +46,7 @@ AllGatherConcatMeshWorkloadFactory::cached_mesh_workload_t AllGatherConcatMeshWo
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -66,7 +66,7 @@ AllGatherConcatMeshWorkloadFactory::cached_program_t AllGatherConcatMeshWorkload
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& temp_tensor = tensor_args.buffer_tensor;
     auto& output_tensor = tensor_return_value;
@@ -597,7 +597,7 @@ void AllGatherConcatMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& input = tensor_args.input_tensor;
     const auto& temp_tensor = tensor_args.buffer_tensor;
     const auto& output = tensor_return_value;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program_factory.hpp
@@ -28,13 +28,13 @@ struct AllGatherConcatMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -43,7 +43,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::all_gather_concat_heads_fused::program

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation.hpp
@@ -15,8 +15,8 @@ namespace ttnn::operations::experimental::ccl::all_reduce_async {
 struct AllReduceAsyncDeviceOperation {
     using operation_attributes_t = all_reduce_async::operation_attributes_t;
     using tensor_args_t = all_reduce_async::tensor_args_t;
-    using spec_return_value_t = all_reduce_async::spec_return_value_t;
-    using tensor_return_value_t = all_reduce_async::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<AllReduceAsyncMeshWorkloadFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -77,8 +77,4 @@ struct tensor_args_t {
     Tensor buffer_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::ccl::all_reduce_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
@@ -88,7 +88,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_mesh_workload_t AllReduceAsyncMeshWork
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
@@ -103,7 +103,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& coord,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& buffer_tensor = tensor_args.buffer_tensor;
 
@@ -596,7 +596,7 @@ void AllReduceAsyncMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     // Update runtime arguments for each program in the mesh workload
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.hpp
@@ -29,13 +29,13 @@ struct AllReduceAsyncMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -44,7 +44,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& coord,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace operations::experimental::ccl::all_reduce_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
@@ -22,8 +22,8 @@ namespace ttnn::operations::experimental::ccl {
 struct AllToAllAsyncDeviceOperation {
     using operation_attributes_t = all_to_all_async::operation_attributes_t;
     using tensor_args_t = all_to_all_async::tensor_args_t;
-    using spec_return_value_t = all_to_all_async::spec_return_value_t;
-    using tensor_return_value_t = all_to_all_async::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
 
     using AllToAllAsyncProgram = all_to_all_async::AllToAllAsyncProgram;
     using program_factory_t = std::variant<AllToAllAsyncProgram>;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
@@ -63,7 +63,4 @@ struct tensor_args_t {
     Tensor persistent_output_buffer;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ccl::all_to_all_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.cpp
@@ -122,7 +122,7 @@ AllToAllAsyncProgram::cached_mesh_workload_t AllToAllAsyncProgram::create_mesh_w
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -139,7 +139,7 @@ ttnn::device_operation::CachedProgram<AllToAllAsyncProgram::shared_variables_t> 
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     log_debug(tt::LogOp, "DEBUG: create_at is called");
     auto* mesh_device = tensor_args.input_tensor.device();
     IDevice* target_device = mesh_device ? mesh_device->get_device(mesh_coordinate) : tensor_args.input_tensor.device();
@@ -573,7 +573,7 @@ void AllToAllAsyncProgram::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     // Update runtime arguments for each program in the mesh workload
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         (void)coordinate_range;     // Suppress unused variable warning

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_program_factory.hpp
@@ -27,19 +27,19 @@ struct AllToAllAsyncProgram {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::all_to_all_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.hpp
@@ -23,8 +23,8 @@ namespace ttnn::operations::experimental::ccl {
 struct AllToAllAsyncGenericDeviceOperation {
     using operation_attributes_t = all_to_all_async_generic::operation_attributes_t;
     using tensor_args_t = all_to_all_async_generic::tensor_args_t;
-    using spec_return_value_t = all_to_all_async_generic::spec_return_value_t;
-    using tensor_return_value_t = all_to_all_async_generic::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
 
     using AllToAllAsyncGenericProgram = all_to_all_async_generic::AllToAllAsyncGenericProgram;
     using program_factory_t = std::variant<AllToAllAsyncGenericProgram>;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation_types.hpp
@@ -27,7 +27,4 @@ struct tensor_args_t {
     std::optional<Tensor> persistent_output_buffer;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ccl::all_to_all_async_generic

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -38,7 +38,7 @@ AllToAllAsyncGenericProgram::cached_mesh_workload_t AllToAllAsyncGenericProgram:
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -72,7 +72,7 @@ AllToAllAsyncGenericProgram::create_at(
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
+    Tensor& tensor_return_value,
     const tt::tt_metal::GlobalSemaphore& init_barrier_semaphore,
     const tt::tt_metal::GlobalSemaphore& final_barrier_semaphore) {
     log_debug(tt::LogOp, "DEBUG: create_at is called");
@@ -256,7 +256,7 @@ void AllToAllAsyncGenericProgram::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         const auto& coord = coordinate_range.start_coord();
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.hpp
@@ -27,13 +27,13 @@ struct AllToAllAsyncGenericProgram {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value,
+        Tensor& tensor_return_value,
         const tt::tt_metal::GlobalSemaphore& init_barrier_semaphore,
         const tt::tt_metal::GlobalSemaphore& final_barrier_semaphore);
 
@@ -41,7 +41,7 @@ struct AllToAllAsyncGenericProgram {
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::all_to_all_async_generic

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
@@ -74,7 +74,7 @@ void DeepseekMinimalBroadcastDeviceOperation::validate_on_program_cache_miss(
         input_shape[1]);
 }
 
-spec_return_value_t DeepseekMinimalBroadcastDeviceOperation::compute_output_specs(
+TensorSpec DeepseekMinimalBroadcastDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& shape = input_tensor.logical_shape();
@@ -84,7 +84,7 @@ spec_return_value_t DeepseekMinimalBroadcastDeviceOperation::compute_output_spec
             input_tensor.dtype(), input_tensor.tensor_spec().page_config(), operation_attributes.output_mem_config));
 }
 
-tensor_return_value_t DeepseekMinimalBroadcastDeviceOperation::create_output_tensors(
+Tensor DeepseekMinimalBroadcastDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
@@ -24,8 +24,8 @@ namespace ttnn::operations::experimental::ccl::deepseek_minimal_broadcast {
 struct DeepseekMinimalBroadcastDeviceOperation {
     using operation_attributes_t = deepseek_minimal_broadcast::operation_attributes_t;
     using tensor_args_t = deepseek_minimal_broadcast::tensor_args_t;
-    using spec_return_value_t = deepseek_minimal_broadcast::spec_return_value_t;
-    using tensor_return_value_t = deepseek_minimal_broadcast::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::DeepseekMinimalBroadcastProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
@@ -24,7 +24,4 @@ struct tensor_args_t {
     Tensor input_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::ccl::deepseek_minimal_broadcast

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.cpp
@@ -39,7 +39,7 @@ DeepseekMinimalBroadcastProgramFactory::create_mesh_workload(
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -73,7 +73,7 @@ DeepseekMinimalBroadcastProgramFactory::cached_program_t DeepseekMinimalBroadcas
     const operation_attributes_t& operation_attributes,
     const MeshCoordinate& self_coord,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor,
+    Tensor& output_tensor,
     const tt::tt_metal::GlobalSemaphore& semaphore,
     const tt::tt_metal::GlobalSemaphore& barrier_semaphore) {
     const auto& input_tensor = tensor_args.input_tensor;
@@ -310,7 +310,7 @@ void DeepseekMinimalBroadcastProgramFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& input = tensor_args.input_tensor;
     const auto& output = tensor_return_value;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
@@ -22,13 +22,13 @@ struct DeepseekMinimalBroadcastProgramFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -37,7 +37,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& coord,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor,
+        Tensor& output_tensor,
         const tt::tt_metal::GlobalSemaphore& semaphore,
         const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
@@ -83,7 +83,7 @@ void NeighborPadAsyncDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t NeighborPadAsyncDeviceOperation::compute_output_specs(
+TensorSpec NeighborPadAsyncDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     auto shape = input_tensor.logical_shape();
@@ -92,7 +92,7 @@ spec_return_value_t NeighborPadAsyncDeviceOperation::compute_output_specs(
         shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
 }
 
-tensor_return_value_t NeighborPadAsyncDeviceOperation::create_output_tensors(
+Tensor NeighborPadAsyncDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
@@ -14,8 +14,8 @@ namespace ttnn::operations::experimental::ccl::neighbor_pad {
 struct NeighborPadAsyncDeviceOperation {
     using operation_attributes_t = neighbor_pad::operation_attributes_t;
     using tensor_args_t = neighbor_pad::tensor_args_t;
-    using spec_return_value_t = neighbor_pad::spec_return_value_t;
-    using tensor_return_value_t = neighbor_pad::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<NeighborPadAsyncMeshWorkloadFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -83,7 +83,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::ccl::neighbor_pad

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -33,7 +33,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_mesh_workload_t NeighborPadAsyncMesh
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -54,7 +54,7 @@ void NeighborPadAsyncMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     // Update runtime arguments for each program in the workload
     for (auto& [coordinate_range, shared_vars] : cached_workload.shared_variables) {
         auto& program = cached_workload.workload.get_programs().at(coordinate_range);
@@ -108,7 +108,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* mesh_device = tensor_args.input_tensor.device();
     IDevice* target_device = mesh_device ? mesh_device->get_device(mesh_coordinate) : tensor_args.input_tensor.device();
     std::vector<IDevice*> devices_to_use = {};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.hpp
@@ -29,13 +29,13 @@ struct NeighborPadAsyncMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -44,7 +44,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::neighbor_pad

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -176,7 +176,7 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         shard_spec.shape[1]);
 }
 
-spec_return_value_t RMSAllGatherDeviceOperation::compute_output_specs(
+TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     if (args.inplace) {
@@ -211,7 +211,7 @@ spec_return_value_t RMSAllGatherDeviceOperation::compute_output_specs(
             output_padded_shape));
 }
 
-tensor_return_value_t RMSAllGatherDeviceOperation::create_output_tensors(
+Tensor RMSAllGatherDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.hpp
@@ -17,8 +17,8 @@ namespace layernorm = ttnn::operations::normalization;
 struct RMSAllGatherDeviceOperation {
     using operation_attributes_t = fused::normalization::operation_attributes_t;
     using tensor_args_t = fused::normalization::tensor_args_t;
-    using spec_return_value_t = fused::normalization::spec_return_value_t;
-    using tensor_return_value_t = fused::normalization::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::RMSAllGatherMeshWorkloadFactory>;
     using shared_variables_t = program::RMSAllGatherMeshWorkloadFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
@@ -90,7 +90,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::fused::normalization

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -34,7 +34,7 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coord,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     // Setup device information
     ttnn::MeshDevice* mesh_device = tensor_args.input.device();
     auto* const target_device = mesh_device->get_device(mesh_coord);
@@ -1228,7 +1228,7 @@ RMSAllGatherMeshWorkloadFactory::cached_mesh_workload_t RMSAllGatherMeshWorkload
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -1249,7 +1249,7 @@ void RMSAllGatherMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     // Update runtime arguments for each program in the workload using shared variables
     for (auto& [range, shared_vars] : cached_workload.shared_variables) {
         auto& program = cached_workload.workload.get_programs().at(range);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.hpp
@@ -34,13 +34,13 @@ struct RMSAllGatherMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -49,7 +49,7 @@ private:
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinate& mesh_coordinate,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::fused::normalization::program

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.cpp
@@ -43,7 +43,7 @@ void SliceReshardAsyncDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(args.num_links > 0, "Error, num_links should be more than 0 but has {}", args.num_links);
 }
 
-spec_return_value_t SliceReshardAsyncDeviceOperation::compute_output_specs(
+TensorSpec SliceReshardAsyncDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     auto shape = input_tensor.logical_shape();
@@ -52,7 +52,7 @@ spec_return_value_t SliceReshardAsyncDeviceOperation::compute_output_specs(
         shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
 }
 
-tensor_return_value_t SliceReshardAsyncDeviceOperation::create_output_tensors(
+Tensor SliceReshardAsyncDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation.hpp
@@ -26,8 +26,8 @@ namespace ttnn::operations::experimental::ccl::slice_reshard_async {
 struct SliceReshardAsyncDeviceOperation {
     using operation_attributes_t = slice_reshard_async::operation_attributes_t;
     using tensor_args_t = slice_reshard_async::tensor_args_t;
-    using spec_return_value_t = slice_reshard_async::spec_return_value_t;
-    using tensor_return_value_t = slice_reshard_async::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::SliceReshardAsyncProgramFactory>;
     using shared_variables_t = program::SliceReshardAsyncProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -82,8 +82,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ccl::slice_reshard_async

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.cpp
@@ -34,7 +34,7 @@ SliceReshardAsyncProgramFactory::cached_mesh_workload_t SliceReshardAsyncProgram
     const operation_attributes_t& args,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_vars;
 
@@ -51,7 +51,7 @@ SliceReshardAsyncProgramFactory::cached_program_t SliceReshardAsyncProgramFactor
     const operation_attributes_t& args,
     const ttnn::MeshCoordinate& mesh_coord,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const ttnn::Tensor& input_tensor = tensor_args.input;
     const ttnn::Tensor& output_tensor = tensor_return_value;
 
@@ -266,7 +266,7 @@ void SliceReshardAsyncProgramFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const ttnn::Tensor& output_tensor = tensor_return_value;
 
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_program_factory.hpp
@@ -24,13 +24,13 @@ struct SliceReshardAsyncProgramFactory {
         const operation_attributes_t& args,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
 private:
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
@@ -39,7 +39,7 @@ private:
         const operation_attributes_t& args,
         const ttnn::MeshCoordinate& mesh_coord,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ccl::slice_reshard_async::program

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
@@ -47,7 +47,7 @@ void ConvertToCHWDeviceOperation::validate_on_program_cache_miss(
         "Output tensor must be width sharded");
 }
 
-spec_return_value_t ConvertToCHWDeviceOperation::compute_output_specs(
+TensorSpec ConvertToCHWDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& shape = tensor_args.input.logical_shape();
     const auto B = shape[0];
@@ -59,7 +59,7 @@ spec_return_value_t ConvertToCHWDeviceOperation::compute_output_specs(
             args.dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), args.memory_config));
 }
 
-tensor_return_value_t ConvertToCHWDeviceOperation::create_output_tensors(
+Tensor ConvertToCHWDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::cnn::to_chw {
 struct ConvertToCHWDeviceOperation {
     using operation_attributes_t = to_chw::operation_attributes_t;
     using tensor_args_t = to_chw::tensor_args_t;
-    using spec_return_value_t = to_chw::spec_return_value_t;
-    using tensor_return_value_t = to_chw::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::ConvertToCHWProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation_types.hpp
@@ -17,8 +17,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::cnn::to_chw

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -37,7 +37,7 @@ void set_runtime_args_for_all_kernels(
 ConvertToCHWProgramFactory::cached_program_t ConvertToCHWProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& a = tensor_args.input;
@@ -161,7 +161,7 @@ void ConvertToCHWProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& program = cached_program.program;
     const auto& cb_in = cached_program.shared_variables.cb_in;
     const auto& cb_out = cached_program.shared_variables.cb_out;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.hpp
@@ -24,13 +24,13 @@ struct ConvertToCHWProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::experimental::cnn::to_chw::program

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -45,7 +45,7 @@ void ConvertToHWCDeviceOperation::validate_on_program_cache_miss(
         "Output tensor must be height sharded");
 }
 
-spec_return_value_t ConvertToHWCDeviceOperation::compute_output_specs(
+TensorSpec ConvertToHWCDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& shape = tensor_args.input.logical_shape();
     const int B = shape[1];
@@ -61,7 +61,7 @@ spec_return_value_t ConvertToHWCDeviceOperation::compute_output_specs(
         TensorLayout(args.dtype, PageConfig(Layout::ROW_MAJOR), args.memory_config));
 }
 
-tensor_return_value_t ConvertToHWCDeviceOperation::create_output_tensors(
+Tensor ConvertToHWCDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::cnn {
 struct ConvertToHWCDeviceOperation {
     using operation_attributes_t = cnn::operation_attributes_t;
     using tensor_args_t = cnn::tensor_args_t;
-    using spec_return_value_t = cnn::spec_return_value_t;
-    using tensor_return_value_t = cnn::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::ConvertToHWCProgramFactory>;
     using shared_variables_t = program::ConvertToHWCProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation_types.hpp
@@ -17,8 +17,4 @@ struct tensor_args_t {
     const Tensor& input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -425,7 +425,7 @@ void set_runtime_arguments(
 ConvertToHWCProgramFactory::cached_program_t ConvertToHWCProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& a = tensor_args.input;
@@ -566,7 +566,7 @@ void ConvertToHWCProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
     const auto& a = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -31,13 +31,13 @@ struct ConvertToHWCProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::cnn::program

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -163,7 +163,7 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
         total_cores);
 }
 
-spec_return_value_t Conv3dDeviceOperation::compute_output_specs(
+TensorSpec Conv3dDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor;
     const auto& input_tensor_a_shape = input_tensor_a.logical_shape();
@@ -184,7 +184,7 @@ spec_return_value_t Conv3dDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(dtype, PageConfig(Layout::ROW_MAJOR), memory_config));
 }
 
-tensor_return_value_t Conv3dDeviceOperation::create_output_tensors(
+Tensor Conv3dDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -22,8 +22,8 @@ namespace ttnn::operations::experimental::conv3d {
 struct Conv3dDeviceOperation {
     using operation_attributes_t = conv3d::operation_attributes_t;
     using tensor_args_t = conv3d::tensor_args_t;
-    using spec_return_value_t = conv3d::spec_return_value_t;
-    using tensor_return_value_t = conv3d::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::Conv3dProgramFactory>;
     using shared_variables_t = program::Conv3dProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -83,10 +83,6 @@ struct tensor_args_t {
     std::optional<const Tensor> bias_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 namespace detail {
 std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
     uint32_t T_in,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -14,9 +14,7 @@
 namespace ttnn::operations::experimental::conv3d::program {
 
 Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& weight_tensor = tensor_args.weight_tensor;
     const auto& bias_tensor = tensor_args.bias_tensor;
@@ -665,7 +663,7 @@ void Conv3dProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     auto& shared_vars = cached_program.shared_variables;

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.hpp
@@ -25,13 +25,13 @@ struct Conv3dProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::conv3d::program

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -87,7 +87,7 @@ void DropoutDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t DropoutDeviceOperation::compute_output_specs(
+TensorSpec DropoutDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -102,7 +102,7 @@ spec_return_value_t DropoutDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(args.output_dtype, output_layout, args.output_memory_config));
 }
 
-tensor_return_value_t DropoutDeviceOperation::create_output_tensors(
+Tensor DropoutDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return *tensor_args.preallocated_output;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::dropout {
 struct DropoutDeviceOperation {
     using operation_attributes_t = dropout::operation_attributes_t;
     using tensor_args_t = dropout::tensor_args_t;
-    using spec_return_value_t = dropout::spec_return_value_t;
-    using tensor_return_value_t = dropout::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::DropoutProgramFactory, program::DropoutMeshWorkloadFactory>;
     using shared_variables_t = program::DropoutProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
@@ -26,8 +26,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::dropout

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -171,7 +171,7 @@ inline void assign_per_core_runtime_args(
 }
 
 DropoutProgramFactory::cached_program_t DropoutProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -290,7 +290,7 @@ void DropoutProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     using namespace tt::tt_metal;
 
     auto& shared_vars = cached_program.shared_variables;
@@ -347,7 +347,7 @@ DropoutMeshWorkloadFactory::cached_mesh_workload_t DropoutMeshWorkloadFactory::c
     const operation_attributes_t& args,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
 
     tt::tt_metal::distributed::MeshWorkload workload;
@@ -368,7 +368,7 @@ void DropoutMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
 
     for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -26,14 +26,14 @@ struct DropoutProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     // operation_attributes_t with some seed value
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 struct DropoutMeshWorkloadFactory {
@@ -48,13 +48,13 @@ struct DropoutMeshWorkloadFactory {
         const operation_attributes_t& args,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::dropout::program

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::experimental::minimal_matmul {
 struct MinimalMatmulDeviceOperation {
     using operation_attributes_t = ttnn::operations::experimental::minimal_matmul::operation_attributes_t;
     using tensor_args_t = ttnn::operations::experimental::minimal_matmul::tensor_args_t;
-    using spec_return_value_t = ttnn::operations::experimental::minimal_matmul::spec_return_value_t;
-    using tensor_return_value_t = ttnn::operations::experimental::minimal_matmul::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
 
     using program_factory_t = std::variant<program::MinimalMatmulProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_device_operation_types.hpp
@@ -38,7 +38,4 @@ struct tensor_args_t {
     std::optional<Tensor> optional_input_tensor;  // for StridedAllGatherMinimalMatmul
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::minimal_matmul

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -661,9 +661,7 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(
 }
 
 MinimalMatmulProgramFactory::cached_program_t MinimalMatmulProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     std::optional<ttnn::experimental::ccl::MinimalMatmulFusedOpSignaler> empty_fused_op_signaler;
 
@@ -685,7 +683,7 @@ void MinimalMatmulProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& override_variables = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.hpp
@@ -26,13 +26,13 @@ struct MinimalMatmulProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper(

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -71,7 +71,7 @@ void PaddedSliceDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t PaddedSliceDeviceOperation::compute_output_specs(
+TensorSpec PaddedSliceDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     SmallVector<uint32_t> out_shape(input_tensor.logical_shape().rank());
@@ -101,7 +101,7 @@ spec_return_value_t PaddedSliceDeviceOperation::compute_output_specs(
     return TensorSpec(output_tensor_shape, tensor_layout);
 }
 
-tensor_return_value_t PaddedSliceDeviceOperation::create_output_tensors(
+Tensor PaddedSliceDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return *tensor_args.preallocated_output;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
@@ -21,8 +21,8 @@ namespace ttnn::operations::experimental::padded_slice {
 struct PaddedSliceDeviceOperation {
     using operation_attributes_t = padded_slice::operation_attributes_t;
     using tensor_args_t = padded_slice::tensor_args_t;
-    using spec_return_value_t = padded_slice::spec_return_value_t;
-    using tensor_return_value_t = padded_slice::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::PaddedSliceRMProgramFactory, program::PaddedSliceTileProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation_types.hpp
@@ -20,8 +20,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::padded_slice

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.cpp
@@ -189,9 +189,7 @@ get_padded_slice_runtime_args_rm_sharded_output(
 }
 
 PaddedSliceRMProgramFactory::cached_program_t PaddedSliceRMProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& output_tensor_start = operation_attributes.padded_slice_start;
     const auto& output_tensor_end = operation_attributes.padded_slice_end;
@@ -351,7 +349,7 @@ void PaddedSliceRMProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& shared_vars = cached_program.shared_variables;
     const auto& src_tensor = tensor_args.input;
     auto& dst_tensor = output;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_rm_program_factory.hpp
@@ -25,15 +25,13 @@ struct PaddedSliceRMProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::experimental::padded_slice::program

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.cpp
@@ -346,9 +346,7 @@ get_padded_slice_runtime_args_tile_sharded_output(
 }
 
 PaddedSliceTileProgramFactory::cached_program_t PaddedSliceTileProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& output_tensor_start = operation_attributes.padded_slice_start;
     const auto& output_tensor_end = operation_attributes.padded_slice_end;
@@ -544,7 +542,7 @@ void PaddedSliceTileProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& shared_vars = cached_program.shared_variables;
     const auto& src_tensor = tensor_args.input;
     auto& dst_tensor = output;

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_tile_program_factory.hpp
@@ -27,15 +27,13 @@ struct PaddedSliceTileProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::experimental::padded_slice::program

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -61,13 +61,13 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t PagedFillCacheDeviceOperation::compute_output_specs(
+TensorSpec PagedFillCacheDeviceOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     // In-place operation, return cache tensor's spec
     return tensor_args.cache_tensor.tensor_spec();
 }
 
-tensor_return_value_t PagedFillCacheDeviceOperation::create_output_tensors(
+Tensor PagedFillCacheDeviceOperation::create_output_tensors(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
     // In-place operation, return the cache tensor
     return tensor_args.cache_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::paged_cache::fill {
 struct PagedFillCacheDeviceOperation {
     using operation_attributes_t = fill::operation_attributes_t;
     using tensor_args_t = fill::tensor_args_t;
-    using spec_return_value_t = fill::spec_return_value_t;
-    using tensor_return_value_t = fill::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::PagedFillCacheProgramFactory, program::PagedFillCacheMeshWorkloadFactory>;
     using shared_variables_t = program::PagedFillCacheProgramFactory::shared_variables_t;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
@@ -23,8 +23,4 @@ struct tensor_args_t {
     std::optional<Tensor> batch_idx_tensor_opt;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::paged_cache::fill

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -22,7 +22,7 @@ using namespace tt;
 PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     Program program{};
 
     const auto& cache_tensor = tensor_args.cache_tensor;
@@ -200,7 +200,7 @@ void PagedFillCacheProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 
@@ -254,7 +254,7 @@ PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWork
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -327,7 +327,7 @@ void PagedFillCacheMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     PagedFillCacheProgramFactory program_factory;
 
     // Determine which coordinates should have noop=true (excluded from mesh_coords)

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.hpp
@@ -28,13 +28,13 @@ struct PagedFillCacheProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 struct PagedFillCacheMeshWorkloadFactory {
@@ -45,13 +45,13 @@ struct PagedFillCacheMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::paged_cache::fill::program

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::experimental::paged_cache::update {
 struct PagedUpdateCacheDeviceOperation {
     using operation_attributes_t = update::operation_attributes_t;
     using tensor_args_t = update::tensor_args_t;
-    using spec_return_value_t = update::spec_return_value_t;
-    using tensor_return_value_t = update::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::PagedUpdateCacheProgramFactory, program::PagedUpdateCacheMeshWorkloadFactory>;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
@@ -29,7 +29,4 @@ struct tensor_args_t {
     std::optional<Tensor> page_table;
 };
 
-using spec_return_value_t = ttnn::TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::paged_cache::update

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -30,7 +30,7 @@ static bool enable_fp32_dest(
 PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     Program program{};
 
     const auto& cache_tensor = tensor_args.cache_tensor;
@@ -312,7 +312,7 @@ PagedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t PagedUpdateCacheMesh
     const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     log_debug(tt::LogOp, "PagedUpdateCacheMeshWorkloadFactory::create_mesh_workload called");
     log_debug(tt::LogOp, "tensor_coords has {} ranges", tensor_coords.ranges().size());
 
@@ -359,7 +359,7 @@ void PagedUpdateCacheProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     auto& program = cached_program.program;
     const auto& shared_vars = cached_program.shared_variables;
 
@@ -408,7 +408,7 @@ void PagedUpdateCacheMeshWorkloadFactory::override_runtime_arguments(
     cached_mesh_workload_t& cached_workload,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     PagedUpdateCacheProgramFactory program_factory;
 
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.hpp
@@ -29,13 +29,13 @@ struct PagedUpdateCacheProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 struct PagedUpdateCacheMeshWorkloadFactory {
@@ -46,13 +46,13 @@ struct PagedUpdateCacheMeshWorkloadFactory {
         const operation_attributes_t& operation_attributes,
         const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::paged_cache::update::program

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -40,7 +40,7 @@ void FastReduceNCDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL((args.dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
 }
 
-spec_return_value_t FastReduceNCDeviceOperation::compute_output_specs(
+TensorSpec FastReduceNCDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -56,7 +56,7 @@ spec_return_value_t FastReduceNCDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(input.dtype(), PageConfig(Layout::TILE), args.output_mem_config));
 }
 
-tensor_return_value_t FastReduceNCDeviceOperation::create_output_tensors(
+Tensor FastReduceNCDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.hpp
@@ -16,8 +16,8 @@ namespace ttnn::operations::experimental::reduction::detail {
 struct FastReduceNCDeviceOperation {
     using operation_attributes_t = detail::operation_attributes_t;
     using tensor_args_t = detail::tensor_args_t;
-    using spec_return_value_t = detail::spec_return_value_t;
-    using tensor_return_value_t = detail::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::FastReduceNCProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation_types.hpp
@@ -20,8 +20,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -50,9 +50,7 @@ std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dim
 }  // namespace
 
 FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -295,7 +293,7 @@ void FastReduceNCProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t&,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto* input_buffer = tensor_args.input.buffer();
     const auto* output_buffer = tensor_return_value.buffer();
     auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.hpp
@@ -22,13 +22,13 @@ struct FastReduceNCProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::reduction::detail::program

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation.hpp
@@ -28,8 +28,8 @@ using namespace tt::stl;
 struct IntImgDeviceOperation {
     using operation_attributes_t = reduction::operation_attributes_t;
     using tensor_args_t = reduction::tensor_args_t;
-    using spec_return_value_t = reduction::spec_return_value_t;
-    using tensor_return_value_t = reduction::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<reduction::IntImgProgramFactory>;
 
     using invocation_result_t = std::tuple<operation_attributes_t, tensor_args_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_device_operation_types.hpp
@@ -14,7 +14,4 @@ struct tensor_args_t {
     const Tensor& input_tensor;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -70,7 +70,7 @@ constexpr uint32_t CORES_Y = 4;
 IntImgProgramFactory::cached_program_t IntImgProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -159,7 +159,7 @@ void IntImgProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& program = cached_program.program;
     const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
     const auto& writer_kernel_id = cached_program.shared_variables.writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.hpp
@@ -41,13 +41,13 @@ struct IntImgProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -89,7 +89,7 @@ void SliceWriteDeviceOperation::validate_on_program_cache_miss(
         input_tensor.padded_shape().rank());
 }
 
-spec_return_value_t SliceWriteDeviceOperation::compute_output_specs(
+TensorSpec SliceWriteDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     return tensor_args.output.tensor_spec();
 }
@@ -120,7 +120,7 @@ tt::stl::hash::hash_t SliceWriteDeviceOperation::compute_program_hash(
     return hash;
 }
 
-tensor_return_value_t SliceWriteDeviceOperation::create_output_tensors(
+Tensor SliceWriteDeviceOperation::create_output_tensors(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     return tensor_args.output;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::slice_write {
 struct SliceWriteDeviceOperation {
     using operation_attributes_t = slice_write::operation_attributes_t;
     using tensor_args_t = slice_write::tensor_args_t;
-    using spec_return_value_t = slice_write::spec_return_value_t;
-    using tensor_return_value_t = slice_write::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::SliceWriteRMShardedInputProgramFactory,
         program::SliceWriteTiledShardedInputProgramFactory,

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation_types.hpp
@@ -22,10 +22,6 @@ struct tensor_args_t {
     Tensor output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 using ReaderKernelArgs = std::vector<uint32_t>;
 using WriterKernelArgs = std::vector<uint32_t>;
 using KernelRuntimeArgs = std::pair<ReaderKernelArgs, WriterKernelArgs>;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
@@ -184,9 +184,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm(
 }  // namespace
 
 SliceWriteRMInterleavedProgramFactory::cached_program_t SliceWriteRMInterleavedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& output_tensor_start = operation_attributes.slice_start;
@@ -324,7 +322,7 @@ void SliceWriteRMInterleavedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& src_tensor = tensor_args.input;
     const auto& dst_tensor = tensor_return_value;
     uint32_t num_cores_x = cached_program.shared_variables.compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.hpp
@@ -23,13 +23,13 @@ struct SliceWriteRMInterleavedProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::slice_write::program

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.cpp
@@ -204,9 +204,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
 }  // namespace
 
 SliceWriteRMShardedInputProgramFactory::cached_program_t SliceWriteRMShardedInputProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& output_tensor_start = operation_attributes.slice_start;
@@ -324,7 +322,7 @@ void SliceWriteRMShardedInputProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& src_tensor = tensor_args.input;
     const auto& dst_tensor = tensor_return_value;
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_sharded_input_program_factory.hpp
@@ -26,13 +26,13 @@ struct SliceWriteRMShardedInputProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::slice_write::program

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.cpp
@@ -205,9 +205,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_tiled_sharded_input(
 }  // namespace
 
 SliceWriteTiledShardedInputProgramFactory::cached_program_t SliceWriteTiledShardedInputProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& output_tensor_start = operation_attributes.slice_start;
@@ -334,7 +332,7 @@ void SliceWriteTiledShardedInputProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& src_tensor = tensor_args.input;
     const auto& dst_tensor = tensor_return_value;
 

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_tiled_sharded_input_program_factory.hpp
@@ -25,13 +25,13 @@ struct SliceWriteTiledShardedInputProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::slice_write::program

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.cpp
@@ -55,7 +55,7 @@ void HCSumReduceDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(((ashape[3] / TILE_WIDTH) % latent == 0), "Final dim/TILE_SIZE must be a multiple of latent size!");
 }
 
-spec_return_value_t HCSumReduceDeviceOperation::compute_output_specs(
+TensorSpec HCSumReduceDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     constexpr uint32_t latent = 32;
     const auto& input_tensor_a = tensor_args.input;
@@ -64,7 +64,7 @@ spec_return_value_t HCSumReduceDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(args.dtype, PageConfig(Layout::TILE), args.memory_config));
 }
 
-tensor_return_value_t HCSumReduceDeviceOperation::create_output_tensors(
+Tensor HCSumReduceDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::ssm::hc_sum_reduce {
 struct HCSumReduceDeviceOperation {
     using operation_attributes_t = hc_sum_reduce::operation_attributes_t;
     using tensor_args_t = hc_sum_reduce::tensor_args_t;
-    using spec_return_value_t = hc_sum_reduce::spec_return_value_t;
-    using tensor_return_value_t = hc_sum_reduce::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::HCSumReduceProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_device_operation_types.hpp
@@ -19,8 +19,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ssm::hc_sum_reduce

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.cpp
@@ -14,9 +14,7 @@ using namespace tt::constants;
 using namespace tt::tt_metal;
 
 HCSumReduceProgramFactory::cached_program_t HCSumReduceProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t LATENT_DIM = TILE_WIDTH;
 
@@ -192,7 +190,7 @@ void HCSumReduceProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t LATENT_DIM = TILE_WIDTH;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_program_factory.hpp
@@ -27,15 +27,13 @@ struct HCSumReduceProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ssm::hc_sum_reduce::program

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -57,7 +57,7 @@ void PrefixScanDeviceOperation::validate_on_program_cache_miss(
         "Expected h tensor to be row major orientation");
 }
 
-spec_return_value_t PrefixScanDeviceOperation::compute_output_specs(
+TensorSpec PrefixScanDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& a = tensor_args.a;
     return TensorSpec(
@@ -66,7 +66,7 @@ spec_return_value_t PrefixScanDeviceOperation::compute_output_specs(
             args.dtype, PageConfig(Layout::TILE), args.memory_config, a.logical_shape(), a.padded_shape()));
 }
 
-tensor_return_value_t PrefixScanDeviceOperation::create_output_tensors(
+Tensor PrefixScanDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.a.device());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::ssm::prefix_scan {
 struct PrefixScanDeviceOperation {
     using operation_attributes_t = prefix_scan::operation_attributes_t;
     using tensor_args_t = prefix_scan::tensor_args_t;
-    using spec_return_value_t = prefix_scan::spec_return_value_t;
-    using tensor_return_value_t = prefix_scan::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::PrefixScanProgramFactory>;
     using shared_variables_t = program::PrefixScanProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation_types.hpp
@@ -21,8 +21,4 @@ struct tensor_args_t {
     Tensor h_prev;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ssm::prefix_scan

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.cpp
@@ -16,9 +16,7 @@ namespace ttnn::operations::experimental::ssm::prefix_scan::program {
 using namespace tt::constants;
 
 PrefixScanProgramFactory::cached_program_t PrefixScanProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& a = tensor_args.a;
@@ -174,7 +172,7 @@ void PrefixScanProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& a = tensor_args.a;
     const auto& bx = tensor_args.bx;
     const auto& h_prev = tensor_args.h_prev;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_program_factory.hpp
@@ -32,13 +32,13 @@ struct PrefixScanProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ssm::prefix_scan::program

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.cpp
@@ -105,7 +105,7 @@ void RepeatAndInterleaveEltwiseMulDeviceOperation::validate_on_program_cache_mis
     }
 }
 
-spec_return_value_t RepeatAndInterleaveEltwiseMulDeviceOperation::compute_output_specs(
+TensorSpec RepeatAndInterleaveEltwiseMulDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -117,7 +117,7 @@ spec_return_value_t RepeatAndInterleaveEltwiseMulDeviceOperation::compute_output
     return TensorSpec(output_shape, TensorLayout(args.dtype, PageConfig(Layout::TILE), args.memory_config));
 }
 
-tensor_return_value_t RepeatAndInterleaveEltwiseMulDeviceOperation::create_output_tensors(
+Tensor RepeatAndInterleaveEltwiseMulDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return *tensor_args.preallocated_output;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::ssm::repeat_mul {
 struct RepeatAndInterleaveEltwiseMulDeviceOperation {
     using operation_attributes_t = repeat_mul::operation_attributes_t;
     using tensor_args_t = repeat_mul::tensor_args_t;
-    using spec_return_value_t = repeat_mul::spec_return_value_t;
-    using tensor_return_value_t = repeat_mul::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::RepeatAndInterleaveEltwiseMulProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_device_operation_types.hpp
@@ -21,8 +21,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::ssm::repeat_mul

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.cpp
@@ -20,9 +20,7 @@ constexpr uint32_t ONE_TILE = 1;
 }  // namespace
 
 RepeatAndInterleaveEltwiseMulProgramFactory::cached_program_t RepeatAndInterleaveEltwiseMulProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
     auto& output = tensor_return_value;
@@ -196,7 +194,7 @@ void RepeatAndInterleaveEltwiseMulProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t&,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
     const auto& output = tensor_return_value;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_program_factory.hpp
@@ -33,13 +33,13 @@ struct RepeatAndInterleaveEltwiseMulProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::experimental::ssm::repeat_mul::program

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -53,7 +53,7 @@ void ConcatenateHeadsDeviceOperation::validate_on_program_cache_miss(
         "Unsupported grid shape");
 }
 
-spec_return_value_t ConcatenateHeadsDeviceOperation::compute_output_specs(
+TensorSpec ConcatenateHeadsDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -68,7 +68,7 @@ spec_return_value_t ConcatenateHeadsDeviceOperation::compute_output_specs(
             input_tensor.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
 }
 
-tensor_return_value_t ConcatenateHeadsDeviceOperation::create_output_tensors(
+Tensor ConcatenateHeadsDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return *tensor_args.preallocated_output;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
@@ -20,8 +20,8 @@ namespace ttnn::operations::experimental::transformer {
 struct ConcatenateHeadsDeviceOperation {
     using operation_attributes_t = transformer::operation_attributes_t;
     using tensor_args_t = transformer::tensor_args_t;
-    using spec_return_value_t = transformer::spec_return_value_t;
-    using tensor_return_value_t = transformer::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::ConcatenateHeadsProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation_types.hpp
@@ -19,8 +19,4 @@ struct tensor_args_t {
     const std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.cpp
@@ -17,9 +17,7 @@ using namespace tt::tt_metal;
 using namespace tt;
 
 ConcatenateHeadsProgramFactory::cached_program_t ConcatenateHeadsProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& ashape = a.padded_shape();
     const auto& compute_with_storage_grid_size = operation_attributes.compute_with_storage_grid_size;
@@ -138,7 +136,7 @@ void ConcatenateHeadsProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     auto& shared_vars = cached_program.shared_variables;
     auto& program = cached_program.program;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_program_factory.hpp
@@ -21,15 +21,13 @@ struct ConcatenateHeadsProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::experimental::transformer::program

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -84,7 +84,7 @@ void GeluBackwardDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t GeluBackwardDeviceOperation::compute_output_specs(
+TensorSpec GeluBackwardDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_input_grad.has_value()) {
         return tensor_args.preallocated_input_grad->tensor_spec();
@@ -104,7 +104,7 @@ spec_return_value_t GeluBackwardDeviceOperation::compute_output_specs(
     return TensorSpec(output_shape, TensorLayout(output_dtype, output_layout, args.output_memory_config));
 }
 
-tensor_return_value_t GeluBackwardDeviceOperation::create_output_tensors(
+Tensor GeluBackwardDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_input_grad.has_value()) {
         return *tensor_args.preallocated_input_grad;

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
@@ -21,8 +21,8 @@ namespace ttnn::operations::experimental::gelu_backward {
 struct GeluBackwardDeviceOperation {
     using operation_attributes_t = gelu_backward::operation_attributes_t;
     using tensor_args_t = gelu_backward::tensor_args_t;
-    using spec_return_value_t = gelu_backward::spec_return_value_t;
-    using tensor_return_value_t = gelu_backward::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::GeluBackwardProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation_types.hpp
@@ -21,8 +21,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_input_grad;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::experimental::gelu_backward

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.cpp
@@ -14,7 +14,7 @@ namespace ttnn::operations::experimental::gelu_backward::program {
 using namespace tt::constants;
 
 GeluBackwardProgramFactory::cached_program_t GeluBackwardProgramFactory::create(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;              // src0
     const auto& grad_output = tensor_args.grad_output;  // src1
 
@@ -134,7 +134,7 @@ void GeluBackwardProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output) {
+    Tensor& output) {
     using namespace tt::tt_metal;
 
     auto& shared_vars = cached_program.shared_variables;

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_program_factory.hpp
@@ -20,13 +20,13 @@ struct GeluBackwardProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        const operation_attributes_t& args, const tensor_args_t& tensor_args, Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output);
+        Tensor& output);
 };
 
 }  // namespace ttnn::operations::experimental::gelu_backward::program

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.hpp
@@ -24,7 +24,7 @@ struct WhereDeviceOperation {
     // Shared types with factory
     using operation_attributes_t = where_ttt_args::operation_attributes_type;
     using tensor_args_t = where_ttt_args::tensor_args_type;
-    using tensor_return_value_t = where_ttt_args::tensor_return_value_type;
+    using tensor_return_value_t = Tensor;
 
     using program_factory_t = std::variant<ElementWiseMultiCoreWhereProgram>;
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
@@ -17,9 +17,7 @@ namespace ttnn::operations::kv_cache::program {
 using namespace tt::constants;
 
 FillCacheMultiCoreProgramFactory::cached_program_t FillCacheMultiCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& /*output_tensor*/) {
     const auto& cache_tensor = tensor_args.cache;
     const auto& input_tensor = tensor_args.input;
     const auto batch_idx = operation_attributes.batch_idx;
@@ -179,7 +177,7 @@ void FillCacheMultiCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     auto& program = cached_program.program;
     const auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
     const auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
@@ -28,15 +28,13 @@ struct FillCacheMultiCoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::kv_cache::program

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -159,13 +159,13 @@ void UpdateKVCacheOperation::validate_on_program_cache_hit(
     validate_on_program_cache_miss(args, tensor_args);
 }
 
-spec_return_value_t UpdateKVCacheOperation::compute_output_specs(
+TensorSpec UpdateKVCacheOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     // Do nothing because it's an in-place operation. Cache Tensor is the output tensor.
     return tensor_args.cache.tensor_spec();
 }
 
-tensor_return_value_t UpdateKVCacheOperation::create_output_tensors(
+Tensor UpdateKVCacheOperation::create_output_tensors(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     // Do nothing because it's an in-place operation. Cache Tensor is the output tensor.
     return tensor_args.cache;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -19,8 +19,8 @@ namespace ttnn::operations::kv_cache {
 struct UpdateKVCacheOperation {
     using operation_attributes_t = kv_cache::operation_attributes_t;
     using tensor_args_t = kv_cache::tensor_args_t;
-    using spec_return_value_t = kv_cache::spec_return_value_t;
-    using tensor_return_value_t = kv_cache::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::UpdateCacheMultiCoreProgramFactory, program::FillCacheMultiCoreProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation_types.hpp
@@ -25,7 +25,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::kv_cache

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -17,9 +17,7 @@ namespace ttnn::operations::kv_cache::program {
 using namespace tt::constants;
 
 UpdateCacheMultiCoreProgramFactory::cached_program_t UpdateCacheMultiCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& /*output_tensor*/) {
     const auto& cache_tensor = tensor_args.cache;
     const auto& input_tensor = tensor_args.input;
     const auto update_idx = operation_attributes.update_idx;
@@ -291,7 +289,7 @@ void UpdateCacheMultiCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     auto& program = cached_program.program;
     const auto Wbytes = cached_program.shared_variables.Wbytes;
     const auto Wt = cached_program.shared_variables.Wt;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
@@ -22,15 +22,13 @@ struct UpdateCacheMultiCoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::kv_cache::program

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -209,7 +209,7 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t GroupNormDeviceOperation::compute_output_specs(
+TensorSpec GroupNormDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 
@@ -237,7 +237,7 @@ spec_return_value_t GroupNormDeviceOperation::compute_output_specs(
         args.program_config);
 }
 
-tensor_return_value_t GroupNormDeviceOperation::create_output_tensors(
+Tensor GroupNormDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
@@ -19,8 +19,8 @@ namespace ttnn::operations::normalization::group_norm {
 struct GroupNormDeviceOperation {
     using operation_attributes_t = group_norm::operation_attributes_t;
     using tensor_args_t = group_norm::tensor_args_t;
-    using spec_return_value_t = group_norm::spec_return_value_t;
-    using tensor_return_value_t = group_norm::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<GroupNormShardedProgramFactory, GroupNormNoMcastProgramFactory, GroupNormMcastProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
@@ -51,7 +51,4 @@ struct tensor_args_t {
     std::optional<Tensor> reciprocals;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::normalization::group_norm

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -22,9 +22,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::normalization::group_norm {
 
 GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     const auto& gamma = tensor_args.gamma;
     const auto& beta = tensor_args.beta;
@@ -889,7 +887,7 @@ void GroupNormMcastProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.hpp
@@ -29,13 +29,13 @@ struct GroupNormMcastProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::normalization::group_norm

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -22,9 +22,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::normalization::group_norm {
 
 GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     const auto& gamma = tensor_args.gamma;
     const auto& beta = tensor_args.beta;
@@ -1111,7 +1109,7 @@ void GroupNormNoMcastProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.hpp
@@ -29,13 +29,13 @@ struct GroupNormNoMcastProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::normalization::group_norm

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -22,9 +22,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::normalization::group_norm {
 
 GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     const auto& gamma = tensor_args.gamma;
     const auto& beta = tensor_args.beta;
@@ -1040,7 +1038,7 @@ void GroupNormShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
     const auto& input = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.hpp
@@ -26,13 +26,13 @@ struct GroupNormShardedProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::normalization::group_norm

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -328,7 +328,7 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
         operation_attributes.program_config);
 }
 
-spec_return_value_t LayerNormDeviceOperation::compute_output_specs(
+TensorSpec LayerNormDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     auto output_shape = input_tensor.logical_shape();
@@ -388,7 +388,7 @@ spec_return_value_t LayerNormDeviceOperation::compute_output_specs(
         operation_attributes.program_config);
 }
 
-tensor_return_value_t LayerNormDeviceOperation::create_output_tensors(
+Tensor LayerNormDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return std::visit(
         [&](const auto& program_config) -> tensor_return_value_t {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp
@@ -21,8 +21,8 @@ namespace ttnn::operations::normalization::layer_norm {
 struct LayerNormDeviceOperation {
     using operation_attributes_t = layer_norm::operation_attributes_t;
     using tensor_args_t = layer_norm::tensor_args_t;
-    using spec_return_value_t = layer_norm::spec_return_value_t;
-    using tensor_return_value_t = layer_norm::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<LayerNormMultiCoreProgramFactory, LayerNormShardedProgramFactory>;
 
     static program_factory_t select_program_factory(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation_types.hpp
@@ -31,8 +31,4 @@ struct tensor_args_t {
     std::optional<Tensor> stats;                  // for POST_ALL_GATHER
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::normalization::layer_norm

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -87,9 +87,7 @@ bool CB_can_fit_in_L1(
 }  // namespace
 
 LayerNormMultiCoreProgramFactory::cached_program_t LayerNormMultiCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
     // Extract from operation_attributes and tensor_args
@@ -552,7 +550,7 @@ void LayerNormMultiCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* const src_a_dram_buffer = tensor_args.input.buffer();
     const auto& src_b_tensor = tensor_args.residual_input_tensor;
     const auto& gamma_tensor = tensor_args.weight;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.hpp
@@ -31,13 +31,13 @@ struct LayerNormMultiCoreProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::normalization::layer_norm

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -100,9 +100,7 @@ uint32_t get_num_blocks(bool mcast_1d, bool row_wise, CoreCoord grid_size, const
 }  // namespace
 
 LayerNormShardedProgramFactory::cached_program_t LayerNormShardedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
     // Extract from operation_attributes and tensor_args
@@ -1414,7 +1412,7 @@ void LayerNormShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* const src_buffer_a = tensor_args.input.buffer();
     const auto& b_tensor = tensor_args.residual_input_tensor;
     const auto& gamma_tensor = tensor_args.weight;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.hpp
@@ -37,13 +37,13 @@ struct LayerNormShardedProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::normalization::layer_norm

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.cpp
@@ -19,9 +19,7 @@
 namespace ttnn::operations::pool::grid_sample::program {
 
 GridSampleBilinearProgramFactory::cached_program_t GridSampleBilinearProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const Tensor& input_tensor = tensor_args.input_tensor;
     const Tensor& grid_tensor = tensor_args.grid;
     bool use_precomputed_grid = operation_attributes.use_precomputed_grid;
@@ -356,7 +354,7 @@ void GridSampleBilinearProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto& prog = cached_program.program;
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& grid_tensor = tensor_args.grid;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_bilinear_program_factory.hpp
@@ -24,15 +24,13 @@ struct GridSampleBilinearProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::pool::grid_sample::program

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.hpp
@@ -23,8 +23,8 @@ constexpr uint32_t STANDARD_GRID_ELEMENTS_PER_POINT = 2;
 struct GridSampleOperation {
     using operation_attributes_t = grid_sample::operation_attributes_t;
     using tensor_args_t = grid_sample::tensor_args_t;
-    using spec_return_value_t = grid_sample::spec_return_value_t;
-    using tensor_return_value_t = grid_sample::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::GridSampleBilinearProgramFactory, program::GridSampleNearestProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation_types.hpp
@@ -34,7 +34,4 @@ struct tensor_args_t {
     Tensor grid;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::pool::grid_sample

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.cpp
@@ -18,9 +18,7 @@
 namespace ttnn::operations::pool::grid_sample::program {
 
 GridSampleNearestProgramFactory::cached_program_t GridSampleNearestProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const Tensor& input_tensor = tensor_args.input_tensor;
     const Tensor& grid_tensor = tensor_args.grid;
     const bool use_precomputed_grid = operation_attributes.use_precomputed_grid;
@@ -241,7 +239,7 @@ void GridSampleNearestProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto& prog = cached_program.program;
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& grid_tensor = tensor_args.grid;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_nearest_program_factory.hpp
@@ -23,15 +23,13 @@ struct GridSampleNearestProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::pool::grid_sample::program

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -20,9 +20,7 @@ constexpr int32_t FIXED_ONE = 1 << FIXED_POINT_SHIFT;
 static FixedPoint float_to_fixed(float value) { return static_cast<FixedPoint>(value * FIXED_ONE); }
 
 UpsampleBilinearProgramFactory::cached_program_t UpsampleBilinearProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const ttnn::Tensor& input = tensor_args.input_tensor;
     const ttnn::Tensor& output = output_tensor;
     const uint32_t scale_factor_h = operation_attributes.scale_factor_h;
@@ -317,7 +315,7 @@ void UpsampleBilinearProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     tt::tt_metal::Program& program = cached_program.program;
     tt::tt_metal::CBHandle& cb_src0 = cached_program.shared_variables.cb_src0;
     tt::tt_metal::CBHandle& out_cb = cached_program.shared_variables.out_cb;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.hpp
@@ -19,15 +19,13 @@ struct UpsampleBilinearProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::pool::upsample::program

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation.hpp
@@ -21,8 +21,8 @@ namespace ttnn::operations::pool::upsample {
 struct UpsampleOperation {
     using operation_attributes_t = upsample::operation_attributes_t;
     using tensor_args_t = upsample::tensor_args_t;
-    using spec_return_value_t = upsample::spec_return_value_t;
-    using tensor_return_value_t = upsample::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::UpsampleBilinearProgramFactory,
         program::UpsampleMultiCoreInterleavedProgramFactory,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_device_operation_types.hpp
@@ -23,7 +23,4 @@ struct tensor_args_t {
    Tensor input_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::pool::upsample

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.cpp
@@ -20,9 +20,7 @@
 namespace ttnn::operations::pool::upsample::program {
 
 UpsampleMultiCoreInterleavedProgramFactory::cached_program_t UpsampleMultiCoreInterleavedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input_tensor;
     auto& output = output_tensor;
     const auto& scale_factor_h = operation_attributes.scale_factor_h;
@@ -261,7 +259,7 @@ void UpsampleMultiCoreInterleavedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto& program = cached_program.program;
     const auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
     const auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_interleaved.hpp
@@ -19,15 +19,13 @@ struct UpsampleMultiCoreInterleavedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::pool::upsample::program

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -242,9 +242,7 @@ static CoreRangeSet get_cores_with_work(
 }
 
 UpsampleMultiCoreShardedProgramFactory::cached_program_t UpsampleMultiCoreShardedProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input_tensor;
     auto& output = output_tensor;
     const auto& scale_factor_h = operation_attributes.scale_factor_h;
@@ -402,7 +400,7 @@ void UpsampleMultiCoreShardedProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    Tensor& output_tensor) {
     auto& program = cached_program.program;
     auto* src_buffer = tensor_args.input_tensor.buffer();
     auto* dst_buffer = output_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp
@@ -21,15 +21,13 @@ struct UpsampleMultiCoreShardedProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::pool::upsample::program

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
@@ -78,7 +78,7 @@ void DramPrefetcherOperation::validate_on_program_cache_hit(
     validate_on_program_cache_miss(args, tensor_args);
 }
 
-spec_return_value_t DramPrefetcherOperation::compute_output_specs(
+TensorSpec DramPrefetcherOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     return TensorSpec(
         ttnn::Shape{32, 32},

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::dram_prefetcher {
 struct DramPrefetcherOperation {
     using operation_attributes_t = dram_prefetcher::operation_attributes_t;
     using tensor_args_t = dram_prefetcher::tensor_args_t;
-    using spec_return_value_t = dram_prefetcher::spec_return_value_t;
-    using tensor_return_value_t = dram_prefetcher::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::DramPrefetcherProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation_types.hpp
@@ -21,7 +21,4 @@ struct tensor_args_t {
     std::vector<Tensor> input_tensors;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::dram_prefetcher

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -32,9 +32,7 @@ std::pair<uint32_t, uint32_t> get_max_page_size_and_num_pages(
 }
 
 DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& /*output_tensor*/) {
     const auto& input_tensors = tensor_args.input_tensors;
     TT_FATAL(!input_tensors.empty(), "Must have at least one input tensor");
     TT_FATAL(operation_attributes.global_cb.has_value(), "Global circular buffer must be provided");
@@ -287,7 +285,7 @@ void DramPrefetcherProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     auto& program = cached_program.program;
     const auto& tensor_addrs_cb = cached_program.shared_variables.tensor_addrs_cb;
     const auto& input_tensors = tensor_args.input_tensors;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.hpp
@@ -16,15 +16,13 @@ struct DramPrefetcherProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        Tensor& output_tensor);
 };
 
 }  // namespace ttnn::operations::dram_prefetcher::program

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.hpp
@@ -26,8 +26,8 @@ using namespace tt::stl;
 struct AccumulationDeviceOperation {
     using operation_attributes_t = accumulation::operation_attributes_t;
     using tensor_args_t = accumulation::tensor_args_t;
-    using spec_return_value_t = accumulation::spec_return_value_t;
-    using tensor_return_value_t = accumulation::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<accumulation::AccumulationProgramFactory>;
 
     using invocation_result_t = std::tuple<operation_attributes_t, tensor_args_t>;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation_types.hpp
@@ -28,7 +28,4 @@ struct tensor_args_t {
     std::optional<Tensor> opt_output;
 };
 
-using spec_return_value_t = TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::reduction::accumulation

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.cpp
@@ -32,9 +32,7 @@ uint32_t AccumulationProgramFactory::calc_input_tile_offset(const Shape& input_s
 }
 
 AccumulationProgramFactory::cached_program_t AccumulationProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
 
@@ -186,7 +184,7 @@ void AccumulationProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     const auto& program = cached_program.program;
     const auto& reader_kernel_id = cached_program.shared_variables.accumulation_reader_kernel_id;
     const auto& writer_kernel_id = cached_program.shared_variables.accumulation_writer_kernel_id;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_program_factory.hpp
@@ -50,13 +50,13 @@ struct AccumulationProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static CBHandle create_cb(
         Program& program,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -70,7 +70,7 @@ void EmaDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!std::isnan(operation_attributes.alpha), "EMA alpha must be a valid number, got NaN");
 }
 
-spec_return_value_t EmaDeviceOperation::compute_output_specs(
+TensorSpec EmaDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.optional_output_tensor.has_value()) {
         return tensor_args.optional_output_tensor->tensor_spec();
@@ -78,7 +78,7 @@ spec_return_value_t EmaDeviceOperation::compute_output_specs(
     return tensor_args.input.tensor_spec().with_memory_config(operation_attributes.output_mem_config);
 }
 
-tensor_return_value_t EmaDeviceOperation::create_output_tensors(
+Tensor EmaDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.optional_output_tensor.has_value()) {
         return tensor_args.optional_output_tensor.value();

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.hpp
@@ -15,8 +15,8 @@ namespace ttnn::operations::reduction::ema {
 struct EmaDeviceOperation {
     using operation_attributes_t = ema::operation_attributes_t;
     using tensor_args_t = ema::tensor_args_t;
-    using spec_return_value_t = ema::spec_return_value_t;
-    using tensor_return_value_t = ema::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::EmaProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation_types.hpp
@@ -22,7 +22,4 @@ struct tensor_args_t {
     std::optional<Tensor> optional_output_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::ema

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -19,9 +19,7 @@ using namespace tt::tt_metal;
 constexpr auto ema_buffer_depth = 2;
 
 EmaProgramFactory::cached_program_t EmaProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     auto& output = tensor_return_value;
 
@@ -187,7 +185,7 @@ void EmaProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     const auto& shared_variables = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.hpp
@@ -21,13 +21,13 @@ struct EmaProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::ema::program

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -159,7 +159,7 @@ void ArgMaxDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t ArgMaxDeviceOperation::compute_output_specs(
+TensorSpec ArgMaxDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.optional_output_tensor.has_value()) {
         return tensor_args.optional_output_tensor->tensor_spec();
@@ -172,7 +172,7 @@ spec_return_value_t ArgMaxDeviceOperation::compute_output_specs(
         TensorLayout(args.output_dtype, PageConfig(Layout::ROW_MAJOR), args.output_mem_config));
 }
 
-tensor_return_value_t ArgMaxDeviceOperation::create_output_tensors(
+Tensor ArgMaxDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.optional_output_tensor.has_value()) {
         return tensor_args.optional_output_tensor.value();

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
@@ -16,8 +16,8 @@ namespace ttnn::operations::reduction::argmax {
 struct ArgMaxDeviceOperation {
     using operation_attributes_t = argmax::operation_attributes_t;
     using tensor_args_t = argmax::tensor_args_t;
-    using spec_return_value_t = argmax::spec_return_value_t;
-    using tensor_return_value_t = argmax::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t =
         std::variant<program::ArgMaxSingleCoreProgramFactory, program::ArgMaxMultiCoreProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
@@ -23,7 +23,4 @@ struct tensor_args_t {
     std::optional<Tensor> optional_output_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::argmax

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -155,9 +155,7 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  *    Refer to the kernel code for info on compile time args and runtime args
  */
 ArgMaxMultiCoreProgramFactory::cached_program_t ArgMaxMultiCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& dim = operation_attributes.dim;
@@ -394,7 +392,7 @@ void ArgMaxMultiCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_buffer = tensor_args.input.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.hpp
@@ -22,13 +22,13 @@ struct ArgMaxMultiCoreProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::argmax::program

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -124,9 +124,7 @@ static std::vector<uint32_t> get_ctime_args_single_core(
 }
 
 ArgMaxSingleCoreProgramFactory::cached_program_t ArgMaxSingleCoreProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_return_value;
     const auto& dim = operation_attributes.dim;
@@ -190,7 +188,7 @@ void ArgMaxSingleCoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_buffer = tensor_args.input.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.hpp
@@ -20,13 +20,13 @@ struct ArgMaxSingleCoreProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::argmax::program

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -19,8 +19,8 @@ namespace ttnn::operations::reduction::generic {
 struct ReduceDeviceOperation {
     using operation_attributes_t = generic::operation_attributes_t;
     using tensor_args_t = generic::tensor_args_t;
-    using spec_return_value_t = generic::spec_return_value_t;
-    using tensor_return_value_t = generic::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
 
     using program_factory_t = std::variant<
         program::ReduceSingleCoreHwProgramFactory,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -26,7 +26,4 @@ struct tensor_args_t {
     Tensor input_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = ttnn::TensorSpec;
-
 }  // namespace ttnn::operations::reduction::generic

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -15,9 +15,7 @@ using namespace tt::constants;
 namespace ttnn::operations::reduction::generic::program {
 
 ReduceMultiCoreHProgramFactory::cached_program_t ReduceMultiCoreHProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.input_tensor;
@@ -273,7 +271,7 @@ void ReduceMultiCoreHProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto* src_buffer = tensor_args.input_tensor.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.hpp
@@ -23,13 +23,13 @@ struct ReduceMultiCoreHProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::generic::program

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -15,9 +15,7 @@ using namespace tt::constants;
 namespace ttnn::operations::reduction::generic::program {
 
 ReduceMultiCoreWProgramFactory::cached_program_t ReduceMultiCoreWProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.input_tensor;
@@ -190,7 +188,7 @@ void ReduceMultiCoreWProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     auto* src_dram_buffer = tensor_args.input_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.hpp
@@ -21,13 +21,13 @@ struct ReduceMultiCoreWProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::generic::program

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -15,9 +15,7 @@ using namespace tt::constants;
 namespace ttnn::operations::reduction::generic::program {
 
 ReduceSingleCoreHwProgramFactory::cached_program_t ReduceSingleCoreHwProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     const auto& a = tensor_args.input_tensor;
@@ -129,7 +127,7 @@ void ReduceSingleCoreHwProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     auto* src_dram_buffer = tensor_args.input_tensor.buffer();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.hpp
@@ -21,13 +21,13 @@ struct ReduceSingleCoreHwProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::generic::program

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_device_operation_types.hpp
@@ -21,7 +21,4 @@ struct tensor_args_t {
     std::optional<Tensor> user_ids = std::nullopt;
 };
 
-using spec_return_value_t = ttnn::TensorSpec;
-using tensor_return_value_t = Tensor;
-
 }  // namespace ttnn::operations::reduction::manual_seed

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_operation.hpp
@@ -17,8 +17,8 @@ namespace ttnn::operations::reduction::manual_seed {
 struct ManualSeedDeviceOperation {
     using operation_attributes_t = manual_seed::operation_attributes_t;
     using tensor_args_t = manual_seed::tensor_args_t;
-    using spec_return_value_t = manual_seed::spec_return_value_t;
-    using tensor_return_value_t = manual_seed::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         program::ManualSeedSingleSeedToAllCoresProgramFactory,
         program::ManualSeedSingleSeedSingleCoreProgramFactory,

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.cpp
@@ -74,7 +74,7 @@ void override_multi_core_runtime_args(
 ManualSeedSingleSeedToAllCoresProgramFactory::cached_program_t ManualSeedSingleSeedToAllCoresProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     tt::tt_metal::Program program{};
 
     // Calculate core grid
@@ -95,14 +95,14 @@ void ManualSeedSingleSeedToAllCoresProgramFactory::override_runtime_arguments(
     cached_program_t& /*cached_program*/,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     // NOTE: No runtime arguments to override for this OP
 }
 
 ManualSeedSingleSeedSingleCoreProgramFactory::cached_program_t ManualSeedSingleSeedSingleCoreProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     tt::tt_metal::Program program{};
 
     uint32_t num_cores{};
@@ -123,14 +123,12 @@ void ManualSeedSingleSeedSingleCoreProgramFactory::override_runtime_arguments(
     cached_program_t& /*cached_program*/,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     // NOTE: No runtime arguments to override for this OP
 }
 
 ManualSeedSingleSeedSetCoresProgramFactory::cached_program_t ManualSeedSingleSeedSetCoresProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& /*output_tensor*/) {
     tt::tt_metal::Program program{};
 
     // Safety check
@@ -195,7 +193,7 @@ void ManualSeedSingleSeedSetCoresProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     TT_FATAL(
         tensor_args.user_ids.has_value(),
         "user_ids tensor must be provided for ManualSeedSingleSeedSetCoresProgramFactory");
@@ -204,9 +202,7 @@ void ManualSeedSingleSeedSetCoresProgramFactory::override_runtime_arguments(
 }
 
 ManualSeedSetSeedsSetCoresProgramFactory::cached_program_t ManualSeedSetSeedsSetCoresProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& /*output_tensor*/) {
     tt::tt_metal::Program program{};
 
     // Safety checks
@@ -283,7 +279,7 @@ void ManualSeedSetSeedsSetCoresProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output_tensor*/) {
+    Tensor& /*output_tensor*/) {
     TT_FATAL(
         tensor_args.user_ids.has_value(),
         "user_ids tensor must be provided for ManualSeedSetSeedsSetCoresProgramFactory");

--- a/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/manual_seed/device/manual_seed_program_factory.hpp
@@ -19,9 +19,9 @@ struct ManualSeedSingleSeedToAllCoresProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 // Case 2: seed=uint32_t, user_ids=uint32_t - set seed to one core based on user_id
@@ -30,9 +30,9 @@ struct ManualSeedSingleSeedSingleCoreProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 // Case 3: seed=uint32_t, user_ids=Tensor - set seeds to cores in user_ids tensor
@@ -44,9 +44,9 @@ struct ManualSeedSingleSeedSetCoresProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 // Case 4: seed=Tensor, user_ids=Tensor - set mapping seeds to cores based on tensors
@@ -58,9 +58,9 @@ struct ManualSeedSetSeedsSetCoresProgramFactory {
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, Tensor&);
     static void override_runtime_arguments(
-        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, Tensor&);
 };
 
 }  // namespace ttnn::operations::reduction::manual_seed::program

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.cpp
@@ -62,7 +62,7 @@ void MoeDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(expert_shape[-2] == 32, "Expert shape inner dim must be equal to 32, got {}", expert_shape[-2]);
 }
 
-spec_return_value_t MoeDeviceOperation::compute_output_specs(
+TensorSpec MoeDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -75,8 +75,7 @@ spec_return_value_t MoeDeviceOperation::compute_output_specs(
         output_shape, TensorLayout(input_tensor.dtype(), PageConfig(Layout::TILE), args.output_memory_config));
 }
 
-tensor_return_value_t MoeDeviceOperation::create_output_tensors(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+Tensor MoeDeviceOperation::create_output_tensors(const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();
     }

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::reduction::moe {
 struct MoeDeviceOperation {
     using operation_attributes_t = moe::operation_attributes_t;
     using tensor_args_t = moe::tensor_args_t;
-    using spec_return_value_t = moe::spec_return_value_t;
-    using tensor_return_value_t = moe::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::MoeProgramFactory>;
     using shared_variables_t = program::MoeProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_device_operation_types.hpp
@@ -21,8 +21,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::moe

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -14,9 +14,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::reduction::moe::program {
 
 MoeProgramFactory::cached_program_t MoeProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     const auto& expert_mask_tensor = tensor_args.expert_mask;
     const auto& topk_mask_tensor = tensor_args.topk_mask;
@@ -219,7 +217,7 @@ void MoeProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
     auto& unary_reader_kernel_id = shared_vars.unary_reader_kernel_id;

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.hpp
@@ -19,15 +19,13 @@ struct MoeProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::moe::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp
@@ -14,8 +14,8 @@ namespace ttnn::operations::reduction::prod_all {
 struct ProdAllDeviceOperation {
     using operation_attributes_t = prod_all::operation_attributes_t;
     using tensor_args_t = prod_all::tensor_args_t;
-    using spec_return_value_t = prod_all::spec_return_value_t;
-    using tensor_return_value_t = prod_all::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::ProdAllProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation_types.hpp
@@ -15,8 +15,4 @@ struct tensor_args_t {
     Tensor input;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::prod_all

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -12,7 +12,7 @@ namespace ttnn::operations::reduction::prod_all::program {
 ProdAllProgramFactory::cached_program_t ProdAllProgramFactory::create(
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
     using namespace tt::constants;
@@ -95,7 +95,7 @@ void ProdAllProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     using namespace tt::tt_metal;
 
     auto& program = cached_program.program;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.hpp
@@ -20,13 +20,13 @@ struct ProdAllProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::prod_all::program

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.hpp
@@ -14,8 +14,8 @@ namespace ttnn::operations::reduction::prod_nc {
 struct ProdNcDeviceOperation {
     using operation_attributes_t = prod_nc::operation_attributes_t;
     using tensor_args_t = prod_nc::tensor_args_t;
-    using spec_return_value_t = prod_nc::spec_return_value_t;
-    using tensor_return_value_t = prod_nc::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::ProdNcProgramFactory>;
     using shared_variables_t = program::ProdNcProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation_types.hpp
@@ -16,8 +16,4 @@ struct tensor_args_t {
     Tensor output;  // Note: output is passed as input (inplace pattern)
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::prod_nc

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -18,7 +18,7 @@ using namespace tt::constants;
 ProdNcProgramFactory::cached_program_t ProdNcProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     const auto& input = tensor_args.input;
     const auto& output = tensor_args.output;
     const int64_t dim = operation_attributes.dim;
@@ -193,7 +193,7 @@ void ProdNcProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/) {
+    Tensor& /*tensor_return_value*/) {
     auto& program = cached_program.program;
     const auto& shared_variables = cached_program.shared_variables;
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.hpp
@@ -21,13 +21,13 @@ struct ProdNcProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::prod_nc::program

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -86,7 +86,7 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(temp.logical_shape() == Shape({32}), "temp must have shape [32]!");
 }
 
-spec_return_value_t SamplingDeviceOperation::compute_output_specs(
+TensorSpec SamplingDeviceOperation::compute_output_specs(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output->tensor_spec();
@@ -101,7 +101,7 @@ spec_return_value_t SamplingDeviceOperation::compute_output_specs(
         TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR), input_values_tensor.memory_config()));
 }
 
-tensor_return_value_t SamplingDeviceOperation::create_output_tensors(
+Tensor SamplingDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
         return tensor_args.preallocated_output.value();

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::reduction::sampling {
 struct SamplingDeviceOperation {
     using operation_attributes_t = sampling::operation_attributes_t;
     using tensor_args_t = sampling::tensor_args_t;
-    using spec_return_value_t = sampling::spec_return_value_t;
-    using tensor_return_value_t = sampling::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::SamplingProgramFactory>;
     using shared_variables_t = program::SamplingProgramFactory::shared_variables_t;
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
@@ -25,8 +25,4 @@ struct tensor_args_t {
     std::optional<Tensor> preallocated_output;
 };
 
-using tensor_return_value_t = Tensor;
-
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::reduction::sampling

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -16,9 +16,7 @@
 namespace ttnn::operations::reduction::sampling::program {
 
 SamplingProgramFactory::cached_program_t SamplingProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensor) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor) {
     using namespace tt::constants;
 
     const auto& input_values_tensor = tensor_args.input_values;
@@ -324,7 +322,7 @@ void SamplingProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& /*operation_attributes*/,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
     auto& shared_vars = cached_program.shared_variables;
     auto& reader_kernel_id = shared_vars.reader_kernel_id;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
@@ -22,15 +22,13 @@ struct SamplingProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output_tensor);
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& output_tensor);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::reduction::sampling::program

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -335,7 +335,7 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-spec_return_value_t SdpaDecodeDeviceOperation::compute_output_specs(
+TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.q;
     Layout output_layout = Layout::TILE;
@@ -352,7 +352,7 @@ spec_return_value_t SdpaDecodeDeviceOperation::compute_output_specs(
         output_shape, TensorLayout(input.dtype(), PageConfig(output_layout), operation_attributes.output_mem_config));
 }
 
-tensor_return_value_t SdpaDecodeDeviceOperation::create_output_tensors(
+Tensor SdpaDecodeDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -19,8 +19,8 @@ namespace ttnn::operations::transformer::sdpa_decode {
 struct SdpaDecodeDeviceOperation {
     using operation_attributes_t = sdpa_decode::operation_attributes_t;
     using tensor_args_t = sdpa_decode::tensor_args_t;
-    using spec_return_value_t = sdpa_decode::spec_return_value_t;
-    using tensor_return_value_t = sdpa_decode::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
 
     using program_factory_t = std::variant<program::SdpaDecodeProgramFactory>;
     using shared_variables_t = program::SdpaDecodeProgramFactory::shared_variables_t;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
@@ -45,7 +45,4 @@ struct tensor_args_t {
     std::optional<Tensor> attention_sink;
 };
 
-using spec_return_value_t = ttnn::TensorSpec;
-using tensor_return_value_t = ttnn::Tensor;
-
 }  // namespace ttnn::operations::transformer::sdpa_decode

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -21,9 +21,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::transformer::sdpa_decode::program {
 
 SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor_q = tensor_args.q;
     const auto& input_tensor_k = tensor_args.k;
     bool use_mla = operation_attributes.use_mla.value_or(false);
@@ -1045,7 +1043,7 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& program = cached_program.program;
 
     const auto& shared_variables = cached_program.shared_variables;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
@@ -39,13 +39,13 @@ struct SdpaDecodeProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa_decode::program

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
@@ -139,14 +139,14 @@ void WindowedScaledDotProductAttentionDeviceOperation::validate_on_program_cache
     validate_padding(v);
 }
 
-spec_return_value_t WindowedScaledDotProductAttentionDeviceOperation::compute_output_specs(
+TensorSpec WindowedScaledDotProductAttentionDeviceOperation::compute_output_specs(
     const operation_attributes_t& attrs, const tensor_args_t& tensors) {
     const auto& input = tensors.q;
     return TensorSpec(
         input.logical_shape(), TensorLayout(input.dtype(), PageConfig(Layout::TILE), attrs.output_mem_config));
 }
 
-tensor_return_value_t WindowedScaledDotProductAttentionDeviceOperation::create_output_tensors(
+Tensor WindowedScaledDotProductAttentionDeviceOperation::create_output_tensors(
     const operation_attributes_t& attrs, const tensor_args_t& tensors) {
     return create_device_tensor(compute_output_specs(attrs, tensors), tensors.q.device());
 }
@@ -165,7 +165,7 @@ tt::stl::hash::hash_t WindowedScaledDotProductAttentionDeviceOperation::compute_
     return hash;
 }
 
-tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>
+tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor>
 WindowedScaledDotProductAttentionDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attrs, const tensor_args_t& tensors, tensor_return_value_t& output_tensor) {
     Tensors input_tensors = {tensors.q, tensors.k, tensors.v, tensors.cu_window_seqlens};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
@@ -26,8 +26,8 @@ static_assert(cu_window_seqlens_nelements == 4096, "cu_window_seqlens_nelements 
 struct WindowedScaledDotProductAttentionDeviceOperation {
     using operation_attributes_t = sdpa_windowed::operation_attributes_t;
     using tensor_args_t = sdpa_windowed::tensor_args_t;
-    using spec_return_value_t = sdpa_windowed::spec_return_value_t;
-    using tensor_return_value_t = sdpa_windowed::tensor_return_value_t;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<program::WindowedSDPAProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation_types.hpp
@@ -26,7 +26,4 @@ struct tensor_args_t {
     Tensor cu_window_seqlens;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = TensorSpec;
-
 }  // namespace ttnn::operations::transformer::sdpa_windowed

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_program_factory.cpp
@@ -28,9 +28,7 @@ namespace ttnn::operations::transformer::sdpa_windowed::program {
 // [INFO] a natural thought for potentially faster implementation is to only compute the SDPA within each windown as
 // defined by cu_window_seqlens; this should be driven by performance analysis results of whole ML model
 WindowedSDPAProgramFactory::cached_program_t WindowedSDPAProgramFactory::create(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor_q = tensor_args.q;
     const auto& input_tensor_k = tensor_args.k;
     const auto& input_tensor_v = tensor_args.v;
@@ -623,7 +621,7 @@ void WindowedSDPAProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t&,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value) {
+    Tensor& tensor_return_value) {
     auto& shared_vars = cached_program.shared_variables;
     auto& program = cached_program.program;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_program_factory.hpp
@@ -27,13 +27,13 @@ struct WindowedSDPAProgramFactory {
     static cached_program_t create(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::operations::transformer::sdpa_windowed::program


### PR DESCRIPTION
### Ticket
None

### Problem description
We got some useless usings for return output type in device ops.
Useless are those which refer to simplest type like Tensor/TensorSpec

### What's changed
Remove useless usings

### Checklist
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/remove_redundant_return_usings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/remove_redundant_return_usings)