### PR TITLE
Check for disallowed params combination in chunked SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -269,6 +269,14 @@ void SDPAOperation::validate_on_program_cache_miss(const operation_attributes_t&
                 "chunk_start_idx must be a multiple of q_chunk_size. Got chunk_start_idx: {}, q_chunk_size: {}",
                 attrs.chunk_start_idx.value(),
                 q_chunk_size);
+
+            // Validate that chunk_start_idx is a multiple of k_chunk_size
+            // Workaround for https://github.com/tenstorrent/tt-metal/issues/35225
+            TT_FATAL(
+                attrs.chunk_start_idx.value() % k_chunk_size == 0,
+                "chunk_start_idx must be a multiple of k_chunk_size. Got chunk_start_idx: {}, k_chunk_size: {}",
+                attrs.chunk_start_idx.value(),
+                k_chunk_size);
         }
 
         // In chunked mode, K's sequence dimension should be >= Q's sequence dimension + chunk_start_idx

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -107,6 +107,7 @@ void bind_sdpa(nb::module_& mod) {
             page_table_tensor (ttnn.Tensor): the page table tensor.  [b x num_pages]
             chunk_start_idx (int): Absolute position in the sequence where this chunk starts.
                 Must be a multiple of program_config.q_chunk_size.
+                Must be a multiple of program_config.k_chunk_size (workaround for https://github.com/tenstorrent/tt-metal/issues/35225)
 
         Keyword args:
             scale (float, optional): Defaults to `None`.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35225

### Problem description
When `ttnn.transformer.chunked_scaled_dot_product_attention()` is called with `k_chunk_size=256` and `chunk_start_idx` in (64, 128, 192), the SDPA results are partly incorrect, with some probability.

Setting `k_chunk_size=64` "fixes" this.

### What's changed
This is a workaround - require `k_chunk_size` to be a multiple of `chunk_start_idx`.
The exact nature of the bug is not resolved.

CI runs: 
* T3K integration tests: https://github.com/tenstorrent/tt-metal/actions/runs/20989522728 (some jobs failing at infra issue `Failed to get line coordinates, got 1 coordinates, expected 4`)
* Nightly tt-metal L2: https://github.com/tenstorrent/tt-metal/actions/runs/20992304897
* L2 nightly SDPA stress test: https://github.com/tenstorrent/tt-metal/actions/runs/20998546843
* Galaxy demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/20992376452
* VLLM nightly: https://github.com/tenstorrent/tt-metal/actions/runs/21023555603

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:viktorpus/sdpa-nondet-check)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/sdpa-nondet-check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/sdpa-nondet-check)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/sdpa-nondet-check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/sdpa-nondet-check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/sdpa-nondet-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/sdpa-nondet-check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
