### PR TITLE
[Refactor] Math Fidelity enum

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
@@ -64,12 +64,12 @@ inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src() {
     }
 }
 
-template <EltwiseBinaryType eltwise_binary_type, DstSync Dst, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, DstSync Dst, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void _llk_math_deepseek_moe_gate_eltwise_binary_(
-    const std::uint32_t num_faces, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t num_faces, std::uint32_t dst_index, const bool clear_fp32_dst_acc) {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
-    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
     static_assert(!(eltwise_binary_type == ELWMUL && high_fidelity), "High fidelity is not supported for ELWMUL");
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
@@ -81,20 +81,20 @@ inline void _llk_math_deepseek_moe_gate_eltwise_binary_(
     math::clear_dst_reg_addr();
 }
 
-template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
 inline void deepseek_moe_gate_eltwise_binary_configure_mop(
     const std::uint32_t acc_to_dest = 0, const std::uint32_t num_faces = 4) {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
-    const uint addr_mod = ADDR_MOD_0;
-    constexpr uint innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
-    uint outerloop = num_faces;
-    auto broadcast_type = p_elwise::SRCB_NO_BCAST;
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    const std::uint32_t addr_mod = ADDR_MOD_0;
+    constexpr std::uint32_t innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
+    std::uint32_t outerloop = num_faces;
+    const auto broadcast_type = p_elwise::SRCB_NO_BCAST;
 
-    constexpr uint32_t dst_tile_offset = 64;  // 1 tile x 64 rows per tile
-    constexpr uint32_t dst_math_offset = 2 * dst_tile_offset;
+    constexpr std::uint32_t dst_tile_offset = 64;  // 1 tile x 64 rows per tile
+    constexpr std::uint32_t dst_math_offset = 2 * dst_tile_offset;
 
-    uint math_op;
+    std::uint32_t math_op;
 
     // TODO: Probably not worth it to use a replay buffer/mop for this
     // Just hardcode the math ops in _llk_math_deepseek_moe_gate_eltwise_binary_ since we only have 1 face
@@ -112,7 +112,7 @@ inline void deepseek_moe_gate_eltwise_binary_configure_mop(
             ckernel::math::replay_buf_offset,  // replay buffer offset
             5,
             [] { deepseek_moe_gate_eltwise_binary_reuse_dest_as_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(); });
-        uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 5);
+        std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 5);
         ckernel_template tmp(outerloop, innerloop, math_op);
         tmp.set_start_op(replay_instr);
         tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
@@ -124,17 +124,16 @@ inline void deepseek_moe_gate_eltwise_binary_configure_mop(
     }
 }
 
-template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int MATH_FIDELITY_DESC = 0>
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
 inline void _llk_math_deepseek_moe_gate_eltwise_binary_init_(
     const std::uint32_t num_faces, const std::uint32_t acc_to_dest) {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
 
     deepseek_moe_gate_eltwise_binary_configure_addrmod<eltwise_binary_type>();
 
     if constexpr (
         (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
-        deepseek_moe_gate_eltwise_binary_configure_mop<eltwise_binary_type, mode, MATH_FIDELITY_PHASES>(
+        deepseek_moe_gate_eltwise_binary_configure_mop<eltwise_binary_type, mode, math_fidelity>(
             acc_to_dest, num_faces);
     }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -17,7 +17,7 @@ using namespace ckernel;
 
 namespace ckernel {
 
-constexpr uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
+constexpr std::uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
 
 // Configure address modifiers for single face transpose
 template <bool is_32bit>
@@ -37,7 +37,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_configure_addrmod() {
         .set(ADDR_MOD_3);
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     // For 16-bit data, simple single-pass transpose
@@ -66,15 +66,15 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
             TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
             TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
         });
-    uint d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
-    uint b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
+    std::uint32_t d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
+    std::uint32_t b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
 
     ckernel_template tmp(num_tiles, 1, d2b_instr, TT_OP_TRNSPSRCB);
     tmp.set_end_op(b2d_instr);
     tmp.program();
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     // For 16-bit data, simple single-pass transpose
@@ -100,13 +100,13 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
             TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
             TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
         });
-    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
+    std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
 
     ckernel_template tmp(num_tiles, 1, replay_instr);
     tmp.program();
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     load_replay_buf(
@@ -122,7 +122,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
             // Move 1 row from SrcB back to DEST
             TTI_MOVB2D(0, 16, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 0);
         });
-    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
+    std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
 
     ckernel_template tmp(num_tiles, 1, replay_instr);
     tmp.program();

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
@@ -15,14 +15,14 @@
 
 using namespace ckernel;
 
-template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, std::uint32_t num_tiles, MathFidelity math_fidelity>
 inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
     const std::uint32_t num_faces = 4, const std::uint32_t acc_to_dest = 0) {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
-    constexpr uint addr_mod = ADDR_MOD_0;
-    uint innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
-    uint outerloop = num_faces;
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t addr_mod = ADDR_MOD_0;
+    std::uint32_t innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
+    std::uint32_t outerloop = num_faces;
     constexpr auto broadcast_type = p_elwise::SRCB_BCAST_ALL;
 
     // Scalar broadcast should not Clear B within a mop.  This is controlled outside of MOP.
@@ -48,7 +48,7 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
         if constexpr (high_fidelity) {
             ckernel_template tmp(
                 num_faces,
-                NUM_FIDELITY_PHASES,
+                to_underlying(math_fidelity),
                 TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_0, 0),
                 TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_2, 0));
             tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
@@ -77,14 +77,14 @@ inline void rmsnorm_bcast_scalar_reuse_dest_as_src() {
 
 template <
     EltwiseBinaryType eltwise_binary_type,
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     DstSync Dst,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     bool clear_dest = false>
-inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_index) {
-    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
-    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(std::uint32_t src_index, std::uint32_t dst_index) {
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(src_index);
     rmsnorm_bcast_scalar_reuse_dest_as_src();
@@ -114,9 +114,10 @@ inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_D);
 }
 
-template <EltwiseBinaryType eltwise_binary_type, int NUM_FIDELITY_PHASES, std::uint32_t FIDELITY_INCREMENT>
+template <EltwiseBinaryType eltwise_binary_type, MathFidelity math_fidelity>
 inline void rmsnorm_bcast_scalar_dest_reuse_configure_addrmod(const std::uint32_t num_faces) {
-    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+    constexpr std::uint32_t fidelity_increment = high_fidelity ? 1 : 0;
     // Use srcA for data movement
     if constexpr (
         (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
@@ -138,7 +139,7 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_addrmod(const std::uint32_
                 .srca = {.incr = 0, .clr = 1},
                 .srcb = {.incr = 0, .clr = 1},
                 .dest = {.incr = 0, .clr = 0, .cr = 1},
-                .fidelity = {.incr = FIDELITY_INCREMENT}}
+                .fidelity = {.incr = fidelity_increment}}
                 .set(ADDR_MOD_2);
 
             addr_mod_t{
@@ -170,21 +171,16 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_addrmod(const std::uint32_
     }
 }
 
-template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int MATH_FIDELITY_DESC = 0>
+template <EltwiseBinaryType eltwise_binary_type, std::uint32_t num_tiles, MathFidelity math_fidelity>
 inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_init_(
     const std::uint32_t num_faces, const std::uint32_t acc_to_dest) {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
-    constexpr int MATH_FIDELITY_INCREMENT = get_math_fidelity_increment(MATH_FIDELITY_DESC);
 
-    rmsnorm_bcast_scalar_dest_reuse_configure_addrmod<
-        eltwise_binary_type,
-        MATH_FIDELITY_PHASES,
-        MATH_FIDELITY_INCREMENT>(num_faces);
+    rmsnorm_bcast_scalar_dest_reuse_configure_addrmod<eltwise_binary_type, math_fidelity>(num_faces);
 
     if constexpr (
         (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
-        rmsnorm_bcast_scalar_dest_reuse_configure_mop<eltwise_binary_type, num_tiles, MATH_FIDELITY_PHASES>(
+        rmsnorm_bcast_scalar_dest_reuse_configure_mop<eltwise_binary_type, num_tiles, math_fidelity>(
             num_faces, acc_to_dest);
     }
 

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_rmsnorm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_rmsnorm.h
@@ -18,7 +18,7 @@ using namespace ckernel;
 using namespace ckernel::unpacker;
 
 template <
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
@@ -39,7 +39,7 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         "Not supported configuration when unpacking to dest!");
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
 
-    static constexpr uint unpack_srca = TT_OP_UNPACR(
+    static constexpr std::uint32_t unpack_srca = TT_OP_UNPACR(
         SrcA,
         0b1 /*Z inc*/,
         0,
@@ -53,7 +53,7 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         0,
         0,
         1);
-    static constexpr uint unpack_srca_to_dest = TT_OP_UNPACR(
+    static constexpr std::uint32_t unpack_srca_to_dest = TT_OP_UNPACR(
         SrcA,
         0b00010001 /*Z inc*/,
         0,
@@ -67,11 +67,11 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         0,
         0,
         1);  // ch0/ch1 z_inc
-    static constexpr uint unpack_srca_to_dest_transpose_of_faces = TT_OP_UNPACR(
+    static constexpr std::uint32_t unpack_srca_to_dest_transpose_of_faces = TT_OP_UNPACR(
         SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);  // inc srcA ch1_z+=1, ch0_z+=2
-    static constexpr uint unpack_srca_set_dvalid =
+    static constexpr std::uint32_t unpack_srca_set_dvalid =
         TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr uint unpack_srcb = TT_OP_UNPACR(
+    static constexpr std::uint32_t unpack_srcb = TT_OP_UNPACR(
         SrcB,
         0b1 /*Z inc*/,
         0,
@@ -85,7 +85,7 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         0,
         0,
         1);
-    static constexpr uint unpack_srcb_inc_z_0 = TT_OP_UNPACR(
+    static constexpr std::uint32_t unpack_srcb_inc_z_0 = TT_OP_UNPACR(
         SrcB,
         0b0 /*Z inc*/,
         0,
@@ -99,20 +99,23 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
         0,
         0,
         1);
-    static constexpr uint unpack_srcb_set_dvalid =
+    static constexpr std::uint32_t unpack_srcb_set_dvalid =
         TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr uint srca_set_z_1 = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);  // set srcA ch0_z = 1
-    static constexpr uint srcb_set_z_2 = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001);  // set srcB ch0_z = 2
-    static constexpr uint srcb_clear_z = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001);  // set srcB ch0_z = 0
+    static constexpr std::uint32_t srca_set_z_1 =
+        TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);  // set srcA ch0_z = 1
+    static constexpr std::uint32_t srcb_set_z_2 =
+        TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001);  // set srcB ch0_z = 2
+    static constexpr std::uint32_t srcb_clear_z =
+        TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001);  // set srcB ch0_z = 0
     if (num_faces == 1) {
-        constexpr uint32_t outerloop = 1;
-        constexpr uint32_t innerloop = num_tiles;
+        constexpr std::uint32_t outerloop = 1;
+        constexpr std::uint32_t innerloop = num_tiles;
         ckernel_template tmp(outerloop, innerloop, unpack_srca);
         tmp.set_start_op(unpack_srcb_set_dvalid);
         tmp.program();
     } else {
-        constexpr uint32_t outerloop = 1;
-        const uint32_t innerloop = num_tiles * num_faces / 2;
+        constexpr std::uint32_t outerloop = 1;
+        const std::uint32_t innerloop = num_tiles * num_faces / 2;
         ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srca);
         tmp.set_start_op(unpack_srcb_set_dvalid);
         tmp.program();
@@ -120,7 +123,7 @@ inline void _llk_unpack_A_rmsnorm_mop_config_(
 }
 
 template <
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -17,7 +17,7 @@ using namespace ckernel;
 
 namespace ckernel {
 
-constexpr uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
+constexpr std::uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
 
 // Configure address modifiers for single face transpose
 template <bool is_32bit>
@@ -37,7 +37,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_configure_addrmod() {
         .set(ADDR_MOD_3);
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     // For 16-bit data, simple single-pass transpose
@@ -63,15 +63,15 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
     TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
     TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
 
-    uint d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
-    uint b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
+    std::uint32_t d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
+    std::uint32_t b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
 
     ckernel_template tmp(num_tiles, 1, d2b_instr, TT_OP_TRNSPSRCB);
     tmp.set_end_op(b2d_instr);
     tmp.program();
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     // For 16-bit data, simple single-pass transpose
@@ -93,13 +93,13 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
     TTI_MOVB2D(0, 26, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 5);
     TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
     TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
-    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
+    std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
 
     ckernel_template tmp(num_tiles, 1, replay_instr);
     tmp.program();
 }
 
-template <uint32_t num_tiles = 1, bool is_32bit>
+template <std::uint32_t num_tiles = 1, bool is_32bit>
 inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 4);
@@ -111,7 +111,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
 
     // Move 1 row from SrcB back to DEST
     TTI_MOVB2D(0, 16, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 0);
-    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
+    std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
 
     ckernel_template tmp(num_tiles, 1, replay_instr);
     tmp.program();

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
@@ -11,25 +11,24 @@
  *************************************************************************/
 
 // Version with operands
-template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
 inline void llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, NUM_FIDELITY_PHASES>(
-        num_faces, acc_to_dest);
+    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, math_fidelity>(num_faces, acc_to_dest);
 }
 
-template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_deepseek_moe_gate_eltwise_binary(
-    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_A,
+    const std::uint32_t operand_B,
+    std::uint32_t dst_index,
+    const bool clear_fp32_dst_acc) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_deepseek_moe_gate_eltwise_binary_<
-        eltwise_binary_type,
-        DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES>(num_faces, dst_index, clear_fp32_dst_acc);
+    _llk_math_deepseek_moe_gate_eltwise_binary_<eltwise_binary_type, DST_SYNC_MODE, is_fp32_dest_acc_en, math_fidelity>(
+        num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
@@ -11,21 +11,21 @@
  *************************************************************************/
 
 // Version with operands
-template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, std::uint32_t num_tiles, MathFidelity math_fidelity>
 inline void llk_math_rmsnorm_bcast_scalar_dest_reuse_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_rmsnorm_bcast_scalar_dest_reuse_init_<eltwise_binary_type, num_tiles, NUM_FIDELITY_PHASES>(
+    _llk_math_rmsnorm_bcast_scalar_dest_reuse_init_<eltwise_binary_type, num_tiles, math_fidelity>(
         num_faces, acc_to_dest);
 }
 
 template <
     EltwiseBinaryType eltwise_binary_type,
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     bool clear_dest = false>
 inline void llk_math_rmsnorm_bcast_scalar_dest_reuse(const std::uint32_t src_index, const std::uint32_t dst_index) {
     _llk_math_rmsnorm_bcast_scalar_dest_reuse_<
@@ -33,6 +33,6 @@ inline void llk_math_rmsnorm_bcast_scalar_dest_reuse(const std::uint32_t src_ind
         num_tiles,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         clear_dest>(src_index, dst_index);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_bcast_col_srcb_reuse_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_bcast_col_srcb_reuse_api.h
@@ -11,14 +11,13 @@
  *************************************************************************/
 
 // Version with operands
-template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, MathFidelity math_fidelity>
 inline void llk_math_sdpa_bcast_col_srcb_reuse_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_sdpa_bcast_col_srcb_reuse_init_<eltwise_binary_type, num_tiles, NUM_FIDELITY_PHASES>(
-        num_faces, acc_to_dest);
+    _llk_math_sdpa_bcast_col_srcb_reuse_init_<eltwise_binary_type, num_tiles, math_fidelity>(num_faces, acc_to_dest);
 }
 
 template <DstSync DST, bool IS_FP32_MATH_DEST_EN, bool clear_dest = false>
@@ -32,12 +31,12 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     uint32_t num_tiles,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0>
+    MathFidelity math_fidelity>
 inline void llk_math_sdpa_bcast_col_srcb_reuse(const std::uint32_t dst_index) {
     _llk_math_sdpa_bcast_col_srcb_reuse_<
         eltwise_binary_type,
         num_tiles,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES>(dst_index);
+        math_fidelity>(dst_index);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
@@ -11,25 +11,24 @@
  *************************************************************************/
 
 // Version with operands
-template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
 inline void llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, NUM_FIDELITY_PHASES>(
-        num_faces, acc_to_dest);
+    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, math_fidelity>(num_faces, acc_to_dest);
 }
 
-template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_deepseek_moe_gate_eltwise_binary(
-    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_A,
+    const std::uint32_t operand_B,
+    std::uint32_t dst_index,
+    const bool clear_fp32_dst_acc) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_deepseek_moe_gate_eltwise_binary_<
-        eltwise_binary_type,
-        DST_SYNC_MODE,
-        is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES>(num_faces, dst_index, clear_fp32_dst_acc);
+    _llk_math_deepseek_moe_gate_eltwise_binary_<eltwise_binary_type, DST_SYNC_MODE, is_fp32_dest_acc_en, math_fidelity>(
+        num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_math.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
 
-            llk_math_eltwise_binary_init<ELWADD, NONE>();
+            llk_math_eltwise_binary_init<ELWADD, NONE, MathFidelity::LoFi>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
                 llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, false>(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -14,12 +14,13 @@ inline void tilizeA_B_binary_init(
     uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
     UNPACK((llk_unpack_tilizeA_B_init<true, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim)));
 
-    MATH((llk_math_eltwise_binary_init<ELWADD, NONE>(0 /*acc_to_dest*/)));
+    MATH((llk_math_eltwise_binary_init<ELWADD, NONE, MathFidelity::LoFi>(0 /*acc_to_dest*/)));
 }
 
 inline void add_tiles_math(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
-    MATH((llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
-        icb0, icb1, idst, true)));
+    MATH(
+        (llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
+             icb0, icb1, idst, true)));
 }
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -34,7 +34,7 @@ void core_agnostic_main() {
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
 
-            llk_math_eltwise_binary_init<ELWADD, NONE>();
+            llk_math_eltwise_binary_init<ELWADD, NONE, MathFidelity::LoFi>();
             for (uint32_t c = 0; c < per_core_block_c_tiles; c++) {
                 llk_math_wait_for_dest_available();
                 llk_math_eltwise_binary<ELWADD, NONE, DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -41,7 +41,7 @@ inline void llk_math_eltwise_mul_reduce_scalar(
 
 template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
 inline void llk_math_mul_reduce_scalar_reduce_init() {
-    _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
+    _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
 }
 
 template <MathFidelity math_fidelity>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -11,7 +11,7 @@
  * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
  *************************************************************************/
 
-template <int NUM_FIDELITY_PHASES = 0>
+template <MathFidelity math_fidelity>
 inline void llk_math_eltwise_mul_reduce_scalar_init(
     const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);
@@ -20,11 +20,11 @@ inline void llk_math_eltwise_mul_reduce_scalar_init(
     _llk_math_eltwise_binary_init_<
         EltwiseBinaryType::ELWMUL,
         BroadcastType::NONE,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         EltwiseBinaryReuseDestType::NONE>(num_faces, acc_to_dest);
 }
 
-template <bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_eltwise_mul_reduce_scalar(
     uint dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t operand_id = get_operand_id(icb0);
@@ -35,25 +35,25 @@ inline void llk_math_eltwise_mul_reduce_scalar(
         BroadcastType::NONE,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         EltwiseBinaryReuseDestType::NONE>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
-template <bool is_fp32_dest_acc_en, int num_fidelity_phases = 0, bool enforce_fp32_accumulation = false>
+template <bool is_fp32_dest_acc_en, MathFidelity math_fidelity, bool enforce_fp32_accumulation = false>
 inline void llk_math_mul_reduce_scalar_reduce_init() {
     _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
 }
 
-template <int num_fidelity_phases = 0>
+template <MathFidelity math_fidelity>
 inline void llk_math_mul_reduce_column(const uint dst_index, const std::uint32_t icb0) {
     const std::uint32_t operand_id = get_operand_id(icb0);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_mul_reduce_column_<num_fidelity_phases>(dst_index, false, num_faces);
+    _llk_math_mul_reduce_column_<math_fidelity>(dst_index, false, num_faces);
 }
 
-template <int num_fidelity_phases = 0>
+template <MathFidelity math_fidelity>
 inline void llk_math_mul_reduce_scalar() {
-    _llk_math_mul_reduce_scalar_<num_fidelity_phases>();
+    _llk_math_mul_reduce_scalar_<math_fidelity>();
 }
 
 inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -14,12 +14,12 @@
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t num_faces = 4;
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
         num_faces, acc_to_dest);
 }
 
@@ -27,7 +27,7 @@ inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
         get_operand_id(operand_A);  // operand_id is used to extract tile dim data which is the same for both operands
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
         num_faces, acc_to_dest);
 }
 
@@ -43,7 +43,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t num_faces = 4;
@@ -53,7 +53,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         src_b_bcast_type,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
@@ -61,13 +61,10 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
-    const std::uint32_t operand_A,
-    const std::uint32_t operand_B,
-    uint dst_index,
-    const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
     const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
@@ -76,6 +73,6 @@ inline void llk_math_eltwise_binary(
         src_b_bcast_type,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -10,7 +10,7 @@
  * LLK MATMUL
  *************************************************************************/
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0>
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -27,11 +27,11 @@ inline void llk_math_matmul_init(
 
     const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<math_fidelity, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    _llk_math_matmul_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -14,11 +14,11 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
     bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -26,14 +26,14 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
     bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -41,10 +41,10 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool enforce_fp32_accumulation = false /*unused*/>
 inline void llk_math_reduce_init() {
-    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
 }
 
 template <bool enforce_fp32_accumulation = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_binary_api.h
@@ -14,12 +14,12 @@
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t num_faces = 4;
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
         num_faces, acc_to_dest);
 }
 
@@ -27,7 +27,7 @@ inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary_init_with_operands(
     const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
@@ -35,7 +35,7 @@ inline void llk_math_eltwise_binary_init_with_operands(
         get_operand_id(operand_A);  // operand_id is used to extract tile dim data which is the same for both operands
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
         num_faces, acc_to_dest);
 }
 
@@ -43,7 +43,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t num_faces = 4;
@@ -53,7 +53,7 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         src_b_bcast_type,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
@@ -61,7 +61,7 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
+    MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
     const std::uint32_t operand_A,
@@ -76,6 +76,6 @@ inline void llk_math_eltwise_binary(
         src_b_bcast_type,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES,
+        math_fidelity,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_matmul_api.h
@@ -10,7 +10,7 @@
  * LLK MATMUL
  *************************************************************************/
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0>
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -27,11 +27,11 @@ inline void llk_math_matmul_init(
 
     const bool partial_face = (in0_tile_r_dim < FACE_R_DIM);
 
-    _llk_math_matmul_init_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(
+    _llk_math_matmul_init_<math_fidelity, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
-template <int NUM_FIDELITY_PHASES, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
-    _llk_math_matmul_<NUM_FIDELITY_PHASES, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
+    _llk_math_matmul_<math_fidelity, THROTTLE_LEVEL>(dst_index, ct_dim, rt_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -14,11 +14,11 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
     bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -26,13 +26,13 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
     bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, is_int_fpu_en, enforce_fp32_accumulation>(
+    _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
 }
 
@@ -40,10 +40,10 @@ template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
+    MathFidelity math_fidelity,
     bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce_init() {
-    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
 }
 
 template <bool enforce_fp32_accumulation = false>

--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -242,7 +242,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line =
     if constexpr (tBcastOp == ELWMUL) {
         MATH((llk_math_eltwise_binary_init<tBcastOp, tBcastDim, MATH_FIDELITY>()));
     } else {
-        MATH((llk_math_eltwise_binary_init<tBcastOp, tBcastDim>()));
+        MATH((llk_math_eltwise_binary_init<tBcastOp, tBcastDim, MathFidelity::LoFi>()));
     }
 
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
@@ -348,7 +348,7 @@ ALWI void add_bcast_rows_init_short(uint32_t icb0, uint32_t icb1, uint32_t call_
  */
 ALWI void add_bcast_cols_init_short(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1, call_line);
-    MATH((llk_math_eltwise_binary_init_with_operands<ELWADD, BroadcastType::COL>(icb0, icb1)));
+    MATH((llk_math_eltwise_binary_init_with_operands<ELWADD, BroadcastType::COL, MathFidelity::LoFi>(icb0, icb1)));
     // FIXME: API Update needed in compute kernel?
     UNPACK((llk_unpack_AB_init<BroadcastType::COL>(icb0, icb1)));
 }

--- a/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
@@ -70,7 +70,7 @@ ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tile
     UNPACK((llk_unpack_mul_reduce_scalar_switch_to_reduce()));
 
     // Step 3: Initialize reduce operation
-    MATH((llk_math_mul_reduce_scalar_reduce_init<DST_ACCUM_MODE, MATH_FIDELITY>()));
+    MATH((llk_math_mul_reduce_scalar_reduce_init<DST_ACCUM_MODE, math_fidelity>()));
 
     // Step 4: Prepare data for first tile's scalar reduction
     // Move dest[0] (first multiply result) to srcA

--- a/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/mul_reduce_scalar.h
@@ -70,7 +70,7 @@ ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tile
     UNPACK((llk_unpack_mul_reduce_scalar_switch_to_reduce()));
 
     // Step 3: Initialize reduce operation
-    MATH((llk_math_mul_reduce_scalar_reduce_init<DST_ACCUM_MODE, math_fidelity>()));
+    MATH((llk_math_mul_reduce_scalar_reduce_init<DST_ACCUM_MODE, MATH_FIDELITY>()));
 
     // Step 4: Prepare data for first tile's scalar reduction
     // Move dest[0] (first multiply result) to srcA

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -519,7 +519,11 @@ void generate_math_fidelity_descriptor(JitBuildOptions& options) {
     ofstream file_stream;
 
     file_stream.open(tmp.path());
-    file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << endl;
+
+    MathFidelity fidelity = desc.get_hlk_math_fidelity();
+
+    file_stream << "constexpr ckernel::MathFidelity MATH_FIDELITY = static_cast<ckernel::MathFidelity>("
+                << static_cast<std::uint32_t>(fidelity) << ");" << endl;
     file_stream.close();
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue
[Match PR](https://github.com/tenstorrent/tt-llk/pull/1084) for [this issue](https://github.com/tenstorrent/tt-llk/issues/952)

### Problem description


### What's changed
Providing API to use MathFidelity enum instead of uint32_t

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/runs/21899084039) 
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/runs/21884055712)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs