### PR TITLE
Update op perf report reading to support new op type format

### DIFF
--- a/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
+++ b/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
@@ -87,7 +87,7 @@ PERF_TARGETS_WH = {config["test_name"]: config["perf_targets"]["wh"] for config 
 PERF_TARGETS_BH_P150 = {config["test_name"]: config["perf_targets"]["bh_p150"] for config in CONV_PERF_CONFIGS}
 
 
-def extract_ops_between_signposts(csv_path, op_name="Conv2dDeviceOperation"):
+def extract_ops_between_signposts(csv_path, op_name):
     """
     Extract operation durations between signpost pairs from a Tracy CSV file.
 
@@ -97,7 +97,7 @@ def extract_ops_between_signposts(csv_path, op_name="Conv2dDeviceOperation"):
 
     Args:
         csv_path (str): Path to the Tracy profiler CSV file.
-        op_name (str, optional): Name of the operation to extract (default: "Conv2dDeviceOperation").
+        op_name (str): Name of the operation to extract.
 
     Returns:
         dict: Dictionary mapping test names to lists of durations in nanoseconds.
@@ -118,7 +118,7 @@ def extract_ops_between_signposts(csv_path, op_name="Conv2dDeviceOperation"):
                 current_region = op_code[:-6]  # Remove "-start" suffix to get test_name
             elif op_code.endswith("-end"):
                 current_region = None
-        elif current_region and row["OP CODE"] == op_name:
+        elif current_region and op_name in str(row["OP CODE"]):
             if current_region not in results:
                 results[current_region] = []
             results[current_region].append(float(row["DEVICE KERNEL DURATION [ns]"]))


### PR DESCRIPTION
### Problem description
197bbceafc changed the format of op type name - eg from `Conv2dDeviceOperation` to `MeshDeviceOperationAdapter<ttnn::operations::conv::conv2d::Conv2dDeviceOperation>`. 
Failed run: https://github.com/tenstorrent/tt-metal/actions/runs/20990289627/job/60334391686

### What's changed
Update op perf report parsing to avoid exact string check.
Also remove default argument in the function being Conv2d since the function will be reused for other ops.

### Checklist

Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/20996078382 ⚙️