### PR TITLE
[skip ci] Fix download artifacts script

### DIFF
--- a/tests/scripts/download_artifacts.sh
+++ b/tests/scripts/download_artifacts.sh
@@ -94,13 +94,16 @@ ttmetal_artifact=""
 eagerdist_artifact=""
 
 if [ "$tracy_enabled" -eq 1 ]; then
-  # Look for artifacts with profiler in the name
+  echo "DEBUG: Tracy enabled, looking for profiler builds..."
+  # Look for artifacts with profiler in the name (TTMetal only)
   ttmetal_artifact="$(echo "$artifacts" | grep "TTMetal_build_any.*_profiler_" | head -1)"
-  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist).*profiler" | head -1)"
+  # Wheel artifacts (ttnn-dist) don't have profiler in the name
+  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist)" | head -1)"
 else
+  echo "DEBUG: Tracy disabled, looking for non-profiler builds..."
   # Look for artifacts without profiler in the name
   ttmetal_artifact="$(echo "$artifacts" | grep "TTMetal_build_any" | grep -v "_profiler_" | head -1)"
-  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist)" | grep -v "profiler" | head -1)"
+  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist)" | head -1)"
 fi
 
 # Download available artifacts

--- a/tests/scripts/download_artifacts.sh
+++ b/tests/scripts/download_artifacts.sh
@@ -96,11 +96,11 @@ eagerdist_artifact=""
 if [ "$tracy_enabled" -eq 1 ]; then
   # Look for artifacts with profiler in the name
   ttmetal_artifact="$(echo "$artifacts" | grep "TTMetal_build_any.*_profiler_" | head -1)"
-  eagerdist_artifact="$(echo "$artifacts" | grep "eager-dist.*profiler" | head -1)"
+  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist).*profiler" | head -1)"
 else
   # Look for artifacts without profiler in the name
   ttmetal_artifact="$(echo "$artifacts" | grep "TTMetal_build_any" | grep -v "_profiler_" | head -1)"
-  eagerdist_artifact="$(echo "$artifacts" | grep "eager-dist" | grep -v "profiler" | head -1)"
+  eagerdist_artifact="$(echo "$artifacts" | grep -E "(eager-dist|ttnn-dist)" | grep -v "profiler" | head -1)"
 fi
 
 # Download available artifacts


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35654)

### Problem description
Download artifacts was failing because of artifact name change

### What's changed
Fix grep for searching artifacts to download

Example old git bisect run: https://github.com/tenstorrent/tt-metal/actions/runs/20920269803 (~2h 30min)
Example new git bisect run: https://github.com/tenstorrent/tt-metal/actions/runs/20995583872 (~13min 30sec)