### PR TITLE
Revert "Don't conditionally dispatch on individual devices during `ttnn.paged_update_cache` (#35656)"

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -6,25 +6,19 @@
 #include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
-    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t Wt = get_compile_time_arg_val(5);
-
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
     const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
     const uint32_t index_tensor_addr = get_arg_val<uint32_t>(2);
     const uint32_t my_batch_idx = get_arg_val<uint32_t>(3);
     const uint32_t page_table_tensor_addr = get_arg_val<uint32_t>(4);
     const bool wait_to_start_signal = get_arg_val<uint32_t>(5) == 1;
-    const uint32_t noop = get_arg_val<uint32_t>(6);
 
-    if (noop == 1) {
-        return;  // Early exit, no work done
-    }
-
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(1);
     constexpr bool use_index_tensor = get_compile_time_arg_val(2) == 1;
     constexpr uint32_t cb_index_id = get_compile_time_arg_val(3);
     constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t Wt = get_compile_time_arg_val(5);
     const uint32_t log_base_2_of_page_size = get_compile_time_arg_val(6);
     const uint32_t index_stick_size_B = get_compile_time_arg_val(7);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -6,6 +6,14 @@
 #include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
+    const uint32_t cache_addr = get_arg_val<uint32_t>(0);
+    const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
+    uint32_t cache_tile_offset_B = get_arg_val<uint32_t>(2);
+    const uint32_t my_batch_idx = get_arg_val<uint32_t>(3);
+    const bool send_signal = get_arg_val<uint32_t>(4) == 1;
+    const uint32_t send_core_x = get_arg_val<uint32_t>(5);
+    const uint32_t send_core_y = get_arg_val<uint32_t>(6);
+
     constexpr uint32_t cache_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(2);
@@ -28,19 +36,6 @@ void kernel_main() {
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
 
     constexpr auto s0_args = TensorAccessorArgs<17>();
-
-    uint32_t cache_addr = get_arg_val<uint32_t>(0);
-    uint32_t cache_start_id = get_arg_val<uint32_t>(1);
-    uint32_t cache_tile_offset_B = get_arg_val<uint32_t>(2);
-    const uint32_t my_batch_idx = get_arg_val<uint32_t>(3);
-    const bool send_signal = get_arg_val<uint32_t>(4) == 1;
-    const uint32_t send_core_x = get_arg_val<uint32_t>(5);
-    const uint32_t send_core_y = get_arg_val<uint32_t>(6);
-    const uint32_t noop = get_arg_val<uint32_t>(7);
-
-    if (noop == 1) {
-        return;  // Early exit, no work done
-    }
 
     constexpr uint32_t head_offset_t = Wt * St;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -214,7 +214,6 @@ tt::stl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
     // - update_idxs: values are runtime-only (used only in runtime args), size is validated to match input tensor shape
     // (already in tensor_args)
     // - batch_offset: validated to be 0, doesn't affect program structure
-    // - noop: runtime-only parameter (used only in runtime args)
     // Include parameters that affect program structure:
     // - compute_kernel_config: affects compile-time args (fp32_dest_acc_en)
     // - share_cache: affects program structure (semaphore setup)

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
@@ -20,7 +20,6 @@ struct operation_attributes_t {
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;
     const bool share_cache;
     const std::optional<std::set<ttnn::MeshCoordinate>> mesh_coords;
-    const bool noop = false;  // When true, kernels early exit
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -276,7 +276,6 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
                 i,
                 is_paged_cache ? page_table.value().buffer()->address() : 0,
                 wait_to_start,
-                (uint32_t)operation_attributes.noop,  // noop flag
             });
 
         SetRuntimeArgs(
@@ -291,7 +290,6 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
                 send_signal,
                 send_core_x,
                 send_core_y,
-                (uint32_t)operation_attributes.noop,  // noop flag
             });
     }
 
@@ -315,6 +313,9 @@ PagedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t PagedUpdateCacheMesh
     const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
+    log_debug(tt::LogOp, "PagedUpdateCacheMeshWorkloadFactory::create_mesh_workload called");
+    log_debug(tt::LogOp, "tensor_coords has {} ranges", tensor_coords.ranges().size());
+
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
@@ -322,67 +323,35 @@ PagedUpdateCacheMeshWorkloadFactory::cached_mesh_workload_t PagedUpdateCacheMesh
     const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords_opt = operation_attributes.mesh_coords;
 
     if (mesh_coords_opt.has_value()) {
-        // Validate that all mesh_coords are present in tensor_coords BEFORE creating programs
-        const auto& mesh_coords_set = mesh_coords_opt.value();
-        const auto tensor_coords_vector = tensor_coords.coords();
-        std::set<ttnn::MeshCoordinate> tensor_coords_set(tensor_coords_vector.begin(), tensor_coords_vector.end());
+        log_debug(tt::LogOp, "mesh_coords provided with {} coordinates", mesh_coords_opt.value().size());
+    } else {
+        log_debug(tt::LogOp, "mesh_coords not provided, using all tensor_coords");
+    }
 
-        for (const auto& mesh_coord : mesh_coords_set) {
-            TT_FATAL(
-                tensor_coords_set.contains(mesh_coord),
-                "Mesh coordinate ({}, {}) is in mesh_coords but not found in tensor_coords. "
-                "mesh_coords size: {}, tensor_coords size: {}",
-                mesh_coord[0],
-                mesh_coord[1],
-                mesh_coords_set.size(),
-                tensor_coords_set.size());
-        }
-        for (const auto& mesh_coord : mesh_coords_set) {
+    // Create programs for each coordinate in tensor_coords (filtered by mesh_coords if provided)
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            // Skip this coordinate if mesh_coords is provided and this coordinate is not in the set
+            if (mesh_coords_opt.has_value()) {
+                const auto& mesh_coords_set = mesh_coords_opt.value();
+                if (!mesh_coords_set.contains(mesh_coord)) {
+                    log_debug(
+                        tt::LogOp, "Skipping coordinate ({}, {}) - not in mesh_coords", mesh_coord[0], mesh_coord[1]);
+                    continue;  // Skip this coordinate
+                }
+            }
+
+            // Create a program for this specific coordinate using the base factory
+            log_debug(tt::LogOp, "Creating program for coordinate ({}, {})", mesh_coord[0], mesh_coord[1]);
             const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
             auto cached_program =
                 PagedUpdateCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
             shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
             mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
         }
-
-        // Create dummy programs for excluded coordinates
-        std::vector<ttnn::MeshCoordinate> dummy_coords;
-        for (const auto& coord : tensor_coords_set) {
-            if (!mesh_coords_set.contains(coord)) {
-                dummy_coords.push_back(coord);
-            }
-        }
-
-        if (!dummy_coords.empty()) {
-            for (const auto& mesh_coord : dummy_coords) {
-                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-                // Create operation attributes with noop=true for dummy programs
-                operation_attributes_t dummy_attrs{
-                    .update_idxs = operation_attributes.update_idxs,
-                    .batch_offset = operation_attributes.batch_offset,
-                    .compute_kernel_config = operation_attributes.compute_kernel_config,
-                    .share_cache = operation_attributes.share_cache,
-                    .mesh_coords = operation_attributes.mesh_coords,
-                    .noop = true};
-                auto cached_program =
-                    PagedUpdateCacheProgramFactory::create(dummy_attrs, tensor_args, tensor_return_value);
-                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-            }
-        }
-    } else {
-        // When mesh_coords is not provided, iterate over all tensor_coords
-        for (const auto& mesh_coord_range : tensor_coords.ranges()) {
-            for (const auto& mesh_coord : mesh_coord_range) {
-                const ttnn::MeshCoordinateRange single_coord_range{mesh_coord, mesh_coord};
-                auto cached_program =
-                    PagedUpdateCacheProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-                shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
-                mesh_workload.add_program(single_coord_range, std::move(cached_program.program));
-            }
-        }
     }
 
+    log_debug(tt::LogOp, "Created mesh workload with {} programs", mesh_workload.get_programs().size());
     return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
 }
 
@@ -424,7 +393,6 @@ void PagedUpdateCacheProgramFactory::override_runtime_arguments(
             runtime_args[1] = cache_start_id;
             runtime_args[2] = index_tensor_addr;
             runtime_args[4] = page_table_tensor_addr;
-            runtime_args[6] = (uint32_t)operation_attributes.noop;  // noop flag
         }
 
         {
@@ -432,7 +400,6 @@ void PagedUpdateCacheProgramFactory::override_runtime_arguments(
             runtime_args[0] = dst_buffer->address();
             runtime_args[1] = cache_start_id;
             runtime_args[2] = tile_update_offset_B;
-            runtime_args[7] = (uint32_t)operation_attributes.noop;  // noop flag
         }
     }
 }
@@ -444,31 +411,17 @@ void PagedUpdateCacheMeshWorkloadFactory::override_runtime_arguments(
     tensor_return_value_t& tensor_return_value) {
     PagedUpdateCacheProgramFactory program_factory;
 
-    // Determine which coordinates should have noop=true (excluded from mesh_coords)
-    std::set<ttnn::MeshCoordinate> mesh_coords_set;
-    if (operation_attributes.mesh_coords.has_value()) {
-        mesh_coords_set = operation_attributes.mesh_coords.value();
-    }
-
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
-        const ttnn::MeshCoordinate coord = *(coordinate_range.begin());
-
-        // Determine if this coordinate should be a noop (dummy program)
-        // If mesh_coords is provided and this coord is not in it, it's a dummy program
-        bool is_dummy = operation_attributes.mesh_coords.has_value() && !mesh_coords_set.contains(coord);
-
-        // Create modified operation_attributes with correct noop value for this coordinate
-        operation_attributes_t coord_attrs{
-            .update_idxs = operation_attributes.update_idxs,
-            .batch_offset = operation_attributes.batch_offset,
-            .compute_kernel_config = operation_attributes.compute_kernel_config,
-            .share_cache = operation_attributes.share_cache,
-            .mesh_coords = operation_attributes.mesh_coords,
-            .noop = is_dummy};
 
         ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
-            program_factory, program, shared_variables, coord_attrs, coord, tensor_args, tensor_return_value);
+            program_factory,
+            program,
+            shared_variables,
+            operation_attributes,
+            *(coordinate_range.begin()),
+            tensor_args,
+            tensor_return_value);
     }
 }
 


### PR DESCRIPTION
…

This reverts commit 9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20.

This broke APC.

### Ticket

APC breakage

### Problem description

APC breakage

### What's changed

Evan gave the blessing for revert

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rkim/0-revert-9e51529aedb7cd6b2cc6e73dbe7ea63979b03e20)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs