### PR TITLE
Alexey zaytsev epam/issue/32603/tensor memcpy unification

### DIFF
--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -127,7 +127,8 @@ void test_raw_host_memory_pointer() {
     // Alternatively, we could allocate memory manually and create Tensors with borrowed storage on the fly to print the
     // data
     void* storage_of_alternative_tensor_for_printing = malloc(shape.volume() * sizeof(bfloat16));
-    tt::tt_metal::memcpy2(storage_of_alternative_tensor_for_printing, c_dev);
+    tt::tt_metal::copy_tensor_to_host_from_device(
+        c_dev.device()->mesh_command_queue(), storage_of_alternative_tensor_for_printing, c_dev);
 
     HostBuffer alternative_tensor_for_printing_buffer(
         tt::stl::Span<bfloat16>(static_cast<bfloat16*>(storage_of_alternative_tensor_for_printing), shape.volume()),

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -113,7 +113,7 @@ void test_raw_host_memory_pointer() {
     Tensor c_dev = ttnn::sqrt(a_dev);
 
     auto dst_host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor_for_printing);
-    copy_tensor_to_host_from_device(c_dev.device()->mesh_command_queue(), dst_host_buffer.view_bytes().data(), c_dev);
+    copy_tensor_to_host_buffer(c_dev.device()->mesh_command_queue(), dst_host_buffer.view_bytes().data(), c_dev);
 
     // Check that cpu tensor has correct data
     bfloat16 output_value = 2.0f;
@@ -128,7 +128,7 @@ void test_raw_host_memory_pointer() {
     // Alternatively, we could allocate memory manually and create Tensors with borrowed storage on the fly to print the
     // data
     void* storage_of_alternative_tensor_for_printing = malloc(shape.volume() * sizeof(bfloat16));
-    tt::tt_metal::copy_tensor_to_host_from_device(
+    tt::tt_metal::copy_tensor_to_host_buffer(
         c_dev.device()->mesh_command_queue(), storage_of_alternative_tensor_for_printing, c_dev);
 
     HostBuffer alternative_tensor_for_printing_buffer(
@@ -160,12 +160,12 @@ void test_raw_host_memory_pointer() {
 
     Tensor d_dev = a_dev;
     auto d_cpu_buffer = tt::tt_metal::host_buffer::get_host_buffer(d_cpu);
-    copy_tensor_to_device_from_host(d_cpu.device()->mesh_command_queue(), d_dev, d_cpu_buffer.view_bytes().data());
+    fill_tensor_from_host_buffer(d_cpu.device()->mesh_command_queue(), d_dev, d_cpu_buffer.view_bytes().data());
 
     Tensor e_dev = ttnn::add(c_dev, d_dev);
 
     auto dst_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor_for_printing);
-    copy_tensor_to_host_from_device(e_dev.device()->mesh_command_queue(), dst_buffer.view_bytes().data(), e_dev);
+    copy_tensor_to_host_buffer(e_dev.device()->mesh_command_queue(), dst_buffer.view_bytes().data(), e_dev);
 
     for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
         TT_FATAL(element == bfloat16(10.0f), "Element does not match expected bfloat16(10.0f)");

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -112,7 +112,7 @@ void test_raw_host_memory_pointer() {
 
     Tensor c_dev = ttnn::sqrt(a_dev);
 
-    tt::tt_metal::memcpy(tensor_for_printing, c_dev);
+    tt::tt_metal::memcpy6(tensor_for_printing, c_dev);
 
     // Check that cpu tensor has correct data
     bfloat16 output_value = 2.0f;
@@ -157,11 +157,11 @@ void test_raw_host_memory_pointer() {
     }
 
     Tensor d_dev = a_dev;
-    memcpy(d_dev, d_cpu);
+    tt::tt_metal::memcpy6(d_dev, d_cpu);
 
     Tensor e_dev = ttnn::add(c_dev, d_dev);
 
-    tt::tt_metal::memcpy(tensor_for_printing, e_dev);
+    tt::tt_metal::memcpy6(tensor_for_printing, e_dev);
 
     for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(tensor_for_printing)) {
         TT_FATAL(element == bfloat16(10.0f), "Element does not match expected bfloat16(10.0f)");

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -127,7 +127,7 @@ void test_raw_host_memory_pointer() {
     // Alternatively, we could allocate memory manually and create Tensors with borrowed storage on the fly to print the
     // data
     void* storage_of_alternative_tensor_for_printing = malloc(shape.volume() * sizeof(bfloat16));
-    tt::tt_metal::memcpy(storage_of_alternative_tensor_for_printing, c_dev);
+    tt::tt_metal::memcpy2(storage_of_alternative_tensor_for_printing, c_dev);
 
     HostBuffer alternative_tensor_for_printing_buffer(
         tt::stl::Span<bfloat16>(static_cast<bfloat16*>(storage_of_alternative_tensor_for_printing), shape.volume()),

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -125,10 +125,9 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             // Create tensor and transfer to device
             std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
+            auto src_buffer = host_buffer::get_host_buffer(host_tensor);
             copy_tensor_to_device_from_host(
-                device->mesh_command_queue(*write_cq),
-                device_tensor,
-                host_buffer::get_host_buffer(host_tensor).view_bytes().data());
+                device->mesh_command_queue(*write_cq), device_tensor, src_buffer.view_bytes().data());
             EXPECT_TRUE(is_device_tensor(device_tensor));
 
             {

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -125,7 +125,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             // Create tensor and transfer to device
             std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
-            memcpy(device->mesh_command_queue(*write_cq), device_tensor, host_tensor);
+            memcpy5(device->mesh_command_queue(*write_cq), device_tensor, host_tensor);
             EXPECT_TRUE(is_device_tensor(device_tensor));
 
             {

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -125,7 +125,10 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             // Create tensor and transfer to device
             std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
-            memcpy5(device->mesh_command_queue(*write_cq), device_tensor, host_tensor);
+            copy_tensor_to_device_from_host(
+                device->mesh_command_queue(*write_cq),
+                device_tensor,
+                host_buffer::get_host_buffer(host_tensor).view_bytes().data());
             EXPECT_TRUE(is_device_tensor(device_tensor));
 
             {

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -126,7 +126,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
             auto src_buffer = host_buffer::get_host_buffer(host_tensor);
-            copy_tensor_to_device_from_host(
+            fill_tensor_from_host_buffer(
                 device->mesh_command_queue(*write_cq), device_tensor, src_buffer.view_bytes().data());
             EXPECT_TRUE(is_device_tensor(device_tensor));
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -292,21 +292,21 @@ void copy_tensor_to_host_from_device(
     bool blocking = true);
 
 void memcpy(
+    void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
+
+void memcpy3(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,
     const void* src,
     const std::optional<BufferRegion>& region = std::nullopt);
+
+void memcpy4(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy5(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,
     const Tensor& src,
     const std::optional<BufferRegion>& region = std::nullopt);
-
-void memcpy(
-    void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
-
-void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy6(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -297,7 +297,7 @@ void memcpy(
     const void* src,
     const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy(
+void memcpy5(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,
     const Tensor& src,
@@ -308,7 +308,7 @@ void memcpy(
 
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
+void memcpy6(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 // Allocates a tensor on host. Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device
 // shard.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -291,7 +291,7 @@ void copy_tensor_to_host_from_device(
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
-void memcpy3(
+void copy_tensor_to_device_from_host(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,
     const void* src,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -300,8 +300,6 @@ void memcpy3(
     const void* src,
     const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy4(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
-
 void memcpy5(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -284,7 +284,7 @@ private:
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);
 
 // The set of memcpy functions below are used to copy data between host buffers/tensors and single-device tensors
-void memcpy(
+void copy_tensor_to_host_from_device(
     distributed::MeshCommandQueue& queue,
     void* dst,
     const Tensor& src,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -297,12 +297,6 @@ void copy_tensor_to_device_from_host(
     const void* src,
     const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy5(
-    distributed::MeshCommandQueue& queue,
-    Tensor& dst,
-    const Tensor& src,
-    const std::optional<BufferRegion>& region = std::nullopt);
-
 void memcpy6(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
 
 // Allocates a tensor on host. Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -297,8 +297,6 @@ void copy_tensor_to_device_from_host(
     const void* src,
     const std::optional<BufferRegion>& region = std::nullopt);
 
-void memcpy6(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
-
 // Allocates a tensor on host. Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device
 // shard.
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -283,8 +283,9 @@ private:
 
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);
 
-// dst need to have enough space data will be copied into dst
-// use of host based tensor for dst memory as most appropriate approach
+// device tensor data will be copied to the dst buffer
+// dst need to have enough space
+// usage of host based tensor for dst memory recommended as most appropriate approach
 void copy_tensor_to_host_buffer(
     distributed::MeshCommandQueue& queue,
     void* dst,
@@ -292,8 +293,8 @@ void copy_tensor_to_host_buffer(
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
-// src could be picked from host based tensor
-// Device tensor will be filled with the data from source tensor
+// Device tensor will be filled with the data from src buffer
+// src could be picked from host based tensor as most recommended approach
 void fill_tensor_from_host_buffer(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -291,9 +291,6 @@ void copy_tensor_to_host_from_device(
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
-void memcpy2(
-    void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
-
 void memcpy3(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -291,7 +291,7 @@ void copy_tensor_to_host_from_device(
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
-void memcpy(
+void memcpy2(
     void* dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt, bool blocking = true);
 
 void memcpy3(

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -283,15 +283,18 @@ private:
 
 Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);
 
-// The set of memcpy functions below are used to copy data between host buffers/tensors and single-device tensors
-void copy_tensor_to_host_from_device(
+// dst need to have enough space data will be copied into dst
+// use of host based tensor for dst memory as most appropriate approach
+void copy_tensor_to_host_buffer(
     distributed::MeshCommandQueue& queue,
     void* dst,
     const Tensor& src,
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
 
-void copy_tensor_to_device_from_host(
+// src could be picked from host based tensor
+// Device tensor will be filled with the data from source tensor
+void fill_tensor_from_host_buffer(
     distributed::MeshCommandQueue& queue,
     Tensor& dst,
     const void* src,

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -18,7 +18,7 @@ void write_buffer(
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(dst);
     for (size_t i = 0; i < device_tensors.size(); i++) {
-        tt::tt_metal::copy_tensor_to_device_from_host(cq, device_tensors[i], src.at(i).get(), region);
+        tt::tt_metal::fill_tensor_from_host_buffer(cq, device_tensors[i], src.at(i).get(), region);
     }
 }
 
@@ -35,7 +35,7 @@ void read_buffer(
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(src);
     for (size_t i = 0; i < device_tensors.size(); i++) {
-        tt::tt_metal::copy_tensor_to_host_from_device(cq, dst.at(i).get(), device_tensors[i], region);
+        tt::tt_metal::copy_tensor_to_host_buffer(cq, dst.at(i).get(), device_tensors[i], region);
     }
 }
 

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -35,7 +35,7 @@ void read_buffer(
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(src);
     for (size_t i = 0; i < device_tensors.size(); i++) {
-        tt::tt_metal::memcpy(cq, dst.at(i).get(), device_tensors[i], region);
+        tt::tt_metal::copy_tensor_to_host_from_device(cq, dst.at(i).get(), device_tensors[i], region);
     }
 }
 

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -18,7 +18,7 @@ void write_buffer(
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(dst);
     for (size_t i = 0; i < device_tensors.size(); i++) {
-        tt::tt_metal::memcpy3(cq, device_tensors[i], src.at(i).get(), region);
+        tt::tt_metal::copy_tensor_to_device_from_host(cq, device_tensors[i], src.at(i).get(), region);
     }
 }
 

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -18,7 +18,7 @@ void write_buffer(
     auto& cq = mesh_device->mesh_command_queue(*cq_id);
     auto device_tensors = ttnn::distributed::get_device_tensors(dst);
     for (size_t i = 0; i < device_tensors.size(); i++) {
-        tt::tt_metal::memcpy(cq, device_tensors[i], src.at(i).get(), region);
+        tt::tt_metal::memcpy3(cq, device_tensors[i], src.at(i).get(), region);
     }
 }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -514,7 +514,7 @@ void copy_tensor_to_host_from_device(
     queue.enqueue_read_shards(shard_data_transfers, src.mesh_buffer(), blocking);
 }
 
-void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
+void memcpy2(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
     ZoneScoped;
     auto* mesh_device = src.device();
     TT_FATAL(mesh_device, "Tensor must be on device");

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -497,7 +497,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
     return output;
 }
 
-void copy_tensor_to_host_from_device(
+void copy_tensor_to_host_buffer(
     distributed::MeshCommandQueue& queue,
     void* dst,
     const Tensor& src,
@@ -514,7 +514,7 @@ void copy_tensor_to_host_from_device(
     queue.enqueue_read_shards(shard_data_transfers, src.mesh_buffer(), blocking);
 }
 
-void copy_tensor_to_device_from_host(
+void fill_tensor_from_host_buffer(
     distributed::MeshCommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -514,13 +514,6 @@ void copy_tensor_to_host_from_device(
     queue.enqueue_read_shards(shard_data_transfers, src.mesh_buffer(), blocking);
 }
 
-void memcpy2(void* dst, const Tensor& src, const std::optional<BufferRegion>& region, bool blocking) {
-    ZoneScoped;
-    auto* mesh_device = src.device();
-    TT_FATAL(mesh_device, "Tensor must be on device");
-    copy_tensor_to_host_from_device(mesh_device->mesh_command_queue(), dst, src, region, blocking);
-}
-
 void memcpy3(
     distributed::MeshCommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -540,7 +540,7 @@ void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& reg
     memcpy(mesh_device->mesh_command_queue(), dst, src, region);
 }
 
-void memcpy(
+void memcpy5(
     distributed::MeshCommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     TT_ASSERT(dst.dtype() == src.dtype());
@@ -557,14 +557,14 @@ void memcpy(
     }
 }
 
-void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
+void memcpy6(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         auto* mesh_device = src.device();
-        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
+        memcpy5(mesh_device->mesh_command_queue(), dst, src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         auto* mesh_device = dst.device();
-        memcpy(mesh_device->mesh_command_queue(), dst, src, region);
+        memcpy5(mesh_device->mesh_command_queue(), dst, src, region);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -497,7 +497,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
     return output;
 }
 
-void memcpy(
+void copy_tensor_to_host_from_device(
     distributed::MeshCommandQueue& queue,
     void* dst,
     const Tensor& src,
@@ -518,7 +518,7 @@ void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& reg
     ZoneScoped;
     auto* mesh_device = src.device();
     TT_FATAL(mesh_device, "Tensor must be on device");
-    memcpy(mesh_device->mesh_command_queue(), dst, src, region, blocking);
+    copy_tensor_to_host_from_device(mesh_device->mesh_command_queue(), dst, src, region, blocking);
 }
 
 void memcpy(
@@ -548,7 +548,7 @@ void memcpy(
 
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         auto dst_buffer = host_buffer::get_host_buffer(dst);
-        memcpy(queue, dst_buffer.view_bytes().data(), src, region);
+        copy_tensor_to_host_from_device(queue, dst_buffer.view_bytes().data(), src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         auto src_buffer = host_buffer::get_host_buffer(src);
         memcpy(queue, dst, src_buffer.view_bytes().data(), region);

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -514,7 +514,7 @@ void copy_tensor_to_host_from_device(
     queue.enqueue_read_shards(shard_data_transfers, src.mesh_buffer(), blocking);
 }
 
-void memcpy3(
+void copy_tensor_to_device_from_host(
     distributed::MeshCommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");
@@ -537,7 +537,7 @@ void memcpy5(
         copy_tensor_to_host_from_device(queue, dst_buffer.view_bytes().data(), src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         auto src_buffer = host_buffer::get_host_buffer(src);
-        memcpy3(queue, dst, src_buffer.view_bytes().data(), region);
+        copy_tensor_to_device_from_host(queue, dst, src_buffer.view_bytes().data(), region);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -521,7 +521,7 @@ void memcpy(void* dst, const Tensor& src, const std::optional<BufferRegion>& reg
     copy_tensor_to_host_from_device(mesh_device->mesh_command_queue(), dst, src, region, blocking);
 }
 
-void memcpy(
+void memcpy3(
     distributed::MeshCommandQueue& queue, Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     TT_FATAL(is_device_tensor(dst), "memcpy: memcpy to non-device tensor is not supported!");
@@ -533,11 +533,11 @@ void memcpy(
     queue.enqueue_write_shards(dst.mesh_buffer(), shard_data_transfers, false);
 }
 
-void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
+void memcpy4(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
     ZoneScoped;
     auto* mesh_device = dst.device();
     TT_FATAL(mesh_device, "Tensor must be on device");
-    memcpy(mesh_device->mesh_command_queue(), dst, src, region);
+    memcpy3(mesh_device->mesh_command_queue(), dst, src, region);
 }
 
 void memcpy5(
@@ -551,7 +551,7 @@ void memcpy5(
         copy_tensor_to_host_from_device(queue, dst_buffer.view_bytes().data(), src, region);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         auto src_buffer = host_buffer::get_host_buffer(src);
-        memcpy(queue, dst, src_buffer.view_bytes().data(), region);
+        memcpy3(queue, dst, src_buffer.view_bytes().data(), region);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -533,13 +533,6 @@ void memcpy3(
     queue.enqueue_write_shards(dst.mesh_buffer(), shard_data_transfers, false);
 }
 
-void memcpy4(Tensor& dst, const void* src, const std::optional<BufferRegion>& region) {
-    ZoneScoped;
-    auto* mesh_device = dst.device();
-    TT_FATAL(mesh_device, "Tensor must be on device");
-    memcpy3(mesh_device->mesh_command_queue(), dst, src, region);
-}
-
 void memcpy5(
     distributed::MeshCommandQueue& queue, Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region) {
     ZoneScoped;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/32603

### Problem description
Tensor files contain custom memcpy -named -related functions
these functions most probably are not being in use

### What's changed
functions got more appropriate naming and reworked to be only two, since initially they reuses themselves
logic have not changed

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
