### PR TITLE
Restore test_clean_init as standalone executable

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -12,7 +12,6 @@ set(UNIT_TESTS_LEGACY_SRC
     test_bcast.cpp
     test_bfp8_conversion.cpp
     test_bmm.cpp
-    test_clean_init.cpp
     test_compile_program.cpp
     test_compile_sets_kernel_binaries.cpp
     test_core_range_set.cpp
@@ -57,6 +56,25 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal
 )
 list(APPEND METAL_TEST_TARGETS unit_tests_legacy)
+
+# Standalone test_clean_init executable (not a gtest - requires custom main with skip-teardown handling)
+add_executable(test_clean_init test_clean_init.cpp)
+target_link_libraries(test_clean_init PUBLIC Metalium::Metal)
+target_include_directories(
+    test_clean_init
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/test_utils
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_target_properties(
+    test_clean_init
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/api)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/data_movement)

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -2,116 +2,173 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
-
 #include <chrono>
+#include <fmt/base.h>
 #include <cstdint>
-#include <array>
-#include <vector>
-
+#include <cstdlib>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <array>
+#include <exception>
+#include <map>
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-logger/tt-logger.hpp>
-#include "impl/context/metal_context.hpp"
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
 #include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/distributed.hpp>
+
+namespace tt::tt_metal {
+class CommandQueue;
+}  // namespace tt::tt_metal
+
+/*
+ * Similar to loopback programming example, except run on al devices and skip device teardown to check if we can
+ * recover from a "bad" state.
+ */
 
 using std::vector;
 using namespace tt::tt_metal;
 
-/*
- * Similar to loopback programming example, except run on all devices.
- * Tests that we can recover from a "bad" state.
- */
-
-// Custom fixture for clean init test - needs multiple devices
-class CleanInitFixture : public ::testing::Test {
-protected:
-    void SetUp() override {
-        if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-            GTEST_SKIP() << "Test not supported with slow dispatch";
-        }
+int main(int argc, char** /*argv*/) {
+    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
+        TT_THROW("Test not supported w/ slow dispatch, exiting");
     }
-};
 
-TEST_F(CleanInitFixture, CleanInit) {
-    auto num_devices = GetNumAvailableDevices();
+    // Any arg means that we shouldn't do teardown.
+    bool skip_teardown = (argc > 1);
+    if (skip_teardown) {
+        log_info(tt::LogTest, "Running loopback test with no teardown, to see if we can recover next run.");
+    } else {
+        log_info(tt::LogTest, "Running loopback test with proper teardown");
+    }
+
+    bool pass = true;
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     vector<tt::ChipId> ids;
     ids.reserve(num_devices);
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
 
-    const auto& dispatch_core_config = MetalContext::instance().rtoptions().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     auto devices = distributed::MeshDevice::create_unit_meshes(
         ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, dispatch_core_config);
 
-    for (size_t device_id = 0; device_id < num_devices; device_id++) {
-        auto device = devices[device_id];
-        auto& cq = device->mesh_command_queue();
+    for (int device_id = 0; device_id < num_devices; device_id++) {
+        try {
+            /*
+             * Silicon accelerator setup
+             */
+            auto device = devices[device_id];
 
-        constexpr uint32_t single_tile_size = 2 * (32 * 32);
-        constexpr uint32_t num_tiles = 50;
-        constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
+            /*
+             * Setup program and command queue to execute along with its buffers and kernels to use
+             */
+            auto& cq = device->mesh_command_queue();
 
-        distributed::DeviceLocalBufferConfig local_l1_config{
-            .page_size = dram_buffer_size, .buffer_type = BufferType::L1};
+            constexpr uint32_t single_tile_size = 2 * (32 * 32);
+            constexpr uint32_t num_tiles = 50;
+            constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-        distributed::DeviceLocalBufferConfig local_dram_config{
-            .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+            distributed::DeviceLocalBufferConfig local_l1_config{
+                .page_size = dram_buffer_size, .buffer_type = tt::tt_metal::BufferType::L1};
 
-        distributed::ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
+            distributed::DeviceLocalBufferConfig local_dram_config{
+                .page_size = dram_buffer_size, .buffer_type = tt::tt_metal::BufferType::DRAM};
 
-        auto l1_buffer = distributed::MeshBuffer::create(global_buffer_config, local_l1_config, device.get());
-        auto input_dram_buffer = distributed::MeshBuffer::create(global_buffer_config, local_dram_config, device.get());
-        auto output_dram_buffer =
-            distributed::MeshBuffer::create(global_buffer_config, local_dram_config, device.get());
+            distributed::ReplicatedBufferConfig global_buffer_config{.size = dram_buffer_size};
 
-        Program program = CreateProgram();
-        auto mesh_workload = distributed::MeshWorkload();
+            auto l1_buffer = distributed::MeshBuffer::create(global_buffer_config, local_l1_config, device.get());
+            auto input_dram_buffer =
+                distributed::MeshBuffer::create(global_buffer_config, local_dram_config, device.get());
 
-        constexpr CoreCoord core = {0, 0};
+            auto output_dram_buffer =
+                distributed::MeshBuffer::create(global_buffer_config, local_dram_config, device.get());
 
-        std::vector<uint32_t> compile_time_args;
-        TensorAccessorArgs(*(input_dram_buffer->get_backing_buffer())).append_to(compile_time_args);
-        TensorAccessorArgs(*(output_dram_buffer->get_backing_buffer())).append_to(compile_time_args);
-        KernelHandle dram_copy_kernel_id = CreateKernel(
-            program,
-            "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = compile_time_args});
+            Program program = CreateProgram();
+            auto mesh_workload = distributed::MeshWorkload();
 
-        std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
-            dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, false);
+            constexpr CoreCoord core = {0, 0};
 
-        const std::array<uint32_t, 8> runtime_args = {
-            l1_buffer->address(),
-            input_dram_buffer->address(),
-            output_dram_buffer->address(),
-            l1_buffer->size(),
-            num_tiles};
+            std::vector<uint32_t> compile_time_args;
+            TensorAccessorArgs(*(input_dram_buffer->get_backing_buffer())).append_to(compile_time_args);
+            TensorAccessorArgs(*(output_dram_buffer->get_backing_buffer())).append_to(compile_time_args);
+            KernelHandle dram_copy_kernel_id = CreateKernel(
+                program,
+                "tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp",
+                core,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0,
+                    .noc = NOC::RISCV_0_default,
+                    .compile_args = compile_time_args});
 
-        SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
-        mesh_workload.add_program(distributed::MeshCoordinateRange(device->shape()), std::move(program));
-        distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
-        log_info(tt::LogTest, "Started program on device {}", device_id);
-        distributed::Finish(cq);
-        log_info(tt::LogTest, "Finished program on device {}", device_id);
+            /*
+             * Create input data and runtime arguments, then execute
+             */
+            std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
+                dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+            distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, false);
 
-        std::vector<uint32_t> result_vec;
-        distributed::ReadShard(cq, result_vec, output_dram_buffer, distributed::MeshCoordinate(0, 0));
+            const std::array<uint32_t, 8> runtime_args = {
+                l1_buffer->address(),
+                input_dram_buffer->address(),
+                output_dram_buffer->address(),
+                l1_buffer->size(),
+                num_tiles};
 
-        EXPECT_EQ(input_vec, result_vec) << "Mismatch on device " << device_id;
+            SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
+            mesh_workload.add_program(distributed::MeshCoordinateRange(device->shape()), std::move(program));
+            distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+            log_info(tt::LogTest, "Started program");
+            distributed::Finish(cq);
+            log_info(tt::LogTest, "Finished program");
+
+            /*
+             * Validation & Teardown
+             */
+            std::vector<uint32_t> result_vec;
+            distributed::ReadShard(cq, result_vec, output_dram_buffer, distributed::MeshCoordinate(0, 0));
+
+            pass &= input_vec == result_vec;
+
+        } catch (const std::exception& e) {
+            log_error(tt::LogTest, "Test failed with exception!");
+            log_error(tt::LogTest, "{}", e.what());
+
+            throw;
+        }
     }
 
-    // Proper teardown
-    for (auto& [device_id, device] : devices) {
-        device->close();
+    if (pass) {
+        log_info(tt::LogTest, "Test Passed");
+    } else {
+        TT_THROW("Test Failed");
     }
+
+    // Skip teardown by throwing.
+    if (skip_teardown) {
+        TT_THROW("Skip teardown by throwing");
+    } else {
+        for (auto& [device_id, device] : devices) {
+            device->close();
+        }
+    }
+
+    // Error out with non-zero return code if we don't detect a pass
+    TT_FATAL(pass, "Error");
+
+    return 0;
 }


### PR DESCRIPTION
### Ticket
Fixes tools tests failure after gtest migration (#35680)

### Problem description
The gtest migration (#35680) inadvertently broke `test_clean_init` by merging it into `unit_tests_legacy` without preserving its custom `main()` function that handles the `--skip-teardown` flag.

The `run_tools_tests.sh` script expects a standalone executable at `./build/test/tt_metal/test_clean_init` that can be run with a `--skip-teardown` argument:

```bash
./build/test/tt_metal/test_clean_init --skip-teardown  # First run, leaves devices dirty
./build/test/tt_metal/test_clean_init                  # Second run, tests recovery
```

This test is designed to verify that the driver can recover from a dirty shutdown (e.g., user program crash, unexpected termination) by:
1. First run: executing a workload then aborting without closing devices
2. Second run: verifying the driver can detect and recover from the dirty device state

### What's changed
- Restored original `test_clean_init.cpp` with custom `main()` and skip-teardown handling (reverts to pre-gtest migration version)
- Added standalone `test_clean_init` executable to `CMakeLists.txt`
- Linked against `Metalium::Metal` only (not gtest, since this is not a gtest)

**Verified locally:** Both first run (skip-teardown) and second run (recovery) work correctly.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/restore-test-clean-init-standalone)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/restore-test-clean-init-standalone)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/restore-test-clean-init-standalone)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/restore-test-clean-init-standalone)
- [x] New/Existing tests provide coverage for changes