### PR TITLE
#32998: Use bcast scalar with dest reuse for RMSNorm

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int NUM_FIDELITY_PHASES = 0>
+inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
+    const std::uint32_t num_faces = 4, const std::uint32_t acc_to_dest = 0) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    constexpr uint addr_mod = ADDR_MOD_0;
+    uint innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
+    uint outerloop = num_faces;
+    constexpr auto broadcast_type = p_elwise::SRCB_BCAST_ALL;
+
+    // Scalar broadcast should not Clear B within a mop.  This is controlled outside of MOP.
+    if constexpr (eltwise_binary_type == ELWADD) {
+        ckernel_template tmp(
+            num_tiles,
+            num_faces,
+            TT_OP_ELWADD(0, acc_to_dest, broadcast_type, ADDR_MOD_0, 0),
+            TT_OP_ELWADD(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_2, 0));
+        tmp.set_last_inner_loop_instr(TT_OP_ELWADD(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
+        tmp.program();
+    } else if constexpr (eltwise_binary_type == ELWSUB) {
+        ckernel_template tmp(
+            num_tiles,
+            num_faces,
+            TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, ADDR_MOD_0, 0),
+            TT_OP_ELWSUB(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_2, 0));
+        tmp.set_last_inner_loop_instr(TT_OP_ELWSUB(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
+        tmp.program();
+    } else if constexpr (eltwise_binary_type == ELWMUL) {
+        if constexpr (high_fidelity) {
+            ckernel_template tmp(
+                num_faces,
+                NUM_FIDELITY_PHASES,
+                TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_0, 0),
+                TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_2, 0));
+            tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
+            tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_4, 0));
+            tmp.program();
+        } else {
+            ckernel_template tmp(
+                num_tiles,
+                num_faces,
+                TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_0, 0),
+                TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_2, 0));
+            tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
+            tmp.program();
+        }
+    }
+}
+
+inline void rmsnorm_bcast_scalar_reuse_dest_as_src() {
+    TTI_STALLWAIT(
+        p_stall::STALL_MATH,
+        p_stall::WAIT_SFPU | p_stall::SRCB_VLD);  // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                  // data_valid, so we want to wait on that
+    TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_1_ROW, 0);
+}
+
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    uint32_t num_tiles,
+    DstSync Dst,
+    bool is_fp32_dest_acc_en,
+    int NUM_FIDELITY_PHASES = 0,
+    bool clear_dest = false>
+inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_index) {
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(src_index);
+    rmsnorm_bcast_scalar_reuse_dest_as_src();
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+
+    if constexpr ((eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB)) {
+        ckernel_template::run();
+    } else if constexpr (eltwise_binary_type == ELWMUL) {
+        // Row and no broadcasted behaves similarly
+        if constexpr (high_fidelity) {
+#pragma GCC unroll 0
+            for (std::uint32_t tile_num = 0; tile_num < num_tiles; tile_num++) {
+                ckernel_template::run();
+            }
+        } else {
+            ckernel_template::run();
+        }
+    }
+    // Manually clear B once mop is done for scaler bcast
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    math::clear_dst_reg_addr();
+}
+
+template <EltwiseBinaryType eltwise_binary_type, int NUM_FIDELITY_PHASES, std::uint32_t FIDELITY_INCREMENT>
+inline void rmsnorm_bcast_scalar_dest_reuse_configure_addrmod(const std::uint32_t num_faces) {
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    // Use srcA for data movement
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        addr_mod_t{
+            .srca = {.incr = 8},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 8},
+        }
+            .set(ADDR_MOD_0);
+        addr_mod_t{
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_1);
+
+        if constexpr (eltwise_binary_type == ELWMUL && high_fidelity) {
+            addr_mod_t{
+                .srca = {.incr = 0, .clr = 1},
+                .srcb = {.incr = 0, .clr = 1},
+                .dest = {.incr = 0, .clr = 0, .cr = 1},
+                .fidelity = {.incr = FIDELITY_INCREMENT}}
+                .set(ADDR_MOD_2);
+
+            addr_mod_t{
+                .srca = {.incr = 0, .clr = 1},
+                .srcb = {.incr = 0, .clr = 1},
+                .dest = {.incr = 8, .clr = 0, .cr = 0, .c_to_cr = 1},
+                .fidelity = {.incr = 0, .clr = 1}}
+                .set(ADDR_MOD_3);
+            addr_mod_t{
+                .srca = {.incr = 0, .clr = 1},
+                .srcb = {.incr = 0, .clr = 1},
+                .dest = {.incr = static_cast<int16_t>(8 + (4 - num_faces) * 16), .clr = 0, .cr = 0, .c_to_cr = 1},
+                .fidelity = {.incr = 0, .clr = 1}}
+                .set(ADDR_MOD_4);
+        } else {
+            addr_mod_t{
+                .srca = {.incr = 0, .clr = 1},  // Clear SrcA counter to 0
+                .srcb = {.incr = 0, .clr = 1},  // Clear SrcB counter to 0
+                .dest = {.incr = 8},
+            }
+                .set(ADDR_MOD_2);
+            addr_mod_t{
+                .srca = {.incr = 0, .clr = 1},  // Clear SrcA counter to 0
+                .srcb = {.incr = 0, .clr = 1},  // Clear SrcB counter to 0
+                .dest = {.incr = static_cast<int16_t>(8 + (4 - num_faces) * 16)},
+            }
+                .set(ADDR_MOD_3);
+        }
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int MATH_FIDELITY_DESC = 0>
+inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_init_(
+    const std::uint32_t num_faces, const std::uint32_t acc_to_dest) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+    constexpr int MATH_FIDELITY_INCREMENT = get_math_fidelity_increment(MATH_FIDELITY_DESC);
+
+    rmsnorm_bcast_scalar_dest_reuse_configure_addrmod<
+        eltwise_binary_type,
+        MATH_FIDELITY_PHASES,
+        MATH_FIDELITY_INCREMENT>(num_faces);
+
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        rmsnorm_bcast_scalar_dest_reuse_configure_mop<eltwise_binary_type, num_tiles, MATH_FIDELITY_PHASES>(
+            num_faces, acc_to_dest);
+    }
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_rmsnorm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_rmsnorm.h
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_globals.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cunpack_common.h"
+#include "llk_assert.h"
+
+using namespace ckernel;
+using namespace ckernel::unpacker;
+
+template <
+    uint32_t num_tiles,
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void _llk_unpack_A_rmsnorm_mop_config_(
+    const bool transpose_of_faces,
+    const std::uint32_t num_faces,
+    const std::uint32_t unpack_src_format,
+    const std::uint32_t unpack_dst_format = 0) {
+    static_assert(
+        ((BType == BroadcastType::SCALAR) && acc_to_dest &&
+         (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)),
+        "Not supported configuration!");
+    static_assert(
+        (((BType == BroadcastType::NONE) && (!acc_to_dest) &&
+          (binary_reuse_dest == EltwiseBinaryReuseDestType::NONE)) ||
+         (!unpack_to_dest)),
+        "Not supported configuration when unpacking to dest!");
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+
+    static constexpr uint unpack_srca = TT_OP_UNPACR(
+        SrcA,
+        0b1 /*Z inc*/,
+        0,
+        0,
+        0,
+        1 /* Set OvrdThreadId*/,
+        1 /*Set Dvalid*/,
+        p_unpacr::RAREFYB_DISABLE,
+        0,
+        0,
+        0,
+        0,
+        1);
+    static constexpr uint unpack_srca_to_dest = TT_OP_UNPACR(
+        SrcA,
+        0b00010001 /*Z inc*/,
+        0,
+        0,
+        0,
+        1 /* Set OvrdThreadId*/,
+        0 /*Set Dvalid*/,
+        p_unpacr::RAREFYB_DISABLE,
+        0,
+        0,
+        0,
+        0,
+        1);  // ch0/ch1 z_inc
+    static constexpr uint unpack_srca_to_dest_transpose_of_faces = TT_OP_UNPACR(
+        SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);  // inc srcA ch1_z+=1, ch0_z+=2
+    static constexpr uint unpack_srca_set_dvalid =
+        TT_OP_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr uint unpack_srcb = TT_OP_UNPACR(
+        SrcB,
+        0b1 /*Z inc*/,
+        0,
+        0,
+        0,
+        1 /* Set OvrdThreadId*/,
+        1 /*Set Dvalid*/,
+        p_unpacr::RAREFYB_DISABLE,
+        0,
+        0,
+        0,
+        0,
+        1);
+    static constexpr uint unpack_srcb_inc_z_0 = TT_OP_UNPACR(
+        SrcB,
+        0b0 /*Z inc*/,
+        0,
+        0,
+        0,
+        1 /* Set OvrdThreadId*/,
+        1 /*Set Dvalid*/,
+        p_unpacr::RAREFYB_DISABLE,
+        0,
+        0,
+        0,
+        0,
+        1);
+    static constexpr uint unpack_srcb_set_dvalid =
+        TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr uint srca_set_z_1 = TT_OP_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 1, 0b0001);  // set srcA ch0_z = 1
+    static constexpr uint srcb_set_z_2 = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001);  // set srcB ch0_z = 2
+    static constexpr uint srcb_clear_z = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001);  // set srcB ch0_z = 0
+    if (num_faces == 1) {
+        constexpr uint32_t outerloop = 1;
+        constexpr uint32_t innerloop = num_tiles;
+        ckernel_template tmp(outerloop, innerloop, unpack_srca);
+        tmp.set_start_op(unpack_srcb_set_dvalid);
+        tmp.program();
+    } else {
+        constexpr uint32_t outerloop = 1;
+        const uint32_t innerloop = num_tiles * num_faces / 2;
+        ckernel_template tmp(outerloop, innerloop, unpack_srca, unpack_srca);
+        tmp.set_start_op(unpack_srcb_set_dvalid);
+        tmp.program();
+    }
+}
+
+template <
+    uint32_t num_tiles,
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void _llk_unpack_A_rmsnorm_init_(
+    const std::uint32_t transpose_of_faces = 0,
+    const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t num_faces = 4,
+    const std::uint32_t unpack_src_format = 0,
+    const std::uint32_t unpack_dst_format = 0) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+
+    // Set transpose register to prevent state pollution
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(within_face_16x16_transpose);
+
+    // TODO NC: Find out why we need to disable src zero flags for uint16 dst format #960
+    // bool disable_src_zero_flag_val = disable_src_zero_flag || (static_cast<uint>(unpack_dst_format) ==
+    // static_cast<uint>(DataFormat::UInt16));
+    // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable_src_zero_flag_val ? 1 : 0);
+
+    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
+    config_unpacker_x_end<UNP_SEL>(face_r_dim);
+
+    _llk_unpack_A_rmsnorm_mop_config_<num_tiles, BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "../../../../../../tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY
+ *************************************************************************/
+
+// Version with operands
+template <EltwiseBinaryType eltwise_binary_type, uint32_t num_tiles, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_rmsnorm_bcast_scalar_dest_reuse_init_with_operands(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_rmsnorm_bcast_scalar_dest_reuse_init_<eltwise_binary_type, num_tiles, NUM_FIDELITY_PHASES>(
+        num_faces, acc_to_dest);
+}
+
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    uint32_t num_tiles,
+    bool is_fp32_dest_acc_en,
+    int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_rmsnorm_bcast_scalar_dest_reuse(const std::uint32_t src_index, const std::uint32_t dst_index) {
+    _llk_math_rmsnorm_bcast_scalar_dest_reuse_<
+        eltwise_binary_type,
+        num_tiles,
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        NUM_FIDELITY_PHASES>(src_index, dst_index);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "../../../../../../tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_rmsnorm.h"
+#include "llk_unpack_common_api.h"
+
+/*************************************************************************
+ * LLK UNPACK A
+ *************************************************************************/
+
+template <
+    uint32_t num_tiles,
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A_rmsnorm_init(
+    const std::uint32_t transpose_of_faces = 0,
+    const std::uint32_t within_face_16x16_transpose = 0,
+    const std::uint32_t operand = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
+    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
+    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+        llk_unpack_dbg_feature_disable();
+    }
+
+    _llk_unpack_A_rmsnorm_init_<num_tiles, BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces,
+        within_face_16x16_transpose,
+        face_r_dim,
+        num_faces,
+        operand_unpack_src_format,
+        operand_unpack_dst_format);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/rmsnorm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/rmsnorm.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/common.h"
+#ifdef TRISC_MATH
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "../../hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h"
+#endif
+
+namespace ckernel {
+
+template <EltwiseBinaryType eltwise_binary_type = ELWADD, uint32_t num_tiles>
+ALWI void rmsnorm_bcast_scalar_reuse_tiles_init(uint32_t icb0) {
+    UNPACK((llk_unpack_A_rmsnorm_init<num_tiles, BroadcastType::SCALAR, true, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+        false, false, icb0)));
+    MATH((llk_math_rmsnorm_bcast_scalar_dest_reuse_init_with_operands<eltwise_binary_type, num_tiles, MATH_FIDELITY>(
+        icb0, icb0, false)));
+}
+
+template <EltwiseBinaryType eltwise_binary_type = ELWADD, uint32_t num_tiles>
+ALWI void rmsnorm_bcast_scalar_reuse_tiles(
+    uint32_t in_cb_id, uint32_t in_tile_index, uint32_t src_tile_index, uint32_t dst_tile_index) {
+    UNPACK(
+        (llk_unpack_A<BroadcastType::SCALAR, true, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(in_cb_id, in_tile_index)));
+    MATH((llk_math_rmsnorm_bcast_scalar_dest_reuse<eltwise_binary_type, num_tiles, DST_ACCUM_MODE, MATH_FIDELITY>(
+        src_tile_index, dst_tile_index)));
+}
+
+template <uint32_t num_tiles>
+ALWI void rmsnorm_mul_bcast_scalar_reuse_tiles_init(uint32_t icb0) {
+    rmsnorm_bcast_scalar_reuse_tiles_init<ELWMUL, num_tiles>(icb0);
+}
+
+template <uint32_t num_tiles>
+ALWI void rmsnorm_mul_bcast_scalar_reuse_tiles(
+    uint32_t in_cb_id, uint32_t in_tile_index, uint32_t src_tile_index, uint32_t dst_tile_index) {
+    rmsnorm_bcast_scalar_reuse_tiles<ELWMUL, num_tiles>(in_cb_id, in_tile_index, src_tile_index, dst_tile_index);
+}
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
@@ -135,7 +135,7 @@ class RMSNormSingleCore:
             tile=tile_descriptor,
         )
         interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=(num_tiles + 1) * cb_page_size,
+            total_size=num_tiles * cb_page_size,
             core_ranges=core_grid,
             format_descriptors=[interm_cb_format],
         )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We want to avoid pack/unpacks within the compute kernel. We can remove spilling the RMS value by using bcast with dest reuse.

### What's changed
Implement bcast with dest reuse and integrate into RMSNorm.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/rmsnorm-update2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/rmsnorm-update2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/rmsnorm-update2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/rmsnorm-update2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/rmsnorm-update2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/rmsnorm-update2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/rmsnorm-update2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs