### PR TITLE
Sdxl 512x512 resolution

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -28,6 +28,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_combined_pipeline i
 def run_demo_inference(
     ttnn_device,
     is_ci_env,
+    image_resolution,
     prompts,
     negative_prompts,
     num_inference_steps,
@@ -87,6 +88,7 @@ def run_demo_inference(
 
     # 2. Create unified config and combined pipeline
     config = TtSDXLCombinedPipelineConfig(
+        image_resolution=image_resolution,
         num_inference_steps=num_inference_steps,
         guidance_scale=guidance_scale,
         is_galaxy=is_galaxy(),
@@ -287,6 +289,7 @@ def test_demo_base_and_refiner(
     validate_fabric_compatibility,
     mesh_device,
     is_ci_env,
+    image_resolution,
     prompt,
     negative_prompt,
     num_inference_steps,
@@ -313,6 +316,7 @@ def test_demo_base_and_refiner(
     return run_demo_inference(
         mesh_device,
         is_ci_env,
+        image_resolution,
         prompt,
         negative_prompt,
         num_inference_steps,

--- a/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
+++ b/models/experimental/stable_diffusion_xl_base/reference/test_base_img2img.py
@@ -31,6 +31,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_sdxl_img2img_pipeline im
 def run_demo_inference(
     ttnn_device,
     is_ci_env,
+    image_resolution,
     prompts,
     negative_prompts,
     num_inference_steps,
@@ -91,6 +92,7 @@ def run_demo_inference(
         ttnn_device=ttnn_device,
         torch_pipeline=pipeline,
         pipeline_config=TtSDXLImg2ImgPipelineConfig(
+            image_resolution=image_resolution,
             capture_trace=capture_trace,
             vae_on_device=vae_on_device,
             encoders_on_device=encoders_on_device,
@@ -126,7 +128,7 @@ def run_demo_inference(
 
     images = [tt_sdxl.torch_pipeline.image_processor.preprocess(image).to(dtype=torch.float32) for image in images]
 
-    images = torch.cat(images, dim=0)  # [batch_size, 3, 1024, 1024]
+    images = torch.cat(images, dim=0)  # [batch_size, 3, height, width]
 
     tt_latents, tt_prompt_embeds, tt_add_text_embeds = tt_sdxl.generate_input_tensors(
         torch_image=torch.randn(batch_size, images.shape[1], images.shape[2], images.shape[3]),
@@ -228,6 +230,14 @@ def run_demo_inference(
     return out_images
 
 
+@pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+        (512, 512),
+    ],
+    ids=["1024x1024", "512x512"],
+)
 # Note: The 'fabric_config' parameter is only required when running with cfg_parallel enabled,
 # as the all_gather_async operation used in this mode depends on fabric being set.
 @pytest.mark.parametrize(
@@ -315,6 +325,7 @@ def test_demo(
     validate_fabric_compatibility,
     mesh_device,
     is_ci_env,
+    image_resolution,
     prompt,
     negative_prompt,
     num_inference_steps,
@@ -334,10 +345,14 @@ def test_demo(
     timesteps,
     sigmas,
 ):
+    if image_resolution == (512, 512):
+        pytest.skip("512x512 image resolution is not yet supported for base img2img pipeline.")
+
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,
         is_ci_env,
+        image_resolution,
         prompt,
         negative_prompt,
         num_inference_steps,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_attention.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_attention import TtAttention
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,19 +15,21 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape, attn_id, down_block_id, query_dim, num_attn_heads, out_dim, block_type",
+    "image_resolution, input_shape, encoder_shape, attn_id, down_block_id, query_dim, num_attn_heads, out_dim, block_type",
     [
-        ((1, 4096, 768), None, 1, 1, 768, 12, 768, "down_blocks"),
-        ((1, 4096, 768), (1, 77, 1280), 2, 1, 768, 12, 768, "down_blocks"),
-        ((1, 1024, 1536), None, 1, 2, 1536, 24, 1536, "down_blocks"),
-        ((1, 1024, 1536), (1, 77, 1280), 2, 2, 1536, 24, 1536, "down_blocks"),
-        ((1, 256, 1536), None, 1, -1, 1536, 24, 1536, "mid_block"),
-        ((1, 256, 1536), (1, 77, 1280), 2, -1, 1536, 24, 1536, "mid_block"),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4096, 768), None, 1, 1, 768, 12, 768, "down_blocks"),
+        ((1024, 1024), (1, 4096, 768), (1, 77, 1280), 2, 1, 768, 12, 768, "down_blocks"),
+        ((1024, 1024), (1, 1024, 1536), None, 1, 2, 1536, 24, 1536, "down_blocks"),
+        ((1024, 1024), (1, 1024, 1536), (1, 77, 1280), 2, 2, 1536, 24, 1536, "down_blocks"),
+        ((1024, 1024), (1, 256, 1536), None, 1, -1, 1536, 24, 1536, "mid_block"),
+        ((1024, 1024), (1, 256, 1536), (1, 77, 1280), 2, -1, 1536, 24, 1536, "mid_block"),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_attention(
     device,
+    image_resolution,
     input_shape,
     encoder_shape,
     attn_id,
@@ -39,6 +41,10 @@ def test_attention(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -64,7 +70,7 @@ def test_attention(
     else:
         raise ValueError(f"Unknown block type: {block_type}")
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_attention = TtAttention(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattndownblock2d import TtCrossAttnDownBlock2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -16,15 +16,17 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
+    "image_resolution, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
-        ((1, 384, 64, 64), (1, 1536), (1, 77, 1280), 768, 12, 768, 1, 0.996),
-        ((1, 768, 32, 32), (1, 1536), (1, 77, 1280), 1536, 24, 1536, 2, 0.990),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 384, 64, 64), (1, 1536), (1, 77, 1280), 768, 12, 768, 1, 0.996),
+        ((1024, 1024), (1, 768, 32, 32), (1, 1536), (1, 77, 1280), 1536, 24, 1536, 2, 0.990),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_crossattndown(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     encoder_shape,
@@ -37,6 +39,10 @@ def test_crossattndown(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -49,7 +55,7 @@ def test_crossattndown(
 
     torch_crosattn = unet.down_blocks[down_block_id]
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_crosattn = TtCrossAttnDownBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattnmidblock2d import TtUNetMidBlock2DCrossAttn
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,14 +15,16 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim",
+    "image_resolution, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim",
     [
-        ((1, 1536, 16, 16), (1, 1536), (1, 77, 1280), 1536, 24, 1536),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 1536, 16, 16), (1, 1536), (1, 77, 1280), 1536, 24, 1536),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_crossattnmid(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     encoder_shape,
@@ -33,6 +35,10 @@ def test_crossattnmid(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -45,7 +51,7 @@ def test_crossattnmid(
 
     torch_crosattn = unet.mid_block
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_crosattn = TtUNetMidBlock2DCrossAttn(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_crossattnupblock.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattnupblock2d import TtCrossAttnUpBlock2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,9 +15,11 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, residuals, encoder_shape, query_dim, num_attn_heads, out_dim, block_id, pcc",
+    "image_resolution, input_shape, temb_shape, residuals, encoder_shape, query_dim, num_attn_heads, out_dim, block_id, pcc",
     [
         (
+            # 1024x1024 image resolution
+            (1024, 1024),
             (1, 1536, 32, 32),
             (1, 1536),
             ((1, 768, 32, 32), (1, 1536, 32, 32), (1, 1536, 32, 32)),
@@ -29,6 +31,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             0.993,
         ),
         (
+            (1024, 1024),
             (1, 1536, 64, 64),
             (1, 1536),
             ((1, 384, 64, 64), (1, 768, 64, 64), (1, 768, 64, 64)),
@@ -44,6 +47,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_crossattnup(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     residuals,
@@ -57,6 +61,10 @@ def test_crossattnup(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -69,7 +77,7 @@ def test_crossattnup(
 
     torch_crosattn = unet.up_blocks[block_id]
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_crosattn = TtCrossAttnUpBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downblock2d import TtDownBlock2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,14 +15,21 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, block_id, pcc",
+    "image_resolution, input_shape, temb_shape, block_id, pcc",
     [
-        ((1, 384, 128, 128), (1, 1536), 0, 0.998),
-        ((1, 1536, 16, 16), (1, 1536), 3, 0.998),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 384, 128, 128), (1, 1536), 0, 0.998),
+        ((1024, 1024), (1, 1536, 16, 16), (1, 1536), 3, 0.998),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_downblock2d(device, temb_shape, input_shape, block_id, pcc, debug_mode, is_ci_env, reset_seeds):
+def test_downblock2d(
+    device, image_resolution, temb_shape, input_shape, block_id, pcc, debug_mode, is_ci_env, reset_seeds
+):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -35,7 +42,7 @@ def test_downblock2d(device, temb_shape, input_shape, block_id, pcc, debug_mode,
 
     torch_downblock = unet.down_blocks[block_id]
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_downblock = TtDownBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_downsample2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downsample2d import TtDownsample2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -20,7 +20,13 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, down_block_id", [((1, 384, 128, 128), 0), ((1, 768, 64, 64), 1), ((1, 1536, 32, 32), 2)]
+    "image_resolution, input_shape, down_block_id",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 384, 128, 128), 0),
+        ((1024, 1024), (1, 768, 64, 64), 1),
+        ((1024, 1024), (1, 1536, 32, 32), 2),
+    ],
 )
 @pytest.mark.parametrize("stride", [(2, 2)])
 @pytest.mark.parametrize("padding", [(1, 1)])
@@ -28,6 +34,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_downsample2d(
     device,
+    image_resolution,
     input_shape,
     down_block_id,
     stride,
@@ -37,6 +44,10 @@ def test_downsample2d(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -50,7 +61,7 @@ def test_downsample2d(
     torch_downsample = unet.down_blocks[down_block_id].downsamplers[0]
     groups = 1
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_downsample = TtDownsample2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_embedding.py
@@ -7,15 +7,16 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_embedding import TtTimestepEmbedding
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
 
 
+@pytest.mark.parametrize("image_resolution", [(1024, 1024), (512, 512)])
 @pytest.mark.parametrize("input_shape, module_path", [((1, 384), "time_embedding"), ((1, 2560), "add_embedding")])
 @pytest.mark.parametrize("linear_weights_dtype", [ttnn.bfloat16])
-def test_embedding(device, input_shape, module_path, is_ci_env, reset_seeds, linear_weights_dtype):
+def test_embedding(device, image_resolution, input_shape, module_path, is_ci_env, reset_seeds, linear_weights_dtype):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -29,7 +30,7 @@ def test_embedding(device, input_shape, module_path, is_ci_env, reset_seeds, lin
     torch_embedding = eval("unet." + module_path)
     assert torch_embedding is not None, f"{module_path} is not a valid UNet module"
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_embedding = TtTimestepEmbedding(
         device, state_dict, module_path, model_config, linear_weights_dtype=linear_weights_dtype
     )

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_feedforward.py
@@ -8,21 +8,28 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_feedforward import TtFeedForward
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape, block_id, transformer_block_id, pcc, block_type",
+    "image_resolution, input_shape, block_id, transformer_block_id, pcc, block_type",
     [
-        ((256, 1536), -1, 0, 0.999, "mid_block"),
-        ((1024, 1536), 2, 0, 0.995, "down_blocks"),
-        ((4096, 768), 1, 0, 0.998, "down_blocks"),
+        # 1024x1024 image resolution
+        ((1024, 1024), (256, 1536), -1, 0, 0.999, "mid_block"),
+        ((1024, 1024), (1024, 1536), 2, 0, 0.995, "down_blocks"),
+        ((1024, 1024), (4096, 768), 1, 0, 0.998, "down_blocks"),
     ],
 )
-def test_feedforward(device, input_shape, block_id, transformer_block_id, pcc, block_type, is_ci_env, reset_seeds):
+def test_feedforward(
+    device, image_resolution, input_shape, block_id, transformer_block_id, pcc, block_type, is_ci_env, reset_seeds
+):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -39,7 +46,7 @@ def test_feedforward(device, input_shape, block_id, transformer_block_id, pcc, b
         torch_ff = unet.down_blocks[block_id].attentions[0].transformer_blocks[transformer_block_id].ff
         block_type = f"down_blocks.{block_id}"
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_ff = TtFeedForward(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_geglu.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_geglu import TtGEGLU
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -16,14 +16,19 @@ from functools import reduce
 
 
 @pytest.mark.parametrize(
-    "input_shape, module_path, pcc",
+    "image_resolution, input_shape, module_path, pcc",
     [
-        ((256, 1536), "mid_block.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
-        ((1024, 1536), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.952),
-        ((4096, 768), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.947),
+        # 1024x1024 image resolution
+        ((1024, 1024), (256, 1536), "mid_block.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
+        ((1024, 1024), (1024, 1536), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.952),
+        ((1024, 1024), (4096, 768), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.947),
     ],
 )
-def test_geglu(device, input_shape, module_path, pcc, is_ci_env, reset_seeds):
+def test_geglu(device, image_resolution, input_shape, module_path, pcc, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -43,7 +48,7 @@ def test_geglu(device, input_shape, module_path, pcc, is_ci_env, reset_seeds):
 
     assert torch_geglu is not None, f"{module_path} is not a valid UNet module"
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_geglu = TtGEGLU(device, state_dict, module_path, model_config)
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_resnetblock2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtResnetBlock2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -16,28 +16,30 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
+    "image_resolution, input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        ((1, 384, 128, 128), (1, 1536), 0, 0, False, "down_blocks", 0.999),
-        ((1, 384, 64, 64), (1, 1536), 1, 0, True, "down_blocks", 0.999),
-        ((1, 768, 64, 64), (1, 1536), 1, 1, False, "down_blocks", 0.999),
-        ((1, 768, 32, 32), (1, 1536), 2, 0, True, "down_blocks", 0.999),
-        ((1, 1536, 32, 32), (1, 1536), 2, 1, False, "down_blocks", 0.998),
-        ((1, 1536, 16, 16), (1, 1536), 3, 0, False, "down_blocks", 0.998),
-        ((1, 1536, 16, 16), (1, 1536), -1, 0, False, "mid_block", 0.996),
-        ((1, 3072, 16, 16), (1, 1536), 0, 0, True, "up_blocks", 0.999),
-        ((1, 3072, 32, 32), (1, 1536), 1, 0, True, "up_blocks", 0.999),
-        ((1, 2304, 32, 32), (1, 1536), 1, 2, True, "up_blocks", 0.999),
-        ((1, 2304, 64, 64), (1, 1536), 2, 0, True, "up_blocks", 0.999),
-        ((1, 1536, 64, 64), (1, 1536), 2, 1, True, "up_blocks", 0.999),
-        ((1, 1152, 64, 64), (1, 1536), 2, 2, True, "up_blocks", 0.999),
-        ((1, 1152, 128, 128), (1, 1536), 3, 0, True, "up_blocks", 0.999),
-        ((1, 768, 128, 128), (1, 1536), 3, 1, True, "up_blocks", 0.999),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 384, 128, 128), (1, 1536), 0, 0, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 384, 64, 64), (1, 1536), 1, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 768, 64, 64), (1, 1536), 1, 1, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 768, 32, 32), (1, 1536), 2, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 1536, 32, 32), (1, 1536), 2, 1, False, "down_blocks", 0.998),
+        ((1024, 1024), (1, 1536, 16, 16), (1, 1536), 3, 0, False, "down_blocks", 0.998),
+        ((1024, 1024), (1, 1536, 16, 16), (1, 1536), -1, 0, False, "mid_block", 0.996),
+        ((1024, 1024), (1, 3072, 16, 16), (1, 1536), 0, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 3072, 32, 32), (1, 1536), 1, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 2304, 32, 32), (1, 1536), 1, 2, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 2304, 64, 64), (1, 1536), 2, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1536, 64, 64), (1, 1536), 2, 1, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1152, 64, 64), (1, 1536), 2, 2, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1152, 128, 128), (1, 1536), 3, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 768, 128, 128), (1, 1536), 3, 1, True, "up_blocks", 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_resnetblock2d(
     device,
+    image_resolution,
     temb_shape,
     input_shape,
     down_block_id,
@@ -49,6 +51,10 @@ def test_resnetblock2d(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -70,7 +76,7 @@ def test_resnetblock2d(
     else:
         assert "Incorrect block name"
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_resnet = TtResnetBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformerblock.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasicTransformerBlock
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,19 +15,21 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc, block_type",
+    "image_resolution, input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc, block_type",
     [
-        ((1, 4096, 768), (1, 77, 1280), 1, 0, 768, 12, 768, 0.999, "down_blocks"),
-        ((1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.997, "down_blocks"),
-        ((1, 1024, 1536), (1, 77, 1280), 2, 0, 1536, 24, 1536, 0.998, "down_blocks"),
-        ((1, 1024, 1536), (1, 77, 1280), 2, 1, 1536, 24, 1536, 0.997, "down_blocks"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.998, "mid_block"),
-        ((1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.997, "mid_block"),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4096, 768), (1, 77, 1280), 1, 0, 768, 12, 768, 0.999, "down_blocks"),
+        ((1024, 1024), (1, 4096, 768), (1, 77, 1280), 1, 1, 768, 12, 768, 0.997, "down_blocks"),
+        ((1024, 1024), (1, 1024, 1536), (1, 77, 1280), 2, 0, 1536, 24, 1536, 0.998, "down_blocks"),
+        ((1024, 1024), (1, 1024, 1536), (1, 77, 1280), 2, 1, 1536, 24, 1536, 0.997, "down_blocks"),
+        ((1024, 1024), (1, 256, 1536), (1, 77, 1280), -1, 0, 1536, 24, 1536, 0.998, "mid_block"),
+        ((1024, 1024), (1, 256, 1536), (1, 77, 1280), -1, 1, 1536, 24, 1536, 0.997, "mid_block"),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_transformerblock(
     device,
+    image_resolution,
     input_shape,
     encoder_shape,
     down_block_id,
@@ -40,6 +42,10 @@ def test_transformerblock(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -58,7 +64,7 @@ def test_transformerblock(
     else:
         raise ValueError(f"Unknown block_type: {block_type}")
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_transformerblock = TtBasicTransformerBlock(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_transformermodel.py
@@ -6,7 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -15,16 +15,18 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc, block_type",
+    "image_resolution, input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc, block_type",
     [
-        ((1, 768, 64, 64), (1, 77, 1280), 1, 768, 12, 768, 0.997, "down_blocks"),
-        ((1, 1536, 32, 32), (1, 77, 1280), 2, 1536, 24, 1536, 0.987, "down_blocks"),
-        ((1, 1536, 16, 16), (1, 77, 1280), -1, 1536, 24, 1536, 0.997, "mid_block"),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 768, 64, 64), (1, 77, 1280), 1, 768, 12, 768, 0.997, "down_blocks"),
+        ((1024, 1024), (1, 1536, 32, 32), (1, 77, 1280), 2, 1536, 24, 1536, 0.987, "down_blocks"),
+        ((1024, 1024), (1, 1536, 16, 16), (1, 77, 1280), -1, 1536, 24, 1536, 0.997, "mid_block"),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_transformermodel(
     device,
+    image_resolution,
     input_shape,
     encoder_shape,
     down_block_id,
@@ -36,6 +38,10 @@ def test_transformermodel(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -54,7 +60,7 @@ def test_transformermodel(
     else:
         raise ValueError(f"Unknown block_type: {block_type}")
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_transformerblock = TtTransformer2DModel(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_unet.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -70,6 +70,7 @@ def prepare_ttnn_tensors(
 
 def run_refiner_unet_model(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
@@ -98,7 +99,7 @@ def run_refiner_unet_model(
 
     torch_unet = unet
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_unet = TtUNet2DConditionModel(
         device,
         state_dict,
@@ -190,14 +191,16 @@ def run_refiner_unet_model(
 
 
 @pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
     [
-        ((1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_unet(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
@@ -209,8 +212,13 @@ def test_unet(
     model_location_generator,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     run_refiner_unet_model(
         device,
+        image_resolution,
         input_shape,
         timestep_shape,
         encoder_shape,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upblock2d import TtUpBlock2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,9 +15,11 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, residuals, block_id, pcc",
+    "image_resolution, input_shape, temb_shape, residuals, block_id, pcc",
     [
+        # 1024x1024 image resolution
         (
+            (1024, 1024),
             (1, 1536, 16, 16),
             (1, 1536),
             ((1, 1536, 16, 16), (1, 1536, 16, 16), (1, 1536, 16, 16)),
@@ -25,6 +27,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             0.995,
         ),
         (
+            (1024, 1024),
             (1, 384, 128, 128),
             (1, 1536),
             ((1, 384, 128, 128), (1, 384, 128, 128), (1, 768, 128, 128)),
@@ -36,6 +39,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_upblock(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     residuals,
@@ -45,6 +49,10 @@ def test_upblock(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -57,7 +65,7 @@ def test_upblock(
 
     torch_crosattn = unet.up_blocks[block_id]
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_crosattn = TtUpBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_upsample2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upsample2d import TtUpsample2D
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -19,7 +19,13 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, up_block_id", [((1, 1536, 16, 16), 0), ((1, 1536, 32, 32), 1), ((1, 768, 64, 64), 2)]
+    "image_resolution, input_shape, up_block_id",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 1536, 16, 16), 0),
+        ((1024, 1024), (1, 1536, 32, 32), 1),
+        ((1024, 1024), (1, 768, 64, 64), 2),
+    ],
 )
 @pytest.mark.parametrize("stride", [(1, 1)])
 @pytest.mark.parametrize("padding", [(1, 1)])
@@ -27,6 +33,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_upsample2d(
     device,
+    image_resolution,
     input_shape,
     up_block_id,
     stride,
@@ -36,6 +43,10 @@ def test_upsample2d(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-refiner-1.0",
         torch_dtype=torch.float32,
@@ -49,7 +60,7 @@ def test_upsample2d(
     torch_upsample = unet.up_blocks[up_block_id].upsamplers[0]
     groups = 1
 
-    model_config = RefinerModelOptimisations()
+    model_config = load_refiner_model_optimisations(image_resolution)
     tt_upsample = TtUpsample2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_unet_loop.py
@@ -10,7 +10,7 @@ from loguru import logger
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     SDXL_L1_SMALL_SIZE,
     SDXL_TRACE_REGION_SIZE,
@@ -31,7 +31,7 @@ UNET_LOOP_PCC = {"10": 0.996, "50": 0.996}
 
 
 @torch.no_grad()
-def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, debug_mode):
+def run_unet_inference(ttnn_device, is_ci_env, image_resolution, prompts, num_inference_steps, debug_mode):
     torch.manual_seed(0)
 
     if isinstance(prompts, str):
@@ -49,8 +49,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, deb
     pcc = UNET_LOOP_PCC.get(str(num_inference_steps), 0)
 
     # 0. Set up default height and width for unet
-    height = 1024
-    width = 1024
+    height, width = image_resolution
 
     # 1. Load components
     base = DiffusionPipeline.from_pretrained(
@@ -70,7 +69,7 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, deb
     )
 
     # 2. Load tt_unet and tt_scheduler
-    tt_model_config = RefinerModelOptimisations()
+    tt_model_config = load_refiner_model_optimisations(image_resolution)
     tt_unet = TtUNet2DConditionModel(
         ttnn_device,
         pipeline.unet.state_dict(),
@@ -351,6 +350,13 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, deb
 
 @pytest.mark.skipif(not is_wormhole_b0(), reason="SDXL supported on WH only")
 @pytest.mark.parametrize(
+    "image_resolution",
+    [
+        # 1024x1024 image resolution
+        (1024, 1024),
+    ],
+)
+@pytest.mark.parametrize(
     "device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE, "trace_region_size": SDXL_TRACE_REGION_SIZE}], indirect=True
 )
 @pytest.mark.parametrize(
@@ -361,8 +367,13 @@ def run_unet_inference(ttnn_device, is_ci_env, prompts, num_inference_steps, deb
 def test_unet_loop(
     device,
     is_ci_env,
+    image_resolution,
     prompt,
     loop_iter_num,
     debug_mode,
 ):
-    return run_unet_inference(device, is_ci_env, prompt, loop_iter_num, debug_mode)
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
+    return run_unet_inference(device, is_ci_env, image_resolution, prompt, loop_iter_num, debug_mode)

--- a/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs/__init__.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs/__init__.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+class RefinerModelOptimisationsBase:
+    """
+    Base class for all refiner model optimisations.
+    This allows isinstance checks to work across all refiner configurations.
+    """
+
+    pass
+
+
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs.model_configs_1024x1024 import (
+    RefinerModelOptimisations1024x1024,
+)
+
+
+def load_refiner_model_optimisations(
+    image_resolution,
+    conv_act_dtype=None,
+    conv_w_dtype=None,
+    attention_weights_dtype=None,
+    ff_weights_dtype=None,
+):
+    """
+    Load the appropriate RefinerModelOptimisation object based on the provided image resolution.
+
+    Args:
+        image_resolution (tuple): A tuple of (height, width) representing the image resolution.
+            Supported resolution is (1024, 1024).
+        conv_act_dtype: Optional dtype for convolution activations. Defaults to ttnn.bfloat16.
+        conv_w_dtype: Optional dtype for convolution weights. Defaults to ttnn.bfloat16.
+        attention_weights_dtype: Optional dtype for attention weights. Defaults to ttnn.bfloat8_b.
+        ff_weights_dtype: Optional dtype for feedforward weights. Defaults to ttnn.bfloat8_b.
+
+    Returns:
+        RefinerModelOptimisations1024x1024: The appropriate RefinerModelOptimisation object based
+            on the image resolution.
+
+    Raises:
+        ValueError: If the image_resolution is not supported.
+
+    Example:
+        >>> model_opt = load_refiner_model_optimisations((1024, 1024))
+    """
+    if not isinstance(image_resolution, (tuple, list)) or len(image_resolution) != 2:
+        raise ValueError(f"image_resolution must be a tuple or list of length 2, got {image_resolution}")
+
+    height, width = image_resolution
+
+    # Prepare kwargs for initialization
+    init_kwargs = {}
+    if conv_act_dtype is not None:
+        init_kwargs["conv_act_dtype"] = conv_act_dtype
+    if conv_w_dtype is not None:
+        init_kwargs["conv_w_dtype"] = conv_w_dtype
+    if attention_weights_dtype is not None:
+        init_kwargs["attention_weights_dtype"] = attention_weights_dtype
+    if ff_weights_dtype is not None:
+        init_kwargs["ff_weights_dtype"] = ff_weights_dtype
+
+    if (height, width) == (1024, 1024):
+        return RefinerModelOptimisations1024x1024(**init_kwargs)
+    else:
+        raise ValueError(f"Unsupported image_resolution: {image_resolution}. " "Only (1024, 1024) is supported.")

--- a/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs/model_configs_1024x1024.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs/model_configs_1024x1024.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations1024x1024
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisationsBase
 
 
-class RefinerModelOptimisations(ModelOptimisations):
+class RefinerModelOptimisations1024x1024(RefinerModelOptimisationsBase, ModelOptimisations1024x1024):
     def __init__(
         self,
         conv_act_dtype=ttnn.bfloat16,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -15,7 +15,10 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize(
     "input_shape",
     [
+        # 1024x1024 image resolution
         (1, 1, 128 * 128, 4),
+        # 512x512 image resolution
+        (1, 1, 64 * 64, 4),
     ],
 )
 @pytest.mark.parametrize("num_inference_steps", [5])
@@ -108,7 +111,10 @@ def test_euler_discrete_scheduler(device, input_shape, num_inference_steps, is_c
 @pytest.mark.parametrize(
     "input_shape",
     [
+        # 1024x1024 image resolution
         (1, 4, 128, 128),
+        # 512x512 image resolution
+        (1, 4, 64, 64),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattnupblock2d import TtCrossAttnUpBlock2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,9 +15,11 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, residuals, encoder_shape, query_dim, num_attn_heads, out_dim, block_id, pcc",
+    "image_resolution, input_shape, temb_shape, residuals, encoder_shape, query_dim, num_attn_heads, out_dim, block_id, pcc",
     [
+        # 1024x1024 image resolution
         (
+            (1024, 1024),
             (1, 1280, 32, 32),
             (1, 1280),
             ((1, 640, 32, 32), (1, 1280, 32, 32), (1, 1280, 32, 32)),
@@ -29,9 +31,35 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
             0.975,
         ),
         (
+            (1024, 1024),
             (1, 1280, 64, 64),
             (1, 1280),
             ((1, 320, 64, 64), (1, 640, 64, 64), (1, 640, 64, 64)),
+            (1, 77, 2048),
+            640,
+            10,
+            640,
+            1,
+            0.994,
+        ),
+        # 512x512 image resolution
+        (
+            (512, 512),
+            (1, 1280, 16, 16),
+            (1, 1280),
+            ((1, 640, 16, 16), (1, 1280, 16, 16), (1, 1280, 16, 16)),
+            (1, 77, 2048),
+            1280,
+            20,
+            1280,
+            0,
+            0.985,
+        ),
+        (
+            (512, 512),
+            (1, 1280, 32, 32),
+            (1, 1280),
+            ((1, 320, 32, 32), (1, 640, 32, 32), (1, 640, 32, 32)),
             (1, 77, 2048),
             640,
             10,
@@ -44,6 +72,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_crossattnup(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     residuals,
@@ -69,7 +98,7 @@ def test_crossattnup(
 
     torch_crosattn = unet.up_blocks[block_id]
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_crosattn = TtCrossAttnUpBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downblock2d import TtDownBlock2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,13 +15,16 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape",
+    "image_resolution, input_shape, temb_shape, pcc",
     [
-        ((1, 320, 128, 128), (1, 1280)),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 320, 128, 128), (1, 1280), 0.999),
+        # 512x512 image resolution
+        ((512, 512), (1, 320, 64, 64), (1, 1280), 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_downblock2d(device, temb_shape, input_shape, debug_mode, is_ci_env, reset_seeds):
+def test_downblock2d(device, image_resolution, input_shape, temb_shape, pcc, debug_mode, is_ci_env, reset_seeds):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -34,7 +37,7 @@ def test_downblock2d(device, temb_shape, input_shape, debug_mode, is_ci_env, res
 
     torch_downblock = unet.down_blocks[0]
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_downblock = TtDownBlock2D(
         device, state_dict, f"down_blocks.0", model_config=model_config, has_downsample=True, debug_mode=debug_mode
     )
@@ -67,5 +70,5 @@ def test_downblock2d(device, temb_shape, input_shape, debug_mode, is_ci_env, res
     del unet, tt_downblock
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downsample2d import TtDownsample2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -19,15 +19,27 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 
 
-@pytest.mark.parametrize("input_shape, down_block_id", [((1, 320, 128, 128), 0), ((1, 640, 64, 64), 1)])
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, down_block_id, pcc",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 320, 128, 128), 0, 0.999),
+        ((1024, 1024), (1, 640, 64, 64), 1, 0.999),
+        # 512x512 image resolution
+        ((512, 512), (1, 320, 64, 64), 0, 0.999),
+        ((512, 512), (1, 640, 32, 32), 1, 0.999),
+    ],
+)
 @pytest.mark.parametrize("stride", [(2, 2)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_downsample2d(
     device,
+    image_resolution,
     input_shape,
     down_block_id,
+    pcc,
     stride,
     padding,
     dilation,
@@ -48,7 +60,7 @@ def test_downsample2d(
     torch_downsample = unet.down_blocks[down_block_id].downsamplers[0]
     groups = 1
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_downsample = TtDownsample2D(
         device,
         state_dict,
@@ -67,7 +79,6 @@ def test_downsample2d(
     ttnn_input_tensor = to_channel_last_ttnn(
         torch_input_tensor, ttnn.bfloat16, device, ttnn.DRAM_MEMORY_CONFIG, ttnn.TILE_LAYOUT
     )
-
     ttnn_output_tensor, output_shape = tt_downsample.forward(ttnn_input_tensor, input_shape)
 
     output_tensor = from_channel_last_ttnn(
@@ -77,5 +88,5 @@ def test_downsample2d(
     del unet, tt_downsample
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_geglu import TtGEGLU
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -16,13 +16,17 @@ from functools import reduce
 
 
 @pytest.mark.parametrize(
-    "input_shape, module_path, pcc",
+    "image_resolution, input_shape, module_path, pcc",
     [
-        ((1024, 1280), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.948),
-        ((4096, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1024, 1280), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.948),
+        ((1024, 1024), (4096, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
+        # 512x512 image resolution
+        ((512, 512), (256, 1280), "down_blocks.2.attentions.0.transformer_blocks.0.ff.net.0", 0.948),
+        ((512, 512), (1024, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0", 0.950),
     ],
 )
-def test_geglu(device, input_shape, module_path, pcc, is_ci_env, reset_seeds):
+def test_geglu(device, image_resolution, input_shape, module_path, pcc, is_ci_env, reset_seeds):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -42,7 +46,7 @@ def test_geglu(device, input_shape, module_path, pcc, is_ci_env, reset_seeds):
 
     assert torch_geglu is not None, f"{module_path} is not a valid UNet module"
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_geglu = TtGEGLU(device, state_dict, module_path, model_config)
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtResnetBlock2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -16,25 +16,40 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
+    "image_resolution, input_shape, temb_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        ((1, 320, 128, 128), (1, 1280), 0, 0, False, "down_blocks", 0.999),
-        ((1, 320, 64, 64), (1, 1280), 1, 0, True, "down_blocks", 0.999),
-        ((1, 640, 64, 64), (1, 1280), 1, 1, False, "down_blocks", 0.999),
-        ((1, 640, 32, 32), (1, 1280), 2, 0, True, "down_blocks", 0.999),
-        ((1, 1280, 32, 32), (1, 1280), 2, 1, False, "down_blocks", 0.999),
-        ((1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998),
-        ((1, 640, 128, 128), (1, 1280), 2, 1, True, "up_blocks", 0.998),
-        ((1, 2560, 32, 32), (1, 1280), 0, 0, True, "up_blocks", 0.999),
-        ((1, 1920, 32, 32), (1, 1280), 0, 2, True, "up_blocks", 0.999),
-        ((1, 1920, 64, 64), (1, 1280), 1, 0, True, "up_blocks", 0.999),
-        ((1, 1280, 64, 64), (1, 1280), 1, 1, True, "up_blocks", 0.999),
-        ((1, 960, 64, 64), (1, 1280), 1, 2, True, "up_blocks", 0.999),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 320, 128, 128), (1, 1280), 0, 0, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 320, 64, 64), (1, 1280), 1, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 640, 64, 64), (1, 1280), 1, 1, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 640, 32, 32), (1, 1280), 2, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 1280, 32, 32), (1, 1280), 2, 1, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 2560, 32, 32), (1, 1280), 0, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1920, 32, 32), (1, 1280), 0, 2, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1920, 64, 64), (1, 1280), 1, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 1280, 64, 64), (1, 1280), 1, 1, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 960, 64, 64), (1, 1280), 1, 2, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 960, 128, 128), (1, 1280), 2, 0, True, "up_blocks", 0.998),
+        ((1024, 1024), (1, 640, 128, 128), (1, 1280), 2, 1, True, "up_blocks", 0.998),
+        # 512x512 image resolution
+        ((512, 512), (1, 320, 64, 64), (1, 1280), 0, 0, False, "down_blocks", 0.999),
+        ((512, 512), (1, 320, 32, 32), (1, 1280), 1, 0, True, "down_blocks", 0.999),
+        ((512, 512), (1, 640, 32, 32), (1, 1280), 1, 1, False, "down_blocks", 0.999),
+        ((512, 512), (1, 640, 16, 16), (1, 1280), 2, 0, True, "down_blocks", 0.999),
+        ((512, 512), (1, 1280, 16, 16), (1, 1280), 2, 1, False, "down_blocks", 0.999),
+        ((512, 512), (1, 2560, 16, 16), (1, 1280), 0, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1920, 16, 16), (1, 1280), 0, 2, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1920, 32, 32), (1, 1280), 1, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 1280, 32, 32), (1, 1280), 1, 1, True, "up_blocks", 0.999),
+        ((512, 512), (1, 960, 32, 32), (1, 1280), 1, 2, True, "up_blocks", 0.999),
+        ((512, 512), (1, 960, 64, 64), (1, 1280), 2, 0, True, "up_blocks", 0.999),
+        ((512, 512), (1, 640, 64, 64), (1, 1280), 2, 1, True, "up_blocks", 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_resnetblock2d(
     device,
+    image_resolution,
     temb_shape,
     input_shape,
     down_block_id,
@@ -63,7 +78,7 @@ def test_resnetblock2d(
     else:
         assert "Incorrect block name"
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_resnet = TtResnetBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
@@ -6,7 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasicTransformerBlock
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -15,17 +15,24 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc",
+    "image_resolution, input_shape, encoder_shape, down_block_id, block_id, query_dim, num_attn_heads, out_dim, pcc",
     [
-        ((1, 4096, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
-        ((1, 4096, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
-        ((1, 1024, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.998),
-        ((1, 1024, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.997),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4096, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
+        ((1024, 1024), (1, 4096, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
+        ((1024, 1024), (1, 1024, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.999),
+        ((1024, 1024), (1, 1024, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.998),
+        # 512x512 image resolution
+        ((512, 512), (1, 1024, 640), (1, 77, 2048), 1, 0, 640, 10, 640, 0.999),
+        ((512, 512), (1, 1024, 640), (1, 77, 2048), 1, 1, 640, 10, 640, 0.998),
+        ((512, 512), (1, 256, 1280), (1, 77, 2048), 2, 0, 1280, 20, 1280, 0.999),
+        ((512, 512), (1, 256, 1280), (1, 77, 2048), 2, 1, 1280, 20, 1280, 0.998),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_transformerblock(
     device,
+    image_resolution,
     input_shape,
     encoder_shape,
     down_block_id,
@@ -48,7 +55,7 @@ def test_transformerblock(
     state_dict = unet.state_dict()
 
     torch_transformerblock = unet.down_blocks[down_block_id].attentions[0].transformer_blocks[block_id]
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_transformerblock = TtBasicTransformerBlock(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -6,7 +6,7 @@ from loguru import logger
 import torch
 import pytest
 import ttnn
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -15,15 +15,20 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
+    "image_resolution, input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
     [
-        ((1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.998),
-        ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.995),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.998),
+        ((1024, 1024), (1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.997),
+        # 512x512 image resolution
+        ((512, 512), (1, 640, 32, 32), (1, 77, 2048), 1, 640, 10, 640, 0.998),
+        ((512, 512), (1, 1280, 16, 16), (1, 77, 2048), 2, 1280, 20, 1280, 0.995),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_transformermodel(
     device,
+    image_resolution,
     input_shape,
     encoder_shape,
     down_block_id,
@@ -45,7 +50,7 @@ def test_transformermodel(
     state_dict = unet.state_dict()
 
     torch_transformerblock = unet.down_blocks[down_block_id].attentions[0]
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_transformerblock = TtTransformer2DModel(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -70,11 +70,13 @@ def prepare_ttnn_tensors(
 
 def run_unet_model(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
     temb_shape,
     time_ids_shape,
+    pcc,
     debug_mode,
     is_ci_env,
     is_ci_v2_env,
@@ -102,7 +104,7 @@ def run_unet_model(
 
     torch_unet = unet
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_unet = TtUNet2DConditionModel(
         device,
         state_dict,
@@ -159,7 +161,7 @@ def run_unet_model(
 
     ttnn.ReadDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.9969)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):
@@ -194,20 +196,26 @@ def run_unet_model(
 
 
 @pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape, pcc",
     [
-        ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
-        ((1, 9, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9969),
+        ((1024, 1024), (1, 9, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9969),
+        # 512x512 image resolution
+        ((512, 512), (1, 4, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9958),
+        ((512, 512), (1, 9, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9958),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_unet(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
     temb_shape,
     time_ids_shape,
+    pcc,
     debug_mode,
     is_ci_env,
     is_ci_v2_env,
@@ -216,11 +224,13 @@ def test_unet(
 ):
     run_unet_model(
         device,
+        image_resolution,
         input_shape,
         timestep_shape,
         encoder_shape,
         temb_shape,
         time_ids_shape,
+        pcc,
         debug_mode,
         is_ci_env,
         is_ci_v2_env,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upblock2d import TtUpBlock2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,23 +15,37 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, temb_shape, residuals, block_id",
+    "image_resolution, input_shape, temb_shape, residuals, block_id, pcc",
     [
+        # 1024x1024 image resolution
         (
+            (1024, 1024),
             (1, 640, 128, 128),
             (1, 1280),
             ((1, 320, 128, 128), (1, 320, 128, 128), (1, 320, 128, 128)),
             2,
+            0.997,
+        ),
+        # 512x512 image resolution
+        (
+            (512, 512),
+            (1, 640, 64, 64),
+            (1, 1280),
+            ((1, 320, 64, 64), (1, 320, 64, 64), (1, 320, 64, 64)),
+            2,
+            0.997,
         ),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_upblock(
     device,
+    image_resolution,
     input_shape,
     temb_shape,
     residuals,
     block_id,
+    pcc,
     debug_mode,
     is_ci_env,
     reset_seeds,
@@ -48,7 +62,7 @@ def test_upblock(
 
     torch_crosattn = unet.up_blocks[block_id]
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_crosattn = TtUpBlock2D(
         device, state_dict, f"up_blocks.{block_id}", model_config=model_config, debug_mode=debug_mode
     )
@@ -92,5 +106,5 @@ def test_upblock(
     del unet
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.996)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upsample2d import TtUpsample2D
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -18,15 +18,27 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 
 
-@pytest.mark.parametrize("input_shape, up_block_id", [((1, 1280, 32, 32), 0), ((1, 640, 64, 64), 1)])
+@pytest.mark.parametrize(
+    "image_resolution, input_shape, up_block_id, pcc",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 1280, 32, 32), 0, 0.999),
+        ((1024, 1024), (1, 640, 64, 64), 1, 0.999),
+        # 512x512 image resolution
+        ((512, 512), (1, 1280, 16, 16), 0, 0.999),
+        ((512, 512), (1, 640, 32, 32), 1, 0.999),
+    ],
+)
 @pytest.mark.parametrize("stride", [(1, 1)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_upsample2d(
     device,
+    image_resolution,
     input_shape,
     up_block_id,
+    pcc,
     stride,
     padding,
     dilation,
@@ -47,7 +59,7 @@ def test_upsample2d(
     torch_upsample = unet.up_blocks[up_block_id].upsamplers[0]
     groups = 1
 
-    model_config = ModelOptimisations()
+    model_config = load_model_optimisations(image_resolution)
     tt_upsample = TtUpsample2D(
         device,
         state_dict,
@@ -76,5 +88,5 @@ def test_upsample2d(
     del unet
     gc.collect()
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
     logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -829,6 +829,88 @@ def run_tt_image_gen(
     one_minus_guidance_rescale=1.0,
     return_latents=False,  # If True, skip VAE decoding and return latents
 ):
+    """Run TT (Tenstorrent) image generation pipeline for Stable Diffusion XL.
+
+    This function executes the complete image generation pipeline including the
+    multiple denoising loops with the UNet model and optional VAE decoding at
+    the end. It supports trace capture and reply for performance optimization,
+    classifier-free guidance (CFG) parallel processing, and guidance rescaling.
+
+    Args:
+        ttnn_device: The TTNN device instance to execute operations on.
+        tt_unet: The TT UNet model for denoising predictions.
+        tt_scheduler: The TT scheduler for managing diffusion timesteps.
+        tt_latents: Initial latent tensor with shape [batch_size, 1, H*W, C].
+            It is assumed that C=4.
+        tt_prompt_embeds: Prompt embeddings tensor. Shape depends on
+            use_cfg_parallel mode.
+        tt_time_ids: Time embedding IDs tensor for conditioning.
+        tt_text_embeds: Additional text embeddings from the text encoder.
+        num_steps (int): Number of denoising steps to perform.
+        tt_extra_step_kwargs: Additional keyword arguments for the scheduler
+            step function.
+        guidance_scale (float): Classifier-free guidance scale. Higher values
+            make the model follow the prompt more closely.
+        scaling_factor (float): VAE scaling factor for latent normalization.
+        input_shape (tuple): Input shape tuple (B, C, H, W) where B is batch
+            size, C is channels, H and W are height and width.
+        vae: VAE model for decoding. Can be either TtAutoencoderKL (TT VAE)
+            or host-based VAE (torch model).
+        batch_size (int): Number of images to generate in the batch.
+        output_device (ttnn.Tensor, optional): Pre-allocated output device
+            tensor for VAE decoding. Used when reusing traces.
+        output_shape (list, optional): Pre-computed output shape [B, C, H, W]
+            for VAE decoding. Used when reusing traces.
+        tid (int, optional): Trace ID for the denoising loop. If provided,
+            the captured trace will be replayed instead of capturing a new one.
+            If None and capture_trace is False, operations run normally.
+        tid_vae (int, optional): Trace ID for the VAE decoding step. If
+            provided, the captured VAE trace will be replayed. If None and
+            capture_trace is False, VAE runs normally.
+        capture_trace (bool): If True, capture execution traces for both
+            denoising loop and VAE. Requires num_steps=1. Defaults to False.
+        use_cfg_parallel (bool): If True, use parallel processing for
+            classifier-free guidance. Defaults to False.
+        guidance_rescale (float): Guidance rescale factor for noise prediction.
+            Defaults to 0.0 (disabled).
+        one_minus_guidance_rescale (float): Complement of guidance_rescale
+            (1.0 - guidance_rescale). Defaults to 1.0.
+        return_latents (bool): If True, skip VAE decoding and return latents
+            instead of decoded images. Useful for multi-stage pipelines.
+            Defaults to False.
+
+    Returns:
+        tuple: A tuple containing:
+            - imgs (torch.Tensor or None): Generated images as a torch tensor
+                with shape [batch_size * B, C, H, W], or None if return_latents
+                is True or warmup run. If return_latents is True, this is
+                replaced by tt_latents (ttnn.Tensor).
+            - tid (int or None): Trace ID for the denoising loop. Can be used
+                for subsequent executions to reuse the captured trace.
+            - output_device (ttnn.Tensor or None): Device tensor containing
+                VAE output (if VAE is on device). Used for trace reuse.
+            - output_shape (list or None): Output shape [B, C, H, W] from VAE
+                decoding. Used for trace reuse.
+            - tid_vae (int or None): Trace ID for VAE decoding. Can be used
+                for subsequent executions to reuse the captured VAE trace.
+
+    Raises:
+        AssertionError: If capture_trace is True and num_steps != 1, as trace
+            capture requires exactly one iteration.
+
+    Note:
+        - The function performs guidance rescaling by computing standard
+            deviations of noise predictions and applying rescaling factors.
+        - When use_cfg_parallel is True, the function uses all_gather to
+            combine parallel predictions.
+        - If vae is a TtAutoencoderKL instance, VAE decoding runs on device.
+            Otherwise, latents are transferred to host and decoded using the
+            torch VAE model.
+        - The scheduler is reset to begin_index=0 after the denoising loop.
+        - Memory management is handled throughout with explicit deallocation
+            of intermediate tensors.
+    """
+
     assert not (capture_trace and num_steps != 1), "Trace should capture only 1 iteration"
     profiler.start("image_gen")
     profiler.start("denoising_loop")

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py
@@ -25,6 +25,14 @@ test_demo_base_and_refiner.__test__ = False
 
 
 @pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+        (512, 512),
+    ],
+    ids=["1024x1024", "512x512"],
+)
+@pytest.mark.parametrize(
     "device_params, use_cfg_parallel",
     [
         (
@@ -109,6 +117,7 @@ def test_accuracy_sdxl(
     validate_fabric_compatibility,
     mesh_device,
     is_ci_env,
+    image_resolution,
     num_inference_steps,
     vae_on_device,
     capture_trace,
@@ -125,6 +134,9 @@ def test_accuracy_sdxl(
     refiner_aesthetic_score,
     refiner_negative_aesthetic_score,
 ):
+    if image_resolution == (512, 512) and (vae_on_device or use_refiner):
+        pytest.skip("Accuracy test on 512x512 image resolution is only supported for UNet on device.")
+
     start_from, num_prompts = evaluation_range
 
     prompts = sdxl_get_prompts(
@@ -139,6 +151,7 @@ def test_accuracy_sdxl(
         validate_fabric_compatibility,
         mesh_device,
         is_ci_env,
+        image_resolution,
         prompts,
         negative_prompt,
         num_inference_steps,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_img2img_accuracy.py
@@ -29,6 +29,14 @@ MAX_N_SAMPLES, MIN_N_SAMPLES = 10000, 2
 
 
 @pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+        (512, 512),
+    ],
+    ids=["1024x1024", "512x512"],
+)
+@pytest.mark.parametrize(
     "device_params, use_cfg_parallel",
     [
         (
@@ -105,6 +113,7 @@ def test_accuracy_sdxl_img2img(
     validate_fabric_compatibility,
     mesh_device,
     is_ci_env,
+    image_resolution,
     negative_prompt,
     num_inference_steps,
     vae_on_device,
@@ -122,6 +131,9 @@ def test_accuracy_sdxl_img2img(
     timesteps,
     sigmas,
 ):
+    if image_resolution == (512, 512):
+        pytest.skip("Accuracy test on 512x512 image resolution is not yet supported for img2img pipeline.")
+
     start_from, num_prompts = evaluation_range
 
     assert (
@@ -136,6 +148,7 @@ def test_accuracy_sdxl_img2img(
         validate_fabric_compatibility,
         mesh_device,
         is_ci_env,
+        image_resolution,
         dataset["edit_prompt"],
         dataset["original_image"],
         negative_prompt,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_inpaint_accuracy.py
@@ -25,6 +25,14 @@ MAX_N_SAMPLES, MIN_N_SAMPLES = 1260, 2
 
 
 @pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+        (512, 512),
+    ],
+    ids=["1024x1024", "512x512"],
+)
+@pytest.mark.parametrize(
     "device_params, use_cfg_parallel",
     [
         (
@@ -91,6 +99,7 @@ def test_accuracy_sdxl_inpaint(
     validate_fabric_compatibility,
     mesh_device,
     is_ci_env,
+    image_resolution,
     num_inference_steps,
     vae_on_device,
     capture_trace,
@@ -102,6 +111,9 @@ def test_accuracy_sdxl_inpaint(
     use_cfg_parallel,
     strength,
 ):
+    if image_resolution == (512, 512):
+        pytest.skip("Accuracy test on 512x512 image resolution is not yet supported for inpainting pipeline.")
+
     start_from, num_prompts = evaluation_range
     input_images, input_masks, prompts = get_dataset_for_inpainting_accuracy(num_prompts)
 
@@ -111,6 +123,7 @@ def test_accuracy_sdxl_inpaint(
         validate_fabric_compatibility,
         mesh_device,
         is_ci_env,
+        image_resolution,
         prompts,
         negative_prompt,
         num_inference_steps,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -80,6 +80,7 @@ def test_conv2d_block_sharded_sdxl(device):
         packer_l1_acc=True,
         act_db=True,
         w_db=True,
+        reshard_if_not_optimal=True,
         perf_test_mode=USE_PERF_TEST_MODE,
     )
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -80,7 +80,6 @@ def test_conv2d_block_sharded_sdxl(device):
         packer_l1_acc=True,
         act_db=True,
         w_db=True,
-        reshard_if_not_optimal=True,
         perf_test_mode=USE_PERF_TEST_MODE,
     )
 

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -114,7 +114,7 @@ def test_refiner_unet(
         ),
         (
             'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
-            87_296_975 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            91_463_635 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             "sdxl_unet_512x512",
             "sdxl_unet_512x512",
             1,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -17,20 +17,26 @@ CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS = 1
 
 
 @pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape, pcc",
     [
-        ((1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6)),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9969),
+        # 512x512 image resolution
+        ((512, 512), (1, 4, 64, 64), (1,), (1, 77, 2048), (1, 1280), (1, 6), 0.9958),
     ],
+    ids=["1024x1024", "512x512"],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
 def test_unet(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
     temb_shape,
     time_ids_shape,
+    pcc,
     iterations,
     is_ci_env,
     is_ci_v2_env,
@@ -39,11 +45,13 @@ def test_unet(
 ):
     run_unet_model(
         device,
+        image_resolution,
         input_shape,
         timestep_shape,
         encoder_shape,
         temb_shape,
         time_ids_shape,
+        pcc,
         debug_mode=False,
         is_ci_env=is_ci_env,
         is_ci_v2_env=is_ci_v2_env,
@@ -53,15 +61,17 @@ def test_unet(
 
 
 @pytest.mark.parametrize(
-    "input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
+    "image_resolution, input_shape, timestep_shape, encoder_shape, temb_shape, time_ids_shape",
     [
-        ((1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), (1,), (1, 77, 1280), (1, 1280), (1, 5)),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize("iterations", [UNET_DEVICE_TEST_TOTAL_ITERATIONS])
 def test_refiner_unet(
     device,
+    image_resolution,
     input_shape,
     timestep_shape,
     encoder_shape,
@@ -75,6 +85,7 @@ def test_refiner_unet(
 ):
     run_refiner_unet_model(
         device,
+        image_resolution,
         input_shape,
         timestep_shape,
         encoder_shape,
@@ -92,10 +103,20 @@ def test_refiner_unet(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
         (
-            "pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet",
+            'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "1024x1024"',
             191_651_771 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
-            "sdxl_unet",
-            "sdxl_unet",
+            "sdxl_unet_1024x1024",
+            "sdxl_unet_1024x1024",
+            1,
+            1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            0.015,
+            f"iterations={UNET_DEVICE_TEST_TOTAL_ITERATIONS}",
+        ),
+        (
+            'pytest models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_unet -k "512x512"',
+            87_296_975 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
+            "sdxl_unet_512x512",
+            "sdxl_unet_512x512",
             1,
             1 * UNET_DEVICE_TEST_TOTAL_ITERATIONS,
             0.015,
@@ -153,7 +174,8 @@ def test_refiner_unet(
         ),
     ],
     ids=[
-        "test_sdxl_unet",
+        "test_sdxl_unet_1024x1024",
+        "test_sdxl_unet_512x512",
         "test_sdxl_refiner_unet",
         "test_sdxl_vae_decode",
         "test_sdxl_vae_encode",

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs/__init__.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs/__init__.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from models.experimental.stable_diffusion_xl_base.tt.model_configs.model_configs_512x512 import (
+    ModelOptimisations512x512,
+)
+from models.experimental.stable_diffusion_xl_base.tt.model_configs.model_configs_1024x1024 import (
+    ModelOptimisations1024x1024,
+)
+
+
+def load_model_optimisations(
+    image_resolution,
+    conv_act_dtype=None,
+    conv_w_dtype=None,
+    attention_weights_dtype=None,
+    ff_weights_dtype=None,
+    force_full_grid=False,
+):
+    """
+    Load the appropriate ModelOptimisation object based on the provided image resolution.
+
+    Args:
+        image_resolution (tuple): A tuple of (height, width) representing the image resolution.
+            Supported resolutions are (512, 512) and (1024, 1024).
+        conv_act_dtype: Optional dtype for convolution activations. Defaults to ttnn.bfloat16.
+        conv_w_dtype: Optional dtype for convolution weights. Defaults to ttnn.bfloat16.
+        attention_weights_dtype: Optional dtype for attention weights. Defaults to ttnn.bfloat8_b.
+        ff_weights_dtype: Optional dtype for feedforward weights. Defaults to ttnn.bfloat8_b.
+        force_full_grid (bool): Optional flag to force full grid. Defaults to False.
+
+    Returns:
+        ModelOptimisations512x512 or ModelOptimisations1024x1024: The appropriate ModelOptimisation
+            object based on the image resolution.
+
+    Raises:
+        ValueError: If the image_resolution is not supported.
+
+    Example:
+        >>> model_opt = load_model_optimisations((512, 512))
+        >>> model_opt = load_model_optimisations((1024, 1024))
+    """
+    if not isinstance(image_resolution, (tuple, list)) or len(image_resolution) != 2:
+        raise ValueError(f"image_resolution must be a tuple or list of length 2, got {image_resolution}")
+
+    height, width = image_resolution
+
+    # Prepare kwargs for initialization
+    init_kwargs = {"force_full_grid": force_full_grid}
+    if conv_act_dtype is not None:
+        init_kwargs["conv_act_dtype"] = conv_act_dtype
+    if conv_w_dtype is not None:
+        init_kwargs["conv_w_dtype"] = conv_w_dtype
+    if attention_weights_dtype is not None:
+        init_kwargs["attention_weights_dtype"] = attention_weights_dtype
+    if ff_weights_dtype is not None:
+        init_kwargs["ff_weights_dtype"] = ff_weights_dtype
+
+    if (height, width) == (512, 512):
+        return ModelOptimisations512x512(**init_kwargs)
+    elif (height, width) == (1024, 1024):
+        return ModelOptimisations1024x1024(**init_kwargs)
+    else:
+        raise ValueError(
+            f"Unsupported image_resolution: {image_resolution}. " "Only (512, 512) and (1024, 1024) are supported."
+        )

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs/model_configs_1024x1024.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs/model_configs_1024x1024.py
@@ -12,7 +12,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 )
 
 
-class ModelOptimisations:
+class ModelOptimisations1024x1024:
     def __init__(
         self,
         conv_act_dtype=ttnn.bfloat16,
@@ -43,7 +43,7 @@ class ModelOptimisations:
             act_block_w_div=1,
             act_block_h_override=1024,
         )
-        self.conv_configs["ABH_256_ADB"] = ttnn.Conv2dConfig(
+        self.conv_configs["ABH_256_ADB_HS"] = ttnn.Conv2dConfig(
             weights_dtype=conv_w_dtype,
             shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             deallocate_activation=True,
@@ -1142,7 +1142,7 @@ class ModelOptimisations:
             return None
 
         if "conv_in" == conv_path:
-            return self.conv_configs["ABH_256_ADB"]
+            return self.conv_configs["ABH_256_ADB_HS"]
 
         # DOWN BLOCK 0
         elif ("down_blocks.0.resnets" in conv_path) and ("conv2" in conv_path):

--- a/models/experimental/stable_diffusion_xl_base/tt/model_configs/model_configs_512x512.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/model_configs/model_configs_512x512.py
@@ -1,0 +1,1061 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import re
+
+from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
+    prepare_gn_mask,
+    prepare_gn_mask_negative_mask,
+    prepare_gn_beta_gamma,
+)
+
+
+class ModelOptimisations512x512:
+    def __init__(
+        self,
+        conv_act_dtype=ttnn.bfloat16,
+        conv_w_dtype=ttnn.bfloat16,
+        attention_weights_dtype=ttnn.bfloat8_b,
+        ff_weights_dtype=ttnn.bfloat8_b,
+        force_full_grid=False,
+    ):
+        self.conv_configs = {}
+        self.conv_output_dtype = conv_act_dtype
+        self.matmul_configs = {}
+        self.compute_configs = {}
+        self.prepared_weights = False
+        self.conv_w_dtype = conv_w_dtype
+        self.conv_ws_dtype = ttnn.bfloat8_b
+        self.attention_weights_dtype = attention_weights_dtype
+        self.ff_weights_dtype = ff_weights_dtype
+
+        # region CONV2D CONFIGS
+        # region HEIGHT SHARDED
+        self.conv_configs["ABH_1024_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=1024,
+        )
+        self.conv_configs["ABH_256_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=conv_w_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+        )
+        self.conv_configs["ABH_256_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+        )
+        self.conv_configs["ABH_128_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=conv_w_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=128,
+        )
+        self.conv_configs["ABH_0_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+        )
+        self.conv_configs["ABH_0_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+        )
+
+        self.conv_configs["ABH_64_NO_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=64,
+        )
+
+        self.conv_configs["ABH_32_ADB_HS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=32,
+        )
+        # endregion HEIGHT SHARDED
+
+        # region BLOCK SHARDED
+        override_output_sharding_config = not force_full_grid
+        override_output_core_grid = (
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(4, 7),
+                    ),
+                }
+            )
+            if override_output_sharding_config
+            else None
+        )
+
+        self.conv_configs["ABH_0_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+
+        self.conv_configs["ABH_0_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=False,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+        self.conv_configs["ABH_64_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=64,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+        self.conv_configs["ABH_128_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=128,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+        self.conv_configs["ABH_128_ADB_WDB_MOVE_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=128,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+        self.conv_configs["ABH_256_NO_ADB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_w_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+        )
+
+        self.conv_configs["ABH_256_ADB_WDB_BS_NO_MOVE"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=False,
+            reallocate_halo_output=False,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+        )
+
+        self.conv_configs["ABH_256_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=256,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+
+        self.conv_configs["ABH_512_NO_ADB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            enable_weights_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=512,
+        )
+
+        self.conv_configs["ABH_512_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=512,
+        )
+
+        self.conv_configs["ABH_128_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=False,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=128,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+
+        self.conv_configs["ABH_512_ADB_WDB_NO_DEALLOC_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=False,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=512,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+
+        self.conv_configs["ABH_1024_NO_ADB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=False,
+            enable_weights_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=1024,
+        )
+
+        self.conv_configs["ABH_1024_ADB_WDB_BS"] = ttnn.Conv2dConfig(
+            weights_dtype=self.conv_ws_dtype,
+            shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            deallocate_activation=True,
+            reallocate_halo_output=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=1024,
+            override_output_sharding_config=override_output_sharding_config,
+            core_grid=override_output_core_grid,
+        )
+        # endregion BLOCK SHARDED
+
+        # region DEFAULT
+        self.conv_configs["DEFAULT"] = ttnn.Conv2dConfig(
+            weights_dtype=conv_w_dtype,
+            shard_layout=None,
+            deallocate_activation=True,
+            enable_act_double_buffer=False,
+            reshard_if_not_optimal=True,
+            act_block_w_div=1,
+            act_block_h_override=0,
+        )
+        # endregion DEFAULT
+        # endregion CONV2D CONFIGS
+
+        # region MATMUL CONFIGS
+        self.matmul_versions = {
+            "40_cores": {
+                "2D_FF2_SEQ_LEN_1024": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    per_core_M=1,
+                    per_core_N=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_FF2_SEQ_LEN_4096": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    out_subblock_h=1,
+                    out_subblock_w=4,
+                    per_core_M=4,
+                    per_core_N=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "1D_RESNET_LINEAR": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=10,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    per_core_M=1,
+                    per_core_N=1,
+                    mcast_in0=True,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "2D_GEGLU_LINEAR_640_SPLIT": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=4,
+                    per_core_N=16,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_GEGLU_LINEAR_640_SPLIT_GELU": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=4,
+                    per_core_N=16,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=[ttnn.UnaryOpType.GELU, True],
+                ),
+                "2D_GEGLU_LINEAR_1280_SPLIT": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=32,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_GEGLU_LINEAR_1280_SPLIT_GELU": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=32,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=[ttnn.UnaryOpType.GELU, True],
+                ),
+                "2D_TM_LINEAR_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=5,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=1,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_TM_LINEAR_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=8,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_ATTN_QKV_LINEAR_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=4,
+                    per_core_N=12,
+                    out_subblock_h=1,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_ATTN_QKV_LINEAR_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=24,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=True,
+                ),
+                "2D_ATTEN_K_V_LINEAR_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(8, 8),
+                    in0_block_w=4,  # max is 64, 4 seems optimal
+                    per_core_M=1,
+                    per_core_N=3,
+                    out_subblock_h=1,
+                    out_subblock_w=3,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "1D_ATTEN_K_V_LINEAR_1280": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(8, 8),
+                    in0_block_w=16,  # max is 64, 16 seems optimal
+                    out_subblock_h=3,
+                    out_subblock_w=1,
+                    per_core_M=3,
+                    per_core_N=1,
+                    mcast_in0=True,
+                    fuse_batch=True,
+                    fused_activation=None,
+                ),
+                "2D_ATTN_OUT_LINEAR_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=2,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=True,
+                ),
+                "2D_ATTN_OUT_LINEAR_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=8,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=True,
+                ),
+                "2D_RESNET_CONV_320_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=2,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=2,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=False,
+                ),
+                "2D_RESNET_CONV_640_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=4,
+                    per_core_M=1,
+                    per_core_N=8,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_RESNET_CONV_2560_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=2,
+                    per_core_M=1,
+                    per_core_N=8,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_RESNET_CONV_1920_1280": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=5,
+                    per_core_M=1,
+                    per_core_N=8,
+                    out_subblock_h=1,
+                    out_subblock_w=8,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=False,
+                ),
+                "2D_RESNET_CONV_1920_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=3,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=2,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_RESNET_CONV_1280_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=1,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=2,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "2D_RESNET_CONV_960_640": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=2,
+                    per_core_M=4,
+                    per_core_N=4,
+                    out_subblock_h=1,
+                    out_subblock_w=4,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                ),
+                "1D_RESNET_CONV_960_320": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(8, 5),
+                    in0_block_w=2,
+                    out_subblock_h=1,
+                    out_subblock_w=5,
+                    per_core_M=13,
+                    per_core_N=10,
+                    mcast_in0=False,
+                    gather_in0=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "1D_RESNET_CONV_640_320": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(5, 8),
+                    in0_block_w=1,
+                    out_subblock_h=1,
+                    out_subblock_w=5,
+                    per_core_M=13,
+                    per_core_N=10,
+                    mcast_in0=False,
+                    gather_in0=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+            },
+        }
+
+        assert not force_full_grid, "Full grid matmul configs are not defined for 512x512 image resolution."
+        self.matmul_configs = (
+            self.matmul_versions["40_cores"] if not force_full_grid else self.matmul_versions["full_grid"]
+        )
+        # endregion
+
+        # region LAYERNORM CONFIGS
+        self.core_grid_x = 5 if not force_full_grid else 8
+
+        self.layernorm_configs = {}
+        self.layernorm_configs["640_config"] = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid_x, 8),
+            subblock_w=640 // 32 // self.core_grid_x,
+            block_h=4,
+            block_w=640 // 32 // self.core_grid_x,
+            inplace=False,
+            legacy_reduction=True,
+            legacy_rsqrt=True,
+        )
+        self.layernorm_configs["1280_config"] = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid_x, 8),
+            subblock_w=1280 // 32 // self.core_grid_x,
+            block_h=1,
+            block_w=1280 // 32 // self.core_grid_x,
+            inplace=False,
+            legacy_reduction=True,
+            legacy_rsqrt=True,
+        )
+        # endregion
+
+        # region GROUPNORM CONFIGS
+        self.groupnorm_configs = {}
+        self.groupnorm_configs["SHARDED_GROUPNORM_INPLACE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=8, x=8),
+                "num_out_blocks": None,
+                "inplace": True,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": False,
+        }
+        self.groupnorm_configs["SHARDED_GROUPNORM_4X4_INPLACE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=4, x=4),
+                "num_out_blocks": None,
+                "inplace": True,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": False,
+        }
+        self.groupnorm_configs["SHARDED_GROUPNORM_INPLACE_NEGATIVE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=8, x=8),
+                "num_out_blocks": None,
+                "inplace": True,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": True,
+        }
+        self.groupnorm_configs["SHARDED_GROUPNORM_NON_INPLACE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=8, x=8),
+                "num_out_blocks": None,
+                "inplace": False,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": False,
+        }
+        self.groupnorm_configs["SHARDED_GROUPNORM_4X8_NON_INPLACE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=8, x=4),
+                "num_out_blocks": None,
+                "inplace": False,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": False,
+        }
+        self.groupnorm_configs["SHARDED_GROUPNORM_NON_INPLACE_NEGATIVE"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=8, x=8),
+                "num_out_blocks": None,
+                "inplace": False,
+            },
+            "memory_config": ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+            "negative_mask": True,
+        }
+        self.groupnorm_configs["DRAM_GROUPNORM_4X4"] = {
+            "op_config": {
+                "core_grid": ttnn.CoreGrid(y=4, x=4),
+                "num_out_blocks": 2,
+                "inplace": False,
+            },
+            "memory_config": ttnn.DRAM_MEMORY_CONFIG,
+            "negative_mask": False,
+        }
+        # endregion
+
+        # region SDPA CONFIGS
+        self.sdpa_configs = {}
+        self.sdpa_configs["1024_K"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            q_chunk_size=128,
+            k_chunk_size=1024,
+            exp_approx_mode=False,
+        )
+        self.sdpa_configs["512_K"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            q_chunk_size=128,
+            k_chunk_size=512,
+            exp_approx_mode=False,
+        )
+        self.sdpa_configs["256_K"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            q_chunk_size=128,
+            k_chunk_size=256,
+            exp_approx_mode=False,
+        )
+        self.sdpa_configs["128_K"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            q_chunk_size=128,
+            k_chunk_size=128,
+            exp_approx_mode=False,
+        )
+        # endregion
+
+        # region COMPUTE KERNEL CONFIGS
+        self.compute_configs["DEFAULT_MM_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+        self.compute_configs["MATH_APPROX_MM_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+
+        self.compute_configs["CONV_LOFI_FP32_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+        self.compute_configs["CONV_HIFI2_FP32_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+        self.compute_configs["CONV_HIFI2_NO_FP32_NO_L1_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        self.compute_configs["CONV_HIFI2_NO_FP32_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
+        # endregion
+
+    def get_matmul_config(self, matmul_path):
+        if matmul_path is None:
+            return None
+
+        # # # RESNET CONV MM # # #
+        if "conv_shortcut" in matmul_path:
+            if "down_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_320_640"]
+            if "down_blocks.2" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_640_1280"]
+            if "up_blocks.0.resnets.0" in matmul_path or "up_blocks.0.resnets.1" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_2560_1280"]
+            if "up_blocks.0.resnets.2" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_1920_1280"]
+            if "up_blocks.1.resnets.0" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_1920_640"]
+            if "up_blocks.1.resnets.1" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_1280_640"]
+            if "up_blocks.1.resnets.2" in matmul_path:
+                return self.matmul_configs["2D_RESNET_CONV_960_640"]
+            if "up_blocks.2.resnets.0" in matmul_path:
+                return self.matmul_configs["1D_RESNET_CONV_960_320"]
+            if "up_blocks.2.resnets.1" in matmul_path or "up_blocks.2.resnets.2" in matmul_path:
+                return self.matmul_configs["1D_RESNET_CONV_640_320"]
+            else:
+                return None
+
+        # # # GEGLU # # #
+        if "net.0.proj" in matmul_path:
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                if "gelu" in matmul_path:
+                    return self.matmul_configs["2D_GEGLU_LINEAR_640_SPLIT_GELU"]
+                else:
+                    return self.matmul_configs["2D_GEGLU_LINEAR_640_SPLIT"]
+
+            else:
+                if "gelu" in matmul_path:
+                    return self.matmul_configs["2D_GEGLU_LINEAR_1280_SPLIT_GELU"]
+                else:
+                    return self.matmul_configs["2D_GEGLU_LINEAR_1280_SPLIT"]
+
+        # # # TM LINEAR # # #
+        if "proj_in" in matmul_path or "proj_out" in matmul_path:
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_TM_LINEAR_640"]
+            else:
+                return self.matmul_configs["2D_TM_LINEAR_1280"]
+
+        # # # ATTN OUT LINEAR # # #
+        if "attn1.to_out" in matmul_path or "attn2.to_out" in matmul_path or "attn2.to_q" in matmul_path:
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_ATTN_OUT_LINEAR_640"]
+            else:
+                return self.matmul_configs["2D_ATTN_OUT_LINEAR_1280"]
+        if "attn1.to_q" in matmul_path:
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_ATTN_QKV_LINEAR_640"]
+            else:
+                return self.matmul_configs["2D_ATTN_QKV_LINEAR_1280"]
+        if (
+            "attn1.to_k" in matmul_path
+            or "attn1.to_v" in matmul_path
+            or "attn2.to_k" in matmul_path
+            or "attn2.to_v" in matmul_path
+        ):
+            if "down_blocks.1" in matmul_path or "up_blocks.1" in matmul_path:
+                return self.matmul_configs["2D_ATTEN_K_V_LINEAR_640"]
+            else:
+                return self.matmul_configs["1D_ATTEN_K_V_LINEAR_1280"]
+
+        pattern_down_blocks_1_ff2 = re.compile(
+            r"down_blocks\.1\.attentions\.[01]\.transformer_blocks\.[01]\.ff\.net\.2"
+        )
+
+        # 4 occurrences
+        if pattern_down_blocks_1_ff2.search(matmul_path):
+            return self.matmul_configs["2D_FF2_SEQ_LEN_4096"]
+
+        pattern_down_blockcs_2_ff2 = re.compile(
+            r"down_blocks\.2\.attentions\.[01]\.transformer_blocks\.[0123456789]\.ff\.net\.2"
+        )
+
+        # 20 occurrences
+        if pattern_down_blockcs_2_ff2.search(matmul_path):
+            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+
+        # # # Mid block  # # #
+        pattern_mid_block_ff2 = re.compile(r"mid_block\.attentions\.0\.transformer_blocks\.[0123456789]\.ff\.net\.2")
+
+        # 10 occurrences
+        if pattern_mid_block_ff2.search(matmul_path):
+            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+
+        pattern_up_blocks_0_ff2 = re.compile(
+            r"up_blocks\.0\.attentions\.[012]\.transformer_blocks\.[0123456789]\.ff\.net\.2"
+        )
+
+        # 30 occurrences
+        if pattern_up_blocks_0_ff2.search(matmul_path):
+            return self.matmul_configs["2D_FF2_SEQ_LEN_1024"]
+
+        pattern_up_blocks_1_ff2 = re.compile(r"up_blocks\.1\.attentions\.[012]\.transformer_blocks\.[01]\.ff\.net\.2")
+
+        # 6 occurrences
+        if pattern_up_blocks_1_ff2.search(matmul_path):
+            return self.matmul_configs["2D_FF2_SEQ_LEN_4096"]
+
+        pattern_resnet_linear = re.compile(
+            r"(down_blocks\.[012]\.resnets\.[01]\.linear|up_blocks\.[012]\.resnets\.[012]\.linear|mid_block\.resnets\.[01]\.linear)"
+        )
+
+        if pattern_resnet_linear.search(matmul_path):
+            return self.matmul_configs["1D_RESNET_LINEAR"]
+        return None
+
+    def get_mm_compute_config(self, module_path):
+        # for now, return default config
+        if ".to_q" in module_path:
+            return self.compute_configs["MATH_APPROX_MM_COMPUTE_CONFIG"]
+        return self.compute_configs["DEFAULT_MM_COMPUTE_CONFIG"]
+
+    def get_mm_output_memory_config(self, module_path):
+        if "attn1" in module_path or "attn2" in module_path:
+            if not "to_out" in module_path:
+                return ttnn.L1_MEMORY_CONFIG
+            else:
+                if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
+                    return ttnn.L1_MEMORY_CONFIG
+                else:
+                    return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        if "ff.net" in module_path:
+            return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        if "attentions" in module_path and "proj_in" in module_path:
+            if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
+                return ttnn.L1_MEMORY_CONFIG
+            else:
+                return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        if "resnets" in module_path and "conv_shortcut" in module_path:
+            if "up_blocks.2" not in module_path:
+                return ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+            else:
+                return ttnn.L1_MEMORY_CONFIG
+        return None
+
+    def get_conv_config(self, conv_path):
+        if conv_path is None:
+            return None
+
+        # CONV IN
+        if "conv_in" == conv_path:
+            return self.conv_configs["ABH_256_ADB_HS"]
+
+        # DOWN BLOCK 0
+        elif "down_blocks.0.resnets.0" in conv_path:
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+        elif "down_blocks.0.resnets.1" in conv_path:
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+        elif "down_blocks.0.downsamplers.0" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_NO_DEALLOC_BS"]
+
+        # DOWN BLOCK 1
+        elif "down_blocks.1.resnets.0.conv1" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif ("down_blocks.1.resnets.0.conv2" == conv_path) or ("down_blocks.1.resnets.1" in conv_path):
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif "down_blocks.1.downsamplers.0" == conv_path:
+            return self.conv_configs["ABH_0_ADB_WDB_NO_DEALLOC_BS"]
+
+        # DOWN BLOCK 2
+        elif "down_blocks.2.resnets.0.conv1" == conv_path:
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+        elif ("down_blocks.2.resnets.0.conv2" == conv_path) or ("down_blocks.2.resnets.1" in conv_path):
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+
+        # MID BLOCK
+        elif "mid_block" in conv_path:
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+
+        # UP BLOCK 0
+        elif ("up_blocks.0.resnets.0.conv1" == conv_path) or ("up_blocks.0.resnets.1.conv1" == conv_path):
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+        elif "up_blocks.0.resnets.2.conv1" == conv_path:
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+        elif ("up_blocks.0.resnets" in conv_path) and ("conv2" in conv_path):
+            return self.conv_configs["ABH_0_ADB_WDB_BS"]
+        elif "up_blocks.0.upsamplers.0" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+
+        # UP BLOCK 1
+        elif "up_blocks.1.resnets.0.conv1" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif "up_blocks.1.resnets.1.conv1" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif "up_blocks.1.resnets.2.conv1" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif ("up_blocks.1.resnets" in conv_path) and ("conv2" in conv_path):
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif "up_blocks.1.upsamplers.0" == conv_path:
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+
+        # UP BLOCK 2
+        elif "up_blocks.2.resnets.0.conv1" == conv_path:
+            return self.conv_configs["ABH_128_ADB_WDB_BS"]
+        elif "up_blocks.2.resnets.1.conv1" == conv_path:
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+        elif "up_blocks.2.resnets.2.conv1" == conv_path:
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+        elif ("up_blocks.2.resnets" in conv_path) and ("conv2" in conv_path):
+            return self.conv_configs["ABH_512_ADB_WDB_BS"]
+
+        # CONV IN
+        elif "conv_out" == conv_path:
+            return self.conv_configs["ABH_0_NO_ADB_HS"]
+
+        # ERROR
+        else:
+            raise ValueError(f"Unknown conv path: {conv_path}")
+
+    def get_conv_compute_config(self, module_path):
+        if "conv_in" in module_path or "conv_out" in module_path:
+            return self.compute_configs["CONV_HIFI2_NO_FP32_NO_L1_COMPUTE_CONFIG"]
+        if "resnets" in module_path:
+            conv1_no_fp32 = {
+                "down_blocks.2.resnets",
+                "down_blocks.0",
+                "down_blocks.1.resnets.0",
+                "up_blocks.0",
+                "mid_block",
+            }
+            conv2_no_fp32 = {"down_blocks.2.resnets", "down_blocks.0", "up_blocks.0", "mid_block"}
+
+            if "conv1" in module_path and any(s in module_path for s in conv1_no_fp32):
+                return self.compute_configs["CONV_HIFI2_NO_FP32_COMPUTE_CONFIG"]
+            if "conv2" in module_path and any(s in module_path for s in conv2_no_fp32):
+                return self.compute_configs["CONV_HIFI2_NO_FP32_COMPUTE_CONFIG"]
+
+            return self.compute_configs["CONV_HIFI2_FP32_COMPUTE_CONFIG"]
+        if "upsamplers" in module_path:
+            if "up_blocks.0" in module_path:
+                return self.compute_configs["CONV_HIFI2_NO_FP32_COMPUTE_CONFIG"]
+            else:
+                return self.compute_configs["CONV_HIFI2_FP32_COMPUTE_CONFIG"]
+
+        return self.compute_configs["CONV_HIFI2_FP32_COMPUTE_CONFIG"]
+
+    def get_conv_output_dtype(self):
+        return self.conv_output_dtype
+
+    def __generate_groupnorm_params(self, config, weights, bias, groups, device):
+        if config["memory_config"] != ttnn.DRAM_MEMORY_CONFIG:
+            gamma, beta = prepare_gn_beta_gamma(device, weights, bias, config["op_config"]["core_grid"].x)
+            mask = prepare_gn_mask(device, weights.shape[0], groups, config["op_config"]["core_grid"].x)
+            negative_mask = (
+                prepare_gn_mask_negative_mask(device, weights.shape[0], groups, config["op_config"]["core_grid"].x)
+                if config["negative_mask"]
+                else None
+            )
+        else:
+            [gamma, beta], mask = ttnn.dram_group_norm_params_from_torch(
+                [weights, bias],
+                weights.shape[0],
+                groups,
+                device,
+                core_grid=config["op_config"]["core_grid"],
+                return_mask=True,
+            )
+            negative_mask = None
+
+        return mask, negative_mask, gamma, beta
+
+    def _get_groupnorm_config(self, module_path):
+        # Workaround GroupNorm configs for Issue #36408
+        if module_path == "down_blocks.2.resnets.0.norm1":
+            return self.groupnorm_configs["SHARDED_GROUPNORM_4X4_INPLACE"]
+        if module_path == "up_blocks.0.resnets.2.norm1":
+            return self.groupnorm_configs["DRAM_GROUPNORM_4X4"]
+
+        # GroupNorm configs for Attentions
+        if "attentions" in module_path:
+            if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
+                return self.groupnorm_configs["SHARDED_GROUPNORM_4X8_NON_INPLACE"]
+
+            # Default config for attentions
+            return self.groupnorm_configs["SHARDED_GROUPNORM_NON_INPLACE"]
+
+        # Default GroupNorm config
+        return self.groupnorm_configs["SHARDED_GROUPNORM_INPLACE"]
+
+    def get_groupnorm_params(self, module_path, weights, bias, groups, device):
+        config = self._get_groupnorm_config(module_path)
+
+        mask, negative_mask, gamma, beta = self.__generate_groupnorm_params(config, weights, bias, groups, device)
+        return config["op_config"], config["memory_config"], mask, negative_mask, gamma, beta
+
+    def get_layernorm_config(self, module_path):
+        if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
+            return self.layernorm_configs["640_config"]
+        else:
+            return self.layernorm_configs["1280_config"]
+
+    def get_sdpa_config(self, module_path, is_self_attention):
+        if not is_self_attention:
+            return self.sdpa_configs["128_K"]
+        if "down_blocks.1" in module_path or "up_blocks.1" in module_path:
+            return self.sdpa_configs["512_K"]
+        else:
+            return self.sdpa_configs["1024_K"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -18,8 +18,8 @@ class TtFeedForward(LightweightModule):
         model_config,
     ):
         super().__init__()
-        self.device = device
 
+        self.device = device
         self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", model_config)
 
         weights = state_dict[f"{module_path}.net.2.weight"].unsqueeze(0).unsqueeze(0)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -18,8 +18,8 @@ class TtFeedForward(LightweightModule):
         model_config,
     ):
         super().__init__()
-
         self.device = device
+
         self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", model_config)
 
         weights = state_dict[f"{module_path}.net.2.weight"].unsqueeze(0).unsqueeze(0)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -6,18 +6,17 @@ import ttnn
 
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare_linear_params
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisationsBase
 
 
 class TtGEGLU(LightweightModule):
     def __init__(self, device, state_dict, module_path, model_config):
         super().__init__()
-
         self.device = device
 
         self.module_path = module_path
 
-        self.is_refiner = isinstance(model_config, RefinerModelOptimisations)
+        self.is_refiner = isinstance(model_config, RefinerModelOptimisationsBase)
 
         weights = state_dict[f"{module_path}.proj.weight"]
         bias = state_dict[f"{module_path}.proj.bias"]

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -162,7 +162,6 @@ class TtResnetBlock2D(LightweightModule):
             **self.groupnorm_config_1,
         )
 
-        # hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         hidden_states = ttnn.silu(hidden_states, output_tensor=hidden_states)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_resnetblock2d.py
@@ -9,7 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
     prepare_conv_params,
     prepare_linear_params,
 )
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisationsBase
 
 
 class TtResnetBlock2D(LightweightModule):
@@ -28,7 +28,7 @@ class TtResnetBlock2D(LightweightModule):
         self.module_path = module_path
         self.debug_mode = debug_mode
 
-        self.is_refiner = isinstance(model_config, RefinerModelOptimisations)
+        self.is_refiner = isinstance(model_config, RefinerModelOptimisationsBase)
 
         # fixed for ResnetBlock
         self.stride = (1, 1)
@@ -162,6 +162,7 @@ class TtResnetBlock2D(LightweightModule):
             **self.groupnorm_config_1,
         )
 
+        # hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
         hidden_states = ttnn.silu(hidden_states, output_tensor=hidden_states)
 
         hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_combined_pipeline.py
@@ -31,6 +31,7 @@ class TtSDXLCombinedPipelineConfig:
     """
 
     # Common parameters (apply to both base and refiner)
+    image_resolution: tuple
     num_inference_steps: int
     guidance_scale: float
     is_galaxy: bool
@@ -66,6 +67,7 @@ class TtSDXLCombinedPipelineConfig:
 
     def create_base_config(self) -> TtSDXLPipelineConfig:
         return TtSDXLPipelineConfig(
+            image_resolution=self.image_resolution,
             num_inference_steps=self.num_inference_steps,
             guidance_scale=self.guidance_scale,
             is_galaxy=self.is_galaxy,
@@ -82,6 +84,7 @@ class TtSDXLCombinedPipelineConfig:
             raise ValueError("Cannot create refiner config when use_refiner=False")
 
         return TtSDXLImg2ImgPipelineConfig(
+            image_resolution=self.image_resolution,
             num_inference_steps=self.num_inference_steps,
             guidance_scale=self.guidance_scale,
             is_galaxy=self.is_galaxy,
@@ -110,6 +113,7 @@ class TtSDXLCombinedPipeline:
 
     Usage (base-only):
         config = TtSDXLCombinedPipelineConfig(
+            image_resolution=(1024, 1024),
             num_inference_steps=50,
             guidance_scale=5.0,
             is_galaxy=True,
@@ -126,6 +130,7 @@ class TtSDXLCombinedPipeline:
 
     Usage (with refiner):
         config = TtSDXLCombinedPipelineConfig(
+            image_resolution=(1024, 1024),
             num_inference_steps=50,
             guidance_scale=5.0,
             is_galaxy=True,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -14,11 +14,9 @@ from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
 from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import (
-    ModelOptimisations,
-    RefinerModelOptimisations,
-)
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import load_refiner_model_optimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from transformers import CLIPTextModelWithProjection, CLIPTextModel
 from models.experimental.stable_diffusion_xl_base.tests.test_common import (
     create_tt_clip_text_encoders,
@@ -36,6 +34,7 @@ class TtSDXLPipelineConfig:
     num_inference_steps: int
     guidance_scale: float
     is_galaxy: bool
+    image_resolution: tuple = (1024, 1024)
     capture_trace: bool = True
     vae_on_device: bool = True
     encoders_on_device: bool = True
@@ -139,9 +138,41 @@ class TtSDXLPipeline(LightweightModule):
         self.num_in_channels_unet = 4
         # Hardcoded input tensor parameters
 
-        # Tensor shapes
-        B, C, H, W = 1, self.num_in_channels_unet, 128, 128
-        self.tt_latents_shape = [B, C, H, W]
+        # Latents tensor shape
+        height, width = self.pipeline_config.image_resolution
+        self.tt_latents_shape = self.get_latents_shape(1, self.num_in_channels_unet, height, width)
+
+    def get_latents_shape(self, batch_size, num_channels_latents, height, width):
+        """
+        Calculate the shape of latent tensors for the given image dimensions.
+
+        Computes the latent space dimensions by scaling down the image height and width
+        using the VAE scale factor.
+
+        Args:
+            batch_size (int): Number of samples in the batch.
+            num_channels_latents (int): Number of channels in the latent representation
+                (typically 4 for SDXL).
+            height (int): Target image height in pixels.
+            width (int): Target image width in pixels.
+
+        Returns:
+            tuple: A 4-tuple representing the latent tensor shape:
+                (batch_size, num_channels_latents, latent_height, latent_width)
+                where latent_height and latent_width are calculated by dividing
+                the input height and width by the VAE scale factor.
+
+        Example:
+            >>> shape = pipeline.get_latents_shape(2, 4, 1024, 1024)
+            >>> # Returns (2, 4, 128, 128) if vae_scale_factor is 8
+        """
+        shape = (
+            batch_size,
+            num_channels_latents,
+            int(height) // self.torch_pipeline.vae_scale_factor,
+            int(width) // self.torch_pipeline.vae_scale_factor,
+        )
+        return shape
 
     def set_num_inference_steps(self, num_inference_steps: int):
         # When changing num_inference_steps, the timesteps and latents need to be recreated.
@@ -194,6 +225,13 @@ class TtSDXLPipeline(LightweightModule):
         assert 0.0 <= guidance_rescale <= 1.0, (
             f"`guidance_rescale` must be in range [0.0, 1.0] but is {guidance_rescale}. "
             "Typical values are 0.0 (no rescale) to 0.7."
+        )
+
+        # Validate image_resolution
+        image_resolution = self.pipeline_config.image_resolution
+        assert image_resolution in [(1024, 1024), (512, 512)], (
+            f"`image_resolution` = {image_resolution} is not allowed. "
+            "Only (1024, 1024) and (512, 512) are supported."
         )
 
         # Validate crop_coords_top_left
@@ -346,7 +384,47 @@ class TtSDXLPipeline(LightweightModule):
             self.image_processing_compiled = True
 
     def encode_prompts(self, prompts, negative_prompts, prompt_2=None, negative_prompt_2=None):
-        # Encode prompts using the text encoders.
+        """Encode text prompts using CLIP text encoders for Stable Diffusion XL.
+
+        This method processes text prompts through the CLIP text encoders (text_encoder and
+        text_encoder_2) to generate embeddings that condition the diffusion model. It supports
+        encoding on either the Tenstorrent device (if encoders_on_device=True) or on the host CPU.
+        The method handles both primary prompts and optional secondary prompts (prompt_2), along
+        with their corresponding negative prompts for classifier-free guidance.
+
+        Args:
+            prompts (str or List[str]): The primary text prompt(s) to encode. Can be a single
+                string or a list of strings for batch processing.
+            negative_prompts (str or List[str]): The negative prompt(s) used for classifier-free
+                guidance. Should match the structure of prompts (single string or list).
+            prompt_2 (str or List[str], optional): Optional secondary prompt(s) for SDXL's dual
+                text encoder architecture. Defaults to None.
+            negative_prompt_2 (str or List[str], optional): Optional secondary negative prompt(s).
+                Defaults to None.
+
+        Returns:
+            tuple: A tuple containing two tensors:
+                - all_prompt_embeds_torch (torch.Tensor): Concatenated embeddings for negative
+                    and positive prompts. Shape: [batch_size, 2, sequence_length, embedding_dim]
+                    where dimension 1 contains [negative_embeds, positive_embeds].
+                - torch_add_text_embeds (torch.Tensor): Concatenated pooled embeddings for
+                    negative and positive prompts. Shape: [batch_size, 2, projection_dim]
+                    where dimension 1 contains [negative_pooled, positive_pooled].
+
+        Raises:
+            AssertionError: If encoders_on_device is True but text encoders are not compiled.
+            ValueError: If input validation fails (via check_inputs method).
+
+        Note:
+            - When encoders_on_device=True, encoding is performed on the Tenstorrent device
+                using compiled text encoders, which requires prior compilation via compile_text_encoding().
+            - When encoders_on_device=False, encoding is performed on the host CPU using the
+                PyTorch pipeline's encode_prompt method.
+            - The method automatically handles batching and processes prompts in batches of
+                size self.batch_size when encoding on device.
+            - All embeddings are concatenated with negative prompts first, then positive prompts,
+                to support classifier-free guidance during inference.
+        """
 
         # Validate prompt inputs at the beginning of execution
         self.check_inputs(
@@ -476,7 +554,50 @@ class TtSDXLPipeline(LightweightModule):
         timesteps=None,
         sigmas=None,
     ):
-        # Generate user input tensors for the TT model.
+        """Generate user input tensors for the TT model.
+
+        This method prepares all input tensors required for the backbone part (UNet)
+        of the Stable Diffusion XL pipeline inference, including latents, prompt
+        embeddings, text embeddings, and time IDs
+
+        Args:
+            all_prompt_embeds_torch (torch.Tensor): Combined prompt embeddings from
+                both positive and negative prompts. Shape should be compatible with
+                the batch size and embedding dimensions.
+            torch_add_text_embeds (torch.Tensor): Additional text embeddings from
+                the text encoder, typically pooled embeddings.
+            start_latent_seed (int, optional): Seed value for generating random
+                latents. If None, latents are generated with random seeds. If
+                provided, this seed is used for deterministic latent generation.
+            fixed_seed_for_batch (bool): If True and start_latent_seed is provided,
+                all samples in the batch use the same seed. If False, each sample
+                uses start_latent_seed + index. Defaults to False.
+            timesteps (torch.Tensor, optional): Custom timesteps for the diffusion
+                process. If None, timesteps are generated based on the scheduler
+                configuration. Cannot be provided together with sigmas.
+            sigmas (torch.Tensor, optional): Custom noise schedule sigmas. If None,
+                sigmas are derived from the scheduler. Cannot be provided together
+                with timesteps.
+
+        Returns:
+            tuple: A tuple containing three tensors:
+                - tt_latents (ttnn.Tensor): Generated latents tensor with shape
+                    [batch_size, 1, H*W, C]. It is assumed that C=4.
+                - tt_prompt_embeds (ttnn.Tensor): Prompt embeddings tensor
+                    converted to TT format.
+                - tt_add_text_embeds (ttnn.Tensor): Additional text embeddings
+                    tensor converted to TT format.
+
+        Raises:
+            AssertionError: If num_channels_latents is not 4, if start_latent_seed
+                is not an integer or None, if text_encoder_projection_dim is not
+                1280, or if both timesteps and sigmas are provided.
+
+        Note:
+            This method sets self.generated_input_tensors to True upon successful
+            completion. The generated tensors are also allocated on the device
+            during this process.
+        """
 
         # Validate timesteps/sigmas at the beginning if custom values are provided
         if timesteps is not None or sigmas is not None:
@@ -487,8 +608,8 @@ class TtSDXLPipeline(LightweightModule):
 
         self._prepare_timesteps(timesteps, sigmas)
 
+        # Validate number of channels in the latent space
         num_channels_latents = self.torch_pipeline.unet.config.in_channels
-        height = width = 1024
         assert (
             num_channels_latents == self.num_in_channels_unet
         ), f"num_channels_latents is {num_channels_latents}, but it should be 4"
@@ -498,6 +619,7 @@ class TtSDXLPipeline(LightweightModule):
 
         # Generate random latents
         latents_list = []
+        height, width = self.pipeline_config.image_resolution
         for index in range(self.batch_size):
             if start_latent_seed is not None:
                 torch.manual_seed(start_latent_seed if fixed_seed_for_batch else start_latent_seed + index)
@@ -523,13 +645,11 @@ class TtSDXLPipeline(LightweightModule):
             text_encoder_projection_dim == 1280
         ), f"text_encoder_projection_dim is {text_encoder_projection_dim}, but it should be 1280"
 
-        original_size = (height, width)
-        target_size = (height, width)
         crops_coords_top_left = self.pipeline_config.crop_coords_top_left
         add_time_ids = self.torch_pipeline._get_add_time_ids(
-            original_size,
+            self.pipeline_config.image_resolution,
             crops_coords_top_left,
-            target_size,
+            self.pipeline_config.image_resolution,
             dtype=all_prompt_embeds_torch.dtype,
             text_encoder_projection_dim=text_encoder_projection_dim,
         )
@@ -624,13 +744,12 @@ class TtSDXLPipeline(LightweightModule):
 
         profiler.start("load_tt_componenets")
         with ttnn.distribute(ttnn.ReplicateTensorToMesh(self.ttnn_device)):
-            # 2. Load tt_unet, tt_vae and tt_scheduler
+            # 1. Load tt_unet
             self.tt_unet_model_config = (
-                ModelOptimisations()
+                load_model_optimisations(self.pipeline_config.image_resolution)
                 if not self.torch_pipeline.unet.state_dict()["conv_in.weight"].shape[0] == 384
-                else RefinerModelOptimisations()
+                else load_refiner_model_optimisations(self.pipeline_config.image_resolution)
             )
-            self.tt_vae_model_config = VAEModelOptimisations()
             self.tt_unet = TtUNet2DConditionModel(
                 self.ttnn_device,
                 self.torch_pipeline.unet.state_dict(),
@@ -638,17 +757,20 @@ class TtSDXLPipeline(LightweightModule):
                 model_config=self.tt_unet_model_config,
                 debug_mode=pipeline_config._debug_mode,
             )
-            # Skip VAE for refiner pipelines
-            self.tt_vae = (
-                TtAutoencoderKL(
+
+            # 2. Load tt_vae
+            if self.pipeline_config.vae_on_device:
+                self.tt_vae_model_config = load_vae_model_optimisations(self.pipeline_config.image_resolution)
+                self.tt_vae = TtAutoencoderKL(
                     self.ttnn_device,
                     self.torch_pipeline.vae.state_dict(),
                     self.tt_vae_model_config,
                     debug_mode=pipeline_config._debug_mode,
                 )
-                if pipeline_config.vae_on_device
-                else None
-            )
+            else:
+                self.tt_vae = None
+
+            # 3. Load tt_scheduler
             if tt_scheduler is not None:
                 self.tt_scheduler = tt_scheduler
             else:
@@ -674,6 +796,7 @@ class TtSDXLPipeline(LightweightModule):
                 )
         self.torch_pipeline.scheduler = self.tt_scheduler
 
+        # 4. Load encoders
         if pipeline_config.encoders_on_device:
             self.tt_text_encoder, self.tt_text_encoder_2 = create_tt_clip_text_encoders(
                 self.torch_pipeline, self.ttnn_device

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformerblock.py
@@ -6,7 +6,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.stable_diffusion_xl_base.tt.tt_attention import TtAttention
 from models.experimental.stable_diffusion_xl_base.tt.tt_feedforward import TtFeedForward
-from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisationsBase
 
 
 class TtBasicTransformerBlock(LightweightModule):
@@ -23,7 +23,7 @@ class TtBasicTransformerBlock(LightweightModule):
         super().__init__()
 
         self.module_path = module_path
-        self.is_refiner = isinstance(model_config, RefinerModelOptimisations)
+        self.is_refiner = isinstance(model_config, RefinerModelOptimisationsBase)
 
         self.attn1 = TtAttention(
             device,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -15,7 +15,6 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 class TtTransformer2DModel(LightweightModule):
     def __init__(self, device, state_dict, module_path, model_config, query_dim, num_attn_heads, out_dim):
         super().__init__()
-
         self.device = device
 
         self.norm_groups = 32

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -15,6 +15,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 class TtTransformer2DModel(LightweightModule):
     def __init__(self, device, state_dict, module_path, model_config, query_dim, num_attn_heads, out_dim):
         super().__init__()
+
         self.device = device
 
         self.norm_groups = 32

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -7,7 +7,7 @@ import pytest
 import ttnn
 from loguru import logger
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -15,9 +15,10 @@ from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape, encoder_shape",
+    "image_resolution, input_shape, encoder_shape",
     [
-        ((1, 512, 128, 128), None),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 512, 128, 128), None),
     ],
 )
 @pytest.mark.parametrize(
@@ -28,7 +29,11 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_attention(device, input_shape, encoder_shape, block_name, pcc, is_ci_env, reset_seeds):
+def test_vae_attention(device, image_resolution, input_shape, encoder_shape, block_name, pcc, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -39,7 +44,7 @@ def test_vae_attention(device, input_shape, encoder_shape, block_name, pcc, is_c
     vae.eval()
     state_dict = vae.state_dict()
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     if block_name == "encoder":
         torch_attention = vae.encoder.mid_block.attentions[0]
         tt_attention = TtAttention(

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -17,17 +17,31 @@ from loguru import logger
 
 @torch.no_grad()
 @pytest.mark.parametrize(
-    "input_shape, pcc, vae_block",
+    "image_resolution, input_shape, pcc, vae_block",
     [
-        ((1, 4, 128, 128), 0.933, "decoder"),
-        ((1, 3, 1024, 1024), 0.9769, "encoder"),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), 0.933, "decoder"),
+        ((1024, 1024), (1, 3, 1024, 1024), 0.9769, "encoder"),
     ],
     ids=("test_decode", "test_encode"),
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae(
-    device, input_shape, vae_block, pcc, debug_mode, is_ci_env, reset_seeds, is_ci_v2_env, model_location_generator
+    device,
+    image_resolution,
+    input_shape,
+    vae_block,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    reset_seeds,
+    is_ci_v2_env,
+    model_location_generator,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     model_location = model_location_generator(
         "stable-diffusion-xl-base-1.0/vae", download_if_ci_v2=True, ci_v2_timeout_in_s=1800
     )
@@ -42,7 +56,7 @@ def test_vae(
     state_dict = vae.state_dict()
 
     logger.info("Loading weights to device")
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_vae = TtAutoencoderKL(device, state_dict, model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_decoder import TtDecoder
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -17,13 +17,18 @@ from loguru import logger
 
 @torch.no_grad()
 @pytest.mark.parametrize(
-    "input_shape, pcc",
+    "image_resolution, input_shape, pcc",
     [
-        ((1, 4, 128, 128), 0.94),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 4, 128, 128), 0.94),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+def test_vae_decoder(device, image_resolution, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -37,7 +42,7 @@ def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seed
     torch_vae = vae.decoder
 
     logger.info("Loading weights to device")
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_vae = TtDecoder(device, state_dict, model_config=model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
@@ -7,7 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_downblock2d import TtDownEncoderBlock2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -15,16 +15,21 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, block_id, pcc",
+    "image_resolution, input_shape, block_id, pcc",
     [
-        ((1, 128, 1024, 1024), 0, 0.999),
-        ((1, 128, 512, 512), 1, 0.998),
-        ((1, 256, 256, 256), 2, 0.999),
-        ((1, 512, 128, 128), 3, 0.999),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 128, 1024, 1024), 0, 0.999),
+        ((1024, 1024), (1, 128, 512, 512), 1, 0.998),
+        ((1024, 1024), (1, 256, 256, 256), 2, 0.999),
+        ((1024, 1024), (1, 512, 128, 128), 3, 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_downblock2d(device, block_id, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+def test_downblock2d(device, image_resolution, block_id, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -37,7 +42,7 @@ def test_downblock2d(device, block_id, input_shape, pcc, debug_mode, is_ci_env, 
 
     torch_downblock = vae.encoder.down_blocks[block_id]
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_downblock = TtDownEncoderBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downsample2d.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_downsample2d import TtDownsample2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -20,7 +20,13 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 
 
 @pytest.mark.parametrize(
-    "input_shape, down_block_id", [((1, 128, 1024, 1024), 0), ((1, 256, 512, 512), 1), ((1, 512, 256, 256), 2)]
+    "image_resolution, input_shape, down_block_id",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 128, 1024, 1024), 0),
+        ((1024, 1024), (1, 256, 512, 512), 1),
+        ((1024, 1024), (1, 512, 256, 256), 2),
+    ],
 )
 @pytest.mark.parametrize("stride", [(2, 2)])
 @pytest.mark.parametrize("padding", [(0, 1, 0, 1)])
@@ -28,6 +34,7 @@ from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_downsample2d(
     device,
+    image_resolution,
     input_shape,
     down_block_id,
     stride,
@@ -37,6 +44,10 @@ def test_downsample2d(
     is_ci_env,
     reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -50,7 +61,7 @@ def test_downsample2d(
     torch_downsample = vae.encoder.down_blocks[down_block_id].downsamplers[0]
     groups = 1
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_downsample = TtDownsample2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_encoder import TtEncoder
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -17,13 +17,18 @@ from loguru import logger
 
 @torch.no_grad()
 @pytest.mark.parametrize(
-    "input_shape, pcc",
+    "image_resolution, input_shape, pcc",
     [
-        ((1, 3, 1024, 1024), 0.97),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 3, 1024, 1024), 0.97),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+def test_vae_decoder(device, image_resolution, input_shape, pcc, debug_mode, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -37,7 +42,7 @@ def test_vae_decoder(device, input_shape, pcc, debug_mode, is_ci_env, reset_seed
     torch_vae = vae.encoder
 
     logger.info("Loading weights to device")
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_vae = TtEncoder(device, state_dict, model_config=model_config, debug_mode=debug_mode)
     logger.info("Loaded weights")
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -14,9 +14,10 @@ from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape",
+    "image_resolution, input_shape",
     [
-        (1, 512, 128, 128),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 512, 128, 128)),
     ],
 )
 @pytest.mark.parametrize(
@@ -27,7 +28,11 @@ from models.common.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_midblock(device, input_shape, block_name, debug_mode, is_ci_env, reset_seeds):
+def test_vae_midblock(device, image_resolution, input_shape, block_name, debug_mode, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -43,7 +48,7 @@ def test_vae_midblock(device, input_shape, block_name, debug_mode, is_ci_env, re
     else:
         torch_midblock = vae.decoder.mid_block
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_midblock = TtUNetMidBlock2D(
         device, state_dict, f"{block_name}.mid_block", model_config=model_config, debug_mode=debug_mode
     )

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import TtResnetBlock2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -14,27 +14,42 @@ from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape, block_id, resnet_id, conv_shortcut, block, pcc",
+    "image_resolution, input_shape, block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        ((1, 512, 128, 128), 0, 0, False, "mid_block", 0.999),
-        ((1, 512, 128, 128), 0, 0, False, "up_blocks", 0.999),
-        ((1, 512, 256, 256), 1, 0, False, "up_blocks", 0.999),
-        ((1, 512, 512, 512), 2, 0, True, "up_blocks", 0.999),
-        ((1, 256, 512, 512), 2, 1, False, "up_blocks", 0.999),
-        ((1, 256, 1024, 1024), 3, 0, True, "up_blocks", 0.999),
-        ((1, 128, 1024, 1024), 3, 1, False, "up_blocks", 0.999),
-        ((1, 128, 1024, 1024), 0, 0, False, "down_blocks", 0.998),
-        ((1, 128, 512, 512), 1, 0, True, "down_blocks", 0.999),
-        ((1, 256, 512, 512), 1, 1, False, "down_blocks", 0.999),
-        ((1, 256, 256, 256), 2, 0, True, "down_blocks", 0.999),
-        ((1, 512, 256, 256), 2, 1, False, "down_blocks", 0.999),
-        ((1, 512, 128, 128), 3, 0, False, "down_blocks", 0.999),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 512, 128, 128), 0, 0, False, "mid_block", 0.999),
+        ((1024, 1024), (1, 512, 128, 128), 0, 0, False, "up_blocks", 0.999),
+        ((1024, 1024), (1, 512, 256, 256), 1, 0, False, "up_blocks", 0.999),
+        ((1024, 1024), (1, 512, 512, 512), 2, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 256, 512, 512), 2, 1, False, "up_blocks", 0.999),
+        ((1024, 1024), (1, 256, 1024, 1024), 3, 0, True, "up_blocks", 0.999),
+        ((1024, 1024), (1, 128, 1024, 1024), 3, 1, False, "up_blocks", 0.999),
+        ((1024, 1024), (1, 128, 1024, 1024), 0, 0, False, "down_blocks", 0.998),
+        ((1024, 1024), (1, 128, 512, 512), 1, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 256, 512, 512), 1, 1, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 256, 256, 256), 2, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 512, 256, 256), 2, 1, False, "down_blocks", 0.999),
+        ((1024, 1024), (1, 512, 128, 128), 3, 0, False, "down_blocks", 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_resnetblock2d(
-    device, input_shape, block_id, resnet_id, conv_shortcut, block, pcc, debug_mode, is_ci_env, reset_seeds
+    device,
+    image_resolution,
+    input_shape,
+    block_id,
+    resnet_id,
+    conv_shortcut,
+    block,
+    pcc,
+    debug_mode,
+    is_ci_env,
+    reset_seeds,
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -57,7 +72,7 @@ def test_vae_resnetblock2d(
         torch_resnet = vae.decoder.mid_block.resnets[resnet_id]
     vae_block = "encoder" if is_encoder else "decoder"
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_resnet = TtResnetBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -14,16 +14,21 @@ from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape, block_id, pcc",
+    "image_resolution, input_shape, block_id, pcc",
     [
-        ((1, 512, 128, 128), 0, 0.999),
-        ((1, 512, 256, 256), 1, 0.995),
-        ((1, 512, 512, 512), 2, 0.998),
-        ((1, 256, 1024, 1024), 3, 0.999),
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 512, 128, 128), 0, 0.999),
+        ((1024, 1024), (1, 512, 256, 256), 1, 0.995),
+        ((1024, 1024), (1, 512, 512, 512), 2, 0.998),
+        ((1024, 1024), (1, 256, 1024, 1024), 3, 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
-def test_vae_upblock(device, input_shape, block_id, pcc, debug_mode, is_ci_env, reset_seeds):
+def test_vae_upblock(device, image_resolution, input_shape, block_id, pcc, debug_mode, is_ci_env, reset_seeds):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -36,7 +41,7 @@ def test_vae_upblock(device, input_shape, block_id, pcc, debug_mode, is_ci_env, 
 
     torch_upblock = vae.decoder.up_blocks[block_id]
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_upblock = TtUpDecoderBlock2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import TtUpsample2D
-from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import VAEModelOptimisations
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
 from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -18,15 +18,25 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 
 
 @pytest.mark.parametrize(
-    "input_shape, up_block_id", [((1, 512, 128, 128), 0), ((1, 512, 256, 256), 1), ((1, 256, 512, 512), 2)]
+    "image_resolution, input_shape, up_block_id",
+    [
+        # 1024x1024 image resolution
+        ((1024, 1024), (1, 512, 128, 128), 0),
+        ((1024, 1024), (1, 512, 256, 256), 1),
+        ((1024, 1024), (1, 256, 512, 512), 2),
+    ],
 )
 @pytest.mark.parametrize("stride", [(1, 1)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": SDXL_L1_SMALL_SIZE}], indirect=True)
 def test_vae_upsample2d(
-    device, input_shape, up_block_id, stride, padding, dilation, debug_mode, is_ci_env, reset_seeds
+    device, image_resolution, input_shape, up_block_id, stride, padding, dilation, debug_mode, is_ci_env, reset_seeds
 ):
+    # Skip unsupported image resolutions
+    if image_resolution != (1024, 1024):
+        pytest.skip(f"Unsupported image resolution: {image_resolution}. Only (1024, 1024) is supported.")
+
     vae = AutoencoderKL.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
@@ -40,7 +50,7 @@ def test_vae_upsample2d(
     torch_upsample = vae.decoder.up_blocks[up_block_id].upsamplers[0]
     groups = 1
 
-    model_config = VAEModelOptimisations()
+    model_config = load_vae_model_optimisations(image_resolution)
     tt_upsample = TtUpsample2D(
         device,
         state_dict,

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/model_configs/__init__.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/model_configs/__init__.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from models.experimental.stable_diffusion_xl_base.vae.tt.model_configs.model_configs_1024x1024 import (
+    VAEModelOptimisations1024x1024,
+)
+
+
+def load_vae_model_optimisations(
+    image_resolution,
+    conv_act_dtype=None,
+    conv_w_dtype=None,
+    attention_weights_dtype=None,
+    ff_weights_dtype=None,
+):
+    """
+    Load the appropriate VAEModelOptimisation object based on the provided image resolution.
+
+    Args:
+        image_resolution (tuple): A tuple of (height, width) representing the image resolution.
+            Supported resolution is (1024, 1024).
+        conv_act_dtype: Optional dtype for convolution activations. Defaults to ttnn.bfloat16.
+        conv_w_dtype: Optional dtype for convolution weights. Defaults to ttnn.bfloat16.
+        attention_weights_dtype: Optional dtype for attention weights. Defaults to ttnn.bfloat8_b.
+        ff_weights_dtype: Optional dtype for feedforward weights. Defaults to ttnn.bfloat8_b.
+
+    Returns:
+        VAEModelOptimisations1024x1024: The appropriate VAEModelOptimisation object based on the
+            image resolution.
+
+    Raises:
+        ValueError: If the image_resolution is not supported.
+
+    Example:
+        >>> model_opt = load_vae_model_optimisations((1024, 1024))
+    """
+    if not isinstance(image_resolution, (tuple, list)) or len(image_resolution) != 2:
+        raise ValueError(f"image_resolution must be a tuple or list of length 2, got {image_resolution}")
+
+    height, width = image_resolution
+
+    # Prepare kwargs for initialization
+    init_kwargs = {}
+    if conv_act_dtype is not None:
+        init_kwargs["conv_act_dtype"] = conv_act_dtype
+    if conv_w_dtype is not None:
+        init_kwargs["conv_w_dtype"] = conv_w_dtype
+    if attention_weights_dtype is not None:
+        init_kwargs["attention_weights_dtype"] = attention_weights_dtype
+    if ff_weights_dtype is not None:
+        init_kwargs["ff_weights_dtype"] = ff_weights_dtype
+
+    if (height, width) == (1024, 1024):
+        return VAEModelOptimisations1024x1024(**init_kwargs)
+    else:
+        raise ValueError(f"Unsupported image_resolution: {image_resolution}. " "Only (1024, 1024) is supported.")

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
@@ -4,10 +4,10 @@
 
 import ttnn
 
-from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations1024x1024
 
 
-class VAEModelOptimisations(ModelOptimisations):
+class VAEModelOptimisations1024x1024(ModelOptimisations1024x1024):
     def __init__(
         self,
         conv_act_dtype=ttnn.bfloat16,

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -197,6 +197,8 @@ run_resnet_func() {
 
 run_sdxl_func() {
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/experimental/stable_diffusion_xl_base/tests/test_sdxl_accuracy.py --start-from=0 --num-prompts=2 -k "device_encoders and device_vae and no_cfg_parallel"
+  # Once the VAE is implemented on device for 512x512 image resolution, this test will run on both resolutions with device_vae. For now, lets use this test config.
+  TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/experimental/stable_diffusion_xl_base/demo/demo.py -k "512x512 and host_vae and device_encoders and with_trace and no_cfg_parallel"
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/experimental/stable_diffusion_xl_base/demo/demo_img2img.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   TT_MM_THROTTLE_PERF=5 $PYTEST_CMD models/experimental/stable_diffusion_xl_base/demo/demo_inpainting.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
 }

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3132,68 +3132,68 @@ def test_conv2d_model_fruit(
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, act_db, w_db, reshard_if_not_optimal",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, act_db, w_db",
     (
         ################################################################## START: 1024x1024 resolution ##################################################################
         # kernel 3x3
-        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 1024, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 640, 640, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 960, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 960, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 1024, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 640, 640, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 960, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 960, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
 
         # stride 2x2
-        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0, 1, False, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0,   1, False, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0, 1, False, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0,   1, False, ttnn.MathFidelity.HiFi2, True, False, True, True),
 
         # output_channels 4
-        (1, 320, 4, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 128,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 320, 4, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 128,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
         # input_channels 4
-        (1, 4, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 4, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
 
         # # input_channels 9
-        (1, 9, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 9, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
         ################################################################### END: 1024x1024 resolution ###################################################################
 
 
 
         ################################################################### START: 512x512 resolution ###################################################################
         # conv_in
-        (1, 4, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
-        (1, 9, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 4, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
+        (1, 9, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
 
         # regular 3x3 kernel
-        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 320, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 1280, 16, 16,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1280, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 2560, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1920, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
-        (1, 1920, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 1280, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 960, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 960, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
-        (1, 640, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 320, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 1280, 16, 16,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1280, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 2560, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1920, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
+        (1, 1920, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 1280, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 960, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 960, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 640, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
 
         # down_blocks.0.downsamplers.0
-        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 128, 1, False, ttnn.MathFidelity.HiFi2, False, False, True, True, True),
+        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 128, 1, False, ttnn.MathFidelity.HiFi2, False, False, True, True),
         # down_blocks.1.downsamplers.0
-        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 32, 1, False, ttnn.MathFidelity.HiFi2, False, False, False, False, True),
+        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 32, 1, False, ttnn.MathFidelity.HiFi2, False, False, False, False),
 
         # conv_out
-        (1, 320, 4, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 320, 4, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
         #################################################################### END: 512x512 resolution ####################################################################
     ),
 )
@@ -3222,7 +3222,6 @@ def test_conv2d_sdxl(
     packer_l1_acc,
     act_db,
     w_db,
-    reshard_if_not_optimal,
     perf_test_mode = False,
 ):
     core_grid = ttnn.CoreRangeSet(
@@ -3240,7 +3239,7 @@ def test_conv2d_sdxl(
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div
-    config_override["reshard_if_not_optimal"] = reshard_if_not_optimal
+    config_override["reshard_if_not_optimal"] = True
 
     run_conv(
         device=device,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -281,6 +281,9 @@ def run_conv(
     if config_override and "act_block_w_div" in config_override and not auto_shard:
         conv_config.act_block_w_div = config_override["act_block_w_div"]
 
+    if config_override and "reshard_if_not_optimal" in config_override:
+        conv_config.reshard_if_not_optimal = config_override["reshard_if_not_optimal"]
+
     if not use_dram_slicing:
         slice_config = ttnn.Conv2dL1FullSliceConfig
 
@@ -3129,42 +3132,71 @@ def test_conv2d_model_fruit(
 
 
 @pytest.mark.parametrize(
-    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, act_db, w_db",
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, output_dtype, groups, kernel, stride, padding, dilation, shard_layout, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, act_db, w_db, reshard_if_not_optimal",
     (
-        # 1024x1024 resolution
-
-        # UNet
+        ################################################################## START: 1024x1024 resolution ##################################################################
         # kernel 3x3
-        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 1024, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True),
-        (1, 640, 640, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 640, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 960, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 960, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1280, 1280, 64, 64, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1280, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1920, 640, 64, 64,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 2560, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 64,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 320, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 1024, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 640, 1280, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 640, 640, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256,  1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 960, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 256, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 960, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
 
         # stride 2x2
-        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0, 1, False, ttnn.MathFidelity.HiFi2, True, False, True, True),
-        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0,   1, False, ttnn.MathFidelity.HiFi2, True, False, True, True),
+        (1, 320, 320, 128, 128, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0, 1, False, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 0,   1, False, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
 
         # output_channels 4
-        (1, 320, 4, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 128,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
-        # # input_channels 4
-        (1, 4, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
+        (1, 320, 4, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 128,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        # input_channels 4
+        (1, 4, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
 
         # # input_channels 9
-        (1, 9, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False),
+        (1, 9, 320, 128, 128,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0,  1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        ################################################################### END: 1024x1024 resolution ###################################################################
 
+
+
+        ################################################################### START: 512x512 resolution ###################################################################
+        # conv_in
+        (1, 4, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        (1, 9, 320, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+
+        # regular 3x3 kernel
+        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 320, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 1280, 16, 16,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1280, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 2560, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1920, 1280, 16, 16, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 0,   1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1280, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, False, True, True, True, True),
+        (1, 1920, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 1280, 640, 32, 32,  ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 960, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 640, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 960, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 512, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+        (1, 640, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), BS, 128, 1, True, ttnn.MathFidelity.HiFi2, True, False, True, True, True),
+
+        # down_blocks.0.downsamplers.0
+        (1, 320, 320, 64, 64,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 128, 1, False, ttnn.MathFidelity.HiFi2, False, False, True, True, True),
+        # down_blocks.1.downsamplers.0
+        (1, 640, 640, 32, 32,   ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (2, 2), (1, 1), (1, 1), BS, 32, 1, False, ttnn.MathFidelity.HiFi2, False, False, False, False, True),
+
+        # conv_out
+        (1, 320, 4, 64, 64,     ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), HS, 0, 1, True, ttnn.MathFidelity.HiFi2, False, False, True, False, True),
+        #################################################################### END: 512x512 resolution ####################################################################
     ),
 )
-
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 2 * 16384}], indirect=True)
 def test_conv2d_sdxl(
     device,
@@ -3190,6 +3222,7 @@ def test_conv2d_sdxl(
     packer_l1_acc,
     act_db,
     w_db,
+    reshard_if_not_optimal,
     perf_test_mode = False,
 ):
     core_grid = ttnn.CoreRangeSet(
@@ -3207,6 +3240,7 @@ def test_conv2d_sdxl(
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div
+    config_override["reshard_if_not_optimal"] = reshard_if_not_optimal
 
     run_conv(
         device=device,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -66,6 +66,8 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
             4,
             4,
         ),  # test all groups on core fit in less than one tile, so need to reduce col core count
+        # SDXL Base
+        (1, 1920, 16, 16, 32, 1, 4, 4),
         #  SDXL VAE
         (1, 256, 256, 256, 32, 4, 8, 8),
         (1, 512, 256, 256, 32, 4, 8, 8),

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -110,7 +110,11 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
 @pytest.mark.parametrize("core_grid", [ttnn.CoreGrid(y=8, x=5)])
 @pytest.mark.parametrize(
     "M, K, N, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, has_gelu",
-    ((1024, 1280, 5120, 4, 1, 8, 4, 32, True),),
+    [
+        (1024, 1280, 5120, 4, 1, 8, 4, 32, True),
+        (256, 1280, 5120, 4, 1, 8, 1, 32, False),
+        (1024, 640, 2560, 4, 1, 8, 4, 16, False),
+    ],
 )
 def test_sdxl_matmul(
     device,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -398,8 +398,7 @@ def test_group_norm_with_block_sharded_v2_8x8_grid_tile_layout(device, N, C, H, 
 def generate_sdxl_test_inputs():
     inputs = []
 
-    # 1024x1024 resoultion
-
+    ##### START: 1024x1024 resolution #####
     # UNet inputs
     inputs.append((1, 1280, 64, 64))
     inputs.append((1, 1280, 32, 32))
@@ -428,6 +427,24 @@ def generate_sdxl_test_inputs():
     inputs.append((1, 384, 64, 64))
     inputs.append((1, 768, 32, 32))
     inputs.append((1, 768, 64, 64))
+    ###### END: 1024x1024 resolution ######
+
+    ##### START: 512x512 resolution #####
+    # UNet inputs
+    inputs.append((1, 320, 64, 64))
+    inputs.append((1, 320, 32, 32))
+    inputs.append((1, 640, 32, 32))
+    inputs.append((1, 640, 16, 16))
+    inputs.append((1, 1280, 16, 16))
+    inputs.append((1, 2560, 16, 16))
+    # This test is removed to test_group_norm_DRAM because of the Issue #36408. To be added back after the issue is resolved.
+    # inputs.append((1, 1920, 16, 16))
+    inputs.append((1, 1920, 32, 32))
+    inputs.append((1, 1280, 32, 32))
+    inputs.append((1, 960, 32, 32))
+    inputs.append((1, 960, 64, 64))
+    inputs.append((1, 640, 64, 64))
+    ###### END: 512x512 resolution ######
 
     return inputs
 
@@ -436,13 +453,17 @@ def generate_sdxl_test_inputs():
 @pytest.mark.parametrize("input_shape", generate_sdxl_test_inputs())
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
 def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=False):
-    num_groups = 32  #  always 32 for SDXL Base 1024x1024
+    num_groups = 32  #  always 32 for SDXL Base
     N, C, H, W = input_shape
     torch.manual_seed(0)
     if device.core_grid.y == 7:
         pytest.skip()
 
-    grid_size = ttnn.CoreGrid(y=8, x=8)
+    # Use 5x5 grid for shape (1, 640, 16, 16) (temporary workaround for issue #36408)
+    if (C, H, W) == (640, 16, 16):
+        grid_size = ttnn.CoreGrid(y=4, x=4)
+    else:
+        grid_size = ttnn.CoreGrid(y=8, x=8)
 
     # Generate torch tensor
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
@@ -492,7 +513,7 @@ def test_sdxl_base_group_norm(device, input_shape, use_welford, perf_test_mode=F
         tt_output_tensor = ttnn.from_device(tt_output_tensor)
         tt_output_tensor = ttnn.to_torch(tt_output_tensor)
 
-        assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9997)
+        assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9996)
 
 
 def generate_sdxl_test_inputs_neg_mask():

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -134,7 +134,9 @@ def run_group_norm_DRAM(
             4,
         ),  # test all groups on core fit in less than one tile, so need to reduce col core count
         # All SDXL/sd35 tests with 512x512 or larger sizes moved to nightly
-        #  SDXL VAE
+        # SDXL Base
+        (1, 1920, 16, 16, 32, 1, 4, 4),
+        # SDXL VAE
         (1, 256, 256, 256, 32, 4, 8, 8),
         (1, 512, 256, 256, 32, 4, 8, 8),
         # SDXL Refiner


### PR DESCRIPTION
This PR introduces new image resolution (512x512) into the SDXL pipeline. [#35733](https://github.com/tenstorrent/tt-metal/issues/35733)

All pytests have been updated to support new image resolution. However, only some of those tests are enabled. Currently, only the base UNet model supports 512x512 image resolution on device. Therefore, following pytests are enabled:
- `models/experimental/stable_diffusion_xl_base/demo/demo.py` (VAE must be on the host for 512x512 resolution)
- `models/experimental/stable_diffusion_xl_base/tests/pcc`
- `models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py::test_sdxl_perf_device`

For now, the high perf margin was left for `test_sdxl_unet_512x512`. This will be narrowed down once the matmul perf optimizations are done.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22389255430)
- [ ] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/22389294368)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22389337123)
- [ ] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22389368342)
- [ ] [TT-metal L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22389439998)