### PR TITLE
Multi-Host Upstream Testing for Exabox

### DIFF
--- a/tools/scaleout/exabox/analyze_validation_results.sh
+++ b/tools/scaleout/exabox/analyze_validation_results.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# Script to analyze validation output logs for health status and errors
+# Usage: ./analyze_validation_results.sh [directory]
+# Default directory: validation_output/
+
+# Set default directory or use provided argument
+VALIDATION_DIR="${1:-validation_output}"
+
+# Check if directory exists
+if [ ! -d "$VALIDATION_DIR" ]; then
+    echo "Error: Directory $VALIDATION_DIR does not exist"
+    exit 1
+fi
+
+# Color codes for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "Validation Results Analysis"
+echo "Directory: $VALIDATION_DIR"
+echo "Timestamp: $(date)"
+echo "=========================================="
+echo ""
+
+# Count total log files
+TOTAL_FILES=$(find "$VALIDATION_DIR" -name "*.log" -type f | wc -l)
+echo "Total log files found: $TOTAL_FILES"
+echo ""
+
+# 1. Check for healthy links
+echo -e "${GREEN}✓ Checking for 'All Detected Links are healthy'${NC}"
+HEALTHY_FILES=$(grep -l "All Detected Links are healthy" "$VALIDATION_DIR"/*.log 2>/dev/null)
+HEALTHY_COUNT=$(echo "$HEALTHY_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $HEALTHY_COUNT"
+if [ $HEALTHY_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$HEALTHY_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 2. Check for unhealthy links
+echo -e "${RED}✗ Checking for 'Found Unhealthy Links'${NC}"
+UNHEALTHY_FILES=$(grep -l "Found Unhealthy Links" "$VALIDATION_DIR"/*.log 2>/dev/null)
+UNHEALTHY_COUNT=$(echo "$UNHEALTHY_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $UNHEALTHY_COUNT"
+if [ $UNHEALTHY_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$UNHEALTHY_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 3. Check for timeout issues
+echo -e "${YELLOW}⏱ Checking for 'Timeout (10000 ms) waiting for physical cores to finish'${NC}"
+TIMEOUT_FILES=$(grep -l "Timeout (10000 ms) waiting for physical cores to finish" "$VALIDATION_DIR"/*.log 2>/dev/null)
+TIMEOUT_COUNT=$(echo "$TIMEOUT_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $TIMEOUT_COUNT"
+if [ $TIMEOUT_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$TIMEOUT_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 4. Check for missing port/cable connections
+echo -e "${BLUE}🔌 Checking for 'missing port/cable connections'${NC}"
+MISSING_CONN_FILES=$(grep -l "missing port/cable connections" "$VALIDATION_DIR"/*.log 2>/dev/null)
+MISSING_CONN_COUNT=$(echo "$MISSING_CONN_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $MISSING_CONN_COUNT"
+if [ $MISSING_CONN_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$MISSING_CONN_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 5. Check for DRAM training failures
+echo -e "${RED}⚠ Checking for 'DRAM training failed'${NC}"
+DRAM_FAIL_FILES=$(grep -l "DRAM training failed" "$VALIDATION_DIR"/*.log 2>/dev/null)
+DRAM_FAIL_COUNT=$(echo "$DRAM_FAIL_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $DRAM_FAIL_COUNT"
+if [ $DRAM_FAIL_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$DRAM_FAIL_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 6. Check for extra port/cable connections
+echo -e "${YELLOW}🔗 Checking for 'extra port/cable connections'${NC}"
+EXTRA_CONN_FILES=$(grep -l "extra port/cable connections" "$VALIDATION_DIR"/*.log 2>/dev/null)
+EXTRA_CONN_COUNT=$(echo "$EXTRA_CONN_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $EXTRA_CONN_COUNT"
+if [ $EXTRA_CONN_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo "$EXTRA_CONN_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# 7. Files with none of these strings (indeterminate/incomplete)
+echo -e "📋 Checking for files with NONE of these strings (indeterminate/incomplete):"
+INDETERMINATE_FILES=""
+for file in "$VALIDATION_DIR"/*.log; do
+    if [ -f "$file" ]; then
+        if ! grep -q "All Detected Links are healthy\|Found Unhealthy Links\|Timeout (10000 ms) waiting for physical cores to finish\|missing port/cable connections\|DRAM training failed\|extra port/cable connections" "$file" 2>/dev/null; then
+            INDETERMINATE_FILES="$INDETERMINATE_FILES$file\n"
+        fi
+    fi
+done
+INDETERMINATE_COUNT=$(echo -e "$INDETERMINATE_FILES" | grep -c "." 2>/dev/null || echo "0")
+echo "  Count: $INDETERMINATE_COUNT"
+if [ $INDETERMINATE_COUNT -gt 0 ]; then
+    echo "  Files:"
+    echo -e "$INDETERMINATE_FILES" | sed 's/^/    /'
+fi
+echo ""
+
+# Summary
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+echo -e "${GREEN}Healthy links:${NC}           $HEALTHY_COUNT / $TOTAL_FILES"
+echo -e "${RED}Unhealthy links:${NC}         $UNHEALTHY_COUNT / $TOTAL_FILES"
+echo -e "${YELLOW}Timeout issues:${NC}          $TIMEOUT_COUNT / $TOTAL_FILES"
+echo -e "${BLUE}Missing connections:${NC}     $MISSING_CONN_COUNT / $TOTAL_FILES"
+echo -e "${RED}DRAM training failures:${NC}  $DRAM_FAIL_COUNT / $TOTAL_FILES"
+echo -e "${YELLOW}Extra connections:${NC}       $EXTRA_CONN_COUNT / $TOTAL_FILES"
+echo "Indeterminate/Incomplete: $INDETERMINATE_COUNT / $TOTAL_FILES"
+echo ""
+
+# Success rate calculation
+if [ $TOTAL_FILES -gt 0 ]; then
+    SUCCESS_RATE=$(echo "scale=2; $HEALTHY_COUNT * 100 / $TOTAL_FILES" | bc)
+    echo "Success Rate: $SUCCESS_RATE%"
+fi

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -1,0 +1,340 @@
+#!/bin/bash
+
+print_usage() {
+    echo "Usage: $0 [--image <image>] [--empty-entrypoint] [--print] [--print-only] [global-mpi-args] <executable> [args...]"
+    echo "       $0 [--image <image>] [--empty-entrypoint] [--print] [--print-only] [global-mpi-args] <per-rank-specs> [: <per-rank-specs> ...]"
+    echo
+    echo "  --image <image>       (Optional) Docker image to use"
+    echo "  --empty-entrypoint    (Optional) Pass --entrypoint=\"\" to docker run"
+    echo "  --print               Print the command alongside execution"
+    echo "  --print-only          Print the command without executing it"
+    echo "  [global-mpi-args]     Global MPI arguments applied to all ranks"
+    echo "                        Examples: --host, --hostfile, --bind-to, --map-by, -np, etc."
+    echo "  <executable> [args]   Executable and arguments (single mode)"
+    echo "  <per-rank-specs>      Per-rank specification: -np <N> [-x VAR=val ...] <executable> [args...]"
+    echo "  :                     Separator for multiple per-rank specifications (optional)"
+    echo
+    echo "Modes:"
+    echo "  1. Single executable mode: Global args followed by executable (no per-rank -np needed)"
+    echo "  2. Multi-rank mode: Global args, then -np with executable (can specify -np in global args)"
+    echo "  3. Per-rank mode: Global args, then per-rank -np specifications separated by ':'"
+    echo
+    echo "Global vs Per-Rank Arguments:"
+    echo "  - Arguments before the first executable or before per-rank -np are global"
+    echo "  - In per-rank mode (with ':'), each rank can have unique -np, -x, and executable"
+    echo
+    echo "Examples:"
+    echo "  # Single executable, let MPI determine ranks from hostfile:"
+    echo "  $0 --image myimage --host host1,host2 ./myapp arg1 arg2"
+    echo
+    echo "  # Single executable with explicit -np in global args:"
+    echo "  $0 --image myimage --host host1,host2 -np 4 ./myapp"
+    echo
+    echo "  # Unique command per rank:"
+    echo "  $0 --image myimage --bind-to none --host host1,host2 -np 1 -x RANK=0 ./myapp : -np 1 -x RANK=1 ./myapp"
+    echo
+    echo "  # With additional global MPI arguments:"
+    echo "  $0 --image myimage --oversubscribe --timeout 300 --host host1,host2 ./myapp"
+}
+
+default() {
+    local image="ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
+    local empty_entrypoint=false
+    local print_flag=false
+    local print_only=false
+
+    # Parse script-specific arguments first
+    local script_args=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --image)
+                image="$2"
+                shift 2
+                ;;
+            --image=*)
+                image="${1#--image=}"
+                shift
+                ;;
+            --empty-entrypoint)
+                empty_entrypoint=true
+                shift
+                ;;
+            --print)
+                print_flag=true
+                shift
+                ;;
+            --print-only)
+                print_only=true
+                shift
+                ;;
+            *)
+                # Remaining arguments are for MPI
+                break
+                ;;
+        esac
+    done
+
+    # Remaining args contain MPI params and commands (possibly with : separators)
+    local remaining_args=("$@")
+
+    if [[ ${#remaining_args[@]} -eq 0 ]]; then
+        echo "Error: MPI arguments and executable are required."
+        print_usage
+        exit 1
+    fi
+
+    # Parse global MPI options (these apply to all ranks)
+    # Any arguments before the first -np are treated as global
+    local global_mpi_args=()
+    local has_host_or_hostfile=false
+    local i=0
+    local found_executable=false
+
+    # List of MPI flags that take arguments
+    local flags_with_args="--host --hostfile -H --bind-to --map-by --rank-by --timeout --output-filename --mca -x"
+
+    while [[ $i -lt ${#remaining_args[@]} ]]; do
+        local arg="${remaining_args[$i]}"
+
+        # Check if this is -np (start of per-rank specifications)
+        if [[ "$arg" == "-np" || "$arg" == "-n" || "$arg" == "--np" ]]; then
+            break
+        fi
+
+        # If we encounter a non-flag argument and we haven't seen it as a value to a flag, it's the executable
+        if [[ "$arg" != -* && "$arg" != ":" ]]; then
+            # This is the executable - stop parsing global args
+            break
+        fi
+
+        # Track if we have host/hostfile
+        if [[ "$arg" == "--host" || "$arg" == "--hostfile" || "$arg" == "-H" ]]; then
+            has_host_or_hostfile=true
+        fi
+
+        # Add this argument to global args
+        global_mpi_args+=("$arg")
+        i=$((i + 1))
+
+        # If this is a known flag that takes arguments, consume them
+        if [[ " $flags_with_args " =~ " $arg " && $i -lt ${#remaining_args[@]} ]]; then
+            # For --mca, we need to consume two more arguments (key and value)
+            if [[ "$arg" == "--mca" ]]; then
+                if [[ $i -lt ${#remaining_args[@]} ]]; then
+                    global_mpi_args+=("${remaining_args[$i]}")
+                    i=$((i + 1))
+                fi
+                if [[ $i -lt ${#remaining_args[@]} ]]; then
+                    global_mpi_args+=("${remaining_args[$i]}")
+                    i=$((i + 1))
+                fi
+            else
+                # Most flags take one argument
+                global_mpi_args+=("${remaining_args[$i]}")
+                i=$((i + 1))
+            fi
+        fi
+    done
+
+    # Remaining args are per-rank specifications
+    local per_rank_args=("${remaining_args[@]:$i}")
+
+    # Check if we have per-rank args (starting with -np) or just an executable
+    local single_executable_mode=false
+    if [[ ${#per_rank_args[@]} -gt 0 && "${per_rank_args[0]}" != "-np" && "${per_rank_args[0]}" != "-n" && "${per_rank_args[0]}" != "--np" ]]; then
+        # We have args but they don't start with -np, so this is single executable mode
+        single_executable_mode=true
+    fi
+
+    # Split per-rank args by colon (:) to support per-rank commands
+    local rank_groups=()
+    local current_group=()
+
+    for arg in "${per_rank_args[@]}"; do
+        if [[ "$arg" == ":" ]]; then
+            if [[ ${#current_group[@]} -gt 0 ]]; then
+                rank_groups+=("$(printf '%s\n' "${current_group[@]}")")
+                current_group=()
+            fi
+        else
+            current_group+=("$arg")
+        fi
+    done
+
+    # Add the last group
+    if [[ ${#current_group[@]} -gt 0 ]]; then
+        rank_groups+=("$(printf '%s\n' "${current_group[@]}")")
+    fi
+
+    if [[ ${#rank_groups[@]} -eq 0 ]]; then
+        echo "Error: No valid rank groups found."
+        print_usage
+        exit 1
+    fi
+
+    if [[ "$has_host_or_hostfile" == false ]]; then
+        echo "Error: Either --host or --hostfile must be specified in MPI arguments."
+        print_usage
+        exit 1
+    fi
+
+    # Build the command for each rank group
+    local base_mpirun_args="--tag-output --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_exclude docker0,lo"
+
+    # Add global MPI args to base
+    if [[ ${#global_mpi_args[@]} -gt 0 ]]; then
+        base_mpirun_args="$base_mpirun_args ${global_mpi_args[*]}"
+    fi
+
+    # Build entrypoint option if empty-entrypoint flag is set
+    local entrypoint_opt=""
+    if [[ "$empty_entrypoint" == true ]]; then
+        entrypoint_opt="--entrypoint=\"\""
+    fi
+
+    # Process each rank group
+    local mpirun_segments=()
+
+    # In single executable mode, we only have one group with just the executable
+    if [[ "$single_executable_mode" == true ]]; then
+        # Just one group, just the executable
+        local group="${rank_groups[0]}"
+        local group_array=()
+        while IFS= read -r line; do
+            group_array+=("$line")
+        done <<< "$group"
+
+        local executable="${group_array[*]}"
+
+        if [[ -z "$executable" ]]; then
+            echo "Error: executable is required."
+            print_usage
+            exit 1
+        fi
+
+        # Extract -x environment variables from global_mpi_args to pass to Docker
+        local docker_env_vars=()
+        local i=0
+        while [[ $i -lt ${#global_mpi_args[@]} ]]; do
+            if [[ "${global_mpi_args[$i]}" == "-x" ]]; then
+                i=$((i + 1))
+                if [[ $i -lt ${#global_mpi_args[@]} ]]; then
+                    docker_env_vars+=("-e")
+                    docker_env_vars+=("${global_mpi_args[$i]}")
+                fi
+            fi
+            i=$((i + 1))
+        done
+
+        # Build docker -e flags for environment variables
+        local docker_env_flags=""
+        if [[ ${#docker_env_vars[@]} -gt 0 ]]; then
+            docker_env_flags="${docker_env_vars[*]}"
+        fi
+
+        # Build docker command
+        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/local-syseng-manual:/data/local-syseng-manual -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+
+        # Single segment without per-rank args
+        mpirun_segments+=("bash -c '$docker_cmd'")
+    else
+        # Multi-executable mode with per-rank specifications
+        for group in "${rank_groups[@]}"; do
+            # Parse this group's arguments (local/per-rank options)
+            local mpi_args=()
+            local docker_env_vars=()
+            local executable=""
+
+            # Read group into array
+            local group_array=()
+            while IFS= read -r line; do
+                group_array+=("$line")
+            done <<< "$group"
+
+            # Parse MPI args and executable for this group
+            local i=0
+            while [[ $i -lt ${#group_array[@]} ]]; do
+                local arg="${group_array[$i]}"
+                case "$arg" in
+                    -np|-n|--np)
+                        mpi_args+=("$arg")
+                        i=$((i + 1))
+                        if [[ $i -lt ${#group_array[@]} ]]; then
+                            mpi_args+=("${group_array[$i]}")
+                            i=$((i + 1))
+                        fi
+                        ;;
+                    -x)
+                        mpi_args+=("$arg")
+                        i=$((i + 1))
+                        if [[ $i -lt ${#group_array[@]} ]]; then
+                            local env_var="${group_array[$i]}"
+                            mpi_args+=("$env_var")
+                            # Extract for docker -e flag
+                            docker_env_vars+=("-e")
+                            docker_env_vars+=("$env_var")
+                            i=$((i + 1))
+                        fi
+                        ;;
+                    --*)
+                        mpi_args+=("$arg")
+                        i=$((i + 1))
+                        # Check if next argument is a value (doesn't start with --)
+                        if [[ $i -lt ${#group_array[@]} && "${group_array[$i]}" != --* && "${group_array[$i]}" != -* ]]; then
+                            mpi_args+=("${group_array[$i]}")
+                            i=$((i + 1))
+                        fi
+                        ;;
+                    *)
+                        # First non-flag argument is start of executable
+                        executable="${group_array[@]:$i}"
+                        break
+                        ;;
+                esac
+            done
+
+            if [[ -z "$executable" ]]; then
+                echo "Error: executable is required for each rank group."
+                print_usage
+                exit 1
+            fi
+
+            # Build docker -e flags for environment variables
+            local docker_env_flags=""
+            if [[ ${#docker_env_vars[@]} -gt 0 ]]; then
+                docker_env_flags="${docker_env_vars[*]}"
+            fi
+
+            # Build docker command for this group
+            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/local-syseng-manual:/data/local-syseng-manual -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+
+            # Combine this group's MPI args with docker command
+            mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")
+        done
+    fi
+
+    # Join all segments with " : "
+    local combined_segments=""
+    for i in "${!mpirun_segments[@]}"; do
+        if [[ $i -eq 0 ]]; then
+            combined_segments="${mpirun_segments[$i]}"
+        else
+            combined_segments="$combined_segments : ${mpirun_segments[$i]}"
+        fi
+    done
+
+    full_cmd="mpirun-ulfm $base_mpirun_args $combined_segments"
+
+    # Handle printing and execution based on flags
+    if [[ "$print_only" == true ]]; then
+        echo "$full_cmd"
+    elif [[ "$print_flag" == true ]]; then
+        echo "$full_cmd"
+        eval "$full_cmd"
+    else
+        eval "$full_cmd"
+    fi
+}
+
+# Call the default function with all script arguments
+default "$@"

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -233,7 +233,7 @@ default() {
         fi
 
         # Build docker command
-        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/local-syseng-manual:/data/local-syseng-manual -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+        local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/scaleout_configs:/data/scaleout_configs -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
 
         # Single segment without per-rank args
         mpirun_segments+=("bash -c '$docker_cmd'")
@@ -306,7 +306,7 @@ default() {
             fi
 
             # Build docker command for this group
-            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/local-syseng-manual:/data/local-syseng-manual -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
+            local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /data/scaleout_configs:/data/scaleout_configs -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro $entrypoint_opt $image $executable"
 
             # Combine this group's MPI args with docker command
             mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")

--- a/tools/scaleout/exabox/recover_4x32.sh
+++ b/tools/scaleout/exabox/recover_4x32.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Script to recover 4x32 cluster (distributed tt-smi reset + cluster validation)
+#
+# Usage: ./recover_4x32.sh <comma-separated-host-list>
+# Example: ./recover_4x32.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+
+# Check if host list is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No host list provided"
+    echo "Usage: $0 <comma-separated-host-list>"
+    echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08"
+    exit 1
+fi
+
+# Get host list from command line argument
+HOSTS="$1"
+
+echo "Using hosts: $HOSTS"
+echo ""
+
+echo "Running tt-smi -glx_reset..."
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+sleep 5
+
+echo ""
+echo "Running cluster validation..."
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/4x4x32_fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/recover_4x32.sh
+++ b/tools/scaleout/exabox/recover_4x32.sh
@@ -25,4 +25,4 @@ sleep 5
 
 echo ""
 echo "Running cluster validation..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/4x4x32_fsd.textproto --send-traffic --num-iterations 5
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/4xBH_4x32_intrapod/fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/recover_8x16.sh
+++ b/tools/scaleout/exabox/recover_8x16.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Script to recover 8x16 cluster (distributed tt-smi reset + cluster validation)
+#
+# Usage: ./recover_8x16.sh <comma-separated-host-list>
+# Example: ./recover_8x16.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+
+# Check if host list is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No host list provided"
+    echo "Usage: $0 <comma-separated-host-list>"
+    echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08"
+    exit 1
+fi
+
+# Get host list from command line argument
+HOSTS="$1"
+
+echo "Using hosts: $HOSTS"
+echo ""
+
+echo "Running tt-smi -glx_reset..."
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+sleep 5
+
+echo ""
+echo "Running cluster validation..."
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/5x8x16_fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/recover_8x16.sh
+++ b/tools/scaleout/exabox/recover_8x16.sh
@@ -25,4 +25,4 @@ sleep 5
 
 echo ""
 echo "Running cluster validation..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/5x8x16_fsd.textproto --send-traffic --num-iterations 5
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+mkdir -p dispatch_test_logs
+HOSTS="$1"
+DOCKER_IMAGE="$2"
+LOG_FILE="dispatch_test_logs/dispatch_tests_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=========================================="
+echo "Running dispatch tests..."
+echo "Using hosts: $HOSTS"
+echo "Logging to: $LOG_FILE"
+echo "Using docker image: $DOCKER_IMAGE"
+echo "=========================================="
+echo ""
+
+./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="\
+UnitMeshCQProgramFixture.TensixTestRandomizedProgram:\
+UnitMeshRandomProgramFixture.TensixTestLargeProgramInBetweenFiveSmallPrograms:\
+UnitMeshRandomProgramTraceFixture.TensixTestLargeProgramInBetweenFiveSmallProgramsTrace:\
+UnitMeshRandomProgramTraceFixture.TensixTestSimpleProgramsTrace:\
+UnitMeshCQTraceFixture.TensixEnqueueMultiProgramTraceBenchmark:\
+UnitMeshCQTraceFixture.TensixEnqueueTwoProgramTrace:\
+UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeL1ReadWrites:\
+UnitMeshCQSingleCardBufferFixture.ShardedBufferLargeDRAMReadWrites:\
+UnitMeshCQSingleCardFixture.TensixTestSubDeviceAllocations:\
+UnitMeshMultiCQMultiDeviceEventFixture.*:\
+UnitMeshCQSingleCardFixture.TensixTestReadWriteMultipleCoresL1" |& tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_fabric_tests_4x32.sh
+++ b/tools/scaleout/exabox/run_fabric_tests_4x32.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+mkdir -p fabric_test_logs
+HOSTS="$1"
+DOCKER_IMAGE="$2"
+LOG_FILE="fabric_test_logs/fabric_tests_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=========================================="
+echo "Running fabric tests..."
+echo "Using hosts: $HOSTS"
+echo "Using docker image: $DOCKER_IMAGE"
+echo "Logging to: $LOG_FILE"
+echo "=========================================="
+echo ""
+
+./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --bind-to none --host $HOSTS -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=0 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=2 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=3 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml |& tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_fabric_tests_8x16.sh
+++ b/tools/scaleout/exabox/run_fabric_tests_8x16.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+mkdir -p fabric_test_logs
+HOSTS="$1"
+DOCKER_IMAGE="$2"
+LOG_FILE="fabric_test_logs/fabric_tests_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=========================================="
+echo "Running fabric tests..."
+echo "Using hosts: $HOSTS"
+echo "Using docker image: $DOCKER_IMAGE"
+echo "Logging to: $LOG_FILE"
+echo "=========================================="
+echo ""
+
+./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --bind-to none --host $HOSTS -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=0 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=2 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml : -np 1 -x TT_MESH_ID=0 -x TT_MESH_GRAPH_DESC_PATH=tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto -x TT_MESH_HOST_RANK=3 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml |& tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -41,7 +41,7 @@ for i in {1..50}; do
 
         echo ""
         echo "Running cluster validation..."
-        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/4x4x32_fsd.textproto --send-traffic --num-iterations 10
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/4xBH_4x32_intrapod/fsd.textproto --send-traffic --num-iterations 10
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Script to run cluster validation commands for 50 iterations
+# Each iteration's output is logged to a separate file
+#
+# Usage: ./run_validation_4x32.sh <comma-separated-host-list>
+# Example: ./run_validation_4x32.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+
+# Check if host list is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No host list provided"
+    echo "Usage: $0 <comma-separated-host-list> <docker-image>"
+    echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
+    exit 1
+fi
+
+# Get host list from command line argument
+HOSTS="$1"
+DOCKER_IMAGE="$2"
+echo "Using hosts: $HOSTS"
+echo "Using docker image: $DOCKER_IMAGE"
+echo ""
+
+# Create output directory if it doesn't exist
+mkdir -p validation_output
+
+for i in {1..50}; do
+    echo "Starting iteration $i of 50..."
+
+    LOG_FILE="validation_output/cluster_validation_iteration_${i}.log"
+
+    {
+        echo "=========================================="
+        echo "Iteration: $i"
+        echo "Timestamp: $(date)"
+        echo "=========================================="
+        echo ""
+
+        echo "Running tt-smi -glx_reset..."
+        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+
+        echo ""
+        echo "Running cluster validation..."
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/4x4x32_fsd.textproto --send-traffic --num-iterations 10
+        echo "Iteration $i completed at $(date)"
+        echo "=========================================="
+    } 2>&1 | tee "$LOG_FILE"
+
+    echo "Iteration $i logged to $LOG_FILE"
+    echo ""
+done
+
+echo "All 50 iterations completed!"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Script to run cluster validation commands for 50 iterations
+# Each iteration's output is logged to a separate file
+#
+# Usage: ./run_validation_8x16.sh <comma-separated-host-list>
+# Example: ./run_validation_8x16.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+
+# Check if host list is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No host list provided"
+    echo "Usage: $0 <comma-separated-host-list> <docker-image>"
+    echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
+    exit 1
+fi
+
+# Get host list from command line argument
+HOSTS="$1"
+DOCKER_IMAGE="$2"
+echo "Using hosts: $HOSTS"
+echo "Using docker image: $DOCKER_IMAGE"
+echo ""
+
+# Create output directory if it doesn't exist
+mkdir -p validation_output
+
+for i in {1..50}; do
+    echo "Starting iteration $i of 50..."
+
+    LOG_FILE="validation_output/cluster_validation_iteration_${i}.log"
+
+    {
+        echo "=========================================="
+        echo "Iteration: $i"
+        echo "Timestamp: $(date)"
+        echo "=========================================="
+        echo ""
+
+        echo "Running tt-smi -glx_reset..."
+        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+        sleep 5
+
+        echo ""
+        echo "Running cluster validation..."
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/5x8x16_fsd.textproto --send-traffic --num-iterations 10
+        echo "Iteration $i completed at $(date)"
+        echo "=========================================="
+    } 2>&1 | tee "$LOG_FILE"
+
+    echo "Iteration $i logged to $LOG_FILE"
+    echo ""
+done
+
+echo "All 50 iterations completed!"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -42,7 +42,7 @@ for i in {1..50}; do
 
         echo ""
         echo "Running cluster validation..."
-        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/local-syseng-manual/5x8x16_fsd.textproto --send-traffic --num-iterations 10
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto --send-traffic --num-iterations 10
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"

--- a/tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
@@ -1,0 +1,12 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 16, 8 ] dim_types: [ RING, RING ] }
+  host_topology   { dims: [ 2, 2 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
@@ -1,0 +1,12 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 32, 4 ] dim_types: [ RING, RING ] }
+  host_topology   { dims: [ 4, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35596

### Problem description
- To parallelize cluster bringup, we need to productize Physical Validation, Fabric and Dispatch tests on Multi-Host systems
- The main requirement is for bringup and qualification teams to run these tests without having to build the repo

### What's changed
- Add system qualification for 8x16 and 4x32 pods under `tools/scaleout/exabox`. These tests will eventually be unified
- These tests use `mpi-docker` to deploy upstream containers across hosts without requiring a Metal build
- The end user is expected to clone the Metal repo once and deploy the test scripts 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/exabox_upstream_testing)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/exabox_upstream_testing)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/exabox_upstream_testing)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/exabox_upstream_testing)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/exabox_upstream_testing)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/exabox_upstream_testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/exabox_upstream_testing)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs