### PR TITLE
[skip ci] make workflow yaml as template for analyzing ND failures workflow

### DIFF
--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -12,6 +12,9 @@ on:
 jobs:
   analyze-nd-failures:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -12,10 +12,6 @@ on:
 jobs:
   analyze-nd-failures:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -1,10 +1,10 @@
-name: Auto Triage
+name: Analyze ND Failures
 
 on:
   workflow_dispatch:
     inputs:
       starting_date:
-        description: "Starting date to analyze failures"
+        description: "Starting date to analyze failures (YYYY-MM-DD)"
         required: true
         type: string
 
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run analyze nd failures
         uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack-output-analysis@main

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -1,0 +1,28 @@
+name: Auto Triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      starting_date:
+        description: "Starting date to analyze failures"
+        required: true
+        type: string
+
+
+jobs:
+  analyze-nd-failures:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run analyze nd failures
+        uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack-output-analysis@main
+        with:
+          starting_date: ${{ inputs.starting_date }}


### PR DESCRIPTION
Creates a yaml workflow that does nothing right now, but will eventually be used to call an action that analyzes previous CI failure reports made by auto-triage.

The end goal is to have it group errors by similarity, and by whether or not they're deterministic. It will then send everything to superset.

Mostly this PR is just to have a workflow that I can call while testing on my own branch.