### PR TITLE
Fix reflection operator<< ordering for unity builds

### DIFF
--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         test_cleanup.cpp
         test_indestructible.cpp
         test_optional_reference.cpp
+        test_reflection.cpp
         test_span.cpp
         test_strong_type.cpp
         test_small_vector.cpp

--- a/tt_stl/tests/test_reflection.cpp
+++ b/tt_stl/tests/test_reflection.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <tt_stl/reflection.hpp>
+#include <sstream>
+#include <string>
+
+// Define test types in a DIFFERENT namespace to avoid ADL finding the operators
+// This is the scenario that triggers the ordering issue
+namespace test_types {
+
+// A simple Reflectable struct (uses reflect library)
+struct ReflectablePoint {
+    int x;
+    int y;
+};
+
+// A struct with compile-time attributes that contains a Reflectable field
+struct ContainerWithReflectable {
+    static constexpr auto attribute_names = std::make_tuple("name", "point");
+    auto attribute_values() const { return std::make_tuple(name, point); }
+
+    std::string name;
+    ReflectablePoint point;
+};
+
+// Another Reflectable struct to test nested scenarios
+struct ReflectableRect {
+    ReflectablePoint top_left;
+    ReflectablePoint bottom_right;
+};
+
+// Enum for testing enum printing
+enum class Color { Red, Green, Blue };
+
+}  // namespace test_types
+
+namespace ttsl::reflection {
+namespace {
+
+using test_types::Color;
+using test_types::ContainerWithReflectable;
+using test_types::ReflectablePoint;
+using test_types::ReflectableRect;
+using ::testing::HasSubstr;
+
+TEST(ReflectionTest, PrintReflectableStruct) {
+    ReflectablePoint p{10, 20};
+    std::stringstream ss;
+    ss << p;
+    std::string result = ss.str();
+
+    EXPECT_THAT(result, HasSubstr("ReflectablePoint"));
+    EXPECT_THAT(result, HasSubstr("x=10"));
+    EXPECT_THAT(result, HasSubstr("y=20"));
+}
+
+TEST(ReflectionTest, PrintNestedReflectableStruct) {
+    ReflectableRect rect{{1, 2}, {3, 4}};
+    std::stringstream ss;
+    ss << rect;
+    std::string result = ss.str();
+
+    EXPECT_THAT(result, HasSubstr("ReflectableRect"));
+    EXPECT_THAT(result, HasSubstr("top_left="));
+    EXPECT_THAT(result, HasSubstr("bottom_right="));
+}
+
+TEST(ReflectionTest, PrintStructWithCompileTimeAttributesContainingReflectable) {
+    // This test verifies that the template ordering is correct.
+    // ContainerWithReflectable uses compile-time attributes (supports_conversion_to_string_v),
+    // and contains a ReflectablePoint field that needs the Reflectable operator<<.
+    ContainerWithReflectable container{"test", {5, 10}};
+    std::stringstream ss;
+    ss << container;
+    std::string result = ss.str();
+
+    EXPECT_THAT(result, HasSubstr("ContainerWithReflectable"));
+    EXPECT_THAT(result, HasSubstr("name=test"));
+    EXPECT_THAT(result, HasSubstr("point="));
+    // The nested ReflectablePoint should also be printed correctly
+    EXPECT_THAT(result, HasSubstr("x=5"));
+    EXPECT_THAT(result, HasSubstr("y=10"));
+}
+
+TEST(ReflectionTest, PrintVectorOfReflectable) {
+    std::vector<ReflectablePoint> points{{1, 2}, {3, 4}};
+    std::stringstream ss;
+    ss << points;
+    std::string result = ss.str();
+
+    EXPECT_THAT(result, HasSubstr("x=1"));
+    EXPECT_THAT(result, HasSubstr("y=2"));
+    EXPECT_THAT(result, HasSubstr("x=3"));
+    EXPECT_THAT(result, HasSubstr("y=4"));
+}
+
+TEST(ReflectionTest, PrintOptionalReflectable) {
+    std::optional<ReflectablePoint> opt_point = ReflectablePoint{7, 8};
+    std::stringstream ss;
+    ss << opt_point;
+    std::string result = ss.str();
+
+    EXPECT_THAT(result, HasSubstr("x=7"));
+    EXPECT_THAT(result, HasSubstr("y=8"));
+}
+
+TEST(ReflectionTest, PrintOptionalNullopt) {
+    std::optional<ReflectablePoint> opt_point = std::nullopt;
+    std::stringstream ss;
+    ss << opt_point;
+    EXPECT_EQ(ss.str(), "std::nullopt");
+}
+
+TEST(ReflectionTest, FmtFormatReflectable) {
+    ReflectablePoint p{42, 99};
+    std::string result = fmt::format("{}", p);
+
+    EXPECT_THAT(result, HasSubstr("ReflectablePoint"));
+    EXPECT_THAT(result, HasSubstr("x=42"));
+    EXPECT_THAT(result, HasSubstr("y=99"));
+}
+
+TEST(ReflectionTest, FmtFormatContainerWithReflectable) {
+    ContainerWithReflectable container{"fmt_test", {15, 25}};
+    std::string result = fmt::format("{}", container);
+
+    EXPECT_THAT(result, HasSubstr("ContainerWithReflectable"));
+    EXPECT_THAT(result, HasSubstr("name=fmt_test"));
+    EXPECT_THAT(result, HasSubstr("x=15"));
+    EXPECT_THAT(result, HasSubstr("y=25"));
+}
+
+}  // namespace
+}  // namespace ttsl::reflection

--- a/tt_stl/tests/test_reflection.cpp
+++ b/tt_stl/tests/test_reflection.cpp
@@ -40,7 +40,6 @@ enum class Color { Red, Green, Blue };
 namespace ttsl::reflection {
 namespace {
 
-using test_types::Color;
 using test_types::ContainerWithReflectable;
 using test_types::ReflectablePoint;
 using test_types::ReflectableRect;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -339,49 +339,8 @@ inline std::ostream& operator<<(std::ostream& os, const Attribute& attribute) {
     return os;
 }
 
-template <typename T>
-typename std::enable_if_t<detail::supports_conversion_to_string_v<T>, std::ostream>& operator<<(
-    std::ostream& os, const T& object) {
-    if constexpr (detail::supports_to_string_v<T>) {
-        os << object.to_string();
-    } else if constexpr (detail::supports_compile_time_attributes_v<T>) {
-        constexpr auto num_attributes = detail::get_num_attributes<T>();
-        os << get_type_name<T>();
-        os << "(";
-
-        if constexpr (num_attributes > 0) {
-            const auto attribute_values = object.attribute_values();
-            [&os, &object, &attribute_values]<std::size_t... Ns>(std::index_sequence<Ns...>) {
-                (
-                    [&os, &object, &attribute_values] {
-                        const auto& attribute = std::get<Ns>(attribute_values);
-                        os << std::get<Ns>(object.attribute_names);
-                        os << "=";
-                        os << attribute;
-                        os << ",";
-                    }(),
-                    ...);
-            }(std::make_index_sequence<num_attributes - 1>{});
-
-            const auto& attribute = std::get<num_attributes - 1>(attribute_values);
-            os << std::get<num_attributes - 1>(object.attribute_names);
-            os << "=";
-            os << attribute;
-        }
-
-        os << ")";
-    } else {
-        static_assert(ttsl::concepts::always_false_v<T>, "Type cannot be converted to string");
-    }
-    return os;
-}
-
-template <typename T>
-typename std::enable_if_t<std::is_enum_v<T>, std::ostream>& operator<<(std::ostream& os, const T& value) {
-    os << enchantum::scoped::to_string(value);
-    return os;
-}
-
+// Container operator<< definitions must come before the generic template below,
+// otherwise `os << attribute` will match `operator<<(ostream&, const Attribute&)` via implicit conversion.
 template <typename T1, typename T2>
 std::ostream& operator<<(std::ostream& os, const std::pair<T1, T2>& pair) {
     os << "{" << pair.first << ", " << pair.second << "}";
@@ -489,6 +448,49 @@ std::ostream& operator<<(std::ostream& os, const std::unordered_map<K, V>& map) 
         }
     }
     os << "}";
+    return os;
+}
+
+template <typename T>
+typename std::enable_if_t<detail::supports_conversion_to_string_v<T>, std::ostream>& operator<<(
+    std::ostream& os, const T& object) {
+    if constexpr (detail::supports_to_string_v<T>) {
+        os << object.to_string();
+    } else if constexpr (detail::supports_compile_time_attributes_v<T>) {
+        constexpr auto num_attributes = detail::get_num_attributes<T>();
+        os << get_type_name<T>();
+        os << "(";
+
+        if constexpr (num_attributes > 0) {
+            const auto attribute_values = object.attribute_values();
+            [&os, &object, &attribute_values]<std::size_t... Ns>(std::index_sequence<Ns...>) {
+                (
+                    [&os, &object, &attribute_values] {
+                        const auto& attribute = std::get<Ns>(attribute_values);
+                        os << std::get<Ns>(object.attribute_names);
+                        os << "=";
+                        os << attribute;
+                        os << ",";
+                    }(),
+                    ...);
+            }(std::make_index_sequence<num_attributes - 1>{});
+
+            const auto& attribute = std::get<num_attributes - 1>(attribute_values);
+            os << std::get<num_attributes - 1>(object.attribute_names);
+            os << "=";
+            os << attribute;
+        }
+
+        os << ")";
+    } else {
+        static_assert(ttsl::concepts::always_false_v<T>, "Type cannot be converted to string");
+    }
+    return os;
+}
+
+template <typename T>
+typename std::enable_if_t<std::is_enum_v<T>, std::ostream>& operator<<(std::ostream& os, const T& value) {
+    os << enchantum::scoped::to_string(value);
     return os;
 }
 


### PR DESCRIPTION
## Problem
Unity builds can fail with compilation errors like:
```
error: implicit instantiation of undefined template 'fmt::detail::type_is_unformattable_for<std::array<unsigned int, 2>, char>'
```

This occurs when printing structs (like `Tile`) that have container attributes (like `std::array`) using the reflection system.

## Root Cause
In `reflection.hpp`, when the generic `operator<<` template executes `os << attribute` (where `attribute` is a container like `std::array`), the compiler finds `operator<<(ostream&, const Attribute&)` first and uses implicit conversion, because the specific container `operator<<` overloads are defined later in the file.

The `Attribute` constructor then calls `fmt::format` on the container, but the `fmt::formatter` specialization for containers is also defined later in the file.

## Fix
Move the container `operator<<` definitions (pair, optional, variant, tuple, array, vector, set, map, unordered_map) before the generic template that outputs attribute values. This ensures the compiler finds the correct overload instead of falling back to implicit conversion.


- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/21012435207)