### PR TITLE
Fix attention dense out matmul on BH LB

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -777,7 +777,7 @@ class ModelArgs:
                 and os.getenv("ACTUAL_DEVICE", "") != "TG"
                 and (self.dim // self.tile_size // self.num_devices) % self.num_devices == 0
                 and self.num_devices > 1
-                and self.ccl_topology == ttnn.Topology.Ring
+                and self.ccl_topology() == ttnn.Topology.Ring
             )
 
             if self.model_config["USE_FUSED_ALL_GATHER_MATMUL"]:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -870,7 +870,7 @@ class ModelArgs:
                     if self.num_devices == 8
                     and os.getenv("ACTUAL_DEVICE", "") != "TG"
                     and not is_blackhole()
-                    and 1024 % (self.dim / self.num_devices) == 0
+                    and 1024 % (self.dim // self.num_devices) == 0
                     else self.dim
                 )
             )

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -777,6 +777,7 @@ class ModelArgs:
                 and os.getenv("ACTUAL_DEVICE", "") != "TG"
                 and (self.dim // self.tile_size // self.num_devices) % self.num_devices == 0
                 and self.num_devices > 1
+                and self.ccl_topology == ttnn.Topology.Ring
             )
 
             if self.model_config["USE_FUSED_ALL_GATHER_MATMUL"]:
@@ -868,6 +869,7 @@ class ModelArgs:
                     1024
                     if self.num_devices == 8
                     and os.getenv("ACTUAL_DEVICE", "") != "TG"
+                    and not is_blackhole()
                     and 1024 % (self.dim / self.num_devices) == 0
                     else self.dim
                 )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33148

### Problem description
There were scaling issues on dense out matmul on BH LB specifically that did not make sense. (behaviour is seen on Llama 8b and 70b shapes)
Perf for BH QB AE Dense out matmul: 30919 nanoseconds (DRAM sharded)
Perf for BH LB Dense out matmul: 62356 nanoseconds (DRAM interleaved)

The reason for this discrepancy in matmul usage is because of the `use_fused_all_gather_matmul` flag. This flag should only be enabled when topology is RING and on T3K however it was set to true for LB as well (see ticket for more details). The DRAM interleaved matmul should only be used for the fused op. 

After the fix we change back to DRAM sharded: 
Perf for BH LB Dense out matmul: 17,071 nanoseconds (DRAM sharded) which is around 45285 nanoseconds improvement per layer in prefill -> roughly 1.2-1.4ms improvement in TTFT


### What's changed
- We only turn this flag on only if topology is RING
- the `n_dim` used for dense out prefill program config is the original dim

### Checklist
- [x] [BH multi card demo tests ](https://github.com/tenstorrent/tt-metal/actions/runs/20999641224) Passing
- [x] [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/21035595213)