### PR TITLE
L2 nightly test failure with ttnn.where()

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -370,25 +370,51 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
         const auto& buffer_type = attributes.memory_config.buffer_type();
         auto shard_spec_opt = attributes.memory_config.shard_spec();
 
-        // If no shard spec is provided, inherit from input tensor
-        if (!shard_spec_opt.has_value()) {
+        // Helper to check if shard spec needs adjustment for output shape
+        auto needs_shard_adjustment = [&](const tt::tt_metal::ShardSpec& shard_spec,
+                                          const ttnn::Shape& padded_out_shape) {
+            // For WIDTH_SHARDED, shard height must equal physical height
+            if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+                uint32_t physical_height = 1;
+                for (size_t i = 0; i < padded_out_shape.rank() - 1; ++i) {
+                    physical_height *= padded_out_shape[i];
+                }
+                return shard_spec.shape[0] != physical_height;
+            }
+            // For HEIGHT_SHARDED and BLOCK_SHARDED, check if shard dimensions changed
+            // This is a heuristic - if the shard spec came from an input tensor with
+            // different shape, we should adjust it
+            return false;
+        };
+
+        // Get padded output shape for validation/adjustment
+        ttnn::Shape padded_out_shape;
+        if (input_tensor_a.is_sharded()) {
+            padded_out_shape = input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+        } else if (tensor_b.has_value() && tensor_b->is_sharded()) {
+            padded_out_shape = tensor_b->tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+        } else {
+            // Use a default tile layout for padding calculation
+            padded_out_shape =
+                TensorLayout(output_dtype, PageConfig(Layout::TILE), MemoryConfig{}).compute_padded_shape(output_shape);
+        }
+
+        // If no shard spec is provided, or provided shard spec is incompatible, inherit from input tensor
+        if (!shard_spec_opt.has_value() || needs_shard_adjustment(*shard_spec_opt, padded_out_shape)) {
             if (input_tensor_a.is_sharded()) {
                 // Adjust shard spec from input A to match output shape
                 const auto& padded_a_shape = input_tensor_a.padded_shape();
-                const auto& padded_out_shape =
-                    input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
                 shard_spec_opt = ttnn::operations::binary_ng::adjust_to_shape(
                     *input_tensor_a.memory_config().shard_spec(), padded_a_shape, padded_out_shape);
             } else if (tensor_b.has_value() && tensor_b->is_sharded()) {
                 // Adjust shard spec from input B to match output shape
                 const auto& padded_b_shape = tensor_b->padded_shape();
-                const auto& padded_out_shape =
-                    tensor_b->tensor_spec().tensor_layout().compute_padded_shape(output_shape);
                 shard_spec_opt = ttnn::operations::binary_ng::adjust_to_shape(
                     *tensor_b->memory_config().shard_spec(), padded_b_shape, padded_out_shape);
-            } else {
+            } else if (!shard_spec_opt.has_value()) {
                 TT_THROW("Output memory config is sharded but has no shard spec, and no input tensors are sharded");
             }
+            // If shard_spec_opt has value but neither input is sharded, keep the provided shard spec
         }
 
         return TensorSpec(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35878)

### Problem description
With this PR https://github.com/tenstorrent/tt-metal/pull/35420 merged,

FAILED tests/ttnn/nightly/unit_tests/operations/eltwise/test_where_sharding.py::test_where_sharded_bcast_hw_mixed_width[scalar=15.5-condition=1-dtype_pt=torch.bfloat16-dtype_tt=DataType.BFLOAT16] - RuntimeError: TT_FATAL @ /project/ttnn/core/tensor/tensor_spec.cpp:49: physical_height == physical_shard_height
info:
Shard height 64 must match physical height 128 for width sharded

### What's changed
For sharded broadcast case, the mem config passed to binary from ternary is not the actual output mem config. Adjust the shard spec.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dchen/35878-where_mem_config)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/35878-where_mem_config)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/35878-where_mem_config)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/35878-where_mem_config)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/35878-where_mem_config)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/35878-where_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/35878-where_mem_config)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs