### PR TITLE
Upgrade default toolchain from Clang 17 to Clang 20

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -40,7 +40,7 @@ on:
       toolchain:
         required: false
         type: string
-        default: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+        default: "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
         description: "Toolchain file to use for build"
       publish-artifact:
         required: false
@@ -150,7 +150,7 @@ on:
       toolchain:
         required: false
         type: string
-        default: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+        default: "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
         description: "Toolchain file to use for build"
       profile:
         required: false

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         config:
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
             build-type: "Debug"
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake"
             build-type: "Release"
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
           - version: "24.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
             build-type: "Release"
             enable-lto: true
           - version: "24.04"

--- a/.github/workflows/galaxy-model-perf-tests.yaml
+++ b/.github/workflows/galaxy-model-perf-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       tracy: true
       build-wheel: true
       version: 22.04
-      toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake" # stopgap until issue 20140 is resolved
+      toolchain: "cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake" # stopgap until issue 20140 is resolved
   galaxy-model-perf-tests:
     needs: build-artifact-profiler
     secrets: inherit

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -152,7 +152,7 @@ jobs:
     secrets: inherit
     with:
       version: "22.04"
-      toolchain: cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+      toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       # Cannot do a Sanitizer build as that's not compatible with the downstream test.
       # Also cannot be Release if the other build was chosen to be Release as the GitHub artifact
       # name clashes.
@@ -359,7 +359,7 @@ jobs:
         cat .clang-tidy
     - name: Prepare compile_commands.json
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=ON -DTT_UNITY_BUILDS=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
         cmake --build build --target all_generated_files
     - name: 'Install jq'
       uses: dcarbone/install-jq-action@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# Hello
-
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -86,13 +86,8 @@ cxx_compiler_path=""
 cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
-toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
 
-# Requested handling for 20.04 -> 22.04 migration
-if [[ "$FLAVOR" == "ubuntu" && "$VERSION" == "20.04" ]]; then
-    echo "WARNING: You are using Ubuntu 20.04 which is end of life. Default toolchain is set to libcpp, which is an unsupported configuration. This default behavior will be removed by June 2025."
-    toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
-fi
 
 configure_only="OFF"
 enable_distributed="ON"

--- a/cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake
@@ -1,0 +1,24 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang-20 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-20 CACHE INTERNAL "C++ compiler")
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-lc++ -lc++abi")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-lc++ -lc++abi")
+
+# Use for configure time
+set(ENABLE_LIBCXX TRUE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-20)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake
@@ -12,7 +12,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_INIT "-lc++ -lc++abi")
 set(ENABLE_LIBCXX TRUE CACHE INTERNAL "Using clang's libc++")
 
 # Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
-# We really need to fix out code, though.
+# We really need to fix our code, though.
 find_program(MOLD ld.mold)
 if(MOLD)
     set(CMAKE_LINKER_TYPE MOLD)


### PR DESCRIPTION
### Ticket
N/A - Infrastructure improvement

### Problem description
The default toolchain for builds was Clang 17, while some CI workflows (merge-gate, pr-gate) were already using Clang 20. This created inconsistency between local developer builds and certain CI configurations.

### What's changed
Upgraded all default toolchain references from Clang 17 to Clang 20:

**New file:**
- `cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake` - New toolchain for Clang 20 with libc++ support

**Updated CI workflows:**
- `build-artifact.yaml` - Default toolchain updated to clang-20-libstdcpp
- `build-wrapper.yaml` - Matrix toolchains updated (clang-20-libstdcpp and clang-20-libcpp)
- `pr-gate.yaml` - Build and clang-tidy-light toolchains updated
- `galaxy-model-perf-tests.yaml` - Profiler build toolchain updated

**Local build:**
- `build_metal.sh` - Default toolchain updated to clang-20-libstdcpp
- Removed deprecated Ubuntu 20.04 special case

This brings consistency between CI and local builds, both now using Clang 20 by default.

### Checklist

- [x] [Merge Gate](https://github.com/tenstorrent/tt-metal/actions/runs/21018836228)
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=upgrade-default-toolchain-to-clang-20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:upgrade-default-toolchain-to-clang-20)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=upgrade-default-toolchain-to-clang-20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:upgrade-default-toolchain-to-clang-20)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=upgrade-default-toolchain-to-clang-20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:upgrade-default-toolchain-to-clang-20)
- [x] New/Existing tests provide coverage for changes (CI will validate the toolchain change)