### PR TITLE
Create conv3dConfig based on in_channels param

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -63,6 +63,11 @@ struct Conv3dConfig {
     }
 };
 
+// Returns a default Conv3dConfig with hardware-optimized blocking parameters
+// based on input channel count. The blocking values are specific to
+// the Mochi model architecture to prevent L1 memory overflow.
+Conv3dConfig get_conv3d_config_for_channels(uint32_t in_channels, const CoreCoord& compute_with_storage_grid_size);
+
 struct Conv3dParams {
     Conv3dConfig config;
     tt::tt_metal::MemoryConfig output_mem_config;


### PR DESCRIPTION
### Ticket
Closes #35436 

### Problem description
In `tt-mlir` we need a way to create and pass valid `ttnn::operations::experimental::conv3d::Conv3dConfig` which includes block settings that are hardware specific. In order to do that we need some `cpp` API from metal side which would return us valid `Conv3dConfig` based on `in_channels` and `grid_size`.


### What's changed
Created `cpp` API which returns valid `Conv3dConfig` based on `in_channels` and `grid_size`.