### PR TITLE
[skip ci] #0: Install uv into basic dev image because now it's being used for Python jobs (tutorials nightly L2)

### DIFF
--- a/.github/workflows/ttnn-tutorials-post-commit.yaml
+++ b/.github/workflows/ttnn-tutorials-post-commit.yaml
@@ -111,7 +111,7 @@ jobs:
         timeout-minutes: 10
         run: |
           cd docs/source/ttnn/ttnn/tutorials/ttnn_tutorials_basic_python
-          uv pip install -r tutorials-dev.txt
+          uv pip install --index-strategy unsafe-best-match --no-cache -r tutorials-dev.txt
 
       - name: 🛠️ Install testing utils
         timeout-minutes: 10
@@ -126,7 +126,7 @@ jobs:
           apt-get install -y curl
           source /opt/venv/bin/activate
           ./scripts/install_debugger.sh
-          uv pip install -r ./tools/triage/requirements.txt
+          uv pip install --index-strategy unsafe-best-match --no-cache -r ./tools/triage/requirements.txt
 
       - name: 🧪 Run tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -44,11 +44,6 @@ COPY /tt_metal/sfpi-version /opt/tt_metal_infra/scripts/docker/sfpi-version
 RUN chmod +x /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
 
-# Install uv with version pinning (centralized in install-uv.sh) for better
-# venv handling
-COPY scripts/install-uv.sh /tmp/install-uv.sh
-RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh
-
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN python3 -m venv $PYTHON_ENV_DIR

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -44,6 +44,11 @@ COPY /tt_metal/sfpi-version /opt/tt_metal_infra/scripts/docker/sfpi-version
 RUN chmod +x /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
 
+# Install uv with version pinning (centralized in install-uv.sh) for better
+# venv handling
+COPY scripts/install-uv.sh /tmp/install-uv.sh
+RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh
+
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN python3 -m venv $PYTHON_ENV_DIR


### PR DESCRIPTION
…

### Ticket

Fix for L2 nightly tutorials

### Problem description

We spread `uv` and its wings across our CI. It's a much nicer interface for venv and dependency management

### What's changed

- Looks like the basic-dev image used for project examples (C++ only) was also used for tutorials, a Python job in L2
- Because basic-dev wasn't meant for Python jobs, we didn't put an install-uv step into the basic-dev image because we think it didn't need it
- We then made a ttnn-runtime basic dev image so we can keep the dependencies for C++ jobs lean, and enable Python jobs on top of that: https://github.com/tenstorrent/tt-metal/pull/25874
- We can uv in that target, not the base target
- We also have to call uv with a bunch of arguments so it doesn't look ONLY in the extra PyTorch CPU-only index for packages, or else it'll say certain packages aren't found

### Checklist

- L2 tutorials https://github.com/tenstorrent/tt-metal/actions/runs/21068923344
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rkim/0-add-uv-basic-dev)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rkim/0-add-uv-basic-dev)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rkim/0-add-uv-basic-dev)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rkim/0-add-uv-basic-dev)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rkim/0-add-uv-basic-dev)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rkim/0-add-uv-basic-dev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rkim/0-add-uv-basic-dev)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs