### PR TITLE
Fix BH LB shapes for prefetcher unit test

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -582,7 +582,7 @@ MESH_SHAPE_TO_MODEL_DIMS = {
     (1, 1): {"dim": 2048, "hidden_dim": 3584, "n_heads": 32, "n_kv_heads": 8},
     (1, 2): {"dim": 4096, "hidden_dim": 7168, "n_heads": 32, "n_kv_heads": 8},
     (1, 4): {"dim": 4096, "hidden_dim": 14336, "n_heads": 32, "n_kv_heads": 8},
-    (1, 8): {"dim": 8192, "hidden_dim": 28672, "n_heads": 64, "n_kv_heads": 8},
+    (1, 8): {"dim": 4096, "hidden_dim": 14336, "n_heads": 32, "n_kv_heads": 8},
 }
 
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
BH LB DRAM prefetcher unit tests were failing due to L1 OOM
the CI run in the initial PR it was passing but due to bad rebase the commit that fixed the LB shapes was removed  

### What's changed
- reduce the test dimensions for LB

### Checklist
- [x] [BH multi card unit test](https://github.com/tenstorrent/tt-metal/actions/runs/21035386085)