### PR TITLE
Fix Quasar FW compilation

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -9,8 +9,11 @@
 #include "api/debug/waypoint.h"
 #include "api/debug/dprint.h"
 #include "internal/debug/stack_usage.h"
+#include "internal/debug/sanitize.h"
+#include "tools/profiler/kernel_profiler.hpp"
 
 uint8_t noc_index;
+constexpr uint8_t noc_mode = DM_DEDICATED_NOC;
 
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));


### PR DESCRIPTION
This PR fixes FW compilation on Quasar being broken due to some `#include`s having gotten moved around.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sagarwal/quasar_fix_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sagarwal/quasar_fix_fw)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/quasar_fix_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/quasar_fix_fw)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/quasar_fix_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/quasar_fix_fw)
- [x] New/Existing tests provide coverage for changes