### PR TITLE
Refactor create_venv and install_uv

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -33,7 +33,7 @@ EXAMPLES:
     ./create_venv.sh
 
     # Specify Python version
-    ./create_venv.sh --python-version 3.11
+    ./create_venv.sh --python-version 3.12
 
     # Custom environment directory
     ./create_venv.sh --env-dir /opt/venv
@@ -42,10 +42,10 @@ EXAMPLES:
     ./create_venv.sh --env-dir /opt/myproject/envs/dev
 
     # Using environment variables
-    PYTHON_ENV_DIR=/opt/venv VENV_PYTHON_VERSION=3.11 ./create_venv.sh
+    PYTHON_ENV_DIR=/opt/venv VENV_PYTHON_VERSION=3.12 ./create_venv.sh
 
     # Arguments override environment variables
-    VENV_PYTHON_VERSION=3.10 ./create_venv.sh --python-version 3.11  # Uses 3.11
+    VENV_PYTHON_VERSION=3.10 ./create_venv.sh --python-version 3.12  # Uses 3.12
 
 NOTE:
     If you encounter venv issues, running "uv pip install -e ." with the venv active

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -230,6 +230,15 @@ validate_env_dir "$PYTHON_ENV_DIR"
 # Determine script directory (used for locating sibling scripts)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Extract UV_VERSION from install-uv.sh for consistency (if available)
+# This ensures we're aware of the version being used, even though install-uv.sh handles installation
+if [ -f "$SCRIPT_DIR/scripts/install-uv.sh" ]; then
+    UV_VERSION=$(grep -m1 '^UV_VERSION=' "$SCRIPT_DIR/scripts/install-uv.sh" | cut -d'"' -f2)
+    if [ -n "$UV_VERSION" ]; then
+        echo "Using uv version from install-uv.sh: $UV_VERSION"
+    fi
+fi
+
 # Install uv if not already available
 if ! command -v uv &>/dev/null; then
     if [ -f "$SCRIPT_DIR/scripts/install-uv.sh" ]; then

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -122,10 +122,10 @@ validate_python_version() {
     major=$((10#$major))
     minor=$((10#$minor))
 
-    # Require Python 3.8+
+    # Require Python 3.10+
     if [[ "$major" -lt 3 ]] || { [[ "$major" -eq 3 ]] && [[ "$minor" -lt 8 ]]; }; then
-        echo "Error: Python version must be 3.8 or higher (got: $version)" >&2
-        echo "Supported versions: 3.8, 3.9, 3.10, 3.11, 3.12, etc." >&2
+        echo "Error: Python version must be 3.10 or higher (got: $version)" >&2
+        echo "Supported versions: 3.10, 3.11, etc." >&2
         exit 1
     fi
 }

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -236,6 +236,14 @@ if [ -f "$SCRIPT_DIR/scripts/install-uv.sh" ]; then
     UV_VERSION=$(grep -m1 '^UV_VERSION=' "$SCRIPT_DIR/scripts/install-uv.sh" | cut -d'"' -f2)
     if [ -n "$UV_VERSION" ]; then
         echo "Using uv version from install-uv.sh: $UV_VERSION"
+        # Optional: Verify installed version matches pinned version (informational only)
+        if command -v uv &>/dev/null; then
+            installed_version=$(uv --version 2>/dev/null | cut -d' ' -f2 || echo "")
+            if [ -n "$installed_version" ] && [ "$installed_version" != "$UV_VERSION" ]; then
+                echo "Warning: Installed uv version ($installed_version) differs from pinned version ($UV_VERSION)" >&2
+                echo "Consider running: bash $SCRIPT_DIR/scripts/install-uv.sh --force" >&2
+            fi
+        fi
     fi
 fi
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -69,13 +69,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Uses the system Python version (3.10 on Ubuntu 22.04, 3.12 on Ubuntu 24.04)
 
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN umask 000 && uv venv $PYTHON_ENV_DIR
-
-# Make venv writable by all users (allows uv pip install at runtime)
+# Set umask 000 to allow all users to write (required for uv pip install at runtime)
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.
 # This is acceptable for single-user containers but should be reconsidered for multi-tenant
 # or security-sensitive deployments. Consider using user-specific venvs in those cases.
-RUN chmod -R a+rwX $PYTHON_ENV_DIR
+RUN umask 000 && uv venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
@@ -200,13 +198,11 @@ FROM base AS release
 
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN uv venv $PYTHON_ENV_DIR
-
-# Make venv writable by all users (allows uv pip install at runtime)
+# Set umask 000 to allow all users to write (required for uv pip install at runtime)
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.
 # This is acceptable for single-user containers but should be reconsidered for multi-tenant
 # or security-sensitive deployments. Consider using user-specific venvs in those cases.
-RUN chmod -R a+rwX $PYTHON_ENV_DIR
+RUN umask 000 && uv venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
@@ -244,16 +240,14 @@ RUN /bin/bash -c "git clone --filter=blob:none --recurse-submodules --tags \
 WORKDIR /tt-metal
 
 # Build tt-metal and venv, then clear cache
-RUN /bin/bash -c "./build_metal.sh \
-    && ./create_venv.sh \
-    && source $PYTHON_ENV_DIR/bin/activate \
-    && rm -rf /root/.cache /root/.cargo /tt-metal/.cpmcache"
-
-# Make venv writable by all users (allows uv pip install at runtime)
+# Set umask 000 to allow all users to write (required for uv pip install at runtime)
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.
 # This is acceptable for single-user containers but should be reconsidered for multi-tenant
 # or security-sensitive deployments. Consider using user-specific venvs in those cases.
-RUN chmod -R a+rwX $PYTHON_ENV_DIR
+RUN umask 000 && /bin/bash -c "./build_metal.sh \
+    && ./create_venv.sh \
+    && source $PYTHON_ENV_DIR/bin/activate \
+    && rm -rf /root/.cache /root/.cargo /tt-metal/.cpmcache"
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -65,11 +65,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtest-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Set up virtual environment using uv with centralized Python version
-# Ubuntu 24.04 has Python 3.12 by default, so use that version for compatibility
+# Set up virtual environment using uv
+# Uses the system Python version (3.10 on Ubuntu 22.04, 3.12 on Ubuntu 24.04)
 
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR
+RUN umask 000 && uv venv $PYTHON_ENV_DIR
 
 # Make venv writable by all users (allows uv pip install at runtime)
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -72,6 +72,9 @@ ENV PYTHON_ENV_DIR=/opt/venv
 RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR
 
 # Make venv writable by all users (allows uv pip install at runtime)
+# SECURITY NOTE: This enables any user in the container to modify the Python environment.
+# This is acceptable for single-user containers but should be reconsidered for multi-tenant
+# or security-sensitive deployments. Consider using user-specific venvs in those cases.
 RUN chmod -R a+rwX $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
@@ -200,6 +203,9 @@ ENV PYTHON_ENV_DIR=/opt/venv
 RUN uv venv $PYTHON_ENV_DIR
 
 # Make venv writable by all users (allows uv pip install at runtime)
+# SECURITY NOTE: This enables any user in the container to modify the Python environment.
+# This is acceptable for single-user containers but should be reconsidered for multi-tenant
+# or security-sensitive deployments. Consider using user-specific venvs in those cases.
 RUN chmod -R a+rwX $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
@@ -244,6 +250,9 @@ RUN /bin/bash -c "./build_metal.sh \
     && rm -rf /root/.cache /root/.cargo /tt-metal/.cpmcache"
 
 # Make venv writable by all users (allows uv pip install at runtime)
+# SECURITY NOTE: This enables any user in the container to modify the Python environment.
+# This is acceptable for single-user containers but should be reconsidered for multi-tenant
+# or security-sensitive deployments. Consider using user-specific venvs in those cases.
 RUN chmod -R a+rwX $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -16,7 +16,7 @@ RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --docke
 
 # Install uv with version pinning (centralized in install-uv.sh)
 COPY scripts/install-uv.sh /tmp/install-uv.sh
-RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh
+RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh --system
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -71,6 +71,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN umask 000 && python3 -m venv $PYTHON_ENV_DIR
 
+# Make venv writable by all users (allows uv pip install at runtime)
+RUN chmod -R a+rwX $PYTHON_ENV_DIR
+
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
 ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
@@ -196,6 +199,9 @@ FROM base AS release
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN uv venv $PYTHON_ENV_DIR
 
+# Make venv writable by all users (allows uv pip install at runtime)
+RUN chmod -R a+rwX $PYTHON_ENV_DIR
+
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
 ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
@@ -236,6 +242,9 @@ RUN /bin/bash -c "./build_metal.sh \
     && ./create_venv.sh \
     && source $PYTHON_ENV_DIR/bin/activate \
     && rm -rf /root/.cache /root/.cargo /tt-metal/.cpmcache"
+
+# Make venv writable by all users (allows uv pip install at runtime)
+RUN chmod -R a+rwX $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -51,6 +51,12 @@ RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN uv venv $PYTHON_ENV_DIR
 
+# Make venv writable by all users (allows uv pip install at runtime)
+# SECURITY NOTE: This enables any user in the container to modify the Python environment.
+# This is acceptable for single-user containers but should be reconsidered for multi-tenant
+# or security-sensitive deployments. Consider using user-specific venvs in those cases.
+RUN chmod -R a+rwX $PYTHON_ENV_DIR
+
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
 ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -34,8 +34,11 @@ RUN apt-get update && apt-get install -y \
     git \
     python3-dev \
     python3-pip \
-    python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+# Install uv with version pinning (centralized in install-uv.sh)
+COPY scripts/install-uv.sh /tmp/install-uv.sh
+RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh --system
 
 # Install the SFPI compiler
 COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
@@ -44,9 +47,9 @@ COPY /tt_metal/sfpi-version /opt/tt_metal_infra/scripts/docker/sfpi-version
 RUN chmod +x /opt/tt_metal_infra/scripts/docker/install_dependencies.sh
 RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
 
-# Set up virtual environment
+# Set up virtual environment using uv
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN python3 -m venv $PYTHON_ENV_DIR
+RUN uv venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -49,13 +49,11 @@ RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_dependencies.sh --sfpi
 
 # Set up virtual environment using uv
 ENV PYTHON_ENV_DIR=/opt/venv
-RUN uv venv $PYTHON_ENV_DIR
-
-# Make venv writable by all users (allows uv pip install at runtime)
+# Set umask 000 to allow all users to write (required for uv pip install at runtime)
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.
 # This is acceptable for single-user containers but should be reconsidered for multi-tenant
 # or security-sensitive deployments. Consider using user-specific venvs in those cases.
-RUN chmod -R a+rwX $PYTHON_ENV_DIR
+RUN umask 000 && uv venv $PYTHON_ENV_DIR
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"

--- a/dockerfile/Dockerfile.evaluation
+++ b/dockerfile/Dockerfile.evaluation
@@ -7,7 +7,7 @@ RUN apt update && apt install -y python3 python3-pip git
 
 # Install uv with version pinning (centralized in install-uv.sh)
 COPY scripts/install-uv.sh /tmp/install-uv.sh
-RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh
+RUN chmod +x /tmp/install-uv.sh && /tmp/install-uv.sh --system
 
 # Install Python deps (skip venv)
 COPY tt_metal/python_env/requirements-dev.txt tt_metal/python_env/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,4 +76,7 @@ build-verbosity = 2
 # - Container environments where the cache and venv may be on different volumes
 # - Scenarios where the uv cache might be cleared independently of the venv
 # Trade-off: Uses more disk space but provides better isolation and portability.
+#
+# To change: Set to "hardlink" for better disk space usage on local filesystems,
+# or "symlink" for fastest operations (requires same filesystem for cache and venv).
 link-mode = "copy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ fallback_version = "0.0.0.dev0"
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
 build-verbosity = 2
+
+[tool.uv]
+link-mode = "copy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,11 @@ skip = "*-musllinux_*"
 build-verbosity = 2
 
 [tool.uv]
+# Use "copy" mode instead of the default "hardlink" or "symlink" modes.
+# This ensures packages are fully independent copies in the virtual environment,
+# which is more compatible with:
+# - Network filesystems (NFS, CIFS) that may not support hardlinks across mount points
+# - Container environments where the cache and venv may be on different volumes
+# - Scenarios where the uv cache might be cleared independently of the venv
+# Trade-off: Uses more disk space but provides better isolation and portability.
 link-mode = "copy"

--- a/scripts/install-uv.sh
+++ b/scripts/install-uv.sh
@@ -1,32 +1,117 @@
 #!/bin/bash
-# Install uv package manager with version pinning
-# This script centralizes uv installation logic to avoid drift between Dockerfiles
-#
-# Usage: install-uv.sh
-#
-# Supports:
-#   - Ubuntu 22.04/24.04 (pip-based installation with PEP 668 handling)
-#   - Fedora (native dnf package available)
-#   - macOS (pip-based installation with PEP 668 handling)
-#
-# The script auto-detects the distribution and uses the appropriate installation method.
-#
-# Requirements:
-#   - Python 3 with pip installed
-#   - For macOS: pip 23.0+ recommended for --break-system-packages support
-#   - For Linux: dnf/yum (Fedora/RHEL) or pip (Ubuntu/Debian)
-#
-# Behavior:
-#   - On failure, the script will exit with a non-zero status code
-#   - For PEP 668 restrictions, the script will automatically retry with appropriate flags
-#   - The script updates PATH to include ~/.local/bin if uv is installed there
-#   - Final verification ensures uv is available before exiting
+# Install uv package manager with version pinning.
+# Run with --help for usage information.
 
 set -euo pipefail
 
-# uv version to install (when using pip)
+# ============================================================================
+# Configuration
+# ============================================================================
+
+# uv version to install
 # Update this version when upgrading uv across all Dockerfiles
 UV_VERSION="0.7.12"
+
+# Installation mode: "system" or "user"
+# - system: Install at system level, fail if not possible
+# - user: Install to ~/.local/bin with pip --user or standalone installer (default)
+INSTALL_MODE="user"
+
+# ============================================================================
+# Help
+# ============================================================================
+
+show_help() {
+    cat << 'EOF'
+Usage: install-uv.sh [OPTIONS]
+
+Install uv package manager with version pinning.
+Auto-detects the OS/distribution and uses the appropriate installation method.
+
+OPTIONS:
+    --user      Install to user directory (~/.local/bin) (default).
+                Uses pip --user or standalone installer.
+                Updates PATH to include ~/.local/bin.
+                Does not require elevated permissions.
+    --system    Install at system level (for Docker containers).
+                Uses system package manager or pip without --user.
+                Requires appropriate permissions (use sudo if needed).
+                Does NOT modify PATH.
+    --help, -h  Show this help message and exit.
+
+SUPPORTED PLATFORMS:
+    - Ubuntu 22.04+ (pip or standalone installer)
+    - Debian 11+ (pip or standalone installer)
+    - Fedora/RHEL/CentOS/Rocky/AlmaLinux (native dnf/yum package)
+    - macOS (pip or standalone installer)
+
+REQUIREMENTS:
+    One of the following:
+    - Python 3 with pip, OR
+    - curl or wget (for standalone installer fallback)
+    - For Fedora/RHEL: dnf or yum package manager
+
+BEHAVIOR:
+    --user (default):
+        - Installs directly to ~/.local/bin
+        - Uses pip --user if available, otherwise standalone installer
+        - Adds ~/.local/bin to PATH if not already present
+        - Does not require elevated permissions
+
+    --system:
+        - Fedora/RHEL: Uses dnf/yum to install system package
+        - Ubuntu/Debian/macOS: Uses pip with --break-system-packages if needed
+        - Falls back to standalone installer if pip unavailable
+        - Fails with error if installation requires elevated permissions
+
+STANDALONE INSTALLER:
+    If pip is not available, the script will attempt to use the official
+    uv standalone installer (https://astral.sh/uv/install.sh) via curl or wget.
+EOF
+}
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --system)
+            INSTALL_MODE="system"
+            shift
+            ;;
+        --user)
+            INSTALL_MODE="user"
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            echo "Run '$0 --help' for usage information." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ============================================================================
+# Early Exit if Already Installed
+# ============================================================================
+
+if command -v uv &>/dev/null; then
+    uv_path=$(command -v uv)
+    uv_version=$(uv --version)
+    echo "uv is already installed:"
+    echo "  Path: ${uv_path}"
+    echo "  Version: ${uv_version}"
+    exit 0
+fi
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
 
 # Helper: Add ~/.local/bin to PATH if needed
 ensure_local_bin_in_path() {
@@ -36,69 +121,14 @@ ensure_local_bin_in_path() {
     fi
 }
 
+# Helper: Check if pip is available
+has_pip() {
+    python3 -m pip --version &>/dev/null
+}
+
 # Helper: Check if pip supports --break-system-packages
 pip_supports_break_system_packages() {
     python3 -m pip install --help 2>&1 | grep -q "\-\-break-system-packages"
-}
-
-# Helper: Install uv via pip with PEP 668 fallback handling
-# Tries: normal install -> --break-system-packages -> --user
-install_uv_with_pip_fallback() {
-    local pip_args="--no-cache-dir"
-
-    # First attempt: standard pip install
-    # shellcheck disable=SC2086
-    local pip_output
-    pip_output=$(python3 -m pip install ${pip_args} "uv==${UV_VERSION}" 2>&1) || true
-    ensure_local_bin_in_path
-
-    # Success on first try
-    if command -v uv &>/dev/null; then
-        return 0
-    fi
-
-    # Check for PEP 668 restriction
-    if echo "$pip_output" | grep -q "externally-managed-environment"; then
-        echo "PEP 668 restriction detected, trying alternative installation methods..."
-
-        # Second attempt: --break-system-packages (if available)
-        if pip_supports_break_system_packages; then
-            echo "Trying --break-system-packages..."
-            # shellcheck disable=SC2086
-            if python3 -m pip install ${pip_args} --break-system-packages "uv==${UV_VERSION}"; then
-                ensure_local_bin_in_path
-                return 0
-            fi
-            echo "Warning: --break-system-packages failed, falling back to --user..." >&2
-        fi
-
-        # Third attempt: --user installation
-        echo "Trying --user installation..."
-        python3 -m pip install --user --no-cache-dir "uv==${UV_VERSION}"
-        ensure_local_bin_in_path
-        return 0
-    fi
-
-    # Non-PEP-668 error - check for actual errors (not just warnings)
-    if echo "$pip_output" | grep -qiE "error:|failed|exception"; then
-        echo "$pip_output" >&2
-        return 1
-    fi
-
-    # Unknown state - let final verification handle it
-    return 0
-}
-
-# Helper: Install uv on Fedora/RHEL family
-install_uv_fedora() {
-    if command -v dnf &>/dev/null; then
-        dnf install -y uv
-    elif command -v yum &>/dev/null; then
-        yum install -y uv
-    else
-        echo "Error: No package manager found (dnf/yum)" >&2
-        return 1
-    fi
 }
 
 # Helper: Check if distro requires --break-system-packages (PEP 668)
@@ -109,14 +139,10 @@ requires_break_system_packages() {
 
     case "${distro_id}" in
         ubuntu)
-            # Ubuntu versions are YY.MM format (e.g., 22.04, 24.04)
-            # PEP 668 enforced starting with 23.04
             local major_version="${distro_version%%.*}"
             [[ "${major_version}" -ge 23 ]]
             ;;
         debian)
-            # Debian uses major version numbers (e.g., 11, 12)
-            # PEP 668 enforced starting with Debian 12
             local major_version="${distro_version%%.*}"
             [[ "${major_version}" -ge 12 ]]
             ;;
@@ -126,64 +152,212 @@ requires_break_system_packages() {
     esac
 }
 
-# Helper: Install uv on Ubuntu/Debian via pip
-install_uv_debian() {
-    local distro_id="$1"
-    local distro_version="$2"
+# ============================================================================
+# Standalone Installer (fallback when pip is unavailable)
+# https://docs.astral.sh/uv/getting-started/installation/
+# ============================================================================
+
+# Install uv using the official standalone installer
+# Supports version pinning via URL: https://astral.sh/uv/{version}/install.sh
+install_uv_standalone() {
+    local installer_url="https://astral.sh/uv/${UV_VERSION}/install.sh"
+
+    echo "Installing uv ${UV_VERSION} using standalone installer..."
+
+    if command -v curl &>/dev/null; then
+        curl -LsSf "$installer_url" | sh
+    elif command -v wget &>/dev/null; then
+        wget -qO- "$installer_url" | sh
+    else
+        echo "Error: Neither curl nor wget is available." >&2
+        echo "Please install curl or wget, or install pip to use pip-based installation." >&2
+        return 1
+    fi
+
+    # Standalone installer puts uv in ~/.local/bin (or ~/.cargo/bin for older versions)
+    ensure_local_bin_in_path
+
+    # Also check ~/.cargo/bin for older installer versions
+    local cargo_bin="${HOME}/.cargo/bin"
+    if [[ -d "$cargo_bin" ]] && [[ ":$PATH:" != *":$cargo_bin:"* ]]; then
+        export PATH="$cargo_bin:$PATH"
+    fi
+}
+
+# ============================================================================
+# User-mode Installation (--user)
+# ============================================================================
+
+# Install uv to ~/.local/bin using pip --user or standalone installer
+install_uv_user() {
+    echo "Installing uv to user directory (~/.local/bin)..."
+
+    if has_pip; then
+        python3 -m pip install --user --no-cache-dir "uv==${UV_VERSION}"
+        ensure_local_bin_in_path
+    else
+        echo "pip not available, using standalone installer..."
+        install_uv_standalone
+    fi
+}
+
+# ============================================================================
+# System-mode Installation (--system)
+# ============================================================================
+
+# Error out when system install fails
+fail_system_install() {
+    echo "Error: System-level installation failed." >&2
+    echo "Run with sudo, or use --user for user-level installation." >&2
+    exit 1
+}
+
+# Install uv on Fedora/RHEL family using system package manager
+install_uv_fedora_system() {
+    if command -v dnf &>/dev/null; then
+        dnf install -y uv
+    elif command -v yum &>/dev/null; then
+        yum install -y uv
+    else
+        echo "Error: No package manager found (dnf/yum)" >&2
+        return 1
+    fi
+}
+
+# Install uv via pip at system level
+install_uv_pip_system() {
+    local distro_id="${1:-}"
+    local distro_version="${2:-}"
     local pip_args="--no-cache-dir"
 
-    if requires_break_system_packages "${distro_id}" "${distro_version}"; then
+    if [[ -n "$distro_id" ]] && requires_break_system_packages "${distro_id}" "${distro_version}"; then
         pip_args="${pip_args} --break-system-packages"
     fi
 
     # shellcheck disable=SC2086
-    python3 -m pip install ${pip_args} "uv==${UV_VERSION}"
+    if ! python3 -m pip install ${pip_args} "uv==${UV_VERSION}"; then
+        fail_system_install
+    fi
+}
+
+# Install uv on macOS at system level with PEP 668 handling
+install_uv_macos_system() {
+    if ! has_pip; then
+        echo "pip not available, using standalone installer..."
+        if ! install_uv_standalone; then
+            fail_system_install
+        fi
+        return 0
+    fi
+
+    local pip_args="--no-cache-dir"
+
+    # First attempt: standard pip install
+    # shellcheck disable=SC2086
+    local pip_output
+    pip_output=$(python3 -m pip install ${pip_args} "uv==${UV_VERSION}" 2>&1) || true
+
+    if command -v uv &>/dev/null; then
+        return 0
+    fi
+
+    # Check for PEP 668 restriction
+    if echo "$pip_output" | grep -q "externally-managed-environment"; then
+        echo "PEP 668 restriction detected, trying --break-system-packages..."
+        if pip_supports_break_system_packages; then
+            # shellcheck disable=SC2086
+            if python3 -m pip install ${pip_args} --break-system-packages "uv==${UV_VERSION}"; then
+                return 0
+            fi
+        fi
+        fail_system_install
+    fi
+
+    # Other error
+    if echo "$pip_output" | grep -qiE "error:|failed|exception"; then
+        echo "$pip_output" >&2
+        fail_system_install
+    fi
+}
+
+# Install uv on Ubuntu/Debian at system level
+install_uv_debian_system() {
+    local distro_id="$1"
+    local distro_version="$2"
+
+    if ! has_pip; then
+        echo "pip not available, using standalone installer..."
+        if ! install_uv_standalone; then
+            fail_system_install
+        fi
+        return 0
+    fi
+
+    install_uv_pip_system "${distro_id}" "${distro_version}"
+}
+
+# Install uv on unknown distro at system level
+install_uv_unknown_system() {
+    echo "Warning: Unknown distribution, attempting installation..." >&2
+
+    if has_pip; then
+        if ! python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"; then
+            fail_system_install
+        fi
+    else
+        echo "pip not available, using standalone installer..."
+        if ! install_uv_standalone; then
+            fail_system_install
+        fi
+    fi
 }
 
 # ============================================================================
 # Main Installation Logic
 # ============================================================================
 
-# Detect OS and install
-case "$(uname -s)" in
-    Darwin)
-        echo "Installing uv ${UV_VERSION} on macOS..."
-        install_uv_with_pip_fallback
-        ;;
-    Linux)
-        if [[ ! -f /etc/os-release ]]; then
-            echo "Error: /etc/os-release not found" >&2
+# Handle user-mode installation separately (simple, direct path)
+if [[ "$INSTALL_MODE" == "user" ]]; then
+    echo "Installing uv ${UV_VERSION} (user mode)..."
+    install_uv_user
+else
+    # System-mode installation
+    case "$(uname -s)" in
+        Darwin)
+            echo "Installing uv ${UV_VERSION} on macOS (system mode)..."
+            install_uv_macos_system
+            ;;
+        Linux)
+            if [[ ! -f /etc/os-release ]]; then
+                echo "Error: /etc/os-release not found" >&2
+                exit 1
+            fi
+
+            # shellcheck source=/dev/null
+            source /etc/os-release
+            DISTRO_ID="${ID:-unknown}"
+            DISTRO_VERSION="${VERSION_ID:-unknown}"
+
+            echo "Installing uv ${UV_VERSION} on ${DISTRO_ID} ${DISTRO_VERSION} (system mode)..."
+
+            case "${DISTRO_ID}" in
+                fedora|rhel|centos|rocky|almalinux)
+                    install_uv_fedora_system
+                    ;;
+                ubuntu|debian)
+                    install_uv_debian_system "${DISTRO_ID}" "${DISTRO_VERSION}"
+                    ;;
+                *)
+                    install_uv_unknown_system
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Error: Unsupported operating system: $(uname -s)" >&2
             exit 1
-        fi
-
-        # shellcheck source=/dev/null
-        source /etc/os-release
-        DISTRO_ID="${ID:-unknown}"
-        DISTRO_VERSION="${VERSION_ID:-unknown}"
-
-        echo "Installing uv ${UV_VERSION} on ${DISTRO_ID} ${DISTRO_VERSION}..."
-
-        case "${DISTRO_ID}" in
-            fedora|rhel|centos|rocky|almalinux)
-                install_uv_fedora
-                ;;
-            ubuntu|debian)
-                install_uv_debian "${DISTRO_ID}" "${DISTRO_VERSION}"
-                ;;
-            *)
-                echo "Warning: Unknown distribution '${DISTRO_ID}', attempting pip installation..." >&2
-                python3 -m pip install --no-cache-dir "uv==${UV_VERSION}" || {
-                    echo "Error: Failed to install uv" >&2
-                    exit 1
-                }
-                ;;
-        esac
-        ;;
-    *)
-        echo "Error: Unsupported operating system: $(uname -s)" >&2
-        exit 1
-        ;;
-esac
+            ;;
+    esac
+fi
 
 # Final verification
 if command -v uv &>/dev/null; then


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/35893


### Problem description
More usability issues with uv and venv

### What's changed
Refactor uv installation and improve create_venv.sh CLI

Overhaul install-uv.sh and create_venv.sh for better usability,
robustness, and Docker compatibility.

install-uv.sh changes:
- Add --user (default) and --system installation modes
- Add early exit when uv is already installed
- Add standalone installer fallback via curl/wget when pip unavailable
- Add comprehensive --help documentation
- Refactor with helper functions to reduce nesting
- Add PEP 668 handling for Ubuntu 23.04+/Debian 12+
- Support Fedora/RHEL via native dnf/yum packages

create_venv.sh changes:
- Add CLI arguments: --python-version, --python-cmd, --env-dir
- Arguments take precedence over environment variables
- Add input validation (Python version format, command exists, dir writable)
- Require Python 3.8+ with clear error messages
- Simplify uv installation by delegating to install-uv.sh
- Improve help documentation with examples

Dockerfile changes:
- Use explicit --system flag for system-level uv installation

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nsexton/0-uv-system)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-uv-system)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-uv-system)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-uv-system)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-uv-system)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-uv-system)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-uv-system)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs