### PR TITLE
[skip ci] Move BH-LB from pipeline-perf label to pipeline-functional

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -59,7 +59,7 @@ jobs:
             num_devices: 2
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 8
           - name: P300 Demo tests
             runner-label: P300-viommu

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -120,7 +120,7 @@ jobs:
           all_systems='[
             {"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "llmbox"},
             {"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"},
-            {"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-perf", "num_devices": 8, "key": "loudbox"},
+            {"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-functional", "num_devices": 8, "key": "loudbox"},
             {"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"}
           ]'
 

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -120,7 +120,7 @@ jobs:
             num_devices: 4
           - name: LoudBox Demo tests
             runner-label: BH-LoudBox
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
             num_devices: 8
           - name: P300 Demo tests
             runner-label: P300-viommu

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -261,7 +261,7 @@ jobs:
             extra-tag: pipeline-functional
           - runner-label: BH-LoudBox
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
-            extra-tag: pipeline-perf
+            extra-tag: pipeline-functional
           - runner-label: BH-QB-GE
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
             extra-tag: pipeline-perf


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/metal-internal-workflows/issues/813

### Problem description
We have 1 `pipeline-perf` Loudbox runner that we are planning to move to IRD.
To replace it we have 2 new LBs in CIv1 as cloud bare-metals, we can run demo tests on all `pipeline-functional` loudboxes now (since the model weights are also accessible on `/mnt/MLperf` via cloud weka)

### What's changed
Switch all the workflows running `BH-Loudbox` with `pipeline-perf` to `pipeline-functional`.

### Checklist

- [x] BH nightly (loudbox only): https://github.com/tenstorrent/tt-metal/actions/runs/21042939193 (failure is known issue on main)