### PR TITLE
Update trace region size for new reduce scatter binary requirements

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -601,8 +601,8 @@ def run_reduce_scatter_impl(
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1531456}, ttnn.Topology.Linear),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1540000}, ttnn.Topology.Ring),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 1540000}, ttnn.Topology.Linear),
     ],
     indirect=["device_params"],
     ids=["fabric_ring", "fabric_linear"],


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

During a recent PR that updated the reduce scatter kernel, the size of the code increased, this caused the trace region to overflow into the fabric region causing fabric to break on all subsequent tests during a e2e t3k test. This includes removing the ability to reset to a new fabric type or initializing fabric

In this PR I increased the static allocation size of the trace buffer a bit for this unit test to prevent the overflow.

### Checklist

https://github.com/tenstorrent/tt-metal/actions/runs/21042424694/job/60508258349