### PR TITLE
[skip ci] fixing edge case handling in pipeline status tracker

### DIFF
--- a/.github/actions/analyze-workflow-data/lib/reporting.js
+++ b/.github/actions/analyze-workflow-data/lib/reporting.js
@@ -534,70 +534,115 @@ function computeStatusChanges(filteredGrouped, filteredPreviousGrouped, context)
   for (const name of allNames) {
     const currentRuns = filteredGrouped.get(name);
     const previousRuns = filteredPreviousGrouped.get(name);
-    if (!currentRuns || !previousRuns) continue;
 
-    const current = computeLatestConclusion(currentRuns);
-    const previous = computeLatestConclusion(previousRuns);
-    if (!current || !previous) continue;
+    // If we have both current and previous data, use comparison logic
+    if (currentRuns && previousRuns) {
+      const current = computeLatestConclusion(currentRuns);
+      const previous = computeLatestConclusion(previousRuns);
+      if (!current || !previous) continue;
 
-    let change;
-    if (previous === 'success' && current === 'success') change = 'stayed_succeeding';
-    else if (previous !== 'success' && current !== 'success') change = 'stayed_failing';
-    else if (previous !== 'success' && current === 'success') change = 'fail_to_success';
-    else if (previous === 'success' && current !== 'success') change = 'success_to_fail';
+      let change;
+      if (previous === 'success' && current === 'success') change = 'stayed_succeeding';
+      else if (previous !== 'success' && current !== 'success') change = 'stayed_failing';
+      else if (previous !== 'success' && current === 'success') change = 'fail_to_success';
+      else if (previous === 'success' && current !== 'success') change = 'success_to_fail';
 
-    if (change) {
-      const info = computeLatestRunInfo(currentRuns);
-      const workflowUrl = info?.path ? getWorkflowLink(context, info.path) : undefined;
-      const aggregateRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-      const commitUrl = info?.head_sha ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${info.head_sha}` : undefined;
-      const commitShort = info?.head_sha ? info.head_sha.substring(0, SHA_SHORT_LENGTH) : undefined;
+      if (change) {
+        const info = computeLatestRunInfo(currentRuns);
+        const workflowUrl = info?.path ? getWorkflowLink(context, info.path) : undefined;
+        const aggregateRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+        const commitUrl = info?.head_sha ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${info.head_sha}` : undefined;
+        const commitShort = info?.head_sha ? info.head_sha.substring(0, SHA_SHORT_LENGTH) : undefined;
 
-      changes.push({
-        name,
-        previous,
-        current,
-        change,
-        run_id: info?.id,
-        run_url: info?.url,
-        created_at: info?.created_at,
-        workflow_url: workflowUrl,
-        workflow_path: info?.path,
-        aggregate_run_url: aggregateRunUrl,
-        commit_sha: info?.head_sha,
-        commit_short: commitShort,
-        commit_url: commitUrl
-      });
-      if (change === 'success_to_fail' && info) {
-        regressedDetails.push({
+        changes.push({
           name,
-          run_id: info.id,
-          run_url: info.url,
-          created_at: info.created_at,
+          previous,
+          current,
+          change,
+          run_id: info?.id,
+          run_url: info?.url,
+          created_at: info?.created_at,
           workflow_url: workflowUrl,
-          workflow_path: info.path,
+          workflow_path: info?.path,
           aggregate_run_url: aggregateRunUrl,
-          commit_sha: info.head_sha,
+          commit_sha: info?.head_sha,
           commit_short: commitShort,
-          commit_url: commitUrl,
-          owners: []
+          commit_url: commitUrl
         });
-      } else if (change === 'stayed_failing' && info) {
-        const previousInfo = computeLatestRunInfo(previousRuns);
-        stayedFailingDetails.push({
-          name,
-          run_id: info.id,
-          run_url: info.url,
-          created_at: info.created_at,
-          workflow_url: workflowUrl,
-          workflow_path: info.path,
-          aggregate_run_url: aggregateRunUrl,
-          commit_sha: info.head_sha,
-          commit_short: commitShort,
-          commit_url: commitUrl,
-          previous_run_id: previousInfo?.id,
-          previous_run_url: previousInfo?.url
-        });
+        if (change === 'success_to_fail' && info) {
+          regressedDetails.push({
+            name,
+            run_id: info.id,
+            run_url: info.url,
+            created_at: info.created_at,
+            workflow_url: workflowUrl,
+            workflow_path: info.path,
+            aggregate_run_url: aggregateRunUrl,
+            commit_sha: info.head_sha,
+            commit_short: commitShort,
+            commit_url: commitUrl,
+            owners: []
+          });
+        } else if (change === 'stayed_failing' && info) {
+          const previousInfo = computeLatestRunInfo(previousRuns);
+          stayedFailingDetails.push({
+            name,
+            run_id: info.id,
+            run_url: info.url,
+            created_at: info.created_at,
+            workflow_url: workflowUrl,
+            workflow_path: info.path,
+            aggregate_run_url: aggregateRunUrl,
+            commit_sha: info.head_sha,
+            commit_short: commitShort,
+            commit_url: commitUrl,
+            previous_run_id: previousInfo?.id,
+            previous_run_url: previousInfo?.url
+          });
+        }
+      }
+    } else if (currentRuns && !previousRuns) {
+      // Handle case where we have current data but no previous data
+      // If workflow is currently failing, check if it has multiple consecutive failures
+      // to determine if it's "still failing" vs a new regression
+      const current = computeLatestConclusion(currentRuns);
+      if (current === 'failure') {
+        const mainBranchRuns = getMainWindowRuns(currentRuns);
+        // Check if there are multiple consecutive failures (at least 2)
+        // This indicates the workflow has been failing for a while
+        let consecutiveFailures = 0;
+        for (const run of mainBranchRuns) {
+          if (run.conclusion === 'success') {
+            break; // Stop counting when we hit a success
+          } else if (run.conclusion && run.conclusion !== 'cancelled' && run.conclusion !== 'skipped') {
+            consecutiveFailures++;
+          }
+        }
+
+        // If there are 2+ consecutive failures, treat as "still failing"
+        // Otherwise, it might be a new regression (but we can't be sure without previous data)
+        if (consecutiveFailures >= 2) {
+          const info = computeLatestRunInfo(currentRuns);
+          const workflowUrl = info?.path ? getWorkflowLink(context, info.path) : undefined;
+          const aggregateRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const commitUrl = info?.head_sha ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${info.head_sha}` : undefined;
+          const commitShort = info?.head_sha ? info.head_sha.substring(0, SHA_SHORT_LENGTH) : undefined;
+
+          stayedFailingDetails.push({
+            name,
+            run_id: info?.id,
+            run_url: info?.url,
+            created_at: info?.created_at,
+            workflow_url: workflowUrl,
+            workflow_path: info?.path,
+            aggregate_run_url: aggregateRunUrl,
+            commit_sha: info?.head_sha,
+            commit_short: commitShort,
+            commit_url: commitUrl,
+            previous_run_id: undefined,
+            previous_run_url: undefined
+          });
+        }
       }
     }
   }

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -242,47 +242,47 @@ jobs:
           retention-days: 1
 
 
-  handle-failures:
-    needs: analyze-data
-    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    outputs:
-      slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Handle failed workflows
-        run: |
-          echo "The following workflows have failed:"
-          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-          # Add any additional failure handling steps here
-      - name: Post regressions to Slack
-        id: slack-report
-        uses: ./.github/actions/slack-report-analyze-workflow-data
-        with:
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  # handle-failures:
+  #   needs: analyze-data
+  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Handle failed workflows
+  #       run: |
+  #         echo "The following workflows have failed:"
+  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+  #         # Add any additional failure handling steps here
+  #     - name: Post regressions to Slack
+  #       id: slack-report
+  #       uses: ./.github/actions/slack-report-analyze-workflow-data
+  #       with:
+  #         channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  trigger-auto-triage:
-    needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-      - name: Install dependencies
-        working-directory: .github/actions/trigger-auto-triage-for-regressions
-        run: npm install
-      - name: Trigger auto-triage for regressed jobs
-        uses: ./.github/actions/trigger-auto-triage-for-regressions
-        with:
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          send-slack-message: true
+  # trigger-auto-triage:
+  #   needs: [analyze-data, handle-failures]
+  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+  #     - name: Install dependencies
+  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
+  #       run: npm install
+  #     - name: Trigger auto-triage for regressed jobs
+  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
+  #       with:
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+  #         send-slack-message: true

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -242,47 +242,47 @@ jobs:
           retention-days: 1
 
 
-  # handle-failures:
-  #   needs: analyze-data
-  #   if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Handle failed workflows
-  #       run: |
-  #         echo "The following workflows have failed:"
-  #         echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
-  #         # Add any additional failure handling steps here
-  #     - name: Post regressions to Slack
-  #       id: slack-report
-  #       uses: ./.github/actions/slack-report-analyze-workflow-data
-  #       with:
-  #         channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  handle-failures:
+    needs: analyze-data
+    if: ${{ fromJson(needs.analyze-data.outputs.failed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    outputs:
+      slack_ts: ${{ steps.slack-report.outputs.slack_ts }}
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Handle failed workflows
+        run: |
+          echo "The following workflows have failed:"
+          echo '${{ needs.analyze-data.outputs.failed_workflows }}' | jq -r '.[]'
+          # Add any additional failure handling steps here
+      - name: Post regressions to Slack
+        id: slack-report
+        uses: ./.github/actions/slack-report-analyze-workflow-data
+        with:
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  # trigger-auto-triage:
-  #   needs: [analyze-data, handle-failures]
-  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
-  #     - name: Install dependencies
-  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
-  #       run: npm install
-  #     - name: Trigger auto-triage for regressed jobs
-  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
-  #       with:
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-  #         send-slack-message: true
+  trigger-auto-triage:
+    needs: [analyze-data, handle-failures]
+    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #@v3
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          send-slack-message: true


### PR DESCRIPTION
### Ticket
NA

### Problem description
There was a bug where, if a previous successful run of aggregate-workflow-data couldn't be found (which sometimes happens because github ._.) it doesn't display any of the failing runs in the still failing section.

### What's changed
account for that edge case.

### Checklist

- [x] [![Aggregate Workflow Data](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml/badge.svg?branch=ebanerjee/fixing-edge-case)](https://github.com/tenstorrent/tt-metal/actions/workflows/aggregate-workflow-data.yaml?query=branch:ebanerjee/fixing-edge-case) https://github.com/tenstorrent/tt-metal/actions/runs/21046132124