### PR TITLE
Haibo sun/issue#31236 Added 2.0 API for all_from_all and all_to_all DM Tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -62,3 +62,16 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
    - 1x1 From 2x2: 1x1 master grid receiving from 2x2 subordinate grid
    - 1x1 From 4x4: 1x1 master grid receiving from 4x4 subordinate grid
    - 2x2 From 2x2: 2x2 master grid receiving from 2x2 subordinate grid
+
+## Device 2.0 API Tests
+This test suite now includes tests using the new device 2.0 experimental NOC API. These tests provide the same functionality as the original tests but use an updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc` and `experimental::UnicastEndpoint` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Kernels:
+- `requestor_2_0.cpp`: Implements the requestor functionality using the experimental NOC API
+- `requestor.cpp`: Original requestor kernel for comparison
+
+Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new experimental API.

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     {
         DeviceZoneScopedN("RISCV1");
         for (uint32_t j = 0; j < num_subordinates; j++) {
-            // Subordinate coordiantes are stored in the runtime arguments starting at index 1
+            // Subordinate coordinates are stored in the runtime arguments starting at index 1
             // Each x coordinate is stores in an odd index
             // Each y coordinate is stored in the next even index
             // The first subordinate's coordinates are at indices 1 and 2, the second at indices 3 and 4, etc.

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "experimental/endpoints.h"
+
+void kernel_main() {
+    // Compile-time arguments
+    const uint32_t test_id = get_compile_time_arg_val(0);
+    const uint32_t mst_l1_base_address = get_compile_time_arg_val(1);
+    const uint32_t sub_l1_base_address = get_compile_time_arg_val(2);
+    const uint32_t num_of_transactions = get_compile_time_arg_val(3);
+    const uint32_t bytes_per_transaction_per_subordinate = get_compile_time_arg_val(4);
+    const uint32_t num_subordinates = get_compile_time_arg_val(5);
+    const uint32_t num_virtual_channels = get_compile_time_arg_val(6);
+
+    // Derivative values
+    uint32_t master_l1_local_address = mst_l1_base_address;
+    uint32_t subordinate_l1_local_address = sub_l1_base_address;
+
+    uint32_t subordinate_x_coord;
+    uint32_t subordinate_y_coord;
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_endpoint;
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t j = 0; j < num_subordinates; j++) {
+            // Subordinate coordiantes are stored in the runtime arguments starting at index 1
+            // Each x coordinate is stores in an odd index
+            // Each y coordinate is stored in the next even index
+            // The first subordinate's coordinates are at indices 1 and 2, the second at indices 3 and 4, etc.
+            subordinate_x_coord = get_arg_val<uint32_t>(j * 2);
+            subordinate_y_coord = get_arg_val<uint32_t>(j * 2 + 1);
+
+            for (uint32_t i = 0; i < num_of_transactions; i++) {
+                // Cycle through virtual channels 0 to (num_virtual_channels - 1)
+                uint32_t current_virtual_channel = i % num_virtual_channels;
+
+                noc.async_read(
+                    unicast_endpoint,
+                    unicast_endpoint,
+                    bytes_per_transaction_per_subordinate,
+                    {
+                        .noc_x = subordinate_x_coord,
+                        .noc_y = subordinate_y_coord,
+                        .addr = subordinate_l1_local_address,
+                    },
+                    {
+                        .addr = master_l1_local_address,
+                    },
+                    current_virtual_channel);
+            }
+        }
+        noc_async_read_barrier();
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
+    DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_subordinate);
+
+    DeviceTimestampedData("NoC Index", noc_index);
+    DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+}

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -63,6 +63,6 @@ void kernel_main() {
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_subordinate);
 
-    DeviceTimestampedData("NoC Index", noc_index);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
 }

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -566,10 +566,8 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
     CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
     CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
 
-    bool use_2_0_api = true;
-
     unit_tests::dm::all_from_all::packet_sizes_test(
-        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size, use_2_0_api);
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size, true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -40,6 +40,7 @@ struct AllFromAllConfig {
     DataFormat l1_data_format = DataFormat::Invalid;
     NOC noc_id = NOC::NOC_1;
     uint32_t num_virtual_channels = 1;
+    bool use_2_0_api = false;
 
     // TODO: Add the following parameters
     //  1. Virtual Channel (only useful for unicast)
@@ -129,10 +130,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
         (uint32_t)test_config.num_virtual_channels,
     };
 
+    std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/";
+    std::string requestor_kernel_filename = "requestor";
+    if (test_config.use_2_0_api) {
+        requestor_kernel_filename += "_2_0";
+    }
+    std::string requestor_kernel_path = kernels_dir + requestor_kernel_filename + ".cpp";
+
     // Create kernels
     auto requestor_kernel = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor.cpp",
+        requestor_kernel_path,
         mst_logical_core_set,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1,
@@ -244,7 +252,8 @@ void packet_sizes_test(
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
     CoreCoord mst_grid_size,
-    CoreCoord sub_grid_size) {
+    CoreCoord sub_grid_size,
+    bool use_2_0_api = false) {
     NOC noc_id = NOC::NOC_1;
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
@@ -284,6 +293,7 @@ void packet_sizes_test(
 
                 .l1_data_format = DataFormat::Float16_b,
                 .noc_id = noc_id,
+                .use_2_0_api = use_2_0_api,
             };
 
             // Run
@@ -541,6 +551,25 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
         num_of_transactions_per_subordinate,
         pages_per_transaction,
         num_virtual_channels);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    uint32_t test_case_id = 319;
+
+    /* Parameters */
+    CoreCoord mst_start_coord = {0, 0};
+    CoreCoord sub_start_coord = {0, 0};
+
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+
+    bool use_2_0_api = true;
+
+    unit_tests::dm::all_from_all::packet_sizes_test(
+        mesh_device, test_case_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size, use_2_0_api);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -62,3 +62,16 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
    - 2x2 To 1x1: 2x2 master grid sending to 1x1 subordinate grid
    - 4x4 To 1x1: 4x4 master grid sending to 1x1 subordinate grid
    - 2x2 To 2x2: 2x2 master grid sending to 2x2 subordinate grid
+
+## Device 2.0 API Tests
+This test suite now includes tests using the new device 2.0 experimental NOC API. These tests provide the same functionality as the original tests but use an updated API design:
+
+### Key Features of Device 2.0 API Tests:
+- **Experimental NOC API**: Uses `experimental::Noc` and `experimental::UnicastEndpoint` for structured NOC operations
+- **Structured Arguments**: Source and destination arguments are defined using structured `noc_traits_t` types
+
+### Device 2.0 Kernels:
+- `sender_2_0.cpp`: Implements the sender functionality using the experimental NOC API
+- `sender.cpp`: Original sender kernel for comparison
+
+Both API versions run the same test cases but use different underlying implementations. The device 2.0 tests serve as a validation and performance comparison for the new experimental API.

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("NoC Index", noc_index);
+    DeviceTimestampedData("NoC Index", noc.get_noc_id());
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_master);
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -40,6 +40,7 @@ struct AllToAllConfig {
     DataFormat l1_data_format = DataFormat::Invalid;
     NOC noc_id = NOC::NOC_0;
     uint32_t num_virtual_channels = 1;  // Number of virtual channels to cycle through
+    bool use_2_0_api = false;
 
     // TODO: Add the following parameters
     //  1. Posted flag (posted multicast has much better performance at larger grid sizes, than non-posted due to
@@ -138,9 +139,16 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
     };
 
     // Create kernels
+    std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/";
+    std::string sender_kernel_filename = "sender";
+    if (test_config.use_2_0_api) {
+        sender_kernel_filename += "_2_0";
+    }
+    std::string sender_kernel_path = kernels_dir + sender_kernel_filename + ".cpp";
+
     auto sender_kernel = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender.cpp",
+        sender_kernel_path,
         mst_logical_core_set,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0,
@@ -255,7 +263,8 @@ void packet_sizes_test(
     CoreCoord mst_start_coord,
     CoreCoord sub_start_coord,
     CoreCoord mst_grid_size,
-    CoreCoord sub_grid_size) {
+    CoreCoord sub_grid_size,
+    bool use_2_0_api = false) {
     NOC noc_id = NOC::NOC_0;
 
     auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
@@ -294,6 +303,7 @@ void packet_sizes_test(
 
                 .l1_data_format = DataFormat::Float16_b,
                 .noc_id = noc_id,
+                .use_2_0_api = use_2_0_api,
             };
 
             // Run
@@ -538,6 +548,25 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllCustom) {
 
     unit_tests::dm::all_to_all::custom_test(
         get_mesh_device(), test_case_id, num_of_transactions, pages_per_transaction, num_virtual_channels);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes2_0) {
+    // Test ID
+    uint32_t test_id = 309;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    /* Parameters */
+    CoreCoord mst_start_coord = {0, 0};
+    CoreCoord sub_start_coord = {0, 0};
+
+    CoreCoord mst_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    CoreCoord sub_grid_size = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+
+    unit_tests::dm::all_to_all::packet_sizes_test(
+        mesh_device, test_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size, true);
+
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -566,7 +566,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllPacketSizes2_0) {
 
     unit_tests::dm::all_to_all::packet_sizes_test(
         mesh_device, test_id, mst_start_coord, sub_start_coord, mst_grid_size, sub_grid_size, true);
-
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#31236 

### Problem description
New Databuffer APIs for Metal 2.0 and we need to update the current DM tests to use new APIs.

### What's changed
This PR updates two DM tests to using 2.0 APIs, specially `all_to_all` and `all_from_all`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Haibo_Sun/issue#32121)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Haibo_Sun/issue#32121)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Haibo_Sun/issue#32121)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Haibo_Sun/issue#32121)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Haibo_Sun/issue#32121)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Haibo_Sun/issue#32121)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Haibo_Sun/issue#32121)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs