### PR TITLE
fix qwen image vae device config

### DIFF
--- a/models/experimental/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/experimental/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -368,7 +368,7 @@ class QwenImagePipeline:
             # The default cofigurations are the best found from sweeping the following: is_fsdp, dynamic_load_encoder, and dynamic_load_vae.
             # The encoder is currently hardcoded to always be FSDP as it is the most memory efficient configuration with little to no performance penalty.
             (2, 4): {
-                "cfg_config": (2, 1),
+                "cfg_config": (2, 0),
                 "sp": (1, 0),
                 "tp": (4, 1),
                 "encoder_tp": (4, 1),

--- a/models/experimental/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/experimental/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -232,6 +232,9 @@ class QwenImagePipeline:
 
         self._traces = None
 
+        logger.info("warming up for tracing...")
+        self.run_single_prompt(prompt="", num_inference_steps=1, seed=0, traced=False)
+
     def _load_transformers(self, idx) -> None:
         """Load transformer weights to device. Called lazily for device encoder path."""
         if self.transformers[idx].is_loaded():

--- a/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -218,7 +218,7 @@ def test_qwenimage_pipeline_performance(
             "total_encoding_time": 0.35,
             "denoising_steps_time": 72.0,
             "vae_decoding_time": 0.65,
-            "total_time": 74.5,
+            "total_time": 75,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         expected_metrics = {

--- a/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -31,7 +31,7 @@ from models.common.utility_functions import is_blackhole
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 47000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 47000000}],
     indirect=True,
 )
 def test_qwenimage_pipeline_performance(
@@ -216,9 +216,9 @@ def test_qwenimage_pipeline_performance(
     if tuple(mesh_device.shape) == (2, 4):
         expected_metrics = {
             "total_encoding_time": 0.35,
-            "denoising_steps_time": 73.0,
+            "denoising_steps_time": 72.0,
             "vae_decoding_time": 0.65,
-            "total_time": 77,
+            "total_time": 74.5,
         }
     elif tuple(mesh_device.shape) == (4, 8):
         expected_metrics = {

--- a/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -285,9 +285,7 @@ def test_qwenimage_pipeline_performance(
             )
             pass_perf_check = False
 
-    # don't fail the test on perf - we're diagnosing
-    if not pass_perf_check:
-        logger.warning("\n".join(assert_msgs))
+    assert pass_perf_check, "\n".join(assert_msgs)
 
     # synchronize all devices
     pipeline.synchronize_devices()

--- a/models/experimental/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py
+++ b/models/experimental/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py
@@ -18,7 +18,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 47000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 47000000}],
     indirect=True,
 )
 @pytest.mark.parametrize(("width", "height", "num_inference_steps"), [(1024, 1024, 50)])


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Qwen image vae is broken after a recent update from main. The fix was to remove the l1_small_size similar to how it was fixed for Wan.