### PR TITLE
Increase CB limit to 64 on Blackhole

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -120,9 +120,9 @@ void verify_cb_config(
     MeshWorkload& workload,
     std::vector<CBConfig>& golden_cb_config,
     CoreRangeSet& crs) {
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
     std::vector<uint32_t> cb_config_vector;
-    uint32_t cb_config_buffer_size =
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t cb_config_buffer_size = max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const auto& [device_range, _] : workload.get_programs()) {
         for (const auto& coord : device_range) {

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -182,8 +182,9 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
     std::map<std::string, std::string> erisc_defines = {{"ERISC", "1"}};
     uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
-    // Reduce page size on Blackhole to fit 64 CBs in L1
-    uint32_t page_size = (MetalContext::instance().hal().get_arch() == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
+    // Smaller page size for architectures with more CBs to ensure all test CBs fit in L1
+    constexpr uint32_t l1_cb_test_budget = 1024 * 32;
+    uint32_t page_size = l1_cb_test_budget / max_cbs;
 
     for (uint32_t i = 0; i < num_programs; i++) {
         Program& program = *programs.emplace_back(std::make_shared<Program>());

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -182,6 +182,7 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     std::map<std::string, std::string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
     std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
     std::map<std::string, std::string> erisc_defines = {{"ERISC", "1"}};
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
 
     for (uint32_t i = 0; i < num_programs; i++) {
         Program& program = *programs.emplace_back(std::make_shared<Program>());
@@ -192,14 +193,14 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
             BRISC_OUTER_LOOP = MAX_LOOP;
             BRISC_MIDDLE_LOOP = MAX_LOOP;
             BRISC_INNER_LOOP = MAX_LOOP;
-            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_CBS = max_cbs;
             NUM_SEMS = NUM_SEMAPHORES;
             USE_MAX_RT_ARGS = true;
         } else {
             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_CBS = rand() % (max_cbs) + 1;
             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
             USE_MAX_RT_ARGS = false;
         }

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -165,7 +165,6 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     uint32_t /*seed*/,
     const std::unordered_set<CoreCoord>& active_eth_cores) {
     uint32_t MAX_LOOP = 100;
-    uint32_t page_size = 1024;
     uint32_t max_eth_cores = 3;
 
     uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
@@ -183,6 +182,8 @@ std::vector<std::shared_ptr<Program>> create_random_programs(
     std::map<std::string, std::string> compute_defines = {{"COMPUTE", "1"}};
     std::map<std::string, std::string> erisc_defines = {{"ERISC", "1"}};
     uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    // Reduce page size on Blackhole to fit 64 CBs in L1
+    uint32_t page_size = (MetalContext::instance().hal().get_arch() == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
 
     for (uint32_t i = 0; i < num_programs; i++) {
         Program& program = *programs.emplace_back(std::make_shared<Program>());

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -52,10 +52,10 @@ void validate_cb_address(
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::EnqueueMeshWorkload(cq, workload, false);
     auto& program = workload.get_programs().at(device_range);
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
 
     vector<uint32_t> cb_config_vector;
-    uint32_t cb_config_buffer_size =
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t cb_config_buffer_size = max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const CoreRange& core_range : cr_set.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -93,7 +93,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
 
         std::map<uint8_t, uint32_t> expected_addresses;
         auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-        for (uint8_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
+        for (uint8_t cb_id = 0; cb_id < max_cbs_; cb_id++) {
             CircularBufferConfig config1 = CircularBufferConfig(cb_config.page_size, {{cb_id, cb_config.data_format}})
                                                .set_page_size(cb_id, cb_config.page_size);
             CreateCircularBuffer(program_, core, config1);
@@ -147,7 +147,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
 
         auto expected_multi_core_address =
             devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1) + (max_num_cbs * cb_config.page_size);
-        uint8_t multicore_buffer_idx = NUM_CIRCULAR_BUFFERS - 1;
+        uint8_t multicore_buffer_idx = max_cbs_ - 1;
         CircularBufferConfig config2 =
             CircularBufferConfig(cb_config.page_size, {{multicore_buffer_idx, cb_config.data_format}})
                 .set_page_size(multicore_buffer_idx, cb_config.page_size);
@@ -236,11 +236,11 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
         initialize_program(program_, cr_set);
 
         uint32_t num_pages =
-            ((l1_buffer->address() - devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1)) /
-             NUM_CIRCULAR_BUFFERS / page_size) +
+            ((l1_buffer->address() - devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1)) / max_cbs_ /
+             page_size) +
             1;
         CBConfig cb_config = {.num_pages = num_pages};
-        for (uint32_t buffer_id = 0; buffer_id < NUM_CIRCULAR_BUFFERS; buffer_id++) {
+        for (uint32_t buffer_id = 0; buffer_id < max_cbs_; buffer_id++) {
             CircularBufferConfig config1 =
                 CircularBufferConfig(cb_config.page_size * cb_config.num_pages, {{buffer_id, cb_config.data_format}})
                     .set_page_size(buffer_id, cb_config.page_size);
@@ -410,8 +410,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
         distributed::EnqueueMeshWorkload(cq, workload, false);
 
         vector<uint32_t> cb_config_vector;
-        uint32_t cb_config_buffer_size =
-            NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+        uint32_t cb_config_buffer_size = max_cbs_ * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
         for (const CoreRange& core_range : cr_set.ranges()) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -147,7 +147,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
 
         auto expected_multi_core_address =
             devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1) + (max_num_cbs * cb_config.page_size);
-        uint8_t multicore_buffer_idx = max_cbs_ - 1;
+        uint32_t multicore_buffer_idx = max_cbs_ - 1;
         CircularBufferConfig config2 =
             CircularBufferConfig(cb_config.page_size, {{multicore_buffer_idx, cb_config.data_format}})
                 .set_page_size(multicore_buffer_idx, cb_config.page_size);

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -93,7 +93,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
 
         std::map<uint8_t, uint32_t> expected_addresses;
         auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-        for (uint8_t cb_id = 0; cb_id < max_cbs_; cb_id++) {
+        for (uint32_t cb_id = 0; cb_id < max_cbs_; cb_id++) {
             CircularBufferConfig config1 = CircularBufferConfig(cb_config.page_size, {{cb_id, cb_config.data_format}})
                                                .set_page_size(cb_id, cb_config.page_size);
             CreateCircularBuffer(program_, core, config1);

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -129,7 +129,7 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferAtValidIndices) {
 TEST_F(MeshDeviceFixture, TestCreateCircularBufferAtInvalidIndex) {
     CBConfig cb_config;
 
-    EXPECT_ANY_THROW(CircularBufferConfig(cb_config.page_size, {{NUM_CIRCULAR_BUFFERS, cb_config.data_format}}));
+    EXPECT_ANY_THROW(CircularBufferConfig(cb_config.page_size, {{max_cbs_, cb_config.data_format}}));
 }
 
 TEST_F(MeshDeviceFixture, TestCreateCircularBufferWithMismatchingConfig) {

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -32,6 +32,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
+        init_max_cbs();
     }
 
     void TearDown() override {
@@ -90,6 +91,7 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        init_max_cbs();
     }
 
     void CreateDevices(const size_t trace_region_size) { this->create_devices(trace_region_size); }
@@ -106,6 +108,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
+        init_max_cbs();
     }
 
     void TearDown() override {
@@ -174,6 +177,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices(90000000);
+        init_max_cbs();
     }
 };
 
@@ -208,6 +212,7 @@ protected:
         for (const auto& [id, device] : reserved_devices) {
             devices_.push_back(device);
         }
+        init_max_cbs();
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -38,6 +38,7 @@ protected:
             ids.push_back(id);
         }
         this->create_devices(ids);
+        init_max_cbs();
     }
 
     void TearDown() override {
@@ -99,6 +100,7 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
+        init_max_cbs();
     }
 
     void TearDown() override {
@@ -154,6 +156,7 @@ protected:
             GTEST_SKIP();
         }
         this->create_devices();
+        init_max_cbs();
     }
 };
 

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -63,6 +63,7 @@ protected:
     bool slow_dispatch_{};
     const size_t l1_small_size_{DEFAULT_L1_SMALL_SIZE};
     const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
+    uint32_t max_cbs_{};
 
     MeshDispatchFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
@@ -72,6 +73,8 @@ protected:
         this->DetectDispatchMode();
         // Must set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        init_max_cbs();
+
         std::vector<ChipId> ids;
         for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
             ids.push_back(id);
@@ -118,6 +121,8 @@ protected:
             this->slow_dispatch_ = false;
         }
     }
+
+    void init_max_cbs() { max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers(); }
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -137,6 +137,8 @@ protected:
                 *config_.mesh_shape);
         }
 
+        init_max_cbs();
+
         // Use ethernet dispatch for more than 1 CQ on T3K/N300
         auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
         bool is_n300_or_t3k_cluster =
@@ -173,7 +175,10 @@ protected:
         }
     }
 
+    void init_max_cbs() { max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers(); }
+
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
+    uint32_t max_cbs_{};
 
 private:
     Config config_;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -194,12 +194,12 @@ bool cb_config_successful(
     distributed::MeshWorkload& workload,
     const DummyProgramMultiCBConfig& program_config) {
     bool pass = true;
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
 
     // Need to use old APIs to read since we cannot allocate a buffer in the reserved space we're trying
     // to read from
     vector<uint32_t> cb_config_vector;
-    uint32_t cb_config_buffer_size =
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t cb_config_buffer_size = max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     auto* device = mesh_device->get_devices()[0];
     uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
     for (const CoreRange& core_range : program_config.cr_set.ranges()) {
@@ -1193,8 +1193,7 @@ TEST_F(UnitMeshCQFixture, TensixTestMultiCBSharedAddressSpaceSentSingleCore) {
     uint32_t num_tiles = 2;
     uint32_t cb_size = num_tiles * single_tile_size;
 
-    uint32_t cb_config_buffer_size =
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t cb_config_buffer_size = max_cbs_ * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     CoreCoord core_coord(0, 0);
 
     for (const auto& device : devices_) {
@@ -1475,8 +1474,8 @@ namespace multicore_tests {
 TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
-    std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
+    for (int i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1496,8 +1495,8 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
 TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
-    std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
+    for (int i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1538,8 +1537,8 @@ TEST_F(UnitMeshCQFixture, TensixTestMultiCbConfigsCorrectlySentUpdateSizeMultiCo
 TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
-    std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
+    for (int i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1562,8 +1561,8 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges)
 TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleCoreRanges) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
-    std::vector<CBConfig> cb_config_vector(NUM_CIRCULAR_BUFFERS, cb_config);
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
+    for (int i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1864,7 +1863,8 @@ namespace stress_tests {
 TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
     uint32_t NUM_WORKLOADS = 100;
     uint32_t MAX_LOOP = 100;
-    uint32_t page_size = 1024;
+    // Reduce page size on Blackhole to fit 64 CBs in L1
+    uint32_t page_size = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
 
     if (this->arch_ == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP();  // Running on second CQ is hanging on CI
@@ -1904,14 +1904,14 @@ TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
             BRISC_OUTER_LOOP = MAX_LOOP;
             BRISC_MIDDLE_LOOP = MAX_LOOP;
             BRISC_INNER_LOOP = MAX_LOOP;
-            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_CBS = max_cbs_;
             NUM_SEMS = NUM_SEMAPHORES;
             USE_MAX_RT_ARGS = true;
         } else {
             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_CBS = rand() % (max_cbs_) + 1;
             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
             USE_MAX_RT_ARGS = false;
         }
@@ -2143,7 +2143,8 @@ TEST_F(UnitMeshCQFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
 TEST_F(UnitMeshCQProgramFixture, TensixTestRandomizedProgram) {
     uint32_t NUM_WORKLOADS = 100;
     uint32_t MAX_LOOP = 100;
-    uint32_t page_size = 1024;
+    // Reduce page size on Blackhole to fit 64 CBs in L1
+    uint32_t page_size = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
 
     // Make random
     auto random_seed = 0;  // (unsigned int)time(NULL);
@@ -2185,14 +2186,14 @@ TEST_F(UnitMeshCQProgramFixture, TensixTestRandomizedProgram) {
             BRISC_OUTER_LOOP = MAX_LOOP;
             BRISC_MIDDLE_LOOP = MAX_LOOP;
             BRISC_INNER_LOOP = MAX_LOOP;
-            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_CBS = max_cbs_;
             NUM_SEMS = NUM_SEMAPHORES;
             USE_MAX_RT_ARGS = true;
         } else {
             BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
             BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
-            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_CBS = rand() % (max_cbs_) + 1;
             NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
             USE_MAX_RT_ARGS = false;
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1475,7 +1475,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultiCore) {
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
-    for (int i = 0; i < max_cbs_; i++) {
+    for (uint32_t i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1496,7 +1496,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultiCore
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
-    for (int i = 0; i < max_cbs_; i++) {
+    for (uint32_t i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1538,7 +1538,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentMultipleCoreRanges)
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
-    for (int i = 0; i < max_cbs_; i++) {
+    for (uint32_t i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1562,7 +1562,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllCbConfigsCorrectlySentUpdateSizeMultipleC
     CBConfig cb_config = {.num_pages = 1, .page_size = 2048, .data_format = tt::DataFormat::Float16_b};
 
     std::vector<CBConfig> cb_config_vector(max_cbs_, cb_config);
-    for (int i = 0; i < max_cbs_; i++) {
+    for (uint32_t i = 0; i < max_cbs_; i++) {
         cb_config_vector[i].cb_id = i;
     }
 
@@ -1863,8 +1863,9 @@ namespace stress_tests {
 TEST_F(UnitMeshMultiCQSingleDeviceProgramFixture, TensixTestRandomizedProgram) {
     uint32_t NUM_WORKLOADS = 100;
     uint32_t MAX_LOOP = 100;
-    // Reduce page size on Blackhole to fit 64 CBs in L1
-    uint32_t page_size = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
+    // Smaller page size for architectures with more CBs to ensure all test CBs fit in L1
+    constexpr uint32_t l1_cb_test_budget = 1024 * 32;
+    uint32_t page_size = l1_cb_test_budget / max_cbs_;
 
     if (this->arch_ == tt::ARCH::BLACKHOLE) {
         GTEST_SKIP();  // Running on second CQ is hanging on CI
@@ -2143,8 +2144,9 @@ TEST_F(UnitMeshCQFixture, DISABLED_TensixTestFillDispatchCoreBuffer) {
 TEST_F(UnitMeshCQProgramFixture, TensixTestRandomizedProgram) {
     uint32_t NUM_WORKLOADS = 100;
     uint32_t MAX_LOOP = 100;
-    // Reduce page size on Blackhole to fit 64 CBs in L1
-    uint32_t page_size = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? 1024 : 512;
+    // Smaller page size for architectures with more CBs to ensure all test CBs fit in L1
+    constexpr uint32_t l1_cb_test_budget = 1024 * 32;
+    uint32_t page_size = l1_cb_test_budget / max_cbs_;
 
     // Make random
     auto random_seed = 0;  // (unsigned int)time(NULL);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -286,8 +286,7 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
     uint32_t num_tiles = 2;
     uint32_t cb_size = num_tiles * single_tile_size;
 
-    uint32_t cb_config_buffer_size =
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t cb_config_buffer_size = max_cbs_ * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -413,8 +413,7 @@ TEST_F(EarlyReturnFixture, TensixKernelEarlyReturn) {
 TEST_F(MeshDispatchFixture, TensixCircularBufferInitFunction) {
     for (const auto& mesh_device : devices_) {
         for (bool use_assembly : {true, false}) {
-            // Test with 64-bit masks (low 32 bits, high 32 bits)
-            // mask_high is only used on Blackhole (64 CBs); Wormhole only has 32 CBs so mask_high is ignored
+            // mask_high only applies to architectures supporting more than 32 circular buffers
             for (auto [mask_low, mask_high] :
                  {std::make_pair(0xffffffffu, 0xffffffffu), std::make_pair(0xaaaaaaaau, 0xaaaaaaaau)}) {
                 CoreCoord core{0, 0};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -413,7 +413,10 @@ TEST_F(EarlyReturnFixture, TensixKernelEarlyReturn) {
 TEST_F(MeshDispatchFixture, TensixCircularBufferInitFunction) {
     for (const auto& mesh_device : devices_) {
         for (bool use_assembly : {true, false}) {
-            for (uint32_t mask : {0xffffffffu, 0xaaaaaaaau}) {
+            // Test with 64-bit masks (low 32 bits, high 32 bits)
+            // mask_high is only used on Blackhole (64 CBs); Wormhole only has 32 CBs so mask_high is ignored
+            for (auto [mask_low, mask_high] :
+                 {std::make_pair(0xffffffffu, 0xffffffffu), std::make_pair(0xaaaaaaaau, 0xaaaaaaaau)}) {
                 CoreCoord core{0, 0};
                 distributed::MeshWorkload workload;
                 auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -434,7 +437,7 @@ TEST_F(MeshDispatchFixture, TensixCircularBufferInitFunction) {
                         .defines = defines,
                         .opt_level = KernelBuildOptLevel::O2});
                 uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-                std::vector<uint32_t> runtime_args{mask, l1_unreserved_base};
+                std::vector<uint32_t> runtime_args{mask_low, mask_high, l1_unreserved_base};
                 SetRuntimeArgs(program, kernel, core, runtime_args);
                 workload.add_program(device_range, std::move(program));
                 this->RunProgram(mesh_device, workload);

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -36,6 +36,7 @@ protected:
         }
 
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        init_max_cbs();
         auto* enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
 
         // Check to deal with TG systems

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -105,6 +105,7 @@ protected:
         this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
 
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        init_max_cbs();
     }
 
     void CreateDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
@@ -149,6 +150,7 @@ protected:
         for (const auto& [id, device] : reserved_devices) {
             this->devices_.push_back(device);
         }
+        init_max_cbs();
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -37,7 +37,7 @@ protected:
     static const uint32_t MAX_NUM_SEMS = NUM_SEMAPHORES;
     static const uint32_t SEM_VAL = 1;
 
-    uint32_t max_num_cbs_;  // Runtime arch-specific value
+    uint32_t max_num_cbs_{0};  // Runtime arch-specific value
     static const uint32_t MIN_NUM_CBS = 0;
     static const uint32_t MIN_CB_PAGE_SIZE = 16;
     static const uint32_t MAX_CB_PAGE_SIZE = 64;
@@ -192,7 +192,7 @@ protected:
         return {unique_rt_args, common_rt_args};
     }
 
-    KernelProperties get_default_kernel_properties() {
+    KernelProperties get_default_kernel_properties() const {
         KernelProperties props;
         props.max_num_cbs = max_num_cbs_;
         return props;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
@@ -7,9 +7,9 @@
 #include "api/debug/assert.h"
 #include "api/debug/dprint.h"
 
-void check_cb_values(bool read, bool write, bool init_wr_tile_ptr, uint32_t initial_value, uint32_t mask) {
+void check_cb_values(bool read, bool write, bool init_wr_tile_ptr, uint32_t initial_value, uint64_t mask) {
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        if (!(mask & (1 << i))) {
+        if (!(mask & (1ULL << i))) {
             continue;  // Skip circular buffers that are not set up
         }
         uint32_t fifo_addr = initial_value + i * 4;
@@ -79,12 +79,17 @@ uint32_t get_clock_lo() {
 
 template <bool read, bool write, bool init_wr_tile_ptr>
 void perform_test(uint32_t initial_value) {
-    uint32_t mask = get_arg_val<uint32_t>(0);
+    // Mask is split into two 32-bit values since setup_local_cb_read_write_interfaces takes a 32-bit mask
+    // mask_high is only used on Blackhole (64 CBs); Wormhole only has 32 CBs so mask_high is ignored
+    uint32_t mask_low = get_arg_val<uint32_t>(0);
+    uint32_t mask_high = get_arg_val<uint32_t>(1);
+    uint64_t mask = (static_cast<uint64_t>(mask_high) << 32) | mask_low;
     DPRINT << "Performing test with read: " << static_cast<uint32_t>(read)
            << ", write: " << static_cast<uint32_t>(write)
-           << ", init_wr_tile_ptr: " << static_cast<uint32_t>(init_wr_tile_ptr) << ", mask: " << mask << ENDL();
+           << ", init_wr_tile_ptr: " << static_cast<uint32_t>(init_wr_tile_ptr) << ", mask_low: " << mask_low
+           << ", mask_high: " << mask_high << ENDL();
 
-    uint32_t tt_l1_ptr* cb_l1_base = get_arg_val<uint32_t tt_l1_ptr*>(1);
+    uint32_t tt_l1_ptr* cb_l1_base = get_arg_val<uint32_t tt_l1_ptr*>(2);
 
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS * 4; i++) {
         ((volatile uint32_t*)cb_l1_base)[i] = initial_value + i;
@@ -95,7 +100,12 @@ void perform_test(uint32_t initial_value) {
     }
 
     uint32_t start_time = get_clock_lo();
-    setup_local_cb_read_write_interfaces<read, write, init_wr_tile_ptr>(cb_l1_base, 0, mask);
+    // Initialize CBs 0-31
+    setup_local_cb_read_write_interfaces<read, write, init_wr_tile_ptr, false>(cb_l1_base, 0, mask_low);
+#ifdef ARCH_BLACKHOLE
+    // Initialize CBs 32-63
+    setup_local_cb_read_write_interfaces<read, write, init_wr_tile_ptr, false>(cb_l1_base, 32, mask_high);
+#endif
     uint32_t end_time = get_clock_lo();
     DPRINT << "Time taken for setup: " << (end_time - start_time) << " cycles" << ENDL();
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_init.cpp
@@ -79,8 +79,8 @@ uint32_t get_clock_lo() {
 
 template <bool read, bool write, bool init_wr_tile_ptr>
 void perform_test(uint32_t initial_value) {
-    // Mask is split into two 32-bit values since setup_local_cb_read_write_interfaces takes a 32-bit mask
-    // mask_high is only used on Blackhole (64 CBs); Wormhole only has 32 CBs so mask_high is ignored
+    // Mask split into 32-bit halves for RISC-V efficiency (setup_local_cb_read_write_interfaces)
+    // mask_high only used on Blackhole (Wormhole uses mask_low only)
     uint32_t mask_low = get_arg_val<uint32_t>(0);
     uint32_t mask_high = get_arg_val<uint32_t>(1);
     uint64_t mask = (static_cast<uint64_t>(mask_high) << 32) | mask_low;

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -91,7 +91,7 @@ def compute_reference_reduce_to_root(
 @pytest.mark.parametrize(
     "device_params",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 217872}),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 225280}),
     ],
     indirect=["device_params"],
     ids=["fabric_1d_linear_trace"],

--- a/tt_metal/api/tt-metalium/circular_buffer_constants.h
+++ b/tt_metal/api/tt-metalium/circular_buffer_constants.h
@@ -7,46 +7,37 @@
 #include <cstdint>
 
 // IMPORTANT: This file is included by BOTH host compilation AND device JIT compilation
-// Host compilation context (e.g., CircularBufferConfig, program building):
-//   - ARCH_WORMHOLE is NEVER defined
-//   - NUM_CIRCULAR_BUFFERS = 64
-//   - Host-side arrays/vectors are sized for 64 CBs (maximum across all architectures)
 //
-// Device compilation context (firmware kernels):
-//   - ARCH_WORMHOLE is defined ONLY when compiling for Wormhole devices
-//   - NUM_CIRCULAR_BUFFERS = 32 on Wormhole, 64 on Blackhole
-//   - Device firmware uses the correct per-architecture limit
+// Host compilation context:
+//   - ARCH_WORMHOLE is NEVER defined
+//   - NUM_CIRCULAR_BUFFERS uses the maximum across all architectures
+//   - Host-side arrays/vectors are sized for this maximum
+//
+// Device compilation context:
+//   - ARCH_WORMHOLE is defined ONLY when compiling for Wormhole
+//   - Wormhole has fewer CBs due to limited TRISC memory (2KB)
+//   - Blackhole supports the full CB count
 //
 // Why this works safely:
-//   - Host allocates space for up to 64 CBs in all data structures
+//   - Host allocates space for the maximum CB count in all data structures
 //   - Runtime validation (via hal.get_arch_num_circular_buffers()) prevents using
-//     CB indices >= 32 on Wormhole, so extra host slots remain unused
-//   - Device firmware only processes the CBs valid for that architecture
+//     CB indices beyond the device's actual limit
+//   - Device firmware only processes CBs valid for that architecture
 //
 // For NEW CODE:
-//   DO NOT USE NUM_CIRCULAR_BUFFERS to get the actual device limit.
+//   DO NOT USE NUM_CIRCULAR_BUFFERS to get the actual device limit
 //   USE: tt::tt_metal::hal::get_arch_num_circular_buffers() instead (See tt_metal/api/tt-metalium/hal.hpp)
 //
-// Why this split exists:
-//   - Host must allocate space for worst-case (64 CBs) in data structures
-//   - Runtime validation prevents using invalid CB indices on each architecture
-//   - Device firmware only processes CBs valid for that specific architecture
-//
-// TODO: This is TEMPORARY code structure : eventually will be replaced by Dataflow Buffers (DFBs)
-
-// Bit width of CB mask (uint64_t)
-constexpr static std::uint32_t CB_MASK_WIDTH = 64;
+// TODO: This is TEMPORARY code structure - eventually will be replaced by Dataflow Buffers (DFBs)
 
 #if defined(ARCH_WORMHOLE)
-// Device compilation for Wormhole: 32 CBs (limited by 2KB TRISC memory)
+// Device compilation for Wormhole (limited by 2KB TRISC memory)
 constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
 #else
-// Blackhole (64 CBs with 4KB TRISC) and HOST (uses max for array sizing)
+// Blackhole device and HOST compilation (uses max for array sizing)
 constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 64;
 #endif
 constexpr static std::uint32_t UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG = 4;
 constexpr static std::uint32_t UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG = 2;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_WORD_SIZE = 16;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT = 4;
-
-static_assert(NUM_CIRCULAR_BUFFERS <= CB_MASK_WIDTH, "Maximum CB count exceeds mask width");

--- a/tt_metal/api/tt-metalium/circular_buffer_constants.h
+++ b/tt_metal/api/tt-metalium/circular_buffer_constants.h
@@ -6,24 +6,47 @@
 
 #include <cstdint>
 
-// TODO: This file is used by both host and device.
-// TODO: This should be in the tt::tt_metal namespace.
+// IMPORTANT: This file is included by BOTH host compilation AND device JIT compilation
+// Host compilation context (e.g., CircularBufferConfig, program building):
+//   - ARCH_WORMHOLE is NEVER defined
+//   - NUM_CIRCULAR_BUFFERS = 64
+//   - Host-side arrays/vectors are sized for 64 CBs (maximum across all architectures)
+//
+// Device compilation context (firmware kernels):
+//   - ARCH_WORMHOLE is defined ONLY when compiling for Wormhole devices
+//   - NUM_CIRCULAR_BUFFERS = 32 on Wormhole, 64 on Blackhole
+//   - Device firmware uses the correct per-architecture limit
+//
+// Why this works safely:
+//   - Host allocates space for up to 64 CBs in all data structures
+//   - Runtime validation (via hal.get_arch_num_circular_buffers()) prevents using
+//     CB indices >= 32 on Wormhole, so extra host slots remain unused
+//   - Device firmware only processes the CBs valid for that architecture
+//
+// For NEW CODE:
+//   DO NOT USE NUM_CIRCULAR_BUFFERS to get the actual device limit.
+//   USE: tt::tt_metal::hal::get_arch_num_circular_buffers() instead (See tt_metal/api/tt-metalium/hal.hpp)
+//
+// Why this split exists:
+//   - Host must allocate space for worst-case (64 CBs) in data structures
+//   - Runtime validation prevents using invalid CB indices on each architecture
+//   - Device firmware only processes CBs valid for that specific architecture
+//
+// TODO: This is TEMPORARY code structure : eventually will be replaced by Dataflow Buffers (DFBs)
 
-// Circular buffer limits per architecture
-constexpr static std::uint32_t CB_MASK_WIDTH = 64;              // For 64-bit mask operations
-constexpr static std::uint32_t MAX_CIRCULAR_BUFFERS = 64;       // Maximum (Blackhole)
-constexpr static std::uint32_t WORMHOLE_CIRCULAR_BUFFERS = 32;  // Wormhole limit (TRISC 2KB)
+// Bit width of CB mask (uint64_t)
+constexpr static std::uint32_t CB_MASK_WIDTH = 64;
 
 #if defined(ARCH_WORMHOLE)
-// Device compilation for Wormhole
-constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = WORMHOLE_CIRCULAR_BUFFERS;
+// Device compilation for Wormhole: 32 CBs (limited by 2KB TRISC memory)
+constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
 #else
-// Blackhole and host (for array sizing)
-constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = MAX_CIRCULAR_BUFFERS;
+// Blackhole (64 CBs with 4KB TRISC) and HOST (uses max for array sizing)
+constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 64;
 #endif
 constexpr static std::uint32_t UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG = 4;
 constexpr static std::uint32_t UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG = 2;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_WORD_SIZE = 16;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT = 4;
 
-static_assert(MAX_CIRCULAR_BUFFERS <= CB_MASK_WIDTH, "Maximum CB count exceeds mask width");
+static_assert(NUM_CIRCULAR_BUFFERS <= CB_MASK_WIDTH, "Maximum CB count exceeds mask width");

--- a/tt_metal/api/tt-metalium/circular_buffer_constants.h
+++ b/tt_metal/api/tt-metalium/circular_buffer_constants.h
@@ -9,9 +9,21 @@
 // TODO: This file is used by both host and device.
 // TODO: This should be in the tt::tt_metal namespace.
 
-// TODO: This will no longer be a constant, swap this out with a getter ASAP.
-constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
+// Circular buffer limits per architecture
+constexpr static std::uint32_t CB_MASK_WIDTH = 64;              // For 64-bit mask operations
+constexpr static std::uint32_t MAX_CIRCULAR_BUFFERS = 64;       // Maximum (Blackhole)
+constexpr static std::uint32_t WORMHOLE_CIRCULAR_BUFFERS = 32;  // Wormhole limit (TRISC 2KB)
+
+#if defined(ARCH_WORMHOLE)
+// Device compilation for Wormhole
+constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = WORMHOLE_CIRCULAR_BUFFERS;
+#else
+// Blackhole and host (for array sizing)
+constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = MAX_CIRCULAR_BUFFERS;
+#endif
 constexpr static std::uint32_t UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG = 4;
 constexpr static std::uint32_t UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG = 2;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_WORD_SIZE = 16;
 constexpr static std::uint32_t CIRCULAR_BUFFER_COMPUTE_ADDR_SHIFT = 4;
+
+static_assert(MAX_CIRCULAR_BUFFERS <= CB_MASK_WIDTH, "Maximum CB count exceeds mask width");

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -98,4 +98,11 @@ float get_nan();
  */
 float get_inf();
 
+/**
+ * @brief Uses the hardware abstraction layer to get the maximum number of circular buffers per core.
+ *
+ * @return Maximum number of circular buffers (64 for Blackhole, 32 for Wormhole)
+ */
+uint32_t get_arch_num_circular_buffers();
+
 }  // namespace tt::tt_metal::hal

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -101,7 +101,7 @@ float get_inf();
 /**
  * @brief Uses the hardware abstraction layer to get the maximum number of circular buffers per core.
  *
- * @return Maximum number of circular buffers (64 for Blackhole, 32 for Wormhole)
+ * @return Maximum number of circular buffers
  */
 uint32_t get_arch_num_circular_buffers();
 

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -192,7 +192,7 @@ KernelHandle CreateKernelFromString(
 //                  HOST API: buffers
 // ==================================================
 /**
- * Creates a Circular Buffer (CB) in L1 memory of all cores within core ranges (inclusive) and adds it to the program. There can be a total of NUM_CIRCULAR_BUFFERS (32 or 64 depending on architecture) circular buffers per core.
+ * Creates a Circular Buffer (CB) in L1 memory of all cores within core ranges (inclusive) and adds it to the program. The number of CBs is architecture-specific.
  * Circular buffers hold data and have an associated config which indicates usage of the address space.
  * If the config is specified for multiple buffer indices, the circular buffer address space is shared and each buffer index can potentially have a unique view of the shared space.
  *

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -192,7 +192,7 @@ KernelHandle CreateKernelFromString(
 //                  HOST API: buffers
 // ==================================================
 /**
- * Creates a Circular Buffer (CB) in L1 memory of all cores within core ranges (inclusive) and adds it to the program. There can be a total of NUM_CIRCULAR_BUFFERS (32) circular buffers per core.
+ * Creates a Circular Buffer (CB) in L1 memory of all cores within core ranges (inclusive) and adds it to the program. There can be a total of NUM_CIRCULAR_BUFFERS (32 or 64 depending on architecture) circular buffers per core.
  * Circular buffers hold data and have an associated config which indicates usage of the address space.
  * If the config is specified for multiple buffer indices, the circular buffer address space is shared and each buffer index can potentially have a unique view of the shared space.
  *

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -61,4 +61,8 @@ float get_nan() { return tt::tt_metal::MetalContext::instance().hal().get_nan();
 
 float get_inf() { return tt::tt_metal::MetalContext::instance().hal().get_inf(); }
 
+uint32_t get_arch_num_circular_buffers() {
+    return tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
+}
+
 }  // namespace tt::tt_metal::hal

--- a/tt_metal/hostdevcommon/api/hostdevcommon/kernel_structs.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/kernel_structs.h
@@ -7,6 +7,9 @@
 
 namespace tt {
 
+// Note: Max CB count is architecture-dependent (Wormhole: 32, Blackhole: 64).
+// Use hal.get_arch_num_circular_buffers() for runtime validation.
+// CB indices c_32 through c_63 are only valid on Blackhole.
 enum CBIndex : std::uint8_t {
     c_0 = 0,
     c_1 = 1,
@@ -40,7 +43,38 @@ enum CBIndex : std::uint8_t {
     c_29 = 29,
     c_30 = 30,
     c_31 = 31,
-    SIZE = 32
+    c_32 = 32,
+    c_33 = 33,
+    c_34 = 34,
+    c_35 = 35,
+    c_36 = 36,
+    c_37 = 37,
+    c_38 = 38,
+    c_39 = 39,
+    c_40 = 40,
+    c_41 = 41,
+    c_42 = 42,
+    c_43 = 43,
+    c_44 = 44,
+    c_45 = 45,
+    c_46 = 46,
+    c_47 = 47,
+    c_48 = 48,
+    c_49 = 49,
+    c_50 = 50,
+    c_51 = 51,
+    c_52 = 52,
+    c_53 = 53,
+    c_54 = 54,
+    c_55 = 55,
+    c_56 = 56,
+    c_57 = 57,
+    c_58 = 58,
+    c_59 = 59,
+    c_60 = 60,
+    c_61 = 61,
+    c_62 = 62,
+    c_63 = 63,
 };
 
 // Deprecated and to be deleted.

--- a/tt_metal/hostdevcommon/api/hostdevcommon/kernel_structs.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/kernel_structs.h
@@ -7,9 +7,8 @@
 
 namespace tt {
 
-// Note: Max CB count is architecture-dependent (Wormhole: 32, Blackhole: 64).
+// Note: Max CB count is architecture-dependent.
 // Use hal.get_arch_num_circular_buffers() for runtime validation.
-// CB indices c_32 through c_63 are only valid on Blackhole.
 enum CBIndex : std::uint8_t {
     c_0 = 0,
     c_1 = 1,

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -478,8 +478,8 @@ int main() {
             WAYPOINT("R");
             int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
             if (enables & (1u << index)) {
-                // CB mask split: low bits for lower CB indices, high bits for upper CB indices
-                // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+                // Split 64-bit CB mask into 32-bit halves for efficient RISC-V processing
+                // Wormhole: lower half only (TRISC memory constraint), Blackhole: both halves
                 uint64_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
                 uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
                 setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -478,12 +478,13 @@ int main() {
             WAYPOINT("R");
             int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
             if (enables & (1u << index)) {
-                // Setup CBs 0-31 from low 32 bits, CBs 32-63 from high 32 bits (Blackhole only)
-                // shift_mask=false since masks are pre-shifted
-                uint32_t local_cb_mask_low = launch_msg_address->kernel_config.local_cb_mask & 0xFFFFFFFF;
+                // CB mask split: low bits for lower CB indices, high bits for upper CB indices
+                // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+                uint64_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
+                uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
                 setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);
 #ifdef ARCH_BLACKHOLE
-                uint32_t local_cb_mask_upper = launch_msg_address->kernel_config.local_cb_mask >> 32;
+                uint32_t local_cb_mask_upper = static_cast<uint32_t>(local_cb_mask >> 32);
                 setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 32, local_cb_mask_upper);
 #endif
                 cb_l1_base =

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -478,8 +478,14 @@ int main() {
             WAYPOINT("R");
             int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
             if (enables & (1u << index)) {
-                uint32_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
-                setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
+                // Setup CBs 0-31 from low 32 bits, CBs 32-63 from high 32 bits (Blackhole only)
+                // shift_mask=false since masks are pre-shifted
+                uint32_t local_cb_mask_low = launch_msg_address->kernel_config.local_cb_mask & 0xFFFFFFFF;
+                setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);
+#ifdef ARCH_BLACKHOLE
+                uint32_t local_cb_mask_upper = launch_msg_address->kernel_config.local_cb_mask >> 32;
+                setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 32, local_cb_mask_upper);
+#endif
                 cb_l1_base =
                     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.remote_cb_offset);
                 uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -139,8 +139,14 @@ int main(int argc, char* argv[]) {
 #endif
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
-        setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
+        // Setup CBs 0-31 from low 32 bits, CBs 32-63 from high 32 bits (Blackhole only)
+        // shift_mask=false since masks are pre-shifted
+        uint32_t local_cb_mask_low = launch_msg->kernel_config.local_cb_mask & 0xFFFFFFFF;
+        setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);
+#ifdef ARCH_BLACKHOLE
+        uint32_t local_cb_mask_upper = launch_msg->kernel_config.local_cb_mask >> 32;
+        setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 32, local_cb_mask_upper);
+#endif
 
 #if defined(ARCH_WORMHOLE)
         l1_to_ncrisc_iram_copy_wait();

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -139,12 +139,13 @@ int main(int argc, char* argv[]) {
 #endif
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        // Setup CBs 0-31 from low 32 bits, CBs 32-63 from high 32 bits (Blackhole only)
-        // shift_mask=false since masks are pre-shifted
-        uint32_t local_cb_mask_low = launch_msg->kernel_config.local_cb_mask & 0xFFFFFFFF;
+        // CB mask split: low bits for lower CB indices, high bits for upper CB indices
+        // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+        uint64_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
+        uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
         setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);
 #ifdef ARCH_BLACKHOLE
-        uint32_t local_cb_mask_upper = launch_msg->kernel_config.local_cb_mask >> 32;
+        uint32_t local_cb_mask_upper = static_cast<uint32_t>(local_cb_mask >> 32);
         setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 32, local_cb_mask_upper);
 #endif
 

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -139,8 +139,8 @@ int main(int argc, char* argv[]) {
 #endif
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        // CB mask split: low bits for lower CB indices, high bits for upper CB indices
-        // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+        // Split 64-bit CB mask into 32-bit halves for efficient RISC-V processing
+        // Wormhole: lower half only (TRISC memory constraint), Blackhole: both halves
         uint64_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
         uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
         setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -155,8 +155,8 @@ int main(int argc, char* argv[]) {
 #if !defined(UCK_CHLKC_MATH)
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        // CB mask split: low bits for lower CB indices, high bits for upper CB indices
-        // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+        // Split 64-bit CB mask into 32-bit halves for efficient RISC-V processing
+        // Wormhole: lower half only (TRISC memory constraint), Blackhole: both halves
         uint64_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
         uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
         setup_local_cb_read_write_interfaces<cb_init_read, cb_init_write, cb_init_write, false>(

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -155,13 +155,14 @@ int main(int argc, char* argv[]) {
 #if !defined(UCK_CHLKC_MATH)
         uint32_t tt_l1_ptr* cb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        // Setup CBs 0-31 from low 32 bits, CBs 32-63 from high 32 bits (Blackhole only)
-        // shift_mask=false since masks are pre-shifted
-        uint32_t local_cb_mask_low = launch_msg->kernel_config.local_cb_mask & 0xFFFFFFFF;
+        // CB mask split: low bits for lower CB indices, high bits for upper CB indices
+        // Wormhole uses only lower half (TRISC memory limit), Blackhole uses both
+        uint64_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
+        uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
         setup_local_cb_read_write_interfaces<cb_init_read, cb_init_write, cb_init_write, false>(
             cb_l1_base, 0, local_cb_mask_low);
 #ifdef ARCH_BLACKHOLE
-        uint32_t local_cb_mask_upper = launch_msg->kernel_config.local_cb_mask >> 32;
+        uint32_t local_cb_mask_upper = static_cast<uint32_t>(local_cb_mask >> 32);
         setup_local_cb_read_write_interfaces<cb_init_read, cb_init_write, cb_init_write, false>(
             cb_l1_base, 32, local_cb_mask_upper);
 #endif

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <utility>
 
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
@@ -179,7 +180,7 @@ static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint32_t) ==
 static_assert(offsetof(kernel_config_msg_t, host_assigned_id) % sizeof(uint32_t) == 0);
 
 // Ensure local_cb_mask size matches CB_MASK_WIDTH
-static_assert(sizeof(((kernel_config_msg_t*)0)->local_cb_mask) * 8 == CB_MASK_WIDTH);
+static_assert(sizeof(decltype(std::declval<kernel_config_msg_t&>().local_cb_mask)) * 8 == CB_MASK_WIDTH);
 
 struct go_msg_t {
     union {

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -160,7 +160,6 @@ struct kernel_config_msg_t {
 
     volatile uint8_t sub_device_origin_x;  // Logical X coordinate of the sub device origin
     volatile uint8_t sub_device_origin_y;  // Logical Y coordinate of the sub device origin
-    // Padding adjusted to maintain 16-byte alignment after local_cb_mask changed to uint64_t
     volatile uint8_t pad3[1 + ((1 - MaxProcessorsPerCoreType % 2) * 2) + 12];  // CODEGEN:skip
 
     volatile uint8_t preload;  // Must be at end, so it's only written when all other data is written.

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -26,11 +26,9 @@
 
 #include <atomic>
 #include <cstdint>
-#include <utility>
 
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
-#include "tt-metalium/circular_buffer_constants.h"
 
 #ifdef HAL_BUILD
 // HAL will include this file for different arch/cores, resulting in conflicting definitions that
@@ -177,9 +175,6 @@ static_assert(offsetof(kernel_config_msg_t, rta_offset) % sizeof(uint16_t) == 0)
 static_assert(offsetof(kernel_config_msg_t, kernel_text_offset) % sizeof(uint32_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint64_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, host_assigned_id) % sizeof(uint32_t) == 0);
-
-// Ensure local_cb_mask size matches CB_MASK_WIDTH
-static_assert(sizeof(decltype(std::declval<kernel_config_msg_t&>().local_cb_mask)) * 8 == CB_MASK_WIDTH);
 
 struct go_msg_t {
     union {

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -173,10 +173,9 @@ static_assert(offsetof(kernel_config_msg_t, kernel_config_base) % sizeof(uint32_
 static_assert(offsetof(kernel_config_msg_t, sem_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, local_cb_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, remote_cb_offset) % sizeof(uint16_t) == 0);
-static_assert(offsetof(kernel_config_msg_t, remote_cb_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, rta_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, kernel_text_offset) % sizeof(uint32_t) == 0);
-static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint32_t) == 0);
+static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint64_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, host_assigned_id) % sizeof(uint32_t) == 0);
 
 // Ensure local_cb_mask size matches CB_MASK_WIDTH

--- a/tt_metal/hw/inc/internal/circular_buffer_init.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_init.h
@@ -13,13 +13,16 @@
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-template <bool read, bool write, bool init_wr_tile_ptr>
+// shift_mask: When true (default), shifts mask by start_cb_index before processing
+// Set shift_mask to false when mask bits are already aligned (pre-shifted for upper CBs)
+template <bool read, bool write, bool init_wr_tile_ptr, bool shift_mask = true>
 FORCE_INLINE void setup_local_cb_read_write_interfaces(
     uint32_t tt_l1_ptr* cb_l1_base, uint32_t start_cb_index, uint32_t local_cb_mask) {
     volatile tt_l1_ptr uint32_t* circular_buffer_config_addr =
         cb_l1_base + start_cb_index * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
-
-    local_cb_mask >>= start_cb_index;
+    if constexpr (shift_mask) {
+        local_cb_mask >>= start_cb_index;
+    }
     uint32_t cb_id = start_cb_index;
     LocalCBInterface* local_interface_ptr = &get_local_cb_interface(cb_id);
 

--- a/tt_metal/hw/inc/internal/circular_buffer_init.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_init.h
@@ -176,6 +176,11 @@ inline void setup_remote_cb_interfaces(
     for (uint32_t cb_id = NUM_CIRCULAR_BUFFERS - 1, end_id = start_cb_index - 1; cb_id != end_id; cb_id--) {
         uint32_t config_addr = circular_buffer_config_addr[0];
         uint32_t page_size = circular_buffer_config_addr[1];
+        circular_buffer_config_addr += UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG;
+        // Skip unconfigured remote CBs - config_addr will be 0 if no remote CB was configured at this index
+        if (config_addr == 0) {
+            continue;
+        }
         volatile tt_l1_ptr uint32_t* l1_remote_cb_config_addr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_addr);
         const bool is_sender = l1_remote_cb_config_addr[0];
@@ -209,7 +214,6 @@ inline void setup_remote_cb_interfaces(
             // Using posted semaphore inc
             resize_remote_receiver_cb_interface<update_remote_over_noc>(cb_id, page_size, noc, nm, posted, cmd_buf);
         }
-        circular_buffer_config_addr += UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG;
     }
 }
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12768
+#define MEM_MAILBOX_SIZE 12896
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -64,20 +64,20 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1024)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 2560)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
-#define MEM_NCRISC_FIRMWARE_SIZE 1536
-#define MEM_TRISC0_FIRMWARE_SIZE 1536
-#define MEM_TRISC1_FIRMWARE_SIZE 1536
-#define MEM_TRISC2_FIRMWARE_SIZE 1536
+#define MEM_NCRISC_FIRMWARE_SIZE (2560)
+#define MEM_TRISC0_FIRMWARE_SIZE (2560)
+#define MEM_TRISC1_FIRMWARE_SIZE (2560)
+#define MEM_TRISC2_FIRMWARE_SIZE (2560)
 
 // Blackhole Architecture - No IRAM constraints
 // Per-kernel limits set to maximum available L1
 // These are enforced by the ELF loader in tt_elffile.cpp
 // The real constraint is the kernel_config_buffer aggregate limit, configurable via
 // worker_l1_size in MeshDevice::create_unit_meshes
-// 1503 KB = 1536 KB (L1 total) - 33 KB (MEM_MAP_END system reserved)
-#define MEM_MAX_KERNEL_SIZE (1503 * 1024)
+// Max kernel size = 1536 KB (L1 total) - MEM_MAP_END (system reserved)
+#define MEM_MAX_KERNEL_SIZE (1497 * 1024)
 
 #define MEM_BRISC_KERNEL_SIZE MEM_MAX_KERNEL_SIZE
 #define MEM_NCRISC_KERNEL_SIZE MEM_MAX_KERNEL_SIZE

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -66,10 +66,10 @@
 // Firmware/kernel code holes
 #define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 2560)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
-#define MEM_NCRISC_FIRMWARE_SIZE (2560)
-#define MEM_TRISC0_FIRMWARE_SIZE (2560)
-#define MEM_TRISC1_FIRMWARE_SIZE (2560)
-#define MEM_TRISC2_FIRMWARE_SIZE (2560)
+#define MEM_NCRISC_FIRMWARE_SIZE 2560
+#define MEM_TRISC0_FIRMWARE_SIZE 2560
+#define MEM_TRISC1_FIRMWARE_SIZE 2560
+#define MEM_TRISC2_FIRMWARE_SIZE 2560
 
 // Blackhole Architecture - No IRAM constraints
 // Per-kernel limits set to maximum available L1

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
@@ -9,15 +9,10 @@
 
 #include "internal/risc_attribs.h"
 
-// TODO: in ll-buda we can probably just start at stream 0 and not at stream 8?
-/*
-   Kernel operand mapping scheme:
-   - ID 0-7 (inputs, unpacker-only) => streams 8-15
-   - ID 8-15 (params, unpacker-only) => streams 16-23
-   - ID 16-23 (outputs, packer-only) => streams 24-31
-   - ID 24-31 (intermediates, packer/unpacker) => streams 32-39
-*/
-const uint32_t OPERAND_START_STREAM = 8;
+// Changed from OPERAND_START_STREAM = 8 to 0 to support 64 CBs on Blackhole
+// Streams 0-7 were previously reserved for legacy ll-buda compatibility but are now used
+// Mapping: CB/operand ID N -> stream N (0-63)
+const uint32_t OPERAND_START_STREAM = 0;
 
 // Indexed with operand = kernel operand ID (0-31) per the table above
 // Used for tile push/pop operations.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
@@ -9,7 +9,7 @@
 
 #include "internal/risc_attribs.h"
 
-// Changed from OPERAND_START_STREAM = 8 to 0 to support 64 CBs on Blackhole
+// Changed from OPERAND_START_STREAM = 8 to 0 to support increased CB count on Blackhole
 // Streams 0-7 were previously reserved for legacy ll-buda compatibility but are now used
 // Mapping: CB/operand ID N -> stream N (0-63)
 const uint32_t OPERAND_START_STREAM = 0;

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/stream_io_map.h
@@ -9,9 +9,7 @@
 
 #include "internal/risc_attribs.h"
 
-// Changed from OPERAND_START_STREAM = 8 to 0 to support increased CB count on Blackhole
-// Streams 0-7 were previously reserved for legacy ll-buda compatibility but are now used
-// Mapping: CB/operand ID N -> stream N (0-63)
+// Stream-to-CB mapping: stream index maps directly to CB index (stream N -> CB N)
 const uint32_t OPERAND_START_STREAM = 0;
 
 // Indexed with operand = kernel operand ID (0-31) per the table above

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -86,7 +86,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12768
+#define MEM_MAILBOX_SIZE 12896
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 8)

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_io_map.h
@@ -9,9 +9,7 @@
 
 #include "internal/risc_attribs.h"
 
-// OPERAND_START_STREAM changed from 8 to 0 for consistency with Blackhole
-// Streams 0-7 were previously reserved but are now used
-// Mapping: CB/operand ID N -> stream N (0-31)
+// Stream-to-CB mapping: stream index maps directly to CB index (stream N -> CB N)
 const uint32_t OPERAND_START_STREAM = 0;
 
 // Indexed with operand = kernel operand ID (0-31) per the table above

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/stream_io_map.h
@@ -9,15 +9,10 @@
 
 #include "internal/risc_attribs.h"
 
-// TODO: in ll-buda we can probably just start at stream 0 and not at stream 8?
-/*
-   Kernel operand mapping scheme:
-   - ID 0-7 (inputs, unpacker-only) => streams 8-15
-   - ID 8-15 (params, unpacker-only) => streams 16-23
-   - ID 16-23 (outputs, packer-only) => streams 24-31
-   - ID 24-31 (intermediates, packer/unpacker) => streams 32-39
-*/
-const uint32_t OPERAND_START_STREAM = 8;
+// OPERAND_START_STREAM changed from 8 to 0 for consistency with Blackhole
+// Streams 0-7 were previously reserved but are now used
+// Mapping: CB/operand ID N -> stream N (0-31)
+const uint32_t OPERAND_START_STREAM = 0;
 
 // Indexed with operand = kernel operand ID (0-31) per the table above
 // Used for tile push/pop operations.

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -96,7 +96,7 @@
 #define MEM_MAILBOX_BASE 16
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 30272
+#define MEM_MAILBOX_SIZE 30400
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/stream_io_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/stream_io_map.h
@@ -9,15 +9,8 @@
 
 #include "internal/risc_attribs.h"
 
-// TODO: in ll-buda we can probably just start at stream 0 and not at stream 8?
-/*
-   Kernel operand mapping scheme:
-   - ID 0-7 (inputs, unpacker-only) => streams 8-15
-   - ID 8-15 (params, unpacker-only) => streams 16-23
-   - ID 16-23 (outputs, packer-only) => streams 24-31
-   - ID 24-31 (intermediates, packer/unpacker) => streams 32-39
-*/
-const uint32_t OPERAND_START_STREAM = 8;
+// Note: Quasar doesn't have streaming registers - these definitions exist for code compatibility
+const uint32_t OPERAND_START_STREAM = 0;
 
 // Indexed with operand = kernel operand ID (0-31) per the table above
 // Used for tile push/pop operations.

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
 #include <tt-logger/tt-logger.hpp>
+#include "impl/context/metal_context.hpp"
 
 namespace tt {
 enum class DataFormat : uint8_t;

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -41,11 +41,12 @@ CircularBufferConfig::CircularBufferConfig(const CBDescriptor& descriptor) : tot
     }
 
     auto process_format_descriptor = [this](const CBFormatDescriptor& format_descriptor) {
-        if (format_descriptor.buffer_index > NUM_CIRCULAR_BUFFERS - 1) {
+        uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+        if (format_descriptor.buffer_index > max_cbs - 1) {
             TT_THROW(
                 "Buffer index ({}) exceeds max number of circular buffers per core ({})",
                 format_descriptor.buffer_index,
-                NUM_CIRCULAR_BUFFERS);
+                max_cbs);
         }
         this->data_formats_[format_descriptor.buffer_index] = format_descriptor.data_format;
         if (this->total_size_ % format_descriptor.page_size != 0) {
@@ -101,11 +102,9 @@ CircularBufferConfig::CircularBufferConfig(
     buffer_size_(buffer_size) {}
 
 CircularBufferConfig& CircularBufferConfig::set_page_size(uint8_t buffer_index, uint32_t page_size) {
-    if (buffer_index > NUM_CIRCULAR_BUFFERS - 1) {
-        TT_THROW(
-            "Buffer index ({}) exceeds max number of circular buffers per core ({})",
-            buffer_index,
-            NUM_CIRCULAR_BUFFERS);
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    if (buffer_index > max_cbs - 1) {
+        TT_THROW("Buffer index ({}) exceeds max number of circular buffers per core ({})", buffer_index, max_cbs);
     }
     if (!this->buffer_indices_.contains(buffer_index)) {
         TT_THROW(
@@ -221,11 +220,9 @@ CircularBufferConfig::Builder CircularBufferConfig::Builder::RemoteBuilder(
 
 CircularBufferConfig::Builder::Builder(CircularBufferConfig& parent, uint8_t buffer_index) :
     parent_(parent), buffer_index_(buffer_index) {
-    if (buffer_index > NUM_CIRCULAR_BUFFERS - 1) {
-        TT_THROW(
-            "Buffer index ({}) exceeds max number of circular buffers per core ({})",
-            buffer_index,
-            NUM_CIRCULAR_BUFFERS);
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    if (buffer_index > max_cbs - 1) {
+        TT_THROW("Buffer index ({}) exceeds max number of circular buffers per core ({})", buffer_index, max_cbs);
     }
     parent_.buffer_indices_.insert(buffer_index_);
 }
@@ -259,19 +256,17 @@ CircularBufferConfig::Builder CircularBufferConfig::remote_index(uint8_t buffer_
 }
 
 void CircularBufferConfig::set_config(const std::map<uint8_t, tt::DataFormat>& data_format_spec) {
-    if (data_format_spec.size() > NUM_CIRCULAR_BUFFERS) {
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    if (data_format_spec.size() > max_cbs) {
         TT_THROW(
             "Only {} circular buffer slots are available but data formats are specified for {} indices",
-            NUM_CIRCULAR_BUFFERS,
+            max_cbs,
             data_format_spec.size());
     }
 
     for (const auto& [buffer_index, data_format] : data_format_spec) {
-        if (buffer_index > NUM_CIRCULAR_BUFFERS - 1) {
-            TT_THROW(
-                "Buffer index ({}) exceeds max number of circular buffers per core ({})",
-                buffer_index,
-                NUM_CIRCULAR_BUFFERS);
+        if (buffer_index > max_cbs - 1) {
+            TT_THROW("Buffer index ({}) exceeds max number of circular buffers per core ({})", buffer_index, max_cbs);
         }
         this->data_formats_[buffer_index] = data_format;
         this->buffer_indices_.insert(buffer_index);

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -41,7 +41,7 @@ CircularBufferConfig::CircularBufferConfig(const CBDescriptor& descriptor) : tot
     }
 
     auto process_format_descriptor = [this](const CBFormatDescriptor& format_descriptor) {
-        uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+        uint32_t max_cbs = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
         if (format_descriptor.buffer_index > max_cbs - 1) {
             TT_THROW(
                 "Buffer index ({}) exceeds max number of circular buffers per core ({})",
@@ -102,7 +102,7 @@ CircularBufferConfig::CircularBufferConfig(
     buffer_size_(buffer_size) {}
 
 CircularBufferConfig& CircularBufferConfig::set_page_size(uint8_t buffer_index, uint32_t page_size) {
-    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    uint32_t max_cbs = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
     if (buffer_index > max_cbs - 1) {
         TT_THROW("Buffer index ({}) exceeds max number of circular buffers per core ({})", buffer_index, max_cbs);
     }
@@ -220,7 +220,7 @@ CircularBufferConfig::Builder CircularBufferConfig::Builder::RemoteBuilder(
 
 CircularBufferConfig::Builder::Builder(CircularBufferConfig& parent, uint8_t buffer_index) :
     parent_(parent), buffer_index_(buffer_index) {
-    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    uint32_t max_cbs = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
     if (buffer_index > max_cbs - 1) {
         TT_THROW("Buffer index ({}) exceeds max number of circular buffers per core ({})", buffer_index, max_cbs);
     }
@@ -256,7 +256,7 @@ CircularBufferConfig::Builder CircularBufferConfig::remote_index(uint8_t buffer_
 }
 
 void CircularBufferConfig::set_config(const std::map<uint8_t, tt::DataFormat>& data_format_spec) {
-    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    uint32_t max_cbs = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
     if (data_format_spec.size() > max_cbs) {
         TT_THROW(
             "Only {} circular buffer slots are available but data formats are specified for {} indices",

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -1055,10 +1055,11 @@ void WatcherDeviceReader::Core::DumpSyncRegs() const {
     }
 
     uint32_t operand_start_stream = hal.get_operand_start_stream();
+    uint32_t max_cbs = hal.get_arch_num_circular_buffers();
 
     // Read back all of the stream state, most of it is unused
     std::vector<uint32_t> data;
-    for (uint32_t operand = 0; operand < NUM_CIRCULAR_BUFFERS; operand++) {
+    for (uint32_t operand = 0; operand < max_cbs; operand++) {
         uint32_t base = NOC_OVERLAY_START_ADDR + ((operand_start_stream + operand) * NOC_STREAM_REG_SPACE_SIZE);
 
         uint32_t rcvd_addr = base + (STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX * sizeof(uint32_t));

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -315,12 +315,8 @@ uint32_t finalize_cbs(
         auto kernel_config = kg->launch_msg.view().kernel_config();
         uint64_t local_cb_mask = kernel_config.local_cb_mask();
         uint32_t current_local_end_index =
-            local_cb_mask == 0 ? 0 : CB_MASK_WIDTH - (uint32_t)__builtin_clzll(local_cb_mask);
-        TT_ASSERT(
-            current_local_end_index <= CB_MASK_WIDTH,
-            "Calculated CB index {} exceeds CB_MASK_WIDTH {}",
-            current_local_end_index,
-            CB_MASK_WIDTH);
+            local_cb_mask == 0 ? 0
+                               : ProgramImpl::cb_mask_width_ - static_cast<uint32_t>(__builtin_clzll(local_cb_mask));
         max_local_end_index = std::max(max_local_end_index, current_local_end_index);
         min_remote_start_index = std::min(min_remote_start_index, (uint32_t)kernel_config.min_remote_cb_start_index());
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -308,16 +308,22 @@ uint32_t finalize_cbs(
     uint32_t& cb_size,
     uint32_t& local_cb_size) {
     uint32_t max_local_end_index = 0;
-    uint32_t min_remote_start_index = NUM_CIRCULAR_BUFFERS;
+    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    uint32_t min_remote_start_index = max_cbs;
 
     for (auto& kg : kernel_groups) {
         auto kernel_config = kg->launch_msg.view().kernel_config();
-        uint32_t local_cb_mask = kernel_config.local_cb_mask();
-        uint32_t current_local_end_index = local_cb_mask == 0 ? 0 : 32 - __builtin_clz(local_cb_mask);
+        uint64_t local_cb_mask = kernel_config.local_cb_mask();
+        uint32_t current_local_end_index =
+            local_cb_mask == 0 ? 0 : CB_MASK_WIDTH - (uint32_t)__builtin_clzll(local_cb_mask);
+        TT_ASSERT(
+            current_local_end_index <= CB_MASK_WIDTH,
+            "Calculated CB index {} exceeds CB_MASK_WIDTH {}",
+            current_local_end_index,
+            CB_MASK_WIDTH);
         max_local_end_index = std::max(max_local_end_index, current_local_end_index);
         min_remote_start_index = std::min(min_remote_start_index, (uint32_t)kernel_config.min_remote_cb_start_index());
     }
-
     local_cb_size = max_local_end_index * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     uint32_t remote_cb_offset = base_offset + local_cb_size;
     for (auto& kg : kernel_groups) {
@@ -325,9 +331,8 @@ uint32_t finalize_cbs(
         kernel_config.local_cb_offset() = base_offset;
         kernel_config.remote_cb_offset() = remote_cb_offset;
     }
-
-    uint32_t remote_cb_size = (NUM_CIRCULAR_BUFFERS - min_remote_start_index) *
-                              UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+    uint32_t remote_cb_size =
+        (max_cbs - min_remote_start_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     uint32_t total_cb_size = local_cb_size + remote_cb_size;
     cb_offset = base_offset;
     cb_size = total_cb_size;
@@ -1071,6 +1076,7 @@ public:
     void construct_commands(
         IDevice* device, const CommandConstants& constants, ProgramImpl& program, BatchedTransfers& batched_transfers) {
         const auto& hal = MetalContext::instance().hal();
+        uint32_t max_cbs = hal.get_arch_num_circular_buffers();
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
         const auto& circular_buffers_unique_coreranges = program.circular_buffers_unique_coreranges();
@@ -1106,8 +1112,8 @@ public:
                     }
                     for (const auto& buffer_index : cb->remote_buffer_indices()) {
                         const uint32_t base_index =
-                            remote_offset_index + ((NUM_CIRCULAR_BUFFERS - 1 - buffer_index) *
-                                                   UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
+                            remote_offset_index +
+                            ((max_cbs - 1 - buffer_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
                         cb_config_payload[base_index] = cb->config_address();
                         cb_config_payload[base_index + 1] = cb->page_size(buffer_index);
                         max_index = std::max(max_index, base_index + UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
@@ -2045,6 +2051,7 @@ void update_program_dispatch_commands(
     }
 
     // Update CB Configs
+    uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
     for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
@@ -2063,7 +2070,7 @@ void update_program_dispatch_commands(
                 cb_config_payload[base_index + 3] = cb->page_size(buffer_index);
             }
             for (const auto& buffer_index : cb->remote_buffer_indices()) {
-                const uint32_t base_index = remote_offset_index + ((NUM_CIRCULAR_BUFFERS - 1 - buffer_index) *
+                const uint32_t base_index = remote_offset_index + ((max_cbs - 1 - buffer_index) *
                                                                    UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
                 cb_config_payload[base_index] = cb->config_address();
                 cb_config_payload[base_index + 1] = cb->page_size(buffer_index);
@@ -2451,11 +2458,12 @@ TraceNode create_trace_node(ProgramImpl& program, IDevice* device, bool use_pref
 
     std::vector<std::vector<uint32_t>> all_cb_configs_payloads;
     const auto& hal = MetalContext::instance().hal();
+    uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
     for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
         all_cb_configs_payloads.push_back(
-            std::vector<uint32_t>(NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG));
+            std::vector<uint32_t>(max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG));
         auto& cb_config_payload = all_cb_configs_payloads.back();
         uint32_t first_unused_index = 0;
         for (const std::shared_ptr<CircularBufferImpl>& cb : cbs_on_core_range) {
@@ -2473,7 +2481,7 @@ TraceNode create_trace_node(ProgramImpl& program, IDevice* device, bool use_pref
                 first_unused_index = std::max(first_unused_index, base_index + 4);
             }
             for (const auto& buffer_index : cb->remote_buffer_indices()) {
-                const uint32_t base_index = remote_offset_index + ((NUM_CIRCULAR_BUFFERS - 1 - buffer_index) *
+                const uint32_t base_index = remote_offset_index + ((max_cbs - 1 - buffer_index) *
                                                                    UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
                 cb_config_payload[base_index] = cb->config_address();
                 cb_config_payload[base_index + 1] = cb->page_size(buffer_index);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1027,6 +1027,12 @@ void detail::ProgramImpl::set_remote_circular_buffer_init(const std::shared_ptr<
             }
             initialized_cbs.insert(circular_buffer->id());
             auto remote_cb_index = *circular_buffer->remote_buffer_indices().begin();
+            TT_FATAL(
+                remote_cb_index >= max_cbs_ / 2,
+                "Remote CB index {} must be in upper half (>= {}) of {} total CBs to avoid local CB collision",
+                remote_cb_index,
+                max_cbs_ / 2,
+                max_cbs_);
             remote_cb_indices.insert(remote_cb_index);
 
             // We only need the first remote buffer index

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1027,12 +1027,6 @@ void detail::ProgramImpl::set_remote_circular_buffer_init(const std::shared_ptr<
             }
             initialized_cbs.insert(circular_buffer->id());
             auto remote_cb_index = *circular_buffer->remote_buffer_indices().begin();
-            TT_FATAL(
-                remote_cb_index >= max_cbs_ / 2,
-                "Remote CB index {} must be in upper half (>= {}) of {} total CBs to avoid local CB collision",
-                remote_cb_index,
-                max_cbs_ / 2,
-                max_cbs_);
             remote_cb_indices.insert(remote_cb_index);
 
             // We only need the first remote buffer index

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -640,7 +640,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                                                 HalProgrammableCoreType::TENSIX));
 
                                         std::string cb_ids;
-                                        for (int i = 0; i < max_cbs_; i++) {
+                                        for (uint32_t i = 0; i < max_cbs_; i++) {
                                             if (non_contiguous_cbs & (1ULL << i)) {
                                                 if (!cb_ids.empty()) {
                                                     cb_ids += ",";
@@ -664,7 +664,8 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                         auto remote_val = per_core_remote_cb_indices_.find(core);
                         if (remote_val != per_core_remote_cb_indices_.end() && remote_val->second.any()) {
                             min_remote_cb_start_index = std::min(
-                                min_remote_cb_start_index, (uint32_t)__builtin_ctzll(remote_val->second.to_ullong()));
+                                min_remote_cb_start_index,
+                                static_cast<uint32_t>(__builtin_ctzll(remote_val->second.to_ullong())));
                         }
 
                         if (not hal.get_supports_dfbs(programmable_core_type_index)) {

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -96,7 +96,7 @@ struct KernelGroup {
         const detail::ProgramImpl& program,
         uint32_t programmable_core_type_index,
         std::vector<KernelHandle> kernel_ids,
-        uint32_t local_cb_mask,
+        uint64_t local_cb_mask,
         uint32_t min_remote_cb_start_index,
         const CoreRangeSet& new_ranges,
         const dev_msgs::Factory& dev_msgs_factory);
@@ -355,6 +355,7 @@ private:
         void reset_available_addresses() { this->l1_regions.clear(); }
     };
     uint32_t programmable_core_count_;
+    uint32_t max_cbs_;  // Architecture-specific max CBs
     uint64_t id;  // Need to make non-const due to move constructor
     uint64_t runtime_id{0};
     static std::atomic<uint64_t> program_counter;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -202,6 +202,11 @@ public:
 
     ~ProgramImpl() noexcept;
 
+    // CB mask width derived from kernel_config_msg_t::local_cb_mask type
+    using LocalCBMaskType = typename dev_msgs::kernel_config_msg_t::
+        FieldTraits<false, dev_msgs::kernel_config_msg_t::Field::local_cb_mask>::element_type;
+    static constexpr size_t cb_mask_width_ = sizeof(LocalCBMaskType) * 8;
+
     void set_runtime_id(ProgramId id);
     ProgramId get_runtime_id() const;
     ProgramId get_id() const;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -88,6 +88,7 @@ void JitBuildEnv::init(
     uint64_t build_key,
     size_t fw_compile_hash,
     tt::ARCH arch,
+    uint32_t max_cbs,
     const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
@@ -95,6 +96,7 @@ void JitBuildEnv::init(
     this->out_root_ = rtoptions.is_cache_dir_specified() ? rtoptions.get_cache_dir() : get_default_root_path();
 
     this->arch_ = arch;
+    this->max_cbs_ = max_cbs;
 
 #ifndef GIT_COMMIT_HASH
     log_info(tt::LogBuildKernels, "GIT_COMMIT_HASH not found");

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -57,9 +57,11 @@ public:
         uint64_t build_key,
         size_t fw_compile_hash,
         tt::ARCH arch,
+        uint32_t max_cbs,
         const std::map<std::string, std::string>& device_kernel_defines);
 
     tt::ARCH get_arch() const { return arch_; }
+    uint32_t get_max_cbs() const { return max_cbs_; };
     const std::string& get_root_path() const { return root_; }
     const std::string& get_out_root_path() const { return out_root_; }
     const std::string& get_out_kernel_root_path() const { return out_kernel_root_; }
@@ -70,6 +72,7 @@ public:
 
 private:
     tt::ARCH arch_{tt::ARCH::Invalid};
+    uint32_t max_cbs_{};
 
     // Paths
     std::string root_;

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -192,8 +192,13 @@ void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs) {
     auto device_kernel_defines = initialize_device_kernel_defines(device_id, num_hw_cqs);
     const size_t fw_compile_hash =
         std::hash<std::string>{}(tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
+    const uint32_t max_cbs = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers();
     device_id_to_build_env_[device_id].build_env.init(
-        build_key, fw_compile_hash, tt::tt_metal::MetalContext::instance().get_cluster().arch(), device_kernel_defines);
+        build_key,
+        fw_compile_hash,
+        tt::tt_metal::MetalContext::instance().get_cluster().arch(),
+        max_cbs,
+        device_kernel_defines);
     device_id_to_build_env_[device_id].firmware_build_states =
         create_build_state(device_id_to_build_env_[device_id].build_env, true);
     device_id_to_build_env_[device_id].kernel_build_states =

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -146,8 +146,8 @@ std::vector<DataFormat> get_unpack_dst_formats(
     bool int_fpu_en) {
     if (!unpack_to_dest_mode.empty()) {
         TT_FATAL(
-            // Allow size >= buf_formats.size() to support host-side allocations that use
-            // NUM_CIRCULAR_BUFFERS (always 64). buf_formats.size() is arch-specific (32 or 64).
+            // Allow size >= buf_formats.size() to support host-side allocations sized for
+            // maximum CB count across all architectures. buf_formats.size() is arch-specific.
             // We only access the first buf_formats.size() elements
             unpack_to_dest_mode.size() >= buf_formats.size(),
             "unpack_to_dest_mode vector must have {} elements",

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -95,9 +95,9 @@ ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats) {
     return get_exp_precision(last_valid_format);
 }
 
-std::vector<DataFormat> get_unpack_src_formats(std::span<DataFormat> data_formats) {
+std::vector<DataFormat> get_unpack_src_formats(std::span<const DataFormat> data_formats) {
     std::vector<DataFormat> unpack_src_format;
-    for (auto& src_format : data_formats) {
+    for (auto src_format : data_formats) {
         if (src_format == DataFormat::RawUInt32 || src_format == DataFormat::RawUInt16 ||
             src_format == DataFormat::RawUInt8) {
             switch (src_format) {
@@ -139,7 +139,7 @@ bool is_all_fp32_formats(std::span<const DataFormat> data_format) {
 }
 
 std::vector<DataFormat> get_unpack_dst_formats(
-    std::span<DataFormat> buf_formats,
+    std::span<const DataFormat> buf_formats,
     DataFormat unpack_conditional_dst_format,
     bool /*fp32_dest_acc_en*/,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
@@ -309,7 +309,7 @@ DataFormat get_single_pack_src_format(
 }
 
 std::vector<DataFormat> get_pack_src_formats(
-    std::span<DataFormat> data_formats,
+    std::span<const DataFormat> data_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     bool bfp8_pack_precise,
@@ -317,7 +317,7 @@ std::vector<DataFormat> get_pack_src_formats(
     tt::ARCH arch) {
     std::vector<DataFormat> pack_src_formats;
     DataFormat pack_src_format;
-    for (const auto& src_format : data_formats) {
+    for (auto src_format : data_formats) {
         pack_src_format = get_single_pack_src_format(
             src_format, unpack_conditional_dst_format, fp32_dest_acc_en, bfp8_pack_precise, int_fpu_en, arch);
         pack_src_formats.push_back(pack_src_format);
@@ -326,10 +326,9 @@ std::vector<DataFormat> get_pack_src_formats(
     return pack_src_formats;
 }
 
-std::vector<DataFormat> get_pack_dst_formats(std::span<DataFormat> buf_formats) {
+std::vector<DataFormat> get_pack_dst_formats(std::span<const DataFormat> buf_formats) {
     std::vector<DataFormat> pack_dst_format;
-    for (auto& dst_format : buf_formats) {
-        // DataFormat dst_format = buf_formats[i];
+    for (auto dst_format : buf_formats) {
         if (dst_format == DataFormat::RawUInt32 || dst_format == DataFormat::RawUInt16 ||
             dst_format == DataFormat::RawUInt8) {
             switch (dst_format) {

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -98,7 +98,6 @@ ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats) {
 std::vector<DataFormat> get_unpack_src_formats(std::span<DataFormat> data_formats) {
     std::vector<DataFormat> unpack_src_format;
     for (auto& src_format : data_formats) {
-        // DataFormat src_format = data_formats[i];
         if (src_format == DataFormat::RawUInt32 || src_format == DataFormat::RawUInt16 ||
             src_format == DataFormat::RawUInt8) {
             switch (src_format) {

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -148,7 +148,9 @@ std::vector<DataFormat> get_unpack_dst_formats(
     bool int_fpu_en) {
     if (!unpack_to_dest_mode.empty()) {
         TT_FATAL(
-            unpack_to_dest_mode.size() == NUM_CIRCULAR_BUFFERS, "unpack_to_dest_mode vector must have 32 elements");
+            unpack_to_dest_mode.size() == NUM_CIRCULAR_BUFFERS,
+            "unpack_to_dest_mode vector must have {} elements",
+            NUM_CIRCULAR_BUFFERS);
     }
 
     std::vector<DataFormat> unpack_dst_format;

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -51,55 +51,54 @@ ExpPrecision get_exp_precision(DataFormat data_format) {
     return (is_exp_b_format(data_format) ? ExpPrecision::B : ExpPrecision::A);
 }
 
-DataFormat check_consistent_format_across_buffers(DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
+DataFormat check_consistent_format_across_buffers(std::span<const DataFormat> data_format) {
     DataFormat last_valid_format = DataFormat::Invalid;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    for (const auto& format : data_format) {
         // Special case where Float32 can pair with any exponent precision, skip checking
-        if ((data_format[i] == DataFormat::Float32) || (data_format[i] == DataFormat::RawUInt32) ||
-            (data_format[i] == DataFormat::UInt32) || (data_format[i] == DataFormat::RawUInt16) ||
-            (data_format[i] == DataFormat::RawUInt8) || (data_format[i] == DataFormat::UInt16) ||
-            (data_format[i] == DataFormat::UInt8) || (data_format[i] == DataFormat::Int32)) {
+        if ((format == DataFormat::Float32) || (format == DataFormat::RawUInt32) || (format == DataFormat::UInt32) ||
+            (format == DataFormat::RawUInt16) || (format == DataFormat::RawUInt8) || (format == DataFormat::UInt16) ||
+            (format == DataFormat::UInt8) || (format == DataFormat::Int32)) {
             continue;
         }
 
-        if (data_format[i] != DataFormat::Invalid) {
-            TT_FATAL(ALL_VALID_FORMATS.contains(data_format[i]), "Format = {} not supported", data_format[i]);
+        if (format != DataFormat::Invalid) {
+            TT_FATAL(ALL_VALID_FORMATS.contains(format), "Format = {} not supported", format);
 
             if (last_valid_format != DataFormat::Invalid) {
                 TT_FATAL(
-                    is_exp_b_format(data_format[i]) == is_exp_b_format(last_valid_format),
+                    is_exp_b_format(format) == is_exp_b_format(last_valid_format),
                     "All input data-formats must have the same exponent format.");
                 // dump_data_formats(data_format);
-                last_valid_format = data_format[i];
+                last_valid_format = format;
 
             } else {
-                last_valid_format = data_format[i];
+                last_valid_format = format;
             }
         }
     }
     return last_valid_format;
 }
 
-DataFormat check_valid_formats_in_out_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
+DataFormat check_valid_formats_in_out_data_formats(std::span<const DataFormat> data_format) {
     DataFormat last_valid_format = DataFormat::Invalid;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        if (data_format[i] != DataFormat::Invalid) {
-            TT_FATAL(ALL_VALID_FORMATS.contains(data_format[i]), "Format = {} not supported", data_format[i]);
-            last_valid_format = data_format[i];
+    for (const auto& format : data_format) {
+        if (format != DataFormat::Invalid) {
+            TT_FATAL(ALL_VALID_FORMATS.contains(format), "Format = {} not supported", format);
+            last_valid_format = format;
         }
     }
     return last_valid_format;
 }
 
-ExpPrecision get_data_exp_precision(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]) {
+ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats) {
     DataFormat last_valid_format = check_consistent_format_across_buffers(data_formats);
     return get_exp_precision(last_valid_format);
 }
 
-std::vector<DataFormat> get_unpack_src_formats(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]) {
+std::vector<DataFormat> get_unpack_src_formats(std::span<DataFormat> data_formats) {
     std::vector<DataFormat> unpack_src_format;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        DataFormat src_format = data_formats[i];
+    for (auto& src_format : data_formats) {
+        // DataFormat src_format = data_formats[i];
         if (src_format == DataFormat::RawUInt32 || src_format == DataFormat::RawUInt16 ||
             src_format == DataFormat::RawUInt8) {
             switch (src_format) {
@@ -131,9 +130,9 @@ DataFormat get_single_unpack_dst_format(
     return dst_format;
 }
 
-bool is_all_fp32_formats(const DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        if (data_format[i] != DataFormat::Invalid && data_format[i] != DataFormat::Float32) {
+bool is_all_fp32_formats(std::span<const DataFormat> data_format) {
+    for (const auto& format : data_format) {
+        if (format != DataFormat::Invalid && format != DataFormat::Float32) {
             return false;
         }
     }
@@ -141,21 +140,24 @@ bool is_all_fp32_formats(const DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
 }
 
 std::vector<DataFormat> get_unpack_dst_formats(
-    DataFormat buf_formats[NUM_CIRCULAR_BUFFERS],
+    std::span<DataFormat> buf_formats,
     DataFormat unpack_conditional_dst_format,
     bool /*fp32_dest_acc_en*/,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
     bool int_fpu_en) {
     if (!unpack_to_dest_mode.empty()) {
         TT_FATAL(
-            unpack_to_dest_mode.size() == NUM_CIRCULAR_BUFFERS,
+            // Allow size >= buf_formats.size() to support host-side allocations that use
+            // NUM_CIRCULAR_BUFFERS (always 64). buf_formats.size() is arch-specific (32 or 64).
+            // We only access the first buf_formats.size() elements
+            unpack_to_dest_mode.size() >= buf_formats.size(),
             "unpack_to_dest_mode vector must have {} elements",
-            NUM_CIRCULAR_BUFFERS);
+            buf_formats.size());
     }
 
     std::vector<DataFormat> unpack_dst_format;
 
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    for (size_t i = 0; i < buf_formats.size(); i++) {
         DataFormat src_format = buf_formats[i];
         if (src_format == DataFormat::RawUInt32 || src_format == DataFormat::RawUInt16 ||
             src_format == DataFormat::RawUInt8) {
@@ -168,7 +170,7 @@ std::vector<DataFormat> get_unpack_dst_formats(
         } else if (int_fpu_en) {
             unpack_dst_format.push_back(src_format);
         } else {
-            if (buf_formats[i] == DataFormat::Float32 && !unpack_to_dest_mode.empty() &&
+            if (src_format == DataFormat::Float32 && !unpack_to_dest_mode.empty() &&
                 unpack_to_dest_mode[i] != UnpackToDestMode::Default) {
                 unpack_dst_format.push_back(
                     get_single_unpack_dst_format(src_format, DataFormat::Invalid, DataFormat::Float32));
@@ -308,7 +310,7 @@ DataFormat get_single_pack_src_format(
 }
 
 std::vector<DataFormat> get_pack_src_formats(
-    DataFormat data_formats[NUM_CIRCULAR_BUFFERS],
+    std::span<DataFormat> data_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     bool bfp8_pack_precise,
@@ -316,19 +318,19 @@ std::vector<DataFormat> get_pack_src_formats(
     tt::ARCH arch) {
     std::vector<DataFormat> pack_src_formats;
     DataFormat pack_src_format;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    for (const auto& src_format : data_formats) {
         pack_src_format = get_single_pack_src_format(
-            data_formats[i], unpack_conditional_dst_format, fp32_dest_acc_en, bfp8_pack_precise, int_fpu_en, arch);
+            src_format, unpack_conditional_dst_format, fp32_dest_acc_en, bfp8_pack_precise, int_fpu_en, arch);
         pack_src_formats.push_back(pack_src_format);
     }
 
     return pack_src_formats;
 }
 
-std::vector<DataFormat> get_pack_dst_formats(DataFormat buf_formats[NUM_CIRCULAR_BUFFERS]) {
+std::vector<DataFormat> get_pack_dst_formats(std::span<DataFormat> buf_formats) {
     std::vector<DataFormat> pack_dst_format;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
-        DataFormat dst_format = buf_formats[i];
+    for (auto& dst_format : buf_formats) {
+        // DataFormat dst_format = buf_formats[i];
         if (dst_format == DataFormat::RawUInt32 || dst_format == DataFormat::RawUInt16 ||
             dst_format == DataFormat::RawUInt8) {
             switch (dst_format) {

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -5,9 +5,9 @@
 #pragma once
 #include <cstdint>
 #include <vector>
+#include <span>
 #include <tt-metalium/tt_backend_api_types.hpp>     // for DataFormat
 #include <umd/device/types/arch.hpp>                // for ARCH
-#include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
 
 enum class UnpackToDestMode : std::uint8_t;
 
@@ -18,26 +18,26 @@ enum class ExpPrecision : std::uint8_t {
     B = 1,
 };
 
-DataFormat check_valid_formats_in_out_data_formats(DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
-ExpPrecision get_data_exp_precision(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]);
+DataFormat check_valid_formats_in_out_data_formats(std::span<const DataFormat> data_format);
+ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats);
 
 // Checks if all formats in format array are fp32/tf32/invalid, then data can be unpacked as tf32 for fp32 accumulation
-bool is_all_fp32_formats(const DataFormat data_format[NUM_CIRCULAR_BUFFERS]);
+bool is_all_fp32_formats(std::span<const DataFormat> data_format);
 
-std::vector<DataFormat> get_unpack_src_formats(DataFormat data_formats[NUM_CIRCULAR_BUFFERS]);
+std::vector<DataFormat> get_unpack_src_formats(std::span<DataFormat> data_formats);
 std::vector<DataFormat> get_unpack_dst_formats(
-    DataFormat buf_formats[NUM_CIRCULAR_BUFFERS],
+    std::span<DataFormat> buf_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
     bool int_fpu_en = false);
 std::vector<DataFormat> get_pack_src_formats(
-    DataFormat data_formats[NUM_CIRCULAR_BUFFERS],
+    std::span<DataFormat> data_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     bool bfp8_pack_precise,
     bool int_fpu_en = false,
     tt::ARCH arch = tt::ARCH::WORMHOLE_B0);
-std::vector<DataFormat> get_pack_dst_formats(DataFormat buf_formats[NUM_CIRCULAR_BUFFERS]);
+std::vector<DataFormat> get_pack_dst_formats(std::span<DataFormat> buf_formats);
 
 }  // namespace tt

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -24,20 +24,20 @@ ExpPrecision get_data_exp_precision(std::span<const DataFormat> data_formats);
 // Checks if all formats in format array are fp32/tf32/invalid, then data can be unpacked as tf32 for fp32 accumulation
 bool is_all_fp32_formats(std::span<const DataFormat> data_format);
 
-std::vector<DataFormat> get_unpack_src_formats(std::span<DataFormat> data_formats);
+std::vector<DataFormat> get_unpack_src_formats(std::span<const DataFormat> data_formats);
 std::vector<DataFormat> get_unpack_dst_formats(
-    std::span<DataFormat> buf_formats,
+    std::span<const DataFormat> buf_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
     bool int_fpu_en = false);
 std::vector<DataFormat> get_pack_src_formats(
-    std::span<DataFormat> data_formats,
+    std::span<const DataFormat> data_formats,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     bool bfp8_pack_precise,
     bool int_fpu_en = false,
     tt::ARCH arch = tt::ARCH::WORMHOLE_B0);
-std::vector<DataFormat> get_pack_dst_formats(std::span<DataFormat> buf_formats);
+std::vector<DataFormat> get_pack_dst_formats(std::span<const DataFormat> buf_formats);
 
 }  // namespace tt

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -413,8 +413,8 @@ void generate_data_format_descriptors(JitBuildOptions& options, const tt::ARCH a
 
 std::string array_to_string(std::span<const uint32_t> arr) {
     std::string formats_string;
-    for (int i = 0; i < arr.size(); i++) {
-        formats_string += to_string((int)arr[i]) + ",";
+    for (const auto& value : arr) {
+        formats_string += std::to_string(value) + ",";
     }
     return formats_string;
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -265,14 +265,15 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_unpack_data
     tt_hlk_desc& desc,
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
-    std::vector<UnpackToDestMode> unpack_to_dest_mode) {
+    std::vector<UnpackToDestMode> unpack_to_dest_mode,
+    uint32_t max_cbs) {
     vector<DataFormat> src_formats = tt::get_unpack_src_formats(desc.buf_dataformat_arr);
 
     vector<DataFormat> dst_formats = tt::get_unpack_dst_formats(
         desc.buf_dataformat_arr, unpack_conditional_dst_format, fp32_dest_acc_en, std::move(unpack_to_dest_mode));
 
-    TT_ASSERT(src_formats.size() == NUM_CIRCULAR_BUFFERS);
-    TT_ASSERT(dst_formats.size() == NUM_CIRCULAR_BUFFERS);
+    TT_ASSERT(src_formats.size() == max_cbs);
+    TT_ASSERT(dst_formats.size() == max_cbs);
 
     return std::make_pair(src_formats, dst_formats);
 }
@@ -280,22 +281,17 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_unpack_data
 void emit_unpack_data_formats(
     const std::string& unpack_data_format_descs,
     const std::vector<DataFormat>& src_formats_all_cbs,
-    const std::vector<DataFormat>& dst_formats_all_cbs) {
+    const std::vector<DataFormat>& dst_formats_all_cbs,
+    uint32_t max_cbs) {
     // TODO: we should be emitting "unsigned char", no reason to use up 4B per data format
     jit_build::utils::FileRenamer tmp(unpack_data_format_descs);
     ofstream file_stream;
     file_stream.open(tmp.path());
     file_stream << "#pragma once\n\n";
     file_stream << create_formats_array_string(
-        "constexpr std::int32_t",
-        "unpack_src_format",
-        NUM_CIRCULAR_BUFFERS,
-        data_format_vec_to_string(src_formats_all_cbs));
+        "constexpr std::int32_t", "unpack_src_format", max_cbs, data_format_vec_to_string(src_formats_all_cbs));
     file_stream << create_formats_array_string(
-        "constexpr std::int32_t",
-        "unpack_dst_format",
-        NUM_CIRCULAR_BUFFERS,
-        data_format_vec_to_string(dst_formats_all_cbs));
+        "constexpr std::int32_t", "unpack_dst_format", max_cbs, data_format_vec_to_string(dst_formats_all_cbs));
     file_stream.close();
 }
 
@@ -304,7 +300,8 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_f
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     bool bfp8_pack_precise,
-    const tt::ARCH arch) {
+    const tt::ARCH arch,
+    uint32_t max_cbs) {
     vector<DataFormat> src_formats = tt::get_pack_src_formats(
         desc.buf_dataformat_arr,
         unpack_conditional_dst_format,
@@ -316,8 +313,8 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_f
     vector<DataFormat> dst_formats = tt::get_pack_dst_formats(
         desc.buf_dataformat_arr);
 
-    TT_ASSERT(src_formats.size() == NUM_CIRCULAR_BUFFERS);
-    TT_ASSERT(dst_formats.size() == NUM_CIRCULAR_BUFFERS);
+    TT_ASSERT(src_formats.size() == max_cbs);
+    TT_ASSERT(dst_formats.size() == max_cbs);
 
     return std::make_pair(src_formats, dst_formats);
 }
@@ -325,21 +322,16 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_f
 void emit_pack_data_formats(
     const std::string& pack_data_format_descs,
     const std::vector<DataFormat>& src_formats_all_cbs,
-    const std::vector<DataFormat>& dst_formats_all_cbs) {
+    const std::vector<DataFormat>& dst_formats_all_cbs,
+    uint32_t max_cbs) {
     jit_build::utils::FileRenamer tmp(pack_data_format_descs);
     ofstream file_stream;
     file_stream.open(tmp.path());
     file_stream << "#pragma once\n\n";
     file_stream << create_formats_array_string(
-        "constexpr unsigned char",
-        "pack_src_format",
-        NUM_CIRCULAR_BUFFERS,
-        data_format_vec_to_string(src_formats_all_cbs));
+        "constexpr unsigned char", "pack_src_format", max_cbs, data_format_vec_to_string(src_formats_all_cbs));
     file_stream << create_formats_array_string(
-        "constexpr unsigned char",
-        "pack_dst_format",
-        NUM_CIRCULAR_BUFFERS,
-        data_format_vec_to_string(dst_formats_all_cbs));
+        "constexpr unsigned char", "pack_dst_format", max_cbs, data_format_vec_to_string(dst_formats_all_cbs));
 
     // budabackend-style format array
     // file_stream << create_formats_array_string("const std::int32_t", "pack_src_format", 16,
@@ -378,7 +370,7 @@ void equalize_data_format_vectors(std::vector<DataFormat>& v1, std::vector<DataF
     }
 }
 
-void generate_data_format_descriptors(JitBuildOptions& options, const tt::ARCH arch) {
+void generate_data_format_descriptors(JitBuildOptions& options, const tt::ARCH arch, uint32_t max_cbs) {
     string out_file_name_base = "chlkc_";
     string out_file_name_suffix = "_data_format.h";
     string unpack_data_format_descs = options.path + out_file_name_base + "unpack" + out_file_name_suffix;
@@ -399,11 +391,12 @@ void generate_data_format_descriptors(JitBuildOptions& options, const tt::ARCH a
         desc.buf_dataformat_arr);
 
     vector<DataFormat> unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs;
-    tie(unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs) = generate_unpack_data_formats(desc, unpack_conditional_dst_format, options.fp32_dest_acc_en, options.unpack_to_dest_mode);
+    tie(unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs) = generate_unpack_data_formats(
+        desc, unpack_conditional_dst_format, options.fp32_dest_acc_en, options.unpack_to_dest_mode, max_cbs);
 
     vector<DataFormat> pack_src_formats_all_cbs, pack_dst_formats_all_cbs;
-    tie(pack_src_formats_all_cbs, pack_dst_formats_all_cbs) =
-        generate_pack_data_formats(desc, unpack_conditional_dst_format, options.fp32_dest_acc_en, options.bfp8_pack_precise, arch);
+    tie(pack_src_formats_all_cbs, pack_dst_formats_all_cbs) = generate_pack_data_formats(
+        desc, unpack_conditional_dst_format, options.fp32_dest_acc_en, options.bfp8_pack_precise, arch, max_cbs);
 
     // equalize "upack src" and "pack dst" data format vectors
     // both "unpack src" and "pack dst" refer to data in L1, "unpack src" == L1, and "pack dst" == L1
@@ -414,49 +407,63 @@ void generate_data_format_descriptors(JitBuildOptions& options, const tt::ARCH a
     // propagate formats to "unpack dst (SRCA/B REG)" / "pack src (DST REG)"
     equalize_data_format_vectors(unpack_src_formats_all_cbs, pack_dst_formats_all_cbs);
 
-    emit_unpack_data_formats(unpack_data_format_descs, unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs);
-    emit_pack_data_formats(pack_data_format_descs, pack_src_formats_all_cbs, pack_dst_formats_all_cbs);
+    emit_unpack_data_formats(unpack_data_format_descs, unpack_src_formats_all_cbs, unpack_dst_formats_all_cbs, max_cbs);
+    emit_pack_data_formats(pack_data_format_descs, pack_src_formats_all_cbs, pack_dst_formats_all_cbs, max_cbs);
 }
 
-std::string array_to_string(const uint32_t arr[]) {
+std::string array_to_string(std::span<const uint32_t> arr) {
     std::string formats_string;
-    for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+    for (int i = 0; i < arr.size(); i++) {
         formats_string += to_string((int)arr[i]) + ",";
     }
     return formats_string;
 }
 
-void emit_unpack_tile_dims(const std::string& unpack_tile_dims_descs, tt_hlk_desc& desc) {
+void emit_unpack_tile_dims(const std::string& unpack_tile_dims_descs, tt_hlk_desc& desc, uint32_t max_cbs) {
     jit_build::utils::FileRenamer tmp(unpack_tile_dims_descs);
     ofstream file_stream;
     file_stream.open(tmp.path());
     file_stream << "#pragma once\n\n";
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_tile_num_faces", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_num_faces_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_partial_face", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_partial_face_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_tile_face_r_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_face_r_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_narrow_tile", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_narrow_tile_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_tile_r_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_r_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "unpack_tile_c_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_c_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint16_t", "unpack_tile_size", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_size_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_tile_num_faces", max_cbs, array_to_string(desc.buf_num_faces_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_partial_face", max_cbs, array_to_string(desc.buf_partial_face_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_tile_face_r_dim", max_cbs, array_to_string(desc.buf_face_r_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_narrow_tile", max_cbs, array_to_string(desc.buf_narrow_tile_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_tile_r_dim", max_cbs, array_to_string(desc.buf_tile_r_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "unpack_tile_c_dim", max_cbs, array_to_string(desc.buf_tile_c_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint16_t", "unpack_tile_size", max_cbs, array_to_string(desc.buf_tile_size_arr));
     file_stream.close();
 }
 
-void emit_pack_tile_dims(const std::string& pack_tile_dims_descs, tt_hlk_desc& desc) {
+void emit_pack_tile_dims(const std::string& pack_tile_dims_descs, tt_hlk_desc& desc, uint32_t max_cbs) {
     jit_build::utils::FileRenamer tmp(pack_tile_dims_descs);
     ofstream file_stream;
     file_stream.open(tmp.path());
     file_stream << "#pragma once\n\n";
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_tile_num_faces", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_num_faces_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_partial_face", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_partial_face_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_tile_face_r_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_face_r_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_narrow_tile", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_narrow_tile_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_tile_r_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_r_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint8_t", "pack_tile_c_dim", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_c_dim_arr));
-    file_stream << create_formats_array_string("constexpr uint16_t", "pack_tile_size", NUM_CIRCULAR_BUFFERS, array_to_string(desc.buf_tile_size_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_tile_num_faces", max_cbs, array_to_string(desc.buf_num_faces_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_partial_face", max_cbs, array_to_string(desc.buf_partial_face_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_tile_face_r_dim", max_cbs, array_to_string(desc.buf_face_r_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_narrow_tile", max_cbs, array_to_string(desc.buf_narrow_tile_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_tile_r_dim", max_cbs, array_to_string(desc.buf_tile_r_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint8_t", "pack_tile_c_dim", max_cbs, array_to_string(desc.buf_tile_c_dim_arr));
+    file_stream << create_formats_array_string(
+        "constexpr uint16_t", "pack_tile_size", max_cbs, array_to_string(desc.buf_tile_size_arr));
     file_stream.close();
 }
 
-void generate_tile_dims_descriptors(JitBuildOptions& options, const tt::ARCH /*arch*/) {
+void generate_tile_dims_descriptors(JitBuildOptions& options, const tt::ARCH /*arch*/, uint32_t max_cbs) {
     string out_file_name_base = "chlkc_";
     string out_file_name_suffix = "_tile_dims.h";
     string unpack_tile_dims_descs = options.path + out_file_name_base + "unpack" + out_file_name_suffix;
@@ -465,8 +472,8 @@ void generate_tile_dims_descriptors(JitBuildOptions& options, const tt::ARCH /*a
     // assuming all cores within a op have the same desc
     tt_hlk_desc& desc = options.hlk_desc;
 
-    emit_unpack_tile_dims(unpack_tile_dims_descs, desc);
-    emit_pack_tile_dims(pack_tile_dims_descs, desc);
+    emit_unpack_tile_dims(unpack_tile_dims_descs, desc, max_cbs);
+    emit_pack_tile_dims(pack_tile_dims_descs, desc, max_cbs);
 }
 
 void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
@@ -539,8 +546,8 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& opt
     //ZoneName((tracyPrefix + options.name).c_str(), options.name.length() + tracyPrefix.length());
     fs::create_directories(options.path);
     try {
-        std::thread td( [&]() { generate_data_format_descriptors(options, env.get_arch()); } );
-        std::thread tt( [&]() { generate_tile_dims_descriptors(options, env.get_arch()); } );
+        std::thread td( [&]() { generate_data_format_descriptors(options, env.get_arch(), env.get_max_cbs()); } );
+        std::thread tt( [&]() { generate_tile_dims_descriptors(options, env.get_arch(), env.get_max_cbs()); } );
         std::thread tm( [&]() { generate_math_fidelity_descriptor(options); } );
         std::thread ta( [&]() { generate_math_approx_mode_descriptor(options); } );
         std::thread tf( [&]() { generate_dst_accum_mode_descriptor(options); } );

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/circular_buffer_constants.h>
 #include <tt_stl/reflection.hpp>
 
 namespace tt {
@@ -31,46 +30,28 @@ private:
     void* hlk_args{nullptr};  // void ptr to user-defined hlk_args_t struct (user writes)
     size_t hlk_args_size{0};  // size of hlk_args_t in bytes (result of sizeof())
 
+    void init(uint32_t max_cbs) {
+        buf_dataformat_arr.assign(max_cbs, DataFormat::Invalid);
+        buf_num_faces_arr.assign(max_cbs, constants::TILE_HW / constants::FACE_HW);
+        buf_partial_face_arr.assign(max_cbs, 0);
+        buf_face_r_dim_arr.assign(max_cbs, constants::FACE_HEIGHT);
+        buf_narrow_tile_arr.assign(max_cbs, 0);
+        buf_tile_r_dim_arr.assign(max_cbs, constants::TILE_HEIGHT);
+        buf_tile_c_dim_arr.assign(max_cbs, constants::TILE_WIDTH);
+        buf_tile_size_arr.assign(max_cbs, constants::BFLOAT8_B_TILE_HW);
+    }
+
 public:
-    DataFormat buf_dataformat_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_num_faces_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_partial_face_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_face_r_dim_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_narrow_tile_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_tile_r_dim_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_tile_c_dim_arr[NUM_CIRCULAR_BUFFERS]{};
-    uint32_t buf_tile_size_arr[NUM_CIRCULAR_BUFFERS]{};
+    std::vector<DataFormat> buf_dataformat_arr;
+    std::vector<uint32_t> buf_num_faces_arr;
+    std::vector<uint32_t> buf_partial_face_arr;
+    std::vector<uint32_t> buf_face_r_dim_arr;
+    std::vector<uint32_t> buf_narrow_tile_arr;
+    std::vector<uint32_t> buf_tile_r_dim_arr;
+    std::vector<uint32_t> buf_tile_c_dim_arr;
+    std::vector<uint32_t> buf_tile_size_arr;
 
-    tt_hlk_desc() {
-        for (int i = 0; i < NUM_CIRCULAR_BUFFERS; ++i) {
-            buf_dataformat_arr[i] = DataFormat::Invalid;
-            buf_num_faces_arr[i] = constants::TILE_HW / constants::FACE_HW;
-            buf_partial_face_arr[i] = 0;
-            buf_face_r_dim_arr[i] = constants::FACE_HEIGHT;
-            buf_narrow_tile_arr[i] = 0;
-            buf_tile_r_dim_arr[i] = constants::TILE_HEIGHT;
-            buf_tile_c_dim_arr[i] = constants::TILE_WIDTH;
-            buf_tile_size_arr[i] = constants::BFLOAT8_B_TILE_HW;
-        }
-    }
-
-    tt_hlk_desc(tt_hlk_desc& in) {
-        for (int i = 0; i < NUM_CIRCULAR_BUFFERS; ++i) {
-            buf_dataformat_arr[i] = in.buf_dataformat_arr[i];
-            buf_num_faces_arr[i] = in.buf_num_faces_arr[i];
-            buf_partial_face_arr[i] = in.buf_partial_face_arr[i];
-            buf_face_r_dim_arr[i] = in.buf_face_r_dim_arr[i];
-            buf_narrow_tile_arr[i] = in.buf_narrow_tile_arr[i];
-            buf_tile_r_dim_arr[i] = in.buf_tile_r_dim_arr[i];
-            buf_tile_c_dim_arr[i] = in.buf_tile_c_dim_arr[i];
-            buf_tile_size_arr[i] = in.buf_tile_size_arr[i];
-        }
-
-        math_fidelity = in.math_fidelity;
-        hlk_args = in.hlk_args;
-        hlk_args_size = in.hlk_args_size;
-        approximation_mode = in.approximation_mode;
-    }
+    tt_hlk_desc(uint32_t max_cbs) { init(max_cbs); }
 
     DataFormat get_buf_dataformat(int buf_idx) const { return buf_dataformat_arr[buf_idx]; }
 
@@ -122,7 +103,7 @@ public:
     // rk: added by fw-dma-test-2 team
     size_t get_hlk_args_size() const { return hlk_args_size; }
 
-    const DataFormat* get_buf_dataformats() const { return buf_dataformat_arr; }
+    const DataFormat* get_buf_dataformats() const { return buf_dataformat_arr.data(); }
 
 };  // tt_hlk_desc
 }  // namespace tt
@@ -151,7 +132,7 @@ template <>
 struct std::hash<tt::tt_hlk_desc> {
     std::size_t operator()(const tt::tt_hlk_desc& obj) const {
         std::size_t hash_value = 0;
-        for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+        for (size_t i = 0; i < obj.buf_dataformat_arr.size(); i++) {
             ttsl::hash::hash_combine(hash_value, hash<tt::DataFormat>{}(obj.get_buf_dataformat(i)));
             ttsl::hash::hash_combine(hash_value, hash<uint32_t>{}(obj.get_buf_tile_r_dim(i)));
             ttsl::hash::hash_combine(hash_value, hash<uint32_t>{}(obj.get_buf_tile_c_dim(i)));

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -30,17 +30,6 @@ private:
     void* hlk_args{nullptr};  // void ptr to user-defined hlk_args_t struct (user writes)
     size_t hlk_args_size{0};  // size of hlk_args_t in bytes (result of sizeof())
 
-    void init(uint32_t max_cbs) {
-        buf_dataformat_arr.assign(max_cbs, DataFormat::Invalid);
-        buf_num_faces_arr.assign(max_cbs, constants::TILE_HW / constants::FACE_HW);
-        buf_partial_face_arr.assign(max_cbs, 0);
-        buf_face_r_dim_arr.assign(max_cbs, constants::FACE_HEIGHT);
-        buf_narrow_tile_arr.assign(max_cbs, 0);
-        buf_tile_r_dim_arr.assign(max_cbs, constants::TILE_HEIGHT);
-        buf_tile_c_dim_arr.assign(max_cbs, constants::TILE_WIDTH);
-        buf_tile_size_arr.assign(max_cbs, constants::BFLOAT8_B_TILE_HW);
-    }
-
 public:
     std::vector<DataFormat> buf_dataformat_arr;
     std::vector<uint32_t> buf_num_faces_arr;
@@ -51,7 +40,15 @@ public:
     std::vector<uint32_t> buf_tile_c_dim_arr;
     std::vector<uint32_t> buf_tile_size_arr;
 
-    tt_hlk_desc(uint32_t max_cbs) { init(max_cbs); }
+    tt_hlk_desc(uint32_t max_cbs) :
+        buf_dataformat_arr(max_cbs, DataFormat::Invalid),
+        buf_num_faces_arr(max_cbs, constants::TILE_HW / constants::FACE_HW),
+        buf_partial_face_arr(max_cbs, 0),
+        buf_face_r_dim_arr(max_cbs, constants::FACE_HEIGHT),
+        buf_narrow_tile_arr(max_cbs, 0),
+        buf_tile_r_dim_arr(max_cbs, constants::TILE_HEIGHT),
+        buf_tile_c_dim_arr(max_cbs, constants::TILE_WIDTH),
+        buf_tile_size_arr(max_cbs, constants::BFLOAT8_B_TILE_HW) {}
 
     DataFormat get_buf_dataformat(int buf_idx) const { return buf_dataformat_arr[buf_idx]; }
 

--- a/tt_metal/jit_build/jit_build_options.cpp
+++ b/tt_metal/jit_build/jit_build_options.cpp
@@ -8,14 +8,9 @@
 
 #include "build.hpp"
 
-enum class MathFidelity : uint8_t;
-namespace tt {
-enum CBIndex : std::uint8_t;
-}  // namespace tt
-
 namespace tt::tt_metal {
 
-JitBuildOptions::JitBuildOptions(const JitBuildEnv& env) : build_env(env) {}
+JitBuildOptions::JitBuildOptions(const JitBuildEnv& env) : build_env(env), hlk_desc(env.get_max_cbs()) {}
 
 void JitBuildOptions::set_name(const std::string& n) {
     name = n;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -33,6 +33,7 @@
 #include <tt_stl/overloaded.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/arch.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
 
 enum class AddressableCoreType : uint8_t;
 
@@ -392,6 +393,10 @@ public:
     float get_eps() const { return eps_; }
     float get_nan() const { return nan_; }
     float get_inf() const { return inf_; }
+
+    uint32_t get_arch_num_circular_buffers() const {
+        return (arch_ == tt::ARCH::WORMHOLE_B0) ? WORMHOLE_CIRCULAR_BUFFERS : MAX_CIRCULAR_BUFFERS;
+    }
 
     template <typename IndexType, typename SizeType, typename CoordType>
     auto noc_coordinate(IndexType noc_index, SizeType noc_size, CoordType coord) const

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -394,9 +394,7 @@ public:
     float get_nan() const { return nan_; }
     float get_inf() const { return inf_; }
 
-    uint32_t get_arch_num_circular_buffers() const {
-        return (arch_ == tt::ARCH::WORMHOLE_B0) ? WORMHOLE_CIRCULAR_BUFFERS : MAX_CIRCULAR_BUFFERS;
-    }
+    uint32_t get_arch_num_circular_buffers() const { return (arch_ == tt::ARCH::WORMHOLE_B0) ? 32 : 64; }
 
     template <typename IndexType, typename SizeType, typename CoordType>
     auto noc_coordinate(IndexType noc_index, SizeType noc_size, CoordType coord) const

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -394,7 +394,10 @@ public:
     float get_nan() const { return nan_; }
     float get_inf() const { return inf_; }
 
-    uint32_t get_arch_num_circular_buffers() const { return (arch_ == tt::ARCH::WORMHOLE_B0) ? 32 : 64; }
+    // NUM_CIRCULAR_BUFFERS is a temporary constant pending DFB migration
+    uint32_t get_arch_num_circular_buffers() const {
+        return (arch_ == tt::ARCH::WORMHOLE_B0) ? 32 : NUM_CIRCULAR_BUFFERS;
+    }
 
     template <typename IndexType, typename SizeType, typename CoordType>
     auto noc_coordinate(IndexType noc_index, SizeType noc_size, CoordType coord) const

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -833,6 +833,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
     const auto& hal = MetalContext::instance().hal();
+    uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
         CoreType core_type = hal.get_core_type(index);
@@ -867,8 +868,8 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         }
                         for (uint32_t buffer_index : circular_buffer->remote_buffer_indices()) {
                             uint32_t base_index =
-                                remote_offset_index + ((NUM_CIRCULAR_BUFFERS - 1 - buffer_index) *
-                                                       UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
+                                remote_offset_index +
+                                ((max_cbs - 1 - buffer_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
                             uint32_t config_address = circular_buffer->config_address();
                             circular_buffer_config_vec[base_index] = config_address;
                             circular_buffer_config_vec[base_index + 1] = circular_buffer->page_size(buffer_index);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operation.hpp"
@@ -204,7 +205,7 @@ process_agmm_fusion_program_and_create_override_variables(
 
     uint32_t src1_cb_index = base_cb_index + 1;
     tt::tt_metal::CBHandle cb_src1;
-    uint32_t remote_cb_index = tt::CBIndex::c_31;
+    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
     if (use_global_cb) {
         uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
         tt_metal::CircularBufferConfig remote_cb_config =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -205,7 +205,7 @@ process_agmm_fusion_program_and_create_override_variables(
 
     uint32_t src1_cb_index = base_cb_index + 1;
     tt::tt_metal::CBHandle cb_src1;
-    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
+    uint32_t remote_cb_index = tt::CBIndex::c_31;
     if (use_global_cb) {
         uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
         tt_metal::CircularBufferConfig remote_cb_config =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operation.hpp"

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -1953,7 +1954,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
     uint32_t src1_cb_index = base_cb_index + 1;
     tt::tt_metal::CBHandle cb_src1;
-    uint32_t remote_cb_index = tt::CBIndex::c_31;
+    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
     if (use_global_cb) {
         uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
         tt_metal::CircularBufferConfig remote_cb_config =

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1954,7 +1954,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 
     uint32_t src1_cb_index = base_cb_index + 1;
     tt::tt_metal::CBHandle cb_src1;
-    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
+    uint32_t remote_cb_index = tt::CBIndex::c_31;
     if (use_global_cb) {
         uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
         tt_metal::CircularBufferConfig remote_cb_config =

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -156,7 +156,7 @@ DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::cre
     uint32_t remote_cb_size = global_cb.size();
 
     auto L1_ALIGNMENT = tt::tt_metal::hal::get_l1_alignment();
-    uint32_t remote_cb_index = tt::CBIndex::c_31;
+    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
     CircularBufferConfig remote_cb_config = CircularBufferConfig(remote_cb_size);
     remote_cb_config.remote_index(remote_cb_index)
         .set_page_size(L1_ALIGNMENT)  // set to 16B so that the infra won't update write pointers to wrong location

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp
@@ -156,7 +156,7 @@ DramPrefetcherProgramFactory::cached_program_t DramPrefetcherProgramFactory::cre
     uint32_t remote_cb_size = global_cb.size();
 
     auto L1_ALIGNMENT = tt::tt_metal::hal::get_l1_alignment();
-    uint32_t remote_cb_index = tt::tt_metal::hal::get_arch_num_circular_buffers() - 1;
+    uint32_t remote_cb_index = tt::CBIndex::c_31;
     CircularBufferConfig remote_cb_config = CircularBufferConfig(remote_cb_size);
     remote_cb_config.remote_index(remote_cb_index)
         .set_page_size(L1_ALIGNMENT)  // set to 16B so that the infra won't update write pointers to wrong location


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35330

### Problem description
Increase CB limit on Blackhole to 64 from 32. The 32 CB limit still exists on Wormhole due to the 2KB TRISC local data RAM constraint (each CB descriptor takes 32 bytes, so 32 CBs consume 1KB of local memory).

Blackhole has 4KB of TRISC local data RAM so we can support 64 CBs.

### What's changed

**Architecture-specific CB limits:**
- Wormhole: Remains at 32 CBs (TRISC memory constraint)
- Blackhole: Increased to 64 CBs

**Key changes:**
1. HAL API addition (`hal.hpp`, `hal.cpp`):
- Added `hal.get_arch_num_circular_buffers()` to query the architecture-specific CB limit at runtime
- **NOTE**: New code should use `hal.get_arch_num_circular_buffers()` to get the actual device limit rather than `NUM_CIRCULAR_BUFFERS`


2. Compile-time constant (`circular_buffer_constants.h`):
- `NUM_CIRCULAR_BUFFERS` is now conditionally defined:
 - `ARCH_WORMHOLE` defined -> 32
 - Otherwise (Blackhole, host) -> 64
- Host uses 64 for array sizing to accommodate all architectures
- This dual-constant approach is temporary; the constant will eventually be replaced by Dataflow Buffers (DFBs)
 
 
3. CB mask widened (`dev_msgs.h`):
- `kernel_config_msg_t::local_cb_mask` changed from `uint32_t` to `uint64_t`
- Padding adjusted to maintain `TT_ARCH_MAX_NOC_WRITE_ALIGNMENT`
 
 
4. Firmware updates (`brisc.cc`, `ncrisc.cc`, `trisc.cc`):
- 64-bit CB mask split into low (CBs 0-31) and high (CBs 32-63) halves (efficient RISC-V 32-bit processing)
- Lower half processed on both architectures
- Upper half only processed on Blackhole
- Added `shift_mask` template parameter to `setup_local_cb_read_write_interfaces` for pre-aligned masks

5. CBIndex enum extension (`kernel_structs.h`):
- Extended CBIndex enum to include c_32 through c_63 for Blackhole's 64 CB support
- Removed unused SIZE member (was hardcoded to 32)
 
6. Memory layout adjustments (`dev_mem_map.h` for Blackhole):
- Firmware sizes increased to accommodate larger CB interface arrays:
 - Each `CBInterface` is 32 bytes, so 32 additional CBs = +1024 bytes
 - NCRISC, TRISC0/1/2: +1024 bytes each (1536 -> 2560)
 - BRISC: +1536 bytes (7168 -> 8704) : +512 bytes additional headroom required beyond CB expansion for certain tests (e.g. profiler-enabled) to pass
- Increased Mailbox sizes by 128 bytes (8 x 16) for expanded structures
- `MEM_MAX_KERNEL_SIZE` reduced from 1503KB to 1497KB to account for increased system reserved space
 
7. Stream mapping (`stream_io_map.h`):
- `OPERAND_START_STREAM` changed from 8 to 0 on both architectures
- Streams 0-7 were previously reserved for legacy ll-buda compatibility but are now used
- Enables CB/operand ID N -> stream N mapping (0-63 on Blackhole)
 
8. Dynamic array sizing (`hlk_desc.hpp`, `data_format.cpp/hpp`):
- `tt_hlk_desc` arrays changed from fixed C arrays to `std::vector`
- Data format functions changed to use `std::span`
- Constructor now takes `max_cbs` parameter

9. Dispatch updates (`dispatch.cpp`, `program.cpp`):
- Updated to use 64-bit masks and `__builtin_clzll`/`__builtin_ctzll`
- CB config buffer sizes calculated dynamically using `max_cbs`
 
10. Test infrastructure:
- Test fixtures (`MeshDispatchFixture`, etc.) now use `max_cbs_` member
- Initialized via `init_max_cbs()` to dynamically test correct CB count per architecture

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/35330_increase_max_CBs)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/35330_increase_max_CBs)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/35330_increase_max_CBs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/35330_increase_max_CBs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/35330_increase_max_CBs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/35330_increase_max_CBs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/35330_increase_max_CBs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs