### PR TITLE
Changes needed for fabric ops support in the TTKernel dialect for tt-mlir

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <tt-metalium/allocator.hpp>
 
 namespace tt::tt_fabric::fabric_router_tests {
 
@@ -42,6 +43,15 @@ class ControlPlaneFixture : public ::testing::Test {
            tt::tt_metal::MetalContext::instance().get_cluster().configure_ethernet_cores_for_fabric_routers(
                tt::tt_fabric::FabricConfig::DISABLED);
        }
+};
+
+struct WorkerMemMap {
+    uint32_t source_l1_buffer_address;
+    uint32_t packet_payload_size_bytes;
+    uint32_t test_results_address;
+    uint32_t target_address;
+    uint32_t notification_mailbox_address;
+    uint32_t test_results_size_bytes;
 };
 
 class BaseFabricFixture : public ::testing::Test {
@@ -149,6 +159,30 @@ public:
             tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();
             tt::tt_metal::distributed::Finish(cq);
         }
+    }
+
+    // Utility function reused across tests to get address params
+    static WorkerMemMap generate_worker_mem_map(
+        const std::shared_ptr<tt_metal::distributed::MeshDevice>& device, Topology /*topology*/) {
+        constexpr uint32_t PACKET_HEADER_RESERVED_BYTES = 45056;
+        constexpr uint32_t DATA_SPACE_RESERVED_BYTES = 851968;
+        constexpr uint32_t TEST_RESULTS_SIZE_BYTES = 128;
+
+        uint32_t base_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+        uint32_t source_l1_buffer_address = base_addr + PACKET_HEADER_RESERVED_BYTES;
+        uint32_t test_results_address = source_l1_buffer_address + DATA_SPACE_RESERVED_BYTES;
+        uint32_t target_address = source_l1_buffer_address;
+        uint32_t notification_mailbox_address = test_results_address + TEST_RESULTS_SIZE_BYTES;
+
+        uint32_t packet_payload_size_bytes = get_tt_fabric_max_payload_size_bytes();
+
+        return {
+            source_l1_buffer_address,
+            packet_payload_size_bytes,
+            test_results_address,
+            target_address,
+            notification_mailbox_address,
+            TEST_RESULTS_SIZE_BYTES};
     }
 };
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -42,39 +42,6 @@ namespace tt::tt_fabric::fabric_router_tests {
 std::random_device rd;  // Non-deterministic seed source
 std::mt19937 global_rng(rd());
 
-struct WorkerMemMap {
-    uint32_t source_l1_buffer_address;
-    uint32_t packet_payload_size_bytes;
-    uint32_t test_results_address;
-    uint32_t target_address;
-    uint32_t notification_mailbox_address;
-    uint32_t test_results_size_bytes;
-};
-
-// Utility function reused across tests to get address params
-WorkerMemMap generate_worker_mem_map(
-    const std::shared_ptr<tt_metal::distributed::MeshDevice>& device, Topology /*topology*/) {
-    constexpr uint32_t PACKET_HEADER_RESERVED_BYTES = 45056;
-    constexpr uint32_t DATA_SPACE_RESERVED_BYTES = 851968;
-    constexpr uint32_t TEST_RESULTS_SIZE_BYTES = 128;
-
-    uint32_t base_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-    uint32_t source_l1_buffer_address = base_addr + PACKET_HEADER_RESERVED_BYTES;
-    uint32_t test_results_address = source_l1_buffer_address + DATA_SPACE_RESERVED_BYTES;
-    uint32_t target_address = source_l1_buffer_address;
-    uint32_t notification_mailbox_address = test_results_address + TEST_RESULTS_SIZE_BYTES;
-
-    uint32_t packet_payload_size_bytes = get_tt_fabric_max_payload_size_bytes();
-
-    return {
-        source_l1_buffer_address,
-        packet_payload_size_bytes,
-        test_results_address,
-        target_address,
-        notification_mailbox_address,
-        TEST_RESULTS_SIZE_BYTES};
-}
-
 // Helper struct for dual RISC memory layout generation
 // Provides memory map generation that supports both single and dual RISC modes
 struct DualRiscMemMapHelper {
@@ -271,7 +238,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
 
     auto mesh_shape = control_plane.get_physical_mesh_shape(sender_id.mesh_id);
 
-    auto worker_mem_map = generate_worker_mem_map(sender_device, edm_config.topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, edm_config.topology);
     uint32_t num_packets = 100;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -466,7 +433,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -591,7 +558,7 @@ void run_unicast_test_bw_chips(
     uint32_t is_2d_fabric = topology == Topology::Mesh;
 
     // test parameters
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -963,7 +930,7 @@ void RunTestMCastConnAPI(
     CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 100;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -1407,7 +1374,7 @@ void RunTest2DMCastConnAPI(
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
     // test parameters
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 100;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -1753,7 +1720,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
         last_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 100;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -2207,7 +2174,7 @@ void FabricUnicastCommon(
 
     tt_metal::Program sender_program = tt_metal::CreateProgram();
 
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
 
     std::vector<uint32_t> compile_time_args = {
         worker_mem_map.test_results_address,
@@ -3163,7 +3130,7 @@ void Fabric2DMulticastCommon(
     }
 
     auto sender_device = fixture->get_device(src_physical_device_id);
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
 
     // Setup connections and collect receiver devices for each multicast route
     std::vector<FabricNodeId> dest_fabric_node_ids;
@@ -3454,7 +3421,7 @@ void FabricMulticastCommon(
     }
 
     auto sender_device = fixture->get_device(src_physical_device_id);
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
 
     // Adjust lists to start from start_distance for each direction
     std::vector<FabricNodeId> dest_fabric_node_ids;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -34,39 +34,6 @@
 
 namespace tt::tt_fabric::fabric_router_tests {
 
-struct WorkerMemMap {
-    uint32_t source_l1_buffer_address;
-    uint32_t packet_payload_size_bytes;
-    uint32_t test_results_address;
-    uint32_t target_address;
-    uint32_t notification_mailbox_address;
-    uint32_t test_results_size_bytes;
-};
-
-// Utility function reused across tests to get address params
-WorkerMemMap generate_worker_mem_map(
-    const std::shared_ptr<tt_metal::distributed::MeshDevice>& device, Topology /*topology*/) {
-    constexpr uint32_t PACKET_HEADER_RESERVED_BYTES = 45056;
-    constexpr uint32_t DATA_SPACE_RESERVED_BYTES = 851968;
-    constexpr uint32_t TEST_RESULTS_SIZE_BYTES = 128;
-
-    uint32_t base_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-    uint32_t source_l1_buffer_address = base_addr + PACKET_HEADER_RESERVED_BYTES;
-    uint32_t test_results_address = source_l1_buffer_address + DATA_SPACE_RESERVED_BYTES;
-    uint32_t target_address = source_l1_buffer_address;
-    uint32_t notification_mailbox_address = test_results_address + TEST_RESULTS_SIZE_BYTES;
-
-    uint32_t packet_payload_size_bytes = get_tt_fabric_max_payload_size_bytes();
-
-    return {
-        source_l1_buffer_address,
-        packet_payload_size_bytes,
-        test_results_address,
-        target_address,
-        notification_mailbox_address,
-        TEST_RESULTS_SIZE_BYTES};
-}
-
 void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
@@ -104,7 +71,7 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto edm_port = *eth_chans.begin();
 
     // Simple test parameters for smoke test
-    auto worker_mem_map = generate_worker_mem_map(sender_device, topology);
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
     uint32_t num_packets = 5;  // Small number for smoke test
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);

--- a/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_generic_op.cpp
@@ -38,6 +38,10 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "ttnn/tensor/shape/shape.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tests/tt_metal/tt_fabric/common/fabric_fixture.hpp"
 
 namespace ttnn::operations::generic::test {
 
@@ -1367,6 +1371,164 @@ TEST_F(MeshDevice1x4FabricFixture, TestGenericOpAllGather) {
             EXPECT_EQ(static_cast<float>(data[i]), expected);
         }
     }
+}
+
+class Fabric1DFixtureGeneric : public tt::tt_fabric::fabric_router_tests::Fabric1DFixture {
+public:
+    Fabric1DFixtureGeneric() : tt::tt_fabric::fabric_router_tests::Fabric1DFixture() {}
+};
+
+TEST_F(Fabric1DFixtureGeneric, TestLinearFabricUnicastNocUnicastWrite) {
+    auto sender_device_coord = distributed::MeshCoordinate(0, 0);
+    auto receiver_device_coord = distributed::MeshCoordinate(0, 0);
+    uint32_t num_hops = 1;
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_fabric::FabricNodeId sender_fabric_node_id(tt::tt_fabric::MeshId{0}, 0);
+    std::vector<tt::tt_fabric::FabricNodeId> receiver_fabric_node_ids;
+    receiver_fabric_node_ids.emplace_back(tt::tt_fabric::MeshId{0}, 1);
+    uint32_t num_packets = 10;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+    tt::tt_fabric::FabricApiType api_type = tt::tt_fabric::FabricApiType::Linear;
+    bool with_state = false;
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+
+    auto sender_device =
+        this->get_device(control_plane.get_physical_chip_id_from_fabric_node_id(sender_fabric_node_id));
+    auto receiver_device =
+        this->get_device(control_plane.get_physical_chip_id_from_fabric_node_id(receiver_fabric_node_ids[0]));
+    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+
+    auto worker_mem_map = this->generate_worker_mem_map(sender_device, topology);
+
+    std::vector<uint32_t> compile_time_args = {
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        worker_mem_map.notification_mailbox_address,
+        worker_mem_map.target_address,
+        0,  // tt::tt_metal::NocSendType::NOC_UNICAST_WRITE
+        1,  // num_send_dir
+        with_state,
+        0  // is_chip_multicast = 0
+    };
+
+    std::vector<uint32_t> sender_runtime_args = {
+        worker_mem_map.source_l1_buffer_address,
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        time_seed,
+        receiver_virtual_core.x,
+        receiver_virtual_core.y,
+        num_hops};
+
+    // Create kernel descriptor (with empty runtime args initially)
+    KernelDescriptor sender_kernel_descriptor = {
+        .kernel_source =
+            "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp",
+        .core_ranges = {sender_logical_core},
+        .compile_time_args = compile_time_args,
+        .runtime_args = {},  // Will be set after append call
+        .common_runtime_args = {},
+        .config = tt::tt_metal::DataMovementConfigDescriptor{},
+    };
+
+    // Create program descriptor so append_routing_plane_connection_manager_rt_args can add semaphores and defines
+    ProgramDescriptor sender_program_descriptor = {
+        .kernels = {sender_kernel_descriptor},
+        .semaphores = {},
+        .cbs = {{}, {}},
+    };
+
+    // Append fabric connection args - this modifies sender_runtime_args and adds semaphores/defines to descriptor
+    tt::tt_metal::KernelHandle kernel_id = static_cast<tt::tt_metal::KernelHandle>(0);
+    tt::tt_fabric::append_routing_plane_connection_manager_rt_args(
+        sender_fabric_node_id,
+        {tt::tt_fabric::RoutingDirection::E},
+        {},
+        sender_program_descriptor,
+        kernel_id,
+        {sender_logical_core},
+        sender_runtime_args,
+        api_type);
+
+    // NOW set the complete runtime args on the kernel (after append has added connection args)
+    sender_program_descriptor.kernels[kernel_id].runtime_args = {{sender_logical_core, sender_runtime_args}};
+
+    ProgramDescriptor receiver_program_descriptor;
+
+    std::vector<uint32_t> receiver_runtime_args = {
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        time_seed,
+    };
+
+    KernelDescriptor receiver_kernel_descriptor = {
+        .kernel_source = "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_receiver.cpp",
+        .core_ranges = {receiver_logical_core},
+        .compile_time_args = compile_time_args,
+        .runtime_args = {{receiver_logical_core, receiver_runtime_args}},
+        .common_runtime_args = {},
+        .config = tt::tt_metal::DataMovementConfigDescriptor{},
+    };
+
+    receiver_program_descriptor = {
+        .kernels = {receiver_kernel_descriptor},
+        .semaphores = {},
+        .cbs = {{}, {}},
+    };
+
+    log_info(tt::LogTest, "Executing fabric unicast test via generic_op...");
+    tt::tt_metal::experimental::MeshProgramDescriptor receiver_mesh_program_descriptor;
+    receiver_mesh_program_descriptor.mesh_programs.emplace_back(
+        ttnn::MeshCoordinateRange(receiver_device_coord), std::move(receiver_program_descriptor));
+    tt::tt_metal::experimental::MeshProgramDescriptor sender_mesh_program_descriptor;
+    sender_mesh_program_descriptor.mesh_programs.emplace_back(
+        ttnn::MeshCoordinateRange(sender_device_coord), std::move(sender_program_descriptor));
+
+    // Create placeholder tensors - generic_op requires at least one input and one output tensor
+    ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+    Tensor input_tensor = ttnn::random::random(shape, tt::tt_metal::DataType::BFLOAT16);
+    Tensor output_tensor = ttnn::random::random(shape, tt::tt_metal::DataType::BFLOAT16);
+    Tensor device_input_tensor_sender = input_tensor.to_device(sender_device.get());
+    Tensor device_output_tensor_sender = output_tensor.to_device(sender_device.get());
+    Tensor device_input_tensor_receiver = input_tensor.to_device(receiver_device.get());
+    Tensor device_output_tensor_receiver = output_tensor.to_device(receiver_device.get());
+
+    ttnn::generic_op(
+        std::vector<Tensor>{device_input_tensor_receiver, device_output_tensor_receiver},
+        receiver_mesh_program_descriptor);
+    ttnn::generic_op(
+        std::vector<Tensor>{device_input_tensor_sender, device_output_tensor_sender}, sender_mesh_program_descriptor);
+    sender_device->quiesce_devices();
+    receiver_device->quiesce_devices();
+
+    std::vector<uint32_t> sender_status;
+    tt::tt_metal::detail::ReadFromDeviceL1(
+        sender_device->get_devices()[0],
+        sender_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        sender_status,
+        tt::CoreType::WORKER);
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    std::vector<uint32_t> receiver_status;
+
+    tt::tt_metal::detail::ReadFromDeviceL1(
+        receiver_device->get_devices()[0],
+        receiver_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        receiver_status,
+        tt::CoreType::WORKER);
+    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    uint64_t sender_words =
+        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
+    uint64_t receiver_words =
+        ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
+    EXPECT_EQ(sender_words, receiver_words);
 }
 
 }  // namespace ttnn::operations::generic::test

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -96,7 +96,7 @@ void append_routing_plane_connection_manager_rt_args(
 template <typename ProgramOrDescriptor>
 uint32_t append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
-    const std::vector<RoutingDirection>& attemped_directions,
+    const std::vector<RoutingDirection>& attempted_directions,
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -93,11 +93,12 @@ void append_routing_plane_connection_manager_rt_args(
 
 // append runtime parameter for RoutingPlaneConnectionManager
 // convenience function using RoutingDirection's
+template <typename ProgramOrDescriptor>
 uint32_t append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<RoutingDirection>& attemped_directions,
     const std::vector<uint32_t>& connection_link_indices,
-    tt::tt_metal::Program& worker_program,
+    ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -91,6 +91,19 @@ void append_routing_plane_connection_manager_rt_args(
     FabricApiType api_type = FabricApiType::Linear,
     CoreType core_type = CoreType::WORKER);
 
+// append runtime parameter for RoutingPlaneConnectionManager
+// convenience function using RoutingDirection's
+uint32_t append_routing_plane_connection_manager_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<RoutingDirection>& attemped_directions,
+    const std::vector<uint32_t>& connection_link_indices,
+    tt::tt_metal::Program& worker_program,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    FabricApiType api_type = FabricApiType::Linear,
+    CoreType core_type = CoreType::WORKER);
+
 // returns which links on a given src chip are available for forwarding the data to a dst chip
 // these link indices can then be used to establish connection with the fabric routers
 std::vector<uint32_t> get_forwarding_link_indices(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -277,14 +277,14 @@ uint32_t append_routing_plane_connection_manager_rt_args(
 
     std::vector<FabricNodeId> dst_nodes;
     std::unordered_set<RoutingDirection> used_directions;
-    for (int i = 0; i < attempted_directionss.size(); i++) {
+    for (auto dir : attempted_directionss) {
         TT_FATAL(
-            !used_directions.contains(attempted_directionss[i]),
+            !used_directions.contains(dir),
             "Multiple ethernet cores in the same direction ({}) are not currently supported. "
             "This restriction will be removed in a future update when proper multi-core routing is implemented.",
-            attempted_directionss[i]);
+            dir);
 
-        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, attempted_directionss[i]);
+        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, dir);
 
         if (!neighbors.empty()) {
             dst_nodes.push_back(FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]));

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -262,11 +262,12 @@ void append_fabric_connection_rt_args(
 
 // append runtime parameter for RoutingPlaneConnectionManager
 // convenience function using RoutingDirection's
+template <typename ProgramOrDescriptor>
 uint32_t append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
     const std::vector<RoutingDirection>& attemped_directions,
     const std::vector<uint32_t>& connection_link_indices,
-    tt::tt_metal::Program& worker_program,
+    ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
@@ -298,7 +299,7 @@ uint32_t append_routing_plane_connection_manager_rt_args(
         src_fabric_node_id,
         dst_nodes,
         connection_link_indices,
-        worker_program,
+        worker_program_or_desc,
         kernel_id,
         worker_core,
         worker_args,
@@ -533,6 +534,28 @@ template void append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
     tt::tt_metal::ProgramDescriptor&,
     const CoreCoord&,
     std::vector<uint32_t>&,
+    CoreType);
+
+template uint32_t append_routing_plane_connection_manager_rt_args<tt::tt_metal::ProgramDescriptor>(
+    const FabricNodeId&,
+    const std::vector<RoutingDirection>&,
+    const std::vector<uint32_t>&,
+    tt::tt_metal::ProgramDescriptor&,
+    tt::tt_metal::KernelHandle&,
+    const CoreCoord&,
+    std::vector<uint32_t>&,
+    FabricApiType,
+    CoreType);
+
+template uint32_t append_routing_plane_connection_manager_rt_args<tt::tt_metal::Program>(
+    const FabricNodeId&,
+    const std::vector<RoutingDirection>&,
+    const std::vector<uint32_t>&,
+    tt::tt_metal::Program&,
+    tt::tt_metal::KernelHandle&,
+    const CoreCoord&,
+    std::vector<uint32_t>&,
+    FabricApiType,
     CoreType);
 
 template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::ProgramDescriptor>(

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -265,7 +265,7 @@ void append_fabric_connection_rt_args(
 template <typename ProgramOrDescriptor>
 uint32_t append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,
-    const std::vector<RoutingDirection>& attemped_directions,
+    const std::vector<RoutingDirection>& attempted_directionss,
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
@@ -277,20 +277,16 @@ uint32_t append_routing_plane_connection_manager_rt_args(
 
     std::vector<FabricNodeId> dst_nodes;
     std::unordered_set<RoutingDirection> used_directions;
-    for (int i = 0; i < attemped_directions.size(); i++) {
+    for (int i = 0; i < attempted_directionss.size(); i++) {
         TT_FATAL(
-            !used_directions.contains(attemped_directions[i]),
+            !used_directions.contains(attempted_directionss[i]),
             "Multiple ethernet cores in the same direction ({}) are not currently supported. "
             "This restriction will be removed in a future update when proper multi-core routing is implemented.",
-            attemped_directions[i]);
+            attempted_directionss[i]);
 
-        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, attemped_directions[i]);
+        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, attempted_directionss[i]);
 
         if (!neighbors.empty()) {
-            // TT_FATAL(
-            //     neighbors.size() == 1,
-            //     "Multiple neighbours ({}) found in direction ({}) of src node ({}) {} {}.",
-            //     neighbors.size(), attemped_directions[i], src_fabric_node_id, neighbors[0], neighbors[1]);
             dst_nodes.push_back(FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]));
         }
     }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -261,6 +261,54 @@ void append_fabric_connection_rt_args(
 }
 
 // append runtime parameter for RoutingPlaneConnectionManager
+// convenience function using RoutingDirection's
+uint32_t append_routing_plane_connection_manager_rt_args(
+    const FabricNodeId& src_fabric_node_id,
+    const std::vector<RoutingDirection>& attemped_directions,
+    const std::vector<uint32_t>& connection_link_indices,
+    tt::tt_metal::Program& worker_program,
+    tt::tt_metal::KernelHandle& kernel_id,
+    const CoreCoord& worker_core,
+    std::vector<uint32_t>& worker_args,
+    FabricApiType api_type,
+    CoreType core_type) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    std::vector<FabricNodeId> dst_nodes;
+    std::unordered_set<RoutingDirection> used_directions;
+    for (int i = 0; i < attemped_directions.size(); i++) {
+        TT_FATAL(
+            !used_directions.contains(attemped_directions[i]),
+            "Multiple ethernet cores in the same direction ({}) are not currently supported. "
+            "This restriction will be removed in a future update when proper multi-core routing is implemented.",
+            attemped_directions[i]);
+
+        auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, attemped_directions[i]);
+
+        if (!neighbors.empty()) {
+            // TT_FATAL(
+            //     neighbors.size() == 1,
+            //     "Multiple neighbours ({}) found in direction ({}) of src node ({}) {} {}.",
+            //     neighbors.size(), attemped_directions[i], src_fabric_node_id, neighbors[0], neighbors[1]);
+            dst_nodes.push_back(FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]));
+        }
+    }
+
+    append_routing_plane_connection_manager_rt_args(
+        src_fabric_node_id,
+        dst_nodes,
+        connection_link_indices,
+        worker_program,
+        kernel_id,
+        worker_core,
+        worker_args,
+        api_type,
+        core_type);
+
+    return dst_nodes.size();
+}
+
+// append runtime parameter for RoutingPlaneConnectionManager
 template <typename ProgramOrDescriptor>
 void append_routing_plane_connection_manager_rt_args(
     const FabricNodeId& src_fabric_node_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -17,7 +17,7 @@ namespace tt::tt_fabric {
 #if defined(FABRIC_2D)
 #define TT_FABRIC_MAX_ROUTING_PLANE_CONNECTIONS 4
 #else  // 1D
-#define TT_FABRIC_MAX_ROUTING_PLANE_CONNECTIONS 2
+#define TT_FABRIC_MAX_ROUTING_PLANE_CONNECTIONS 4
 // TODO: 3D, dragonfly and custom etc.
 #endif
 #endif


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-mlir/issues/6618

### Problem description/What's changed
This is a convenience function for the metal runtime in tt-mlir to be able to add connection arguments for worker cores in all routing directions.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadeem/ttkernel_fabric_ops)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/ttkernel_fabric_ops)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/ttkernel_fabric_ops)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/ttkernel_fabric_ops)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/ttkernel_fabric_ops)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/ttkernel_fabric_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/ttkernel_fabric_ops)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs