### PR TITLE
Support dynamic `trace_region_size`

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_single_device_trace.py
@@ -13,7 +13,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("blocking", [True, False])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 0}], indirect=True)
 def test_single_device_single_trace(device, shape, blocking):
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
@@ -68,7 +68,7 @@ def test_single_device_single_trace(device, shape, blocking):
 
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)])
 @pytest.mark.parametrize("blocking", [True, False])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 86016}, {"trace_region_size": 0}], indirect=True)
 def test_single_device_multi_trace(device, shape, blocking):
     # Preallocate activation tensors. These will be used when capturing and executing the trace
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -160,7 +160,7 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
     mesh_cq.device()->set_trace_buffers_size(current_trace_buffers_size + padded_size);
     const auto new_trace_buffer_size = mesh_cq.device()->get_trace_buffers_size();
 
-    // check trace_regin_size if it's not zero
+    // check trace_region_size if it's not zero
     auto trace_region_size = mesh_cq.device()->allocator_impl()->get_config().trace_region_size;
     if (trace_region_size != 0) {
         TT_FATAL(
@@ -169,7 +169,7 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
             new_trace_buffer_size,
             mesh_cq.device()->id(),
             trace_region_size);
-    } else {
+    } else if (new_trace_buffer_size > current_trace_buffers_size) {
         mesh_cq.device()->allocator_impl()->expand_trace_region_size(current_trace_buffers_size, new_trace_buffer_size);
     }
 

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -147,7 +147,8 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
             DeviceLocalBufferConfig device_local_kernel_bin_buf_config = {
                 .page_size = HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
                 .buffer_type = BufferType::DRAM,
-                .bottom_up = false,
+                // kernel bin position changed for easy implementation for dynamic trace region size
+                .bottom_up = true,
             };
             ReplicatedBufferConfig global_kernel_bin_buf_config = {
                 .size = max_kernel_bin_buf_size,

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -564,7 +564,6 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     } else {
         // loop and scan the block list to find if the shrink cut into any allocated block
         size_t block_to_shrink = -1;
-        // DeviceAddr shrunk_address = shrink_size_ + shrink_size;
         DeviceAddr shrunk_address = max_size_bytes_ - (shrink_size_ + shrink_size);
 
         // TODO: There must be a way to force the beginning of all blocks be at index 0
@@ -574,14 +573,13 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
             if (!meta_block_is_allocated_[idx]) {
                 continue;
             }
-            if (block_address_[idx] <= shrunk_address && block_address_[idx] + block_size_[idx] >= shrunk_address) {
-                if (block_is_allocated_[idx]) {
-                    TT_FATAL(
-                        block_address_[idx] >= shrunk_address,
-                        "Shrink size {} cuts into allocated block at address {}",
-                        shrunk_address,
-                        block_address_[idx]);
-                }
+            if (block_address_[idx] <= shrunk_address && shrunk_address <= block_address_[idx] + block_size_[idx]) {
+                TT_FATAL(
+                    block_is_allocated_[idx] == false,
+                    "shrunk_address {} cuts into allocated block at address [{}, {}]",
+                    shrunk_address,
+                    block_address_[idx],
+                    block_address_[idx] + block_size_[idx]);
                 block_to_shrink = idx;
                 break;
             }

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -95,6 +95,11 @@ void AllocatorImpl::init_one_bank_per_channel() {
 
 void AllocatorImpl::expand_trace_region_size(
     const size_t previous_trace_region_size, const size_t new_trace_region_size) {
+    TT_FATAL(
+        new_trace_region_size > previous_trace_region_size,
+        "expand_trace_region_size expects new_trace_region_size={} > previous_trace_region_size={}",
+        new_trace_region_size,
+        previous_trace_region_size);
     {
         auto bottom_up = false;
         auto dram_shrink_size_per_bank =
@@ -112,7 +117,7 @@ void AllocatorImpl::expand_trace_region_size(
             config_->dram_bank_size - config_->dram_unreserved_base - trace_region_size_per_bank;
         DeviceAddr trace_bank_size = dram_bank_size + trace_region_size_per_bank;
 
-        // bottom up shirnk
+        // bottom up shrink
         auto trace_shrink_size = trace_bank_size - new_trace_region_size / config_->num_dram_channels;
         auto bottom_up = true;
         trace_buffer_manager_->shrink_size(trace_shrink_size, bottom_up);

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -71,6 +71,8 @@ public:
     void shrink_allocator_size(const BufferType& buffer_type, DeviceAddr shrink_size, bool bottom_up = true);
     void reset_allocator_size(const BufferType& buffer_type);
 
+    void expand_trace_region_size(const size_t previous_trace_region_size, const size_t trace_region_size);
+
     void mark_allocations_unsafe();
     void mark_allocations_safe();
 


### PR DESCRIPTION
### Ticket

### Problem description
1. Manually set `trace_region_size` is cumbersome.

### What's changed
1. Use 0 for automatic `trace_region_size` configuration.
2. Move kernel binary position on DRAM from bottom to top.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:hschoi/dynamic_trace_region_size)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:hschoi/dynamic_trace_region_size)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:hschoi/dynamic_trace_region_size)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:hschoi/dynamic_trace_region_size)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:hschoi/dynamic_trace_region_size)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=hschoi/dynamic_trace_region_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:hschoi/dynamic_trace_region_size)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs