### PR TITLE
Allow larger inputs to CQPrefetchRelayLinearHCmd

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1069,7 +1069,6 @@ protected:
 
 public:
     std::vector<HostMemDeviceCommand> generate_prefetch_relay_h_commands(
-        const CoreCoord first_worker,
         const uint32_t mmio_dram_base,
         const uint32_t dram_alignment,
         Common::DeviceData& src_device_data,
@@ -2045,7 +2044,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
         remote_device_, worker_range, l1_base, remote_dram_base, nullptr, true, 0 /* don't prepopulate */, cfg_);
 
     auto commands_per_iteration =
-        generate_prefetch_relay_h_commands(first_worker, mmio_dram_base, dram_alignment, mmio_device_data, device_data);
+        generate_prefetch_relay_h_commands(mmio_dram_base, dram_alignment, mmio_device_data, device_data);
 
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1074,7 +1074,6 @@ public:
         const uint32_t dram_alignment,
         Common::DeviceData& src_device_data,
         Common::DeviceData& dest_device_data) {
-
         // Destination: DRAM bank 0 on Remote Device
         const uint32_t dest_dram_bank_id = 0;
         const auto dest_dram_channel =
@@ -2038,8 +2037,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
         const uint32_t num_banks = remote_device_->allocator_impl()->get_num_banks(BufferType::DRAM);
 
         for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
-            tt::tt_metal::detail::WriteToDeviceDRAMChannel(
-                remote_device_, bank_id, remote_dram_base, dirty_data);
+            tt::tt_metal::detail::WriteToDeviceDRAMChannel(remote_device_, bank_id, remote_dram_base, dirty_data);
         }
         MetalContext::instance().get_cluster().dram_barrier(remote_device_->id());
     }
@@ -2048,7 +2046,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
 
     auto commands_per_iteration =
         generate_prefetch_relay_h_commands(first_worker, mmio_dram_base, dram_alignment, mmio_device_data, device_data);
-    
+
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
     const bool pass_after = device_data.validate(remote_device_);
     EXPECT_TRUE(pass_after) << "Dispatcher test failed validation";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -48,7 +48,7 @@ namespace tt::tt_metal::tt_dispatch_tests::prefetcher_tests {
 constexpr uint32_t DEFAULT_ITERATIONS = 5;
 constexpr uint32_t DEFAULT_ITERATIONS_SMOKE_RANDOM = 1000;
 constexpr uint32_t DEVICE_DATA_SIZE = 768 * 1024;
-constexpr uint32_t DEVICE_DATA_SIZE_LARGE = 20 * 1024 * 1024;  // 20MB for large DRAM transfers
+constexpr uint32_t DEVICE_DATA_SIZE_LARGE = 20 * 1024 * 1024;
 constexpr uint32_t DRAM_PAGE_SIZE_DEFAULT = 1024;
 constexpr uint32_t DRAM_PAGES_TO_READ_DEFAULT = 16;
 constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 16 * 1024;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2048,8 +2048,6 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
         generate_prefetch_relay_h_commands(first_worker, mmio_dram_base, dram_alignment, mmio_device_data, device_data);
 
     execute_generated_commands(commands_per_iteration, device_data, worker_range.size(), num_iterations);
-    const bool pass_after = device_data.validate(remote_device_);
-    EXPECT_TRUE(pass_after) << "Dispatcher test failed validation";
 }
 
 // Smoke test of prefetcher/dispatcher commands except add_dispatch_write_host

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1074,11 +1074,6 @@ public:
         const uint32_t dram_alignment,
         Common::DeviceData& src_device_data,
         Common::DeviceData& dest_device_data) {
-        const uint32_t max_read_size =
-            std::min(
-                DEFAULT_SCRATCH_DB_SIZE,
-                DEFAULT_PREFETCH_Q_ENTRIES * (uint32_t)sizeof(DispatchSettings::prefetch_q_entry_type)) -
-            64;
 
         // Destination: DRAM bank 0 on Remote Device
         const uint32_t dest_dram_bank_id = 0;
@@ -1102,7 +1097,7 @@ public:
         while (remaining_bytes > 0) {
             uint32_t length = std::min(
                 tt::align(
-                    std::max(MIN_READ_SIZE, payload_generator_->get_rand<uint32_t>(0, max_read_size - 1)),
+                    std::max(MIN_READ_SIZE, payload_generator_->get_rand<uint32_t>(0, remaining_bytes)),
                     dram_alignment),
                 remaining_bytes);
 

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -96,11 +96,10 @@ struct CQPrefetchRelayLinearCmd {
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH). Must be only
 // command in fetchq entry.
 struct CQPrefetchRelayLinearHCmd {
-    uint8_t pad1;
-    uint16_t pad2;
+    uint16_t pad1;
+    uint64_t length;
     uint32_t noc_xy_addr;
     uint64_t addr;
-    uint32_t length;  // Length must be <= min(scratch_db_size, max command size) - sizeof(CQPrefetchHToPrefetchDHeader)
 } __attribute__((packed));
 
 constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0xff;

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -87,19 +87,21 @@ struct CQPrefetchBaseCmd {
 
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH)
 struct CQPrefetchRelayLinearCmd {
-    uint16_t pad1;
-    uint64_t length;
+    uint8_t pad1;
+    uint16_t pad2;
     uint32_t noc_xy_addr;
     uint64_t addr;
+    uint64_t length;
 } __attribute__((packed));
 
 // Flushes an extra page at the end (so it can only be used after CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH). Must be only
 // command in fetchq entry.
 struct CQPrefetchRelayLinearHCmd {
-    uint16_t pad1;
-    uint64_t length;
+    uint8_t pad1;
+    uint16_t pad2;
     uint32_t noc_xy_addr;
     uint64_t addr;
+    uint64_t length;
 } __attribute__((packed));
 
 constexpr uint32_t CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK = 0xff;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -494,6 +494,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
     }
 
     while (length != 0) {
+        #if 1
         // Transfer size is min(remaining_length, data_available_in_cb)
 #if defined(FABRIC_RELAY)
         uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
@@ -519,6 +520,11 @@ void process_write_linear(uint32_t num_mcast_dests) {
         uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
         noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
         noc_nonposted_writes_acked[noc_index] += num_mcast_dests * num_noc_packets_written;
+        #endif
+        #if 0
+        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+        uint32_t xfer_size = length > available_data ? available_data : length;
+        #endif
         length -= xfer_size;
         data_ptr += xfer_size;
         dst_addr += xfer_size;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -494,7 +494,6 @@ void process_write_linear(uint32_t num_mcast_dests) {
     }
 
     while (length != 0) {
-#if 1
         // Transfer size is min(remaining_length, data_available_in_cb)
 #if defined(FABRIC_RELAY)
         uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
@@ -520,11 +519,6 @@ void process_write_linear(uint32_t num_mcast_dests) {
         uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
         noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
         noc_nonposted_writes_acked[noc_index] += num_mcast_dests * num_noc_packets_written;
-#endif
-#if 0
-        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
-        uint32_t xfer_size = length > available_data ? available_data : length;
-#endif
         length -= xfer_size;
         data_ptr += xfer_size;
         dst_addr += xfer_size;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -494,7 +494,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
     }
 
     while (length != 0) {
-        #if 1
+#if 1
         // Transfer size is min(remaining_length, data_available_in_cb)
 #if defined(FABRIC_RELAY)
         uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
@@ -520,11 +520,11 @@ void process_write_linear(uint32_t num_mcast_dests) {
         uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
         noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
         noc_nonposted_writes_acked[noc_index] += num_mcast_dests * num_noc_packets_written;
-        #endif
-        #if 0
+#endif
+#if 0
         uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
         uint32_t xfer_size = length > available_data ? available_data : length;
-        #endif
+#endif
         length -= xfer_size;
         data_ptr += xfer_size;
         dst_addr += xfer_size;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1662,7 +1662,7 @@ bool process_cmd(
 /* Relay linear bytes to dispatch_hd or dispatch_d via prefetch_d. test_for_nonzero is an optimization that can be false
  * if amt_to_write >= downstream_cb_page_size. For simplicity this code will always acquire the exact number of pages
  * needed, unlike write_pages_to_dispatcher which may acquire an extra page if we hit an exact page boundary. */
-template<bool test_for_nonzero>
+template <bool test_for_nonzero>
 static void relay_linear_to_downstream(
     uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
     // Unlike in write_pages_to_dispatcher we always round npages down, so if downstream_data_ptr is at the start of a

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1772,11 +1772,10 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
     uint32_t amt_to_write = amt_to_read;
     uint32_t npages = relay_linear_to_downstream(downstream_data_ptr, scratch_write_addr, amt_to_write);
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-    constexpr auto additional_page = is_d_variant ? 1 : 0;
 #if defined(FABRIC_RELAY)
-    relay_client.release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + additional_page);
+    relay_client.release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 #else
-    DispatchRelayInlineState::cb_writer.release_pages(npages + additional_page, downstream_data_ptr);
+    DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr);
 #endif
 
     return 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1724,6 +1724,8 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
     uint32_t scratch_write_addr;
     // Add back start_offset to amt_to_read to ensure all bytes from scratch_db are transferred
     amt_to_read += start_offset;
+    // Calculate the largest multiple of scratch_db_half_size that can fit in a uint32_t. This allows most of the math
+    // to be done in 32 bits.
     constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
     while (wlength != 0) {
         uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -535,7 +535,7 @@ static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dis
 // top of the first page At the end, do not grab page N+1
 template <int32_t round, bool test_for_nonzero>
 static uint32_t write_pages_to_dispatcher(
-    uint32_t& downstream_data_ptr, uint32_t& scratch_write_addr, uint32_t amt_to_write) {
+    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
     uint32_t page_residual_space = downstream_cb_page_size - (downstream_data_ptr & (downstream_cb_page_size - 1));
     uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - round) / downstream_cb_page_size;
 
@@ -1759,7 +1759,7 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
 
     // Third step - write from DB
     uint32_t amt_to_write = amt_to_read;
-    relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
+    relay_linear_to_downstream<true>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // RelayLinearH is a large command.

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -28,9 +28,8 @@ constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC P
 static_assert(sizeof(CQPrefetchCmd) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
 static_assert(sizeof(CQPrefetchCmdLarge) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
 struct CQPrefetchHToPrefetchDHeader_s {
-    uint32_t length;
-    uint8_t raw_copy;     // If true, copy the data directly to the downstream.
-    uint8_t extra_pages;  // Number of extra pages to flush at the end (if doing raw copy)
+    uint64_t length;
+    uint8_t raw_copy;  // If true, copy the data directly to the downstream.
 };
 union CQPrefetchHToPrefetchDHeader {
     CQPrefetchHToPrefetchDHeader_s header;
@@ -225,6 +224,8 @@ struct PrefetchExecBufState {
     uint32_t read_ptr;
     uint32_t prefetch_length;
 };
+
+uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr);
 
 // Global Variables
 static uint32_t pcie_read_ptr = pcie_base;
@@ -534,7 +535,7 @@ static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dis
 // top of the first page At the end, do not grab page N+1
 template <int32_t round, bool test_for_nonzero>
 static uint32_t write_pages_to_dispatcher(
-    uint32_t& downstream_data_ptr, uint32_t& scratch_write_addr, uint32_t& amt_to_write) {
+    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
     uint32_t page_residual_space = downstream_cb_page_size - (downstream_data_ptr & (downstream_cb_page_size - 1));
     uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - round) / downstream_cb_page_size;
 
@@ -1532,6 +1533,11 @@ bool process_cmd(
             stride = process_relay_linear_cmd(cmd_ptr, downstream_data_ptr);
             break;
 
+        case CQ_PREFETCH_CMD_RELAY_LINEAR_H:
+            // DPRINT << "relay_linear_h: " << HEX() << cmd_ptr << DEC() << ENDL();
+            stride = process_relay_linear_h_cmd(cmd_ptr, downstream_data_ptr);
+            break;
+
         case CQ_PREFETCH_CMD_RELAY_PAGED:
             // DPRINT << "relay paged: " << cmd_ptr << ENDL();
             {
@@ -1658,75 +1664,135 @@ bool process_cmd(
     return done;
 }
 
+/* Relay linear bytes to dispatch_hd or dispatch_d via prefetch_d */
+static uint32_t relay_linear_to_downstream(
+    uint32_t& downstream_data_ptr, uint32_t& scratch_write_addr, uint32_t& amt_to_write) {
+    uint32_t page_residual_space = (downstream_cb_page_size - (downstream_data_ptr & (downstream_cb_page_size - 1))) &
+                                   (downstream_cb_page_size - 1);
+    // Following is fine if downstream cb block is bigger than scratch and there are at least a couple of them
+    uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - 1) / downstream_cb_page_size;
+    if (npages != 0) {
+        DispatchRelayInlineState::cb_writer.acquire_pages(npages);
+    }
+    uint64_t noc_addr;
+    if (downstream_data_ptr == downstream_cb_end) {
+        downstream_data_ptr = downstream_cb_base;
+    } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
+        uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
+        noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+#if defined(FABRIC_RELAY)
+        relay_client.write_any_len<my_noc_index, true, NCRISC_WR_CMD_BUF>(
+            scratch_write_addr, noc_addr, last_chunk_size);
+#else
+        cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
+#endif
+        downstream_data_ptr = downstream_cb_base;
+        scratch_write_addr += last_chunk_size;
+        amt_to_write -= last_chunk_size;
+    }
+    noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+#if defined(FABRIC_RELAY)
+    // consider calling relay_client.write_atomic_inc_any_len instead
+    relay_client.write_any_len<my_noc_index, true, NCRISC_WR_CMD_BUF>(scratch_write_addr, noc_addr, amt_to_write);
+#else
+    cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
+#endif
+    downstream_data_ptr += amt_to_write;
+    return npages;
+}
+
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr) {
-    // This ensures that a previous cmd using the scratch buf has finished
-    noc_async_writes_flushed();
-
-    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd =
-        (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
-    uint64_t read_addr = cmd->relay_linear_h.addr;
-    uint32_t length = cmd->relay_linear_h.length;
-
-    uint32_t total_length = length + CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-    ASSERT(total_length <= scratch_db_size);
-
-    // DPRINT << "relay_linear_h: " << ((uint32_t)cmd_ptr) << " " << static_cast<uint32_t>(cmd->base.cmd_id) << " " <<
-    // length << " " << read_addr << " " << noc_xy_addr << " dest " << scratch_db_top[0] << ENDL();
-
-    uint32_t data_ptr = scratch_db_top[0];
-    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_db_top[0];
-    dptr->header.length = total_length;
-    dptr->header.raw_copy = true;
-    // Set 1 extra page to flush, because we assume this command follows a CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH which
-    // sends a command header.
-    dptr->header.extra_pages = 1;
-
-    uint32_t payload_ptr = data_ptr + sizeof(CQPrefetchHToPrefetchDHeader);
-
-    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, payload_ptr, length);
-    noc_async_read_barrier();
-
-    uint32_t npages = (total_length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
-    // Assume the dispatch buffer is big relative to cmddat command size that we can
-    // grab what we need in one chunk
-    DispatchRelayInlineState::cb_writer.acquire_pages(npages);
-
-    // Write sizes below may exceed NOC_MAX_BURST_SIZE so we use the any_len version
-    // Amount to write depends on how much free space
-    uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
-    if (downstream_pages_left >= npages) {
-        // WAIT is not needed here because previous writes have already been flushed. Prefetch H only uses this
-        // function and this function always flushes before returning
-        relay_client
-            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), total_length, npages);
-        downstream_data_ptr += npages * downstream_cb_page_size;
-    } else {
-        uint32_t tail_pages = npages - downstream_pages_left;
-        uint32_t available = downstream_pages_left * downstream_cb_page_size;
-        if (available > 0) {
-            relay_client.write_any_len<my_noc_index, false, NCRISC_WR_CMD_BUF, true>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
-            data_ptr += available;
-            total_length -= available;
-        }
-
-        // Remainder
-        // WAIT is needed here because previously "if (available > 0)" then it used the write buf which may still be
-        // busy at this point
-        relay_client
-            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), total_length, npages);
-
-        downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
+uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
+    if constexpr (is_d_variant) {
+        // This ensures that a previous cmd using the scratch buf has finished
+        // Unnecessary for prefetch_h because writes are flushed in the end
+        noc_async_writes_flushed();
     }
 
-    noc_async_writes_flushed();
+    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
+    if constexpr (not is_d_variant) {
+        cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    } else {
+        cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)cmd_ptr;
+    }
+    uint64_t wlength = cmd->relay_linear_h.length;
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    constexpr uint32_t start_offset = is_d_variant ? 0 : sizeof(CQPrefetchHToPrefetchDHeader);
+    if constexpr (not is_d_variant) {
+        // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
+        volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
+            (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
+        dptr->header.length = wlength + sizeof(CQPrefetchHToPrefetchDHeader);
+        dptr->header.raw_copy = true;
+        scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
+    }
 
-    return CQ_PREFETCH_CMD_BARE_MIN_SIZE + sizeof(CQPrefetchHToPrefetchDHeader);
+    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
+    uint64_t read_addr = cmd->relay_linear_h.addr;
+
+    // DPRINT << "relay_linear_h: cmd_ptr:0x" << HEX() << (uint32_t)cmd_ptr << ", length:0x " << wlength << ", addr:0x"
+    // << read_addr << ", nocxy:0x" << noc_xy_addr << ", downstream_data_ptr:0x" << downstream_data_ptr << DEC() <<
+    // ENDL();
+
+    // First step - read into DB0
+    uint32_t amt_to_read =
+        (scratch_db_half_size - start_offset > wlength) ? wlength : scratch_db_half_size - start_offset;
+    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+
+    read_addr += amt_to_read;
+    wlength -= amt_to_read;
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+    // Add back start_offset to amt_to_read to ensure all bytes from scratch_db are transferred
+    amt_to_read += start_offset;
+    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
+    while (wlength != 0) {
+        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
+        wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            noc_async_writes_flushed();
+
+            db_toggle ^= 1;
+            scratch_read_addr = scratch_db_top[db_toggle];
+            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+            uint32_t amt_to_write = amt_to_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            noc_read_64bit_any_len<false>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+            read_addr += amt_to_read;
+
+            // Third step - write from DB
+            uint32_t npages = relay_linear_to_downstream(downstream_data_ptr, scratch_write_addr, amt_to_write);
+#if defined(FABRIC_RELAY)
+            relay_client.release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+#else
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, true);
+#endif
+            read_length -= amt_to_read;
+
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
+        }
+    }
+
+    // Third step - write from DB
+    scratch_write_addr = scratch_db_top[db_toggle];
+    uint32_t amt_to_write = amt_to_read;
+    uint32_t npages = relay_linear_to_downstream(downstream_data_ptr, scratch_write_addr, amt_to_write);
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+    constexpr auto additional_page = is_d_variant ? 1 : 0;
+#if defined(FABRIC_RELAY)
+    relay_client.release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + additional_page);
+#else
+    DispatchRelayInlineState::cb_writer.release_pages(npages + additional_page, downstream_data_ptr);
+#endif
+
+    return is_d_variant ? CQ_PREFETCH_CMD_BARE_MIN_SIZE : 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 // This function is only valid when called on the H variant
@@ -1758,8 +1824,7 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
     // Amount to write depends on how much free space
     uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
     if (downstream_pages_left >= npages) {
-        // WAIT is not needed here because previous writes have already been flushed. Prefetch H only uses this
-        // function and this function always flushes before returning
+        // WAIT is not needed here because previous writes were flushed at the end of the loop in the caller (kernel_h)
         relay_client
             .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
                 data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length, npages);
@@ -1784,8 +1849,6 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
         downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
     }
 
-    noc_async_writes_flushed();
-
     return fence;
 }
 
@@ -1804,24 +1867,20 @@ CBReaderWithManualRelease<
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 // Since the size of the data is less that the size of the cmddat_q, we let the caller return pages to the upstream all
 // at once.
-template <typename RelayInlineState>
 inline void relay_raw_data_to_downstream(
-    uint32_t& data_ptr, uint32_t length, uint32_t& local_downstream_data_ptr, uint8_t extra_pages) {
-    ASSERT(length < (cmddat_q_end - cmddat_q_base));
-    // Stream data to downstream as it arrives. Acquire upstream pages incrementally using h_cmddat_q_reader.
-    uint32_t remaining = length;
-
-    while (remaining > 0) {
+    uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
+    // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
+    while (wlength > 0) {
         // Ensure at least one upstream page is available
         uint32_t available_data = h_cmddat_q_reader.wait_for_available_data(data_ptr);
 
         uint32_t can_read_now = available_data;
-        if (can_read_now > remaining) {
-            can_read_now = remaining;
+        if (can_read_now > wlength) {
+            can_read_now = wlength;
         }
 
         // Decide whether this is the final chunk
-        bool is_final_chunk = (can_read_now == remaining);
+        bool is_final_chunk = (can_read_now == wlength);
 
         uint32_t npages;
         if (is_final_chunk) {
@@ -1830,28 +1889,26 @@ inline void relay_raw_data_to_downstream(
             npages = write_pages_to_dispatcher<0, false>(local_downstream_data_ptr, data_ptr, can_read_now);
         }
 
-        // Release pages consumed by this chunk; include extra_pages on final chunk
-        uint32_t pages_to_release = npages;
-        if (is_final_chunk) {
-            pages_to_release += extra_pages;
-        }
-        if (pages_to_release != 0) {
-            RelayInlineState::cb_writer.release_pages(pages_to_release, local_downstream_data_ptr);
+        // Release pages consumed by this chunk
+        if (npages != 0) {
+            DispatchRelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr, true);
         }
 
-        // Advance pointers and remaining
-        data_ptr += can_read_now;
-        remaining -= can_read_now;
+        // Advance pointers and wlength
+        h_cmddat_q_reader.consumed_data(data_ptr, can_read_now);
+        wlength -= can_read_now;
 
-        // Wrap upstream data_ptr if needed
-        if (data_ptr == cmddat_q_end) {
-            data_ptr = cmddat_q_base;
-        }
+        // Release upstream pages so prefetch_h can make more available. Ensure to flush the writes just made to prevent
+        // data race.
+        noc_async_writes_flushed();
+        uint32_t pages_to_free = (can_read_now + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        relay_client.release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
     }
-
-    // Align downstream write pointer
-    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
-
+    local_downstream_data_ptr =
+        round_up_pow2(local_downstream_data_ptr, DispatchRelayInlineState::downstream_page_size);
+    // Release an extra page to account for the dispatch command (via CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH) that would
+    // have headed the first relayed segment
+    DispatchRelayInlineState::cb_writer.release_pages(1, local_downstream_data_ptr);
     // Round upstream pointer to next cmddat page boundary for next command
     data_ptr = round_up_pow2(data_ptr, cmddat_q_page_size);
 }
@@ -1865,26 +1922,19 @@ inline void relay_raw_data_to_downstream(
 // until commands are received.
 inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_ptr) {
     while (true) {
-        // DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end <<
-        // ENDL();
+        // DPRINT << "get_commands: data_ptr:0x" << HEX() << data_ptr << ", fence:0x" << fence << ",
+        // downstream_data_ptr:0x" << downstream_data_ptr << ENDL();
         h_cmddat_q_reader.wait_for_available_data(data_ptr);
 
         volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
             (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
-        uint32_t length = cmd_ptr->header.length;
 
         if (cmd_ptr->header.raw_copy) {
+            uint64_t wlength = cmd_ptr->header.length;
             data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
-            relay_raw_data_to_downstream<DispatchRelayInlineState>(
-                data_ptr,
-                length - sizeof(CQPrefetchHToPrefetchDHeader),
-                downstream_data_ptr,
-                cmd_ptr->header.extra_pages);
-            // Ensure all writes that consumed this payload have completed before releasing upstream pages
-            noc_async_writes_flushed();
-            uint32_t pages_to_free = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
-            relay_client.release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
+            relay_raw_data_to_downstream(data_ptr, wlength - sizeof(CQPrefetchHToPrefetchDHeader), downstream_data_ptr);
         } else {
+            uint32_t length = cmd_ptr->header.length;
             // Ensure the entire command payload is present before returning
             uint32_t pages_ready = h_cmddat_q_reader.available_bytes(data_ptr) >> cmddat_q_log_page_size;
             uint32_t pages_needed = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
@@ -1909,7 +1959,7 @@ void kernel_main_h() {
     bool done = false;
     uint32_t heartbeat = 0;
 
-    // Fetch q uses read buf. Write buf for process_relay_inline_all can be setup once
+    // Fetch q uses read buf. Write buf for process_relay_inline_all/process_relay_linear_h_cmd can be setup once
     relay_client.init<
         my_noc_index,
         fabric_mux_x,
@@ -1941,10 +1991,11 @@ void kernel_main_h() {
         // Infer that an exec_buf command is to be executed based on the stall state.
         bool is_exec_buf = (stall_state == STALLED);
         if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_H) {
-            cmd_ptr += process_relay_linear_h_cmd(cmd_ptr);
+            cmd_ptr += process_relay_linear_h_cmd(cmd_ptr, downstream_data_ptr);
         } else {
             cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
         }
+        noc_async_writes_flushed();
 
         // Note: one fetch_q entry can contain multiple commands
         // The code below assumes these commands arrive individually, packing them would require parsing all cmds

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1867,8 +1867,7 @@ CBReaderWithManualRelease<
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 // Since the size of the data is less that the size of the cmddat_q, we let the caller return pages to the upstream all
 // at once.
-inline void relay_raw_data_to_downstream(
-    uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
+inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
     // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
     while (wlength > 0) {
         // Ensure at least one upstream page is available

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1661,10 +1661,10 @@ bool process_cmd(
 
 /* Relay linear bytes to dispatch_hd or dispatch_d via prefetch_d. test_for_nonzero is an optimization that can be false
  * if amt_to_write >= downstream_cb_page_size. For simplicity this code will always acquire the exact number of pages
- * needed, unlike write_pages_to_dispatcher may acquire an extra page if we hit an exact page boundary. */
+ * needed, unlike write_pages_to_dispatcher which may acquire an extra page if we hit an exact page boundary. */
 template<bool test_for_nonzero>
 static void relay_linear_to_downstream(
-    uint32_t& downstream_data_ptr, uint32_t& scratch_write_addr, uint32_t& amt_to_write) {
+    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
     // Unlike in write_pages_to_dispatcher we always round npages down, so if downstream_data_ptr is at the start of a
     // page, that means page_residual_space is 0. This is why the logic is different from write_pages_to_dispatcher.
     uint32_t page_residual_space = -downstream_data_ptr & (downstream_cb_page_size - 1);
@@ -1763,6 +1763,7 @@ uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_
     relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
+    // RelayLinearH is a large command.
     return 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1865,8 +1865,6 @@ CBReaderWithManualRelease<
     h_cmddat_q_reader;
 
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-// Since the size of the data is less that the size of the cmddat_q, we let the caller return pages to the upstream all
-// at once.
 inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
     // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
     while (wlength > 0) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1691,14 +1691,10 @@ static uint32_t relay_linear_to_downstream(
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
-    if constexpr (not is_d_variant) {
-        cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    } else {
-        cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)cmd_ptr;
-    }
+    cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint64_t wlength = cmd->relay_linear_h.length;
     uint32_t scratch_read_addr = scratch_db_top[0];
-    constexpr uint32_t start_offset = is_d_variant ? 0 : sizeof(CQPrefetchHToPrefetchDHeader);
+    constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
     // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
         (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;


### PR DESCRIPTION
### Ticket
#25673 

### Problem description
Currently CQPrefetchRelayLinearHCmd can copy at most the size of the cmdq in a single command. This is slow because reads aren't pipelined at all, and it requires a lot of relay commands to be generated.

### What's changed
Allow the command to ping-pong through the scratch buffer, and reserve only half of the scratch DB at most at once, instead of all the data needed for the entire transfer. On the consumer side, it needs to return credits to the writer immediately, rather than all at once after everything is read.

Also modify the test_prefetcher test to write to DRAM instead of a worker so we can test storing larger amounts of data. Continue using CQ_DISPATCH_CMD_WRITE_LINEAR (so we only write to one bank) to ensure writes have a low dispatch RISC overhead, rather than switching to paging. Only wormhole we're currently doing around 9GB/s, so we're not limited by the bandwidth of a single DRAM bank yet.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/relaytodram)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/relaytodram)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/relaytodram)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/relaytodram)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/relaytodram)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/relaytodram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/relaytodram)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs