### PR TITLE
tighten t3k unit test timeouts

### DIFF
--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -22,7 +22,7 @@
   sku: wh_llmbox
   owner_id: UBHPP2NDP # Joseph Chu
   team: ttnn
-  timeout: 45
+  timeout: 25
 
 - name: t3k_tt_metal_multiprocess_tests
   cmd: run_t3000_tt_metal_multiprocess_tests
@@ -43,7 +43,7 @@
   sku: wh_llmbox
   owner_id: UBHPP2NDP # Joseph Chu
   team: models
-  timeout: 30
+  timeout: 10
   model-name: falcon7b
 
 - name: t3k_falcon40b_tests
@@ -51,7 +51,7 @@
   sku: wh_llmbox
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
-  timeout: 30
+  timeout: 10
   model-name: falcon40b
 
 - name: t3k_llama3-small_tests
@@ -67,7 +67,7 @@
   sku: wh_llmbox
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
-  timeout: 30
+  timeout: 15
   model-name: llama3.2-11b
 
 - name: t3k_llama3.2-11b-vision_tests
@@ -75,7 +75,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 30
+  timeout: 10
   model-name: llama3.2-11b-vision
 
 - name: t3k_n300_mesh_llama3.2-11b-vision_tests
@@ -83,7 +83,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 30
+  timeout: 10
   model-name: n300 mesh llama3.2-11b-vision
 
 - name: t3k_llama3.2-90b-vision_tests
@@ -91,7 +91,7 @@
   sku: wh_llmbox
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
-  timeout: 30
+  timeout: 10
   model-name: llama3.2-90b-vision
 
 - name: t3k_llama3.2-90b_tests
@@ -99,7 +99,7 @@
   sku: wh_llmbox
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
-  timeout: 30
+  timeout: 20
   model-name: llama3.2-90b
 
 - name: t3k_mixtral_tests
@@ -107,7 +107,7 @@
   sku: wh_llmbox
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
-  timeout: 30
+  timeout: 15
   model-name: mixtral
 
 - name: t3k_grok_tests
@@ -115,7 +115,7 @@
   sku: wh_llmbox
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
-  timeout: 30
+  timeout: 10
   model-name: grok
 
 - name: t3k_unet_shallow_tests
@@ -131,7 +131,7 @@
   sku: wh_llmbox
   owner_id: U0896VBAKFC # Pratikkumar Prajapati
   team: models
-  timeout: 30
+  timeout: 15
   model-name: mistral
 
 - name: t3k_qwen25_vl_tests
@@ -147,7 +147,7 @@
   sku: wh_llmbox
   owner_id: U08E1JCDVNX # Pavle Petrovic
   team: models
-  timeout: 30
+  timeout: 25
   model-name: gemma3-small
 
 - name: t3k_dits_tests
@@ -155,7 +155,7 @@
   sku: wh_llmbox
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
-  timeout: 20
+  timeout: 15
   model-name: dits
 
 - name: t3k_gpt-oss_unit_tests


### PR DESCRIPTION
Many timeouts set in T3K unit tests were much higher than typical runtime using up more of the time budget than they should. By analysing most recent successful run times(https://superset.tenstorrent.com/superset/dashboard/450):
<img width="910" height="744" alt="image" src="https://github.com/user-attachments/assets/e348f041-fd92-4969-83f9-df512412cf11" />


we are able to reduce many of these timeouts.

<img width="636" height="500" alt="image" src="https://github.com/user-attachments/assets/db8f4a74-0aae-42bb-8906-a7c58bc9a29a" />

### Checklist

- [ ] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=handrews/tighten-t3k-unit-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:handrews/tighten-t3k-unit-timeouts)
