### PR TITLE
Suggesting uv pip to install requirements if possible

### DIFF
--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -40,6 +40,7 @@ Owner:
 # Check if tt-exalens is installed
 import inspect
 import os
+import shutil
 import threading
 from time import time
 import traceback
@@ -74,7 +75,8 @@ except ImportError as e:
     script_dir = os.path.dirname(os.path.abspath(__file__))
     requirements_path = os.path.join(script_dir, "requirements.txt")
     print(f"Module '{e}' not found. Please install requirements.txt:")
-    print(f"  {GREEN}pip install -r {requirements_path}{RST}")
+    pip_cmd = "uv pip" if shutil.which("uv") is not None else "pip"
+    print(f"  {GREEN}{pip_cmd} install -r {requirements_path}{RST}")
     exit(1)
 
 # Import necessary libraries


### PR DESCRIPTION
Since we are now using `uv pip` to install `tt-exalens` we should suggest it to install requirements as well.