### PR TITLE
SDXL Enabling TP=2 on Galaxy

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto
+++ b/models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto
@@ -1,0 +1,14 @@
+# --- Meshes ---------------------------------------------------------------
+mesh_descriptors {
+  name: "MESH"
+  arch: WORMHOLE_B0
+  device_topology { dims: [ 2, 16 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 4
+    policy: RELAXED
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "MESH" mesh_id: 0 } }

--- a/models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto
+++ b/models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto
@@ -1,6 +1,6 @@
 # --- Meshes ---------------------------------------------------------------
 mesh_descriptors {
-  name: "MESH"
+  name: "M0"
   arch: WORMHOLE_B0
   device_topology { dims: [ 2, 16 ] }
   host_topology   { dims: [ 1, 1 ] }
@@ -11,4 +11,4 @@ mesh_descriptors {
 }
 
 # --- Instantiation ----------------------------------------------------------
-top_level_instance { mesh { mesh_descriptor: "MESH" mesh_id: 0 } }
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }


### PR DESCRIPTION
## Ticket
SDXL: support TP=2 accuracy test on galaxy #34492

### Problem description
Can't reshape Galaxy to MeshShape (2, 16) or (16, 2) https://github.com/tenstorrent/tt-metal/issues/26118

### What's changed
- `models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto` added custom graph descriptor


## How to use
1) export env variables
```
TT_MESH_GRAPH_DESC_PATH="models/experimental/stable_diffusion_xl_base/utils/custom_galaxy_descriptor_2_16.textproto"
TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=7,7
```
2) run test😂

### Checklist
- [x] [sdxl accuracy, "device_vae and with_trace and device_encoders and no_refiner", `Galaxy`](https://github.com/tenstorrent/tt-shield/actions/runs/21067606804/job/60590946036) passes

### Notes
- similar mesh_graph_descriptor [t3k mesh_graph_descriptor](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto)

