### PR TITLE
[skip ci] Set watcher to 120s

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -84,7 +84,7 @@ runs:
       working-directory: ${{ inputs.path }}
       run: |
         echo "Enabling TT Metal Watcher"
-        echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
+        echo "TT_METAL_WATCHER=120" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35901)

### Problem description
Ops team wants for watcher to run longer in order to debug it better

### What's changed
Set TT_METAL_WATCHER to 120 (seconds)

PS this can only be enabled manually trough apc select tests workflow