### PR TITLE
Fix T3K unit tests due to changed Attention class arguments + Disable qk fused ops for VL models

### DIFF
--- a/models/demos/gemma3/tests/test_attention.py
+++ b/models/demos/gemma3/tests/test_attention.py
@@ -132,6 +132,7 @@ def test_attention_inference(
     tt_model = Attention(
         mesh_device,
         tt_ccl,
+        model_args,
         state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         layer_num=0,

--- a/models/demos/gemma3/tests/test_attention_prefill.py
+++ b/models/demos/gemma3/tests/test_attention_prefill.py
@@ -130,6 +130,7 @@ def test_attention_inference(
     tt_model = Attention(
         mesh_device,
         tt_ccl,
+        model_args,
         state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         layer_num=0,

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -359,6 +359,9 @@ def test_demo(
 
     processor = model_args.processor
     tokenizer = model_args.tokenizer
+
+    # NOTE: For qwen 2.5 vl, we do not use QK fused ops
+    model_args.use_qk_fused = False
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
     # Load vision model and processor

--- a/models/tt_transformers/tests/mixtral/test_mixtral_decoder.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_decoder.py
@@ -68,6 +68,7 @@ def test_mixtral_decoder_inference(mesh_device, reset_seeds, batch, device_param
 
     hf_config = load_hf_mixtral_config()
     model_args = ModelArgs(mesh_device, max_seq_len=max_seq_len, max_batch_size=batch)
+    model_args.use_qk_fused = False
     state_dict = model_args.load_state_dict()
     partial_state_dict = {k[9:]: v for k, v in state_dict.items() if (k.startswith(f"layers.{layer_idx}."))}
     reference_model = MixtralDecoderLayer(hf_config, layer_idx)

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -127,6 +127,7 @@ def test_attention_inference(
     tt_model = Attention(
         mesh_device,
         tt_ccl,
+        model_args,
         state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         layer_num=0,

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -91,6 +91,7 @@ def test_attention_inference(
         model_args.max_seq_len,
         model_args.rope_theta,
         model_args.rope_scaling,
+        model_args.use_qk_fused,
     )
 
     transformation_mats = rope_setup.get_both_trans_mats()

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -129,6 +129,7 @@ def test_attention_inference(
     tt_model = Attention(
         mesh_device,
         tt_ccl,
+        model_args,
         state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         layer_num=0,

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -84,6 +84,7 @@ def test_decoder_inference(
         model_args.max_seq_len,
         model_args.rope_theta,
         model_args.rope_scaling,
+        model_args.use_qk_fused,
     )
 
     if model_args.rope_theta_local is not None:


### PR DESCRIPTION
### Ticket
Failures in T3K pipelines for Qwen25 VL with signature:
```
Cos and Sin are repeated for Q and K, so they must have the same batch size as the sum of Q and K batch sizes
```
and
```
TypeError: Attention.__init__() missing 1 required positional argument: 'state_dict'
```

### Problem description
In attention unit tests the model args was not passed to the Attention class and the qwe25 vl demo has their own model args that did not disable the qk fused flag 

### What's changed
- pass model args back
- manually disable the qk fused flag in the qwen 25 demo

### Checklist
- [ ] [T3K unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21076792351)
- [ ] [Single card demo for Qwen 25 VL](https://github.com/tenstorrent/tt-metal/actions/runs/21052126282)
- [ ] [T3K demo for Qwen25 VL](https://github.com/tenstorrent/tt-metal/actions/runs/21070397476)