### PR TITLE
reduce t3k demo timeouts

### DIFF
--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -15,7 +15,7 @@
   sku: wh_llmbox
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
-  timeout: 50
+  timeout: 45
   model-name: mixtral
 
 - name: t3k_falcon40b_tests
@@ -23,7 +23,7 @@
   sku: wh_llmbox
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
-  timeout: 50
+  timeout: 25
   model-name: falcon40b
 
 - name: t3k_llama3_tests
@@ -39,7 +39,7 @@
   sku: wh_llmbox
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
-  timeout: 60
+  timeout: 55
   model-name: qwen25
 
 - name: t3k_llama3_vision_tests
@@ -47,7 +47,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 45
+  timeout: 25
   model-name: llama3_vision
 
 - name: t3k_llama3_90b_vision_tests
@@ -63,7 +63,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 60
+  timeout: 30
   model-name: llama3_70b
 
 - name: t3k_falcon7b_tests
@@ -71,7 +71,7 @@
   sku: wh_llmbox
   owner_id: U05RWH3QUPM # Salar Hosseini
   team: models
-  timeout: 90
+  timeout: 10
   model-name: falcon7b
 
 - name: t3k_resnet50_tests
@@ -79,7 +79,7 @@
   sku: wh_llmbox
   owner_id: U0837MYG788 # Marko Radosavljevic
   team: models
-  timeout: 50
+  timeout: 10
   model-name: resnet50
 
 - name: t3k_sentence_bert_tests
@@ -87,7 +87,7 @@
   sku: wh_llmbox
   owner_id: U045U3DEKM4 # Mohamed Bahnas (Aniruddha Tupe)
   team: models
-  timeout: 75
+  timeout: 5
   model-name: sentence_bert
 
 - name: t3k_sd35_large_tests
@@ -95,7 +95,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 60
+  timeout: 10
   model-name: sd35_large
 
 - name: t3k_flux1-dev_tests
@@ -103,7 +103,7 @@
   sku: wh_llmbox
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
-  timeout: 35
+  timeout: 10
   model-name: flux1-dev
 
 - name: t3k_motif_tests
@@ -111,7 +111,7 @@
   sku: wh_llmbox
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
-  timeout: 25
+  timeout: 15
   model-name: motif
 
 - name: t3k_qwenimage_tests
@@ -127,7 +127,7 @@
   sku: wh_llmbox
   owner_id: U0896VBAKFC # Pratikkumar Prajapati
   team: models
-  timeout: 90
+  timeout: 15
   model-name: mistral
 
 - name: t3k_qwen3_tests
@@ -135,7 +135,7 @@
   sku: wh_llmbox
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
-  timeout: 60
+  timeout: 40
   model-name: qwen3
 
 - name: t3k_qwen25_vl_tests
@@ -151,7 +151,7 @@
   sku: wh_llmbox
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
-  timeout: 30
+  timeout: 25
   model-name: gemma3
 
 - name: t3k_wan2.2_tests
@@ -159,7 +159,7 @@
   sku: wh_llmbox
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
-  timeout: 45
+  timeout: 25
   model-name: wan22
 
 - name: t3k_mochi_tests
@@ -167,7 +167,7 @@
   sku: wh_llmbox
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
-  timeout: 60
+  timeout: 30
   model-name: mochi
 
 - name: t3k_whisper_tests
@@ -175,7 +175,7 @@
   sku: wh_llmbox
   owner_id: U088413NP0Q # Ashai Reddy
   team: models
-  timeout: 20
+  timeout: 10
   model-name: whisper
 
 - name: t3k_gpt_oss_tests
@@ -183,5 +183,5 @@
   sku: wh_llmbox
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
-  timeout: 30
+  timeout: 25
   model-name: gpt-oss


### PR DESCRIPTION
Many timeouts set in T3K demo tests were much higher than typical runtime using up more of the time budget than they should. By analysing most recent successful run times(https://superset.tenstorrent.com/superset/dashboard/450):

<img width="805" height="733" alt="image" src="https://github.com/user-attachments/assets/35792242-284e-4444-9bb8-da3bfb3dd611" />

we are able to reduce many of these timeouts.

<img width="579" height="595" alt="image" src="https://github.com/user-attachments/assets/a7232130-99bb-4980-b647-1b2c6048fe85" />
<img width="601" height="378" alt="image" src="https://github.com/user-attachments/assets/41794a5c-04db-4dc4-97fc-713a2c77378d" />


### Checklist

- [ ] [![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=handrews/reduce-t3k-demo-times)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch:handrews/reduce-t3k-demo-times)