### PR TITLE
#35997: Add matmul shapes for Deepseek Blitz

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
@@ -4,11 +4,25 @@
 
 """
 TTNN Matmul Micro Op Test - Single Core
-Tests matmul operation with shape [1, 7K] x [7K, 32]
-All tensors on a single core:
-- Input A (in0): 1x7K, HEIGHT_SHARDED on single core
-- Input B (in1): 7Kx32, WIDTH_SHARDED on single core
-- Output: 1x32, WIDTH_SHARDED on single core
+Tests matmul operation for various DeepSeek v3 shapes:
+
+Before SDPA (bfloat16 in0, bfloat8_b in1):
+- Q down + K down: [1, 7168] x [7168, 32]
+- Q down with split inner dim: [1, 3584] x [3584, 32]
+- Q up: [1, 1536] x [1536, 128]
+- Q nope: [1, 128] x [128, 512]
+
+SDPA (bfloat16 in0, bfloat8_b in1):
+- Q @ K.T: [8, 576] x [576, 256/512]
+- S @ V: [8, 256/512] x [256/512, 512]
+
+After SDPA (bfloat16 in0, bfloat8_b in1):
+- V out: [1, 512] x [512, 128]
+- Out: [1, 8192] x [8192, 64]
+
+MoE (bfloat16 in0, bfloat4_b in1):
+- Gate proj + up proj: [1, 7168] x [7168, 32]
+- Down proj: [1, 2048] x [2048, 32]
 """
 
 import pytest
@@ -21,19 +35,33 @@ from models.demos.deepseek_v3_b1.micro_ops.matmul.op import MatmulSingleCore
 
 
 @pytest.mark.parametrize(
-    "M, K, N",
+    "M, K, N, in0_dtype, in1_dtype",
     [
-        (1, 7168, 32),  # Single core: 1x7K x 7Kx32 -> 1x32
-        (1, 1536, 128),  # Single core: 1x1536 x 1536x128 -> 1x128
+        # Before SDPA (bfloat16 srcB/in0, bfloat8_b srcA/in1)
+        (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat8_b),  # Q down + K down
+        (1, 3584, 32, ttnn.bfloat16, ttnn.bfloat8_b),  # Q down with split inner dim
+        (1, 1536, 128, ttnn.bfloat16, ttnn.bfloat8_b),  # Q up
+        (1, 128, 512, ttnn.bfloat16, ttnn.bfloat8_b),  # Q nope
+        # SDPA (bfloat16 srcB/in0, bfloat8_b srcA/in1)
+        (8, 576, 256, ttnn.bfloat16, ttnn.bfloat8_b),  # SDPA Q @ K.T (KV_chunk_size=256)
+        (8, 576, 512, ttnn.bfloat16, ttnn.bfloat8_b),  # SDPA Q @ K.T (KV_chunk_size=512)
+        (8, 256, 512, ttnn.bfloat16, ttnn.bfloat8_b),  # SDPA S @ V (KV_chunk_size=256)
+        (8, 512, 512, ttnn.bfloat16, ttnn.bfloat8_b),  # SDPA S @ V (KV_chunk_size=512)
+        # After SDPA (bfloat16 srcB/in0, bfloat8_b srcA/in1)
+        (1, 512, 128, ttnn.bfloat16, ttnn.bfloat8_b),  # V out
+        (1, 8192, 64, ttnn.bfloat16, ttnn.bfloat8_b),  # Out
+        # MoE (bfloat16 srcB/in0, bfloat8_b srcA/in1 - potentially bfloat4_b if accurate enough)
+        (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Gate proj + up proj
+        (1, 2048, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Down proj
     ],
 )
-def test_matmul_single_core(device, M, K, N):
+def test_matmul_single_core(device, M, K, N, in0_dtype, in1_dtype):
     """Test single-core matmul operation with fully sharded inputs"""
 
     # Tile dimensions
-    a_tile = ttnn.Tile([1, 32])  # Tiny tile height for A and output
+    a_tile = ttnn.Tile([M, 32])  # Tile height matches M for A
     b_tile = ttnn.Tile([32, 32])  # Standard tile for B
-    out_tile = ttnn.Tile([1, 32])  # Tiny tile height for output
+    out_tile = ttnn.Tile([M, 32])  # Tile height matches M for output
 
     # Single core
     core = ttnn.CoreCoord(0, 0)
@@ -44,7 +72,7 @@ def test_matmul_single_core(device, M, K, N):
     num_tiles_k = K // a_tile.tile_shape[1]
     num_tiles_n = N // b_tile.tile_shape[1]
 
-    logger.info(f"Testing single-core matmul with shape [{M}, {K}] x [{K}, {N}]")
+    logger.info(f"Testing single-core matmul with shape [{M}, {K}] x [{K}, {N}], in0={in0_dtype}, in1={in1_dtype}")
     logger.info(f"Tiles: M={num_tiles_m}, K={num_tiles_k}, N={num_tiles_n}")
 
     # Create input A and input B PyTorch tensors
@@ -70,7 +98,7 @@ def test_matmul_single_core(device, M, K, N):
     # Create input A (height-sharded on single core)
     ttnn_a = ttnn.from_torch(
         torch_a,
-        dtype=ttnn.bfloat16,
+        dtype=in0_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=input_a_mem_config,
@@ -94,7 +122,7 @@ def test_matmul_single_core(device, M, K, N):
     # Create input B (width-sharded on single core)
     ttnn_b = ttnn.from_torch(
         torch_b,
-        dtype=ttnn.bfloat8_b,
+        dtype=in1_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=input_b_mem_config,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35997)

### Problem description
For Deepseek Blitz, we would like to optimize matmul for all relevant shapes. Adding key unit tests for performance optimization and tracking. 

### What's changed
- Added all relevant matmul shapes for Deepseek Blitz
- Uplift generic mm path in matmul.hpp to support arbitary width


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}}): https://github.com/tenstorrent/tt-metal/actions/runs/21082688098
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}}): https://github.com/tenstorrent/tt-metal/actions/runs/21082691504
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs