### PR TITLE
Add Quasar tile counter definitions

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/tile_counters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/tile_counters.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#ifndef COMPILE_FOR_TRISC
+#include <overlay/meta/registers/overlay_reg_defines_core.h>
+#endif
+
+// Adds tile counters base array + struct definition
+
+#ifndef _TILE_COUNTERS_H_
+#define _TILE_COUNTERS_H_
+
+#ifndef COMPILE_FOR_TRISC
+#define TILE_COUNTERS_BASE  TT_OVERLAY_LLK_TILE_COUNTERS_REG_MAP_BASE_ADDR
+#else
+#define TILE_COUNTERS_BASE  0x0080c000
+#endif
+
+constexpr uint32_t NUM_TILE_COUNTERS = 16;
+constexpr uint32_t NUM_WORDS_TILE_CNT = 8;
+
+typedef struct {
+    std::uint32_t reserved0;
+    std::uint32_t reset;
+    std::uint32_t posted;
+    std::uint32_t acked;
+    std::uint32_t buf_capacity;
+    std::uint32_t tiles_posted_raw;
+    std::uint32_t tiles_acked_raw;
+    std::uint32_t error_status;
+} tile_counter_t;
+
+static_assert(sizeof(tile_counter_t) == NUM_WORDS_TILE_CNT*sizeof(uint32_t), "tile_counter_t must be 8 words (32 bytes)!");
+
+typedef union {
+    uint32_t words[NUM_WORDS_TILE_CNT];
+    tile_counter_t f;
+} tile_counter_u;
+
+extern tile_counter_u volatile * const tile_counters;
+
+inline void tile_counters_reset() {
+    for (uint32_t i = 0; i < NUM_TILE_COUNTERS; i++) {
+        tile_counters[i].f.reset = 1;
+    }
+}
+
+#endif  // ifndef _TILE_COUNTERS_H_


### PR DESCRIPTION
### Ticket
#35976


### Problem description
Quasar tile counter definition was missing

### What's changed
Added Quasar tile counter definition

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rtawfik/add_quasar_tile_counters)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rtawfik/add_quasar_tile_counters)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/add_quasar_tile_counters)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/add_quasar_tile_counters)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/add_quasar_tile_counters)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/add_quasar_tile_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/add_quasar_tile_counters)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs