### PR TITLE
#35078: add in1 batch size check for mm with fused batch

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -176,8 +176,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     if (attributes.bcast_batch.value()) {
         TT_FATAL(
             get_batch_size(b_shape) == 1,
-            "The batch bcast variant of matmul requires input tensors of shapes "
-            "BCMK*11KN=BCMN or equivalent. Please change the second input or adjust the program config.");
+            "The batch bcast variant of matmul requires input tensors of shapes BCMK*11KN=BCMN "
+            "or equivalent. Please change the second input tensor or adjust the program config.");
     } else {
         // same condition as above, different message
         TT_FATAL(
@@ -320,8 +320,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 if (program_config.fuse_batch) {
                     TT_FATAL(
                         get_batch_size(b_shape_padded) == 1,
-                        "Matmul with fused batch requires input tensors of shapes "
-                        "BCMK*11KN=BCMN or equivalent. Please change the second input or adjust the program config.");
+                        "Matmul with fused batch requires input tensors of shapes BCMK*11KN=BCMN "
+                        "or equivalent. Please change the second input tensor or adjust the program config.");
                 }
             }
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -176,8 +176,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     if (attributes.bcast_batch.value()) {
         TT_FATAL(
             get_batch_size(b_shape) == 1,
-            "matmul (batch bcast variant) expects input tensors of shapes "
-            "BCMK*11KN=BCMN or equivalent");
+            "The batch bcast variant of matmul requires input tensors of shapes "
+            "BCMK*11KN=BCMN or equivalent. Please change the second input or adjust the program config.");
     } else {
         // same condition as above, different message
         TT_FATAL(
@@ -317,6 +317,12 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(program_config.out_block_w != 0, "out_block_w is 0, which is not valid");
                 TT_FATAL(program_config.per_core_M != 0, "per_core_M is 0, which is not valid");
                 TT_FATAL(program_config.per_core_N != 0, "per_core_N is 0, which is not valid");
+                if (program_config.fuse_batch) {
+                    TT_FATAL(
+                        get_batch_size(b_shape_padded) == 1,
+                        "Matmul with fused batch requires input tensors of shapes "
+                        "BCMK*11KN=BCMN or equivalent. Please change the second input or adjust the program config.");
+                }
             }
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core
             // or single row/col We can uplift these variants to skip mcasting to

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -242,7 +242,7 @@ void py_module(nb::module_& mod) {
         efficient processing of batched matrix multiplications. This can improve performance
         for operations with large batch sizes. Defaults to true.
 
-        Note: the batch dimensions need to all be 1 for second input when fuse_batch is true.
+        Note: the batch dimensions need to all be 1 for the second input tensor when fuse_batch is true.
     )doc");
 
     auto matmul_multi_core_reuse_multicast_1d_program_config =
@@ -375,7 +375,7 @@ void py_module(nb::module_& mod) {
             allowing for more efficient processing of batched operations in the 1D
             multicast implementation.
 
-            Note: the batch dimensions need to all be 1 for second input when fuse_batch is true.
+            Note: the batch dimensions need to all be 1 for the second input tensor when fuse_batch is true.
         )doc")
         .def_rw("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation, R"doc(
             Optional fused activation function to apply during computation.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -241,6 +241,8 @@ void py_module(nb::module_& mod) {
         When true, batch dimensions are fused with the M dimension, allowing for more
         efficient processing of batched matrix multiplications. This can improve performance
         for operations with large batch sizes. Defaults to true.
+
+        Note: the batch dimensions need to all be 1 for second input when fuse_batch is true.
     )doc");
 
     auto matmul_multi_core_reuse_multicast_1d_program_config =
@@ -372,6 +374,8 @@ void py_module(nb::module_& mod) {
             When true, batch dimensions are incorporated into the matrix computation,
             allowing for more efficient processing of batched operations in the 1D
             multicast implementation.
+
+            Note: the batch dimensions need to all be 1 for second input when fuse_batch is true.
         )doc")
         .def_rw("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation, R"doc(
             Optional fused activation function to apply during computation.


### PR DESCRIPTION
### Ticket
Link to Github Issue #35078

### Problem description
Automated tools require validation to catch all cases where combinations of inputs are not allowed. Validation did not exist for the unsupported scenario where the program config fuses batch and in1 is batched.

### What's changed
- Added validation for this scenario. Added notes to the documentation indicating this scenario is not supported.
- Updated the text of the same check for a different scenario.

Tested locally that the case in the issue is caught by validation.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-35078_fuse_check) https://github.com/tenstorrent/tt-metal/actions/runs/21080918670
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-35078_fuse_check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-35078_fuse_check)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-35078_fuse_check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-35078_fuse_check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-35078_fuse_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-35078_fuse_check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs