### PR TITLE
Update mcast core to be on bottom row for deepseek

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -104,6 +104,7 @@ KERNEL_ENTRY {
     using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;  // BRISC is no-op
     using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
         get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid"),
         Core::is_input_core && Core::is_matmul2_core>;  // Always mcast to the main grid
 
     // RMSNorm writer args (BRISC is no-op)

--- a/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
@@ -51,7 +51,8 @@ KERNEL_ENTRY {
 #elif defined(COMPILE_FOR_BRISC)
     using McastCTArgs = Mcast::SenderCTArgs<
         get_named_compile_time_arg_val("mcast_num_cores"),
-        Core::is_sender_core && Core::is_receiver_core>;  // is_part_of_receiver_grid = sender is also a receiver
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid"),
+        Core::is_sender_core && Core::is_receiver_core>;  // loopback = sender is also a receiver
 
     // Mcast CB index from named compile-time args
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -37,7 +37,7 @@ def test_pre_sdpa(device, epsilon, use_fp32):
 
     # Mcast/gather core coordinates (same as RMSNorm input core)
     mcast_core_x = matmul2_grid_x - 1  # 11 for P150, 10 for non-P150
-    mcast_core_y = 8
+    mcast_core_y = 9
 
     tile = ttnn.Tile([1, 32])
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -202,12 +202,12 @@ struct Mcast {
     // ========================================================================
 
     // Sender CTArgs (BRISC): mcast_num_cores, is_part_of_receiver_grid
-    // loopback is inferred: if sender is part of receiver grid, it needs loopback to receive its own mcast
-    template <uint32_t McastNumCores, bool IsPartOfReceiverGrid>
+    // If sender is part of receiver grid, it needs loopback to receive its own mcast
+    template <uint32_t McastNumCores, bool IsPartOfReceiverGrid, bool Loopback>
     struct SenderCTArgs {
         static constexpr uint32_t mcast_num_cores = McastNumCores;
         static constexpr bool is_part_of_receiver_grid = IsPartOfReceiverGrid;
-        static constexpr bool loopback = IsPartOfReceiverGrid;  // Inferred from is_part_of_receiver_grid
+        static constexpr bool loopback = Loopback;
     };
 
     // Receiver CTArgs (NCRISC): none needed

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -472,7 +472,24 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::arg("end"))
         .def_ro("start", &CoreRange::start_coord)
         .def_ro("end", &CoreRange::end_coord)
-        .def("grid_size", &CoreRange::grid_size);
+        .def("grid_size", &CoreRange::grid_size)
+        .def(
+            "contains",
+            nb::overload_cast<const CoreCoord&>(&CoreRange::contains, nb::const_),
+            nb::arg("core"),
+            "Check if a core coordinate is contained in this CoreRange")
+        .def(
+            "contains",
+            nb::overload_cast<const CoreRange&>(&CoreRange::contains, nb::const_),
+            nb::arg("core_range"),
+            "Check if a core range is contained in this CoreRange")
+        .def(
+            "contains",
+            nb::overload_cast<const CoreRangeSet&>(&CoreRange::contains, nb::const_),
+            nb::arg("core_range_set"),
+            "Check if a core range set is contained in this CoreRange")
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self);
 
     auto pyCoreRangeSet = static_cast<nb::class_<CoreRangeSet>>(m_tensor.attr("CoreRangeSet"));
     pyCoreRangeSet
@@ -500,6 +517,16 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
             nb::overload_cast<const CoreCoord&>(&CoreRangeSet::contains, nb::const_),
             nb::arg("core"),
             "Check if a core coordinate is contained in this CoreRangeSet")
+        .def(
+            "contains",
+            nb::overload_cast<const CoreRange&>(&CoreRangeSet::contains, nb::const_),
+            nb::arg("core_range"),
+            "Check if a core range is contained in this CoreRangeSet")
+        .def(
+            "contains",
+            nb::overload_cast<const CoreRangeSet&>(&CoreRangeSet::contains, nb::const_),
+            nb::arg("core_range_set"),
+            "Check if a core range set is contained in this CoreRangeSet")
         .def(
             "merge",
             &CoreRangeSet::merge<CoreRangeSet>,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Model design was changed to move the mcast core to the bottom row of the grid.

### What's changed
Update unit tests and op support for deepseek to support mcaster at the bottom row.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/mcast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/mcast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/mcast)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/mcast)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs