### PR TITLE
Fix dead store in RingbufferCache randomized test

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -144,11 +144,8 @@ TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
     constexpr size_t num_iterations = 10'000'000;
     for (size_t i = 0; i < num_iterations; ++i) {
         pgm_id = dist_pgm_id(gen_pgm_id);
-        if (pgm_id_size_map.contains(pgm_id)) {
-            pgm_size = pgm_id_size_map[pgm_id];
-        } else {
-            pgm_size = dist_pgm_size(gen_pgm_size);
-            pgm_id_size_map[pgm_id] = pgm_size;
+        if (!pgm_id_size_map.contains(pgm_id)) {
+            pgm_id_size_map[pgm_id] = dist_pgm_size(gen_pgm_size);
         }
     }
 


### PR DESCRIPTION
### Ticket
Clang Static Analyzer report: https://blozano-tt.github.io/clangsa-results/test_ringbuffer_cache.cpp_clangsa_5cbfd1380d57881af4d5c45ef127beac.plist.html#reportHash=d939b1b6ca1c3d70ee0bda0671183197

### Problem description
The Clang Static Analyzer flagged a dead store in `test_ringbuffer_cache.cpp`. In the first loop that populates `pgm_id_size_map`, when a `pgm_id` already exists in the map, the code was assigning the value to `pgm_size` but never reading it before the next iteration overwrote it.

```cpp
// Before: Dead store on line 148
for (size_t i = 0; i < num_iterations; ++i) {
    pgm_id = dist_pgm_id(gen_pgm_id);
    if (pgm_id_size_map.contains(pgm_id)) {
        pgm_size = pgm_id_size_map[pgm_id];  // Value never used!
    } else {
        pgm_size = dist_pgm_size(gen_pgm_size);
        pgm_id_size_map[pgm_id] = pgm_size;
    }
}
```

### What's changed
Simplified the loop to only handle the case where a new entry needs to be added:

```cpp
// After: No dead store
for (size_t i = 0; i < num_iterations; ++i) {
    pgm_id = dist_pgm_id(gen_pgm_id);
    if (!pgm_id_size_map.contains(pgm_id)) {
        pgm_id_size_map[pgm_id] = dist_pgm_size(gen_pgm_size);
    }
}
```

This change:
- Removes the dead store warning
- Simplifies the logic by removing the unnecessary `else` branch
- Makes the intent clearer (the loop only populates the map with new entries)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/remove-dead-store-ringbuffer-cache-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/remove-dead-store-ringbuffer-cache-test)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/remove-dead-store-ringbuffer-cache-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/remove-dead-store-ringbuffer-cache-test)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/remove-dead-store-ringbuffer-cache-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/remove-dead-store-ringbuffer-cache-test)
- [x] New/Existing tests provide coverage for changes