### PR TITLE
Fix dead store in embeddings_rm_program_factory.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/embeddings_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embeddings_rm_program_factory.cpp
@@ -62,20 +62,19 @@ EmbeddingsRMProgramFactory::cached_program_t EmbeddingsRMProgramFactory::create(
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
 
-    uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2;
+    uint32_t num_blocks_per_core_group_1, num_blocks_per_core_group_2;
     CoreRangeSet all_cores, core_group_1, core_group_2;
     bool row_major = false;
     if (output_sharded) {
         const auto& shard_spec = output.shard_spec().value();
         all_cores = shard_spec.grid;
         core_group_1 = all_cores;
-        num_cores = all_cores.num_cores();
         num_blocks_per_core_group_1 = shard_spec.shape[0];
         num_blocks_per_core_group_2 = 0;
         row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     } else {
         std::tie(
-            num_cores,
+            std::ignore,
             all_cores,
             core_group_1,
             core_group_2,


### PR DESCRIPTION
### Ticket
Clang Static Analyzer report

### Problem description
The Clang Static Analyzer flagged a dead store in `embeddings_rm_program_factory.cpp`. The variable `num_cores` was assigned a value (either from `all_cores.num_cores()` in the sharded case or from `split_work_to_cores` in the non-sharded case) but was never read afterward.

### What's changed
- Removed the `num_cores` variable declaration
- Removed the unused assignment in the sharded case
- Changed to use `std::ignore` in the `split_work_to_cores` call to explicitly discard the unused return value

This matches the pattern already used in `embeddings_fused_program_factory.cpp`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/remove-dead-store-embeddings-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/remove-dead-store-embeddings-rm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/remove-dead-store-embeddings-rm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/remove-dead-store-embeddings-rm)
- [x] New/Existing tests provide coverage for changes