### PR TITLE
Fix dead store in fold.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -35,7 +35,7 @@ std::vector<Tensor> fold_with_transpose_(
     uint32_t pad_w) {
     using namespace tt::constants;
 
-    // Validate we have a device
+    // Get the device
     if (input.storage_type() != StorageType::DEVICE) {
         TT_ASSERT(
             ttnn::GetDefaultDevice() != nullptr, "Requires setting default device if no inputs to op are on device");
@@ -156,7 +156,7 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     const std::optional<MemoryConfig>& override_memory_config) {
     using namespace tt::constants;
 
-    // Validate we have a device
+    // Get the device
     if (input.storage_type() != StorageType::DEVICE) {
         TT_ASSERT(
             ttnn::GetDefaultDevice() != nullptr, "Requires setting default device if no inputs to op are on device");

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -34,14 +34,11 @@ std::vector<Tensor> fold_with_transpose_(
     uint32_t pad_h,
     uint32_t pad_w) {
     using namespace tt::constants;
-    IDevice* device;
 
-    // Get the device
+    // Validate we have a device
     if (input.storage_type() != StorageType::DEVICE) {
-        device = ttnn::GetDefaultDevice();
-        TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
-    } else {
-        device = input.device();
+        TT_ASSERT(
+            ttnn::GetDefaultDevice() != nullptr, "Requires setting default device if no inputs to op are on device");
     }
 
     uint32_t n = input.logical_shape()[0], c = input.logical_shape()[1], h = input.logical_shape()[2],
@@ -158,14 +155,11 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     const CoreRangeSet& grid_size,
     const std::optional<MemoryConfig>& override_memory_config) {
     using namespace tt::constants;
-    IDevice* device;
 
-    // Get the device
+    // Validate we have a device
     if (input.storage_type() != StorageType::DEVICE) {
-        device = ttnn::GetDefaultDevice();
-        TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
-    } else {
-        device = input.device();
+        TT_ASSERT(
+            ttnn::GetDefaultDevice() != nullptr, "Requires setting default device if no inputs to op are on device");
     }
 
     uint32_t n = input.logical_shape()[0], c = input.logical_shape()[1], h = input.logical_shape()[2],


### PR DESCRIPTION
### Ticket
Clang Static Analyzer report

### Problem description
The Clang Static Analyzer flagged dead stores in `fold.cpp`. The `device` variable was assigned in two functions (`fold_with_transpose_and` and `fold_with_transpose_rm`) but was only used for validation, then never used for any actual operations.

### What's changed
Removed the unused `device` variable and simplified the validation to just check that a default device exists when the input tensor is not on a device.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/remove-dead-store-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/remove-dead-store-fold)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/remove-dead-store-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/remove-dead-store-fold)
- [x] New/Existing tests provide coverage for changes