### PR TITLE
[skip ci] deprecate pipeline status slack pings

### DIFF
--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -87,8 +87,3 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/rerun-failed-jobs
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U08BNDNLUCD # akirby-tt

--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -83,8 +83,3 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/rerun-failed-jobs
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U014XCQ9CF8 # tt-rkim

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -170,11 +170,6 @@ jobs:
               pipelinecopy_*.json
               workflow.json
               workflow_jobs.json
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U0883RN6CRE # William Ly
   test-produce-complete-benchmark-with-environment:
     # Check if triggered by `workflow_run` with specific conclusion states,
     # or if it's triggered by `workflow_call` or `workflow_dispatch`

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -32,23 +32,20 @@ jobs:
             name: "whisper performance",
             arch: blackhole,
             runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"],
-            cmd: pytest models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
-            owner_id: U05RWH3QUPM # Salar Hosseini
+            cmd: pytest models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
           },
           {
             name: "llama3-8b performance",
             arch: blackhole,
             runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"],
             # I think we can get rid of TT_CACHE_PATH here by using a NFS export
-            cmd:  HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci and not performance-ci-stress-1" --max_seq_len 131072,
-            owner_id: U03PUAKE719 # Miguel Tairum
+            cmd:  HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci and not performance-ci-stress-1" --max_seq_len 131072
           },
           { # This should be moved to a BH perf regression pipeline in the future
             name: "unet-shallow performance",
             arch: blackhole,
             runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"],
-            cmd: pytest -sv models/experimental/functional_unet/tests/test_unet_perf.py -k "test_unet_trace_perf and not test_unet_trace_perf_multi_device",
-            owner_id: U06ECNVR0EN # Evan Smal
+            cmd: pytest -sv models/experimental/functional_unet/tests/test_unet_perf.py -k "test_unet_trace_perf and not test_unet_trace_perf_multi_device"
           }
         ]
 
@@ -118,11 +115,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   single-card-p150-demo-tests:
@@ -136,14 +128,12 @@ jobs:
             { # This test shall be executed on the BH with 20 cores
               name: "panoptic_deeplab demo - 20 cores",
               arch: blackhole,
-              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline',
-              owner_id: U09LK84G4TF # Nikola Milicevic
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="4, 3" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline'
             },
             { # This test shall be executed on the BH P150 on 110 cores
               name: "panoptic_deeplab demo - 110 cores",
               arch: blackhole,
-              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10, 9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline',
-              owner_id: U09LK84G4TF # Nikola Milicevic
+              cmd: 'TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10, 9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline'
             },
           ]
     name: ${{ matrix.test-group.name }}
@@ -180,9 +170,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -43,23 +43,18 @@ jobs:
           - name: "llama3.1-8b ${{ inputs.runner-label }} performance"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 1 --max_seq_len 131072
-            owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.1-8b ${{ inputs.runner-label }} data-parallel=${{ inputs.num_devices }} performance"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel ${{ inputs.num_devices }} --max_seq_len 131072
-            owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.1-8b ${{ inputs.runner-label }} data-parallel=${{ inputs.num_devices }} stress"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-stress-1" --data_parallel ${{ inputs.num_devices }} --max_generated_tokens 22000
-            owner_id: U03PUAKE719 # Miguel Tairum
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "decode-llama3_8b-2-131072-2-10-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
           - name: "llama3.1-8b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)"
             arch: blackhole
             cmd: HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k "prefill-llama3_8b-2-131072-2-2-1-1-False"
-            owner_id: U08GELBB1AP # Ambrose Ling
     name: ${{ matrix.test-group.name }}
     runs-on:
       - "in-service"
@@ -148,11 +143,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   generate-large-models-matrix:
@@ -172,48 +162,36 @@ jobs:
               "model": "llama3.3-70b",
               "arch": "blackhole",
               "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k \"performance and ci-32\" --max_seq_len 131072",
-              "owner_id": "U03PUAKE719",
-              "owner_name": "Miguel Tairum"
             },
             {
               "name": "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf prefill (layers=2)",
               "model": "llama3.3-70b",
               "arch": "blackhole",
               "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k \"prefill-llama3_70b-2-131072-2-2-1-1-False\"",
-              "owner_id": "U08GELBB1AP",
-              "owner_name": "Ambrose Ling"
             },
             {
               "name": "llama3.3-70b ${{ inputs.runner-label }} batch-1 TP device perf decode (layers=10)",
               "model": "llama3.3-70b",
               "arch": "blackhole",
               "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/meta-llama/Llama-3.3-70B-Instruct pytest models/tt_transformers/tests/test_device_perf.py -k \"decode-llama3_70b-2-131072-2-10-1-1-False\"",
-              "owner_id": "U08GELBB1AP",
-              "owner_name": "Ambrose Ling"
             },
             {
               "name": "qwen3-32b ${{ inputs.runner-label }} batch-32 performance",
               "model": "qwen3-32b",
               "arch": "blackhole",
-              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k \"performance and ci-32\" --max_seq_len 32768",
-              "owner_id": "U08GELBB1AP",
-              "owner_name": "Ambrose Ling"
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/demo/simple_text_demo.py -k \"performance and ci-32\" --max_seq_len 40960",
             },
             {
               "name": "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf prefill",
               "model": "qwen3-32b",
               "arch": "blackhole",
-              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"prefill-qwen3_32b-2-32768-2-2-1-1-False\"",
-              "owner_id": "U08GELBB1AP",
-              "owner_name": "Ambrose Ling"
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"prefill-qwen3_32b-2-40960-2-2-1-1-False\"",
             },
             {
               "name": "qwen3-32b ${{ inputs.runner-label }} batch-1 TP device perf decode",
               "model": "qwen3-32b",
               "arch": "blackhole",
-              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"decode-qwen3_32b-2-32768-2-10-1-1-False\"",
-              "owner_id": "U08GELBB1AP",
-              "owner_name": "Ambrose Ling"
+              "cmd": "HF_MODEL=/localdev/blackhole_demos/huggingface_data/Qwen/Qwen3-32B pytest models/tt_transformers/tests/test_device_perf.py -k \"decode-qwen3_32b-2-40960-2-10-1-1-False\"",
             }
           ]'
 
@@ -317,11 +295,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   generate-tt-dit-matrix:
@@ -345,8 +318,6 @@ jobs:
               "arch": "blackhole",
               "runner-label": "P300-viommu",
               "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"1x2sp0tp1\"",
-              "owner_id": "U08TED0JM9D",
-              "owner_name": "Samuel Adesoye"
             },
             {
               "name": "Flux.1-dev BH-QB-GE performance (2x2sp0tp1)",
@@ -354,8 +325,6 @@ jobs:
               "arch": "blackhole",
               "runner-label": "BH-QB-GE",
               "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"2x2sp0tp1\"",
-              "owner_id": "U08TED0JM9D",
-              "owner_name": "Samuel Adesoye"
             },
             {
               "name": "Flux.1-dev BH-LoudBox performance (bh_2x4sp0tp1)",
@@ -371,18 +340,7 @@ jobs:
               "model": "wan2.2-t2v-a14b",
               "arch": "blackhole",
               "runner-label": "BH-QB-GE",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"2x2sp0tp1 and resolution_480p\"",
-              "owner_id": "U08TED0JM9D",
-              "owner_name": "Samuel Adesoye"
-            },
-            {
-              "name": "Wan2.2-T2V-A14B BH-LoudBox performance",
-              "model": "wan2.2-t2v-a14b",
-              "arch": "blackhole",
-              "runner-label": "BH-LoudBox",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"1x8sp0tp1 and resolution_480p\"",
-              "owner_id": "U09ELB03XRU",
-              "owner_name": "Stephen Osborne"
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"1x4sp0tp1 and resolution_480p\"",
             }
           ]'
 
@@ -502,10 +460,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -332,8 +332,6 @@ jobs:
               "arch": "blackhole",
               "runner-label": "BH-LoudBox",
               "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"bh_2x4sp0tp1\"",
-              "owner_id": "U09ELB03XRU",
-              "owner_name": "Stephen Osborne"
             },
             {
               "name": "Wan2.2-T2V-A14B BH-QB-GE performance",

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -75,11 +75,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U0883RN6CRE # William Ly
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -127,11 +127,6 @@ jobs:
         if: ${{ failure() }}
         run: |
           tt-smi -s
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U0883RN6CRE # William Ly
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-20-cores-impl.yaml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            { model: oft, owner_id: U08AWRT6U3E, cmd: pytest models/experimental/oft/tests/pcc/ }, # Boris Janjic
-            { model: panoptic-deeplab, owner_id: U08ARDXARPF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Ilija Anastasijevic
+            { model: oft, cmd: pytest models/experimental/oft/tests/pcc/ }, # Boris Janjic
+            { model: panoptic-deeplab, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Ilija Anastasijevic
           ]
     name: Nightly 20 cores ${{ matrix.test-group.model }}
     # CIv2 to get weights
@@ -75,9 +75,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            { model: whisper, owner_id: U05RWH3QUPM , cmd: pytest tests/nightly/single_card/whisper },  #Salar Hosseini
-            { model: llama3.1-8b, owner_id: U03PUAKE719, cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1 }, # Miguel Tairum
+            { model: whisper, cmd: pytest tests/nightly/single_card/whisper },  #Salar Hosseini
+            { model: llama3.1-8b, cmd: HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1 }, # Miguel Tairum
           ]
     name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }}
     runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"]
@@ -78,12 +78,6 @@ jobs:
         with:
           prefix: "test_reports_"
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
-
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   nightly-bh-models-ci-v2:
@@ -94,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            { model: panoptic-deeplab, owner_id: U09LK84G4TF, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
+            { model: panoptic-deeplab, cmd: pytest models/experimental/panoptic_deeplab/tests/pcc/ }, # Nikola Milicevic
           ]
     name: Nightly P150 110 cores ${{ matrix.test-group.model }}
     # CIv2 to get weights
@@ -132,9 +126,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -120,11 +120,6 @@ jobs:
           mkdir -p generated/test_reports
           GTEST_FILTER="${{inputs.gtest_filter}}"
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/conda-post-commit.yaml
+++ b/.github/workflows/conda-post-commit.yaml
@@ -143,11 +143,6 @@ jobs:
           export LD_LIBRARY_PATH=$CONDA_PREFIX/lib
           ${{ matrix.test-group.cmd }}
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U07J3K6KS1K # Bryan Lozano
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -143,11 +143,6 @@ jobs:
             mkdir -p generated/test_reports
             GTEST_FILTER="${{inputs.gtest_filter}}"
             ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/didt-tests.yaml
+++ b/.github/workflows/didt-tests.yaml
@@ -65,10 +65,5 @@ jobs:
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_matmul.py::test_sdxl_matmul -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
           TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_sdxl_conv_1280x1280_upsample.py::test_sdxl_conv -k "all" --didt-workload-iterations 100 --determinism-check-interval 1
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U08JJGXKWKB # Radomir Djogo
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -89,11 +89,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -87,11 +87,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -99,11 +99,6 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e GTEST_OUTPUT=xml:generated/test_reports/
           run_args: ${{ matrix.test-group.run-args }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U01Q0T3J3D0 # Paul Keller
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-apc-fast-tests-impl.yaml
+++ b/.github/workflows/galaxy-apc-fast-tests-impl.yaml
@@ -41,8 +41,7 @@ jobs:
             arch: wormhole_b0,
             cmd: 'LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k apc',
             model: llama3,
-            timeout: 10,
-            owner_id: U053W15B6JF
+            timeout: 10
           }, # Djordje Ivanovic
         ]
     runs-on:
@@ -84,8 +83,3 @@ jobs:
         run: |
           echo "Running command: ${{ matrix.test-group.cmd }}"
           eval "${{ matrix.test-group.cmd }}"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -35,8 +35,8 @@ jobs:
         id: generate
         run: |
           all_tests=$(jq -n '[
-            { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 15, "owner_id": "U03HY7MK4BT" },
-            { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 150, "owner_id": "U03HY7MK4BT" }
+            { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 15U03HY7MK4BT" },
+            { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 150U03HY7MK4BT" }
           ]')
 
           # Filter matrix based on test-type selection
@@ -115,11 +115,6 @@ jobs:
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --timeout 600  --durations=0
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       # - name: Save environment data
       #   id: save-environment-data
       #   if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -59,20 +59,20 @@ jobs:
           ]'
 
           all_tests='[
-            { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 15, "owner_id": "U053W15B6JF" },
-            { "name": "Galaxy Llama3 8B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_8b_dp", "timeout": 20, "owner_id": "U08BH66EXAL" },
-            { "name": "Galaxy Llama3 70B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_70b_dp", "timeout": 20, "owner_id": "U08BH66EXAL" },
-            { "name": "Galaxy Falcon7b demo tests", "arch": "wormhole_b0", "model": "falcon7b", "timeout": 10, "owner_id": "U05RWH3QUPM" },
-            { "name": "Galaxy SentenceBert demo tests", "arch": "wormhole_b0", "model": "sentence_bert", "timeout": 5, "owner_id": "U088413NP0Q" },
-            { "name": "Galaxy Whisper demo tests", "arch": "wormhole_b0", "model": "whisper", "timeout": 5, "owner_id": "U08HL8X1ECD" },
-            { "name": "Galaxy Stable Diffusion 3.5 Large demo tests", "arch": "wormhole_b0", "model": "sd35", "timeout": 10, "owner_id": "U03FJB5TM5Y" },
-            { "name": "Galaxy Flux.1-dev demo tests", "arch": "wormhole_b0", "model": "flux1", "timeout": 15, "owner_id": "U08TED0JM9D" },
-            { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 25, "owner_id": "U08TJ70UFRT" },
-            { "name": "Galaxy Motif-Image-6B-Preview demo tests", "arch": "wormhole_b0", "model": "motif", "timeout": 15, "owner_id": "U08TED0JM9D" },
-            { "name": "Galaxy Wan2.2 demo tests", "arch": "wormhole_b0", "model": "wan22", "timeout": 20, "owner_id": "U03FJB5TM5Y" },
-            { "name": "Galaxy Mochi demo tests", "arch": "wormhole_b0", "model": "mochi", "timeout": 15, "owner_id": "U09ELB03XRU" },
-            { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10, "owner_id": "U08H32XUS9W" },
-            { "name": "Galaxy QwenImage demo tests", "arch": "wormhole_b0", "model": "qwenimage", "timeout": 20, "owner_id": "U08TED0JM9D" }
+            { "name": "Galaxy Llama3 demo tests", "arch": "wormhole_b0", "model": "llama3", "timeout": 15 },
+            { "name": "Galaxy Llama3 8B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_8b_dp", "timeout": 20 },
+            { "name": "Galaxy Llama3 70B data-parallel demo tests", "arch": "wormhole_b0", "model": "llama3_70b_dp", "timeout": 20 },
+            { "name": "Galaxy Falcon7b demo tests", "arch": "wormhole_b0", "model": "falcon7b", "timeout": 10 },
+            { "name": "Galaxy SentenceBert demo tests", "arch": "wormhole_b0", "model": "sentence_bert", "timeout": 5 },
+            { "name": "Galaxy Whisper demo tests", "arch": "wormhole_b0", "model": "whisper", "timeout": 5 },
+            { "name": "Galaxy Stable Diffusion 3.5 Large demo tests", "arch": "wormhole_b0", "model": "sd35", "timeout": 10 },
+            { "name": "Galaxy Flux.1-dev demo tests", "arch": "wormhole_b0", "model": "flux1", "timeout": 15 },
+            { "name": "Galaxy GPT-OSS demo tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 25 },
+            { "name": "Galaxy Motif-Image-6B-Preview demo tests", "arch": "wormhole_b0", "model": "motif", "timeout": 15 },
+            { "name": "Galaxy Wan2.2 demo tests", "arch": "wormhole_b0", "model": "wan22", "timeout": 20 },
+            { "name": "Galaxy Mochi demo tests", "arch": "wormhole_b0", "model": "mochi", "timeout": 15 },
+            { "name": "Galaxy DeepSeek v3 demo tests", "arch": "wormhole_b0", "model": "deepseek_v3", "timeout": 10 },
+            { "name": "Galaxy QwenImage demo tests", "arch": "wormhole_b0", "model": "qwenimage", "timeout": 20 }
           ]'
 
           # Filter matrix based on model selection

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -54,8 +54,8 @@ jobs:
           # Yousef Al Rawwash - deepseek
 
           disabled_tests='[
-            { "name": "Galaxy Llama3 long context demo tests", "arch": "wormhole_b0", "model": "llama3_long_context", "timeout": 60, "owner_id": "U03PUAKE719" },
-            { "name": "Galaxy Llama3 evals tests", "arch": "wormhole_b0", "model": "llama3_evals", "timeout": 45, "owner_id": "U03PUAKE719" },
+            { "name": "Galaxy Llama3 long context demo tests", "arch": "wormhole_b0", "model": "llama3_long_context", "timeout": 60 },
+            { "name": "Galaxy Llama3 evals tests", "arch": "wormhole_b0", "model": "llama3_evals", "timeout": 45 },
           ]'
 
           all_tests='[
@@ -315,11 +315,6 @@ jobs:
             models/experimental/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py \
             -k "4x8" \
             --timeout 1200
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-frequent-tests-impl.yaml
+++ b/.github/workflows/galaxy-frequent-tests-impl.yaml
@@ -40,65 +40,56 @@ jobs:
             #   "name": "Galaxy Llama3 frequent tests",
             #   "arch": "wormhole_b0",
             #   "model": "llama3",
-            #   "timeout": 70,
-            #   "owner_id": "U053W15B6JF"
-            # }, # Djordje Ivanovic
+            #   "timeout": 70
+            # },
             {
               "name": "Galaxy resnet50 frequent tests",
               "arch": "wormhole_b0",
               "model": "resnet50",
               "timeout": 50,
-              "owner_id": "U052J2QDDKQ"
-            }, # Pavle Josipovic
+            },
             {
               "name": "Galaxy unit/distributed frequent tests",
               "arch": "wormhole_b0",
               "model": "unit",
               "timeout": 50,
-              "owner_id": "UBHPP2NDP"
-            }, # Joseph Chu
+            },
             {
               "name": "Galaxy SD3.5 frequent tests",
               "arch": "wormhole_b0",
               "model": "sd35",
               "timeout": 50,
-              "owner_id": "U03FJB5TM5Y"
-            }, # Colman Glagovich
+            },
             {
               "name": "Galaxy Wan2.2 frequent tests",
               "arch": "wormhole_b0",
               "model": "wan22",
               "timeout": 40,
-              "owner_id": "U03FJB5TM5Y"
-            }, # Colman Glagovich
+            },
             {
               "name": "Galaxy mochi frequent tests",
               "arch": "wormhole_b0",
               "model": "mochi",
               "timeout": 80,
-              "owner_id": "U09ELB03XRU"
-            }, # Stephen Osborne
+            },
             {
               "name": "Galaxy Flux.1 frequent tests",
               "arch": "wormhole_b0",
               "model": "flux1",
               "timeout": 50,
-              "owner_id": "U08TED0JM9D"
-            }, # Samuel Adesoye
+            },
             {
               "name": "Galaxy Motif frequent tests",
               "arch": "wormhole_b0",
               "model": "motif",
-              "timeout": 10,
-              "owner_id": "U08TED0JM9D"
-            }, # Samuel Adesoye
+              "timeout": 10
+            },
             {
               "name": "Galaxy Qwen-Image frequent tests",
               "arch": "wormhole_b0",
               "model": "qwenimage",
               "timeout": 10,
-              "owner_id": "U08TED0JM9D"
-            } # Samuel Adesoye
+            }
           ]' --compact-output)
 
           # Filter matrix based on model selection
@@ -154,11 +145,6 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tg_device --dispatch-mode "" --model ${{ matrix.test-group.model }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -44,7 +44,7 @@ jobs:
               "save-perf-data": false,
               "timeout": 50,
               "cmd": "TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE=\"7,7\" pytest -n auto models/demos/ttnn_resnet/tests/test_perf_e2e_resnet50.py -m \"model_perf_tg\" && python3 models/perf/merge_perf_results.py --upper-threshold 1.10"
-            }, # Pavle Josipovic
+            },
             {
               "name": "Galaxy Llama 70B model perf tests",
               "model-type": "Llama-70B",
@@ -53,8 +53,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 60,
               "cmd": "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch --timeout=600 && TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_decoder_device_perf.py::test_llama_TG_perf_device --timeout=600",
-              "owner_id": "U053W15B6JF"
-            }, # Djordje Ivanovic
+            },
             {
               "name": "Llama Galaxy Perf Unit Tests",
               "model-name": "llama_unit_tests",
@@ -63,8 +62,7 @@ jobs:
               "timeout": 100,
               "tracy": true,
               "save-perf-data": true,
-              "owner_id": "U053W15B6JF"
-            }, # Djordje Ivanovic
+            },
             {
               "name": "Galaxy Llama 70B prefill perf tests",
               "model-type": "Llama-70B",
@@ -73,8 +71,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 60,
               "cmd": "FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest -n auto models/demos/llama3_70b_galaxy/tests/test_prefill_device_perf.py::test_llama_TG_perf_device --timeout=1000",
-              "owner_id": "U03PUAKE719"
-            }, # Miguel Tairum
+            },
             {
               "name": "Galaxy Sentence Bert tests",
               "arch": "wormhole_b0",
@@ -83,8 +80,7 @@ jobs:
               "save-perf-data": false,
               "cmd": "pytest models/demos/tg/sentence_bert/tests/device_perf_test.py && python3 models/perf/merge_perf_results.py",
               "timeout": 30,
-              "owner_id": "U088413NP0Q"
-            } # Ashai Reddy
+            }
           ]' --compact-output)
 
           ACTIVE_MODELS=$(jq -n '[
@@ -96,8 +92,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 50,
               "cmd": "pytest models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k \"4x8cfg1sp0tp1\"",
-              "owner_id": "U03FJB5TM5Y"
-            }, # Colman Glagovich
+            },
             {
               "name": "Galaxy DiT Flux.1 model perf tests",
               "model-type": "Flux.1-Dev",
@@ -106,8 +101,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 50,
               "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"wh_4x8sp0tp1\"",
-              "owner_id": "U08TED0JM9D"
-            }, # Samuel Adesoye
+            },
             {
               "name": "Galaxy DiT Motif model perf tests",
               "model-type": "Motif",
@@ -116,8 +110,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 15,
               "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/motif/test_performance_motif.py -k \"4x8cfg1sp0tp1\"",
-              "owner_id": "U08TED0JM9D"
-            }, # Samuel Adesoye
+            },
             {
               "name": "Galaxy DiT Wan2.2 model perf tests",
               "model-type": "Wan2.2",
@@ -126,8 +119,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 35,
               "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"wh_4x8sp1tp0 and resolution_720p\"",
-              "owner_id": "U03FJB5TM5Y"
-            }, # Colman Glagovich
+            },
             {
               "name": "Galaxy Mochi model perf tests",
               "model-type": "mochi",
@@ -136,8 +128,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 50,
               "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && export NO_PROMPT=1 && pytest models/experimental/tt_dit/tests/models/mochi/test_performance_mochi.py -k \"4x8sp1tp0 \"",
-              "owner_id": "U09ELB03XRU"
-            }, # Stephen Osborne
+            },
             {
               "name": "Galaxy DiT Qwen-Image model perf tests",
               "model-type": "QwenImage",
@@ -146,8 +137,7 @@ jobs:
               "save-perf-data": true,
               "timeout": 20,
               "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k \"4x8\"",
-              "owner_id": "U08TED0JM9D"
-            } # Samuel Adesoye
+            }
           ]' --compact-output)
 
           # Combine both arrays into full matrix
@@ -295,11 +285,6 @@ jobs:
           name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.model }}-bare-metal
           path:
             ${{ steps.check-perf-report.outputs.perf_report_filename_all_gather }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-nightly-tests-impl.yaml
+++ b/.github/workflows/galaxy-nightly-tests-impl.yaml
@@ -35,15 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40, owner_id: U05ACKAJTHS}, # Naif Tarafdar
-          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
-          { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45, owner_id: U08UBDUKH6Z}, # Neel Nyamagoudar
+          { name: "Galaxy CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 40}, # Naif Tarafdar
+          { name: "Galaxy Fabric unit tests", arch: wormhole_b0, cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*", timeout: 25}, # Neel Nyamagoudar
+          { name: "Galaxy Fabric 2D Torus Nightly Tests", arch: wormhole_b0, cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_2d_torus_nightly.yaml, timeout: 45}, # Neel Nyamagoudar
           # {
           #   name: "Llama Galaxy Accuracy Test",
           #   arch: wormhole_b0,
           #   cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/tests/test_llama_accuracy.py",
-          #   timeout: 15,
-          #   owner_id: U053W15B6JF
+          #   timeout: 15
           # } # Djordje Ivanovic
         ]
     name: ${{ matrix.test-group.name }}
@@ -85,11 +84,6 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -104,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "BH Galaxy CCL tests", arch: blackhole, cmd: "pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly", timeout: 40, owner_id: U05ACKAJTHS} # Naif Tarafdar, Camilo Vega
+          { name: "BH Galaxy CCL tests", arch: blackhole, cmd: "pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly", timeout: 40} # Naif Tarafdar, Camilo Vega
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -145,11 +139,6 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -76,11 +76,6 @@ jobs:
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_deadlock_stability_6U_galaxy.yaml
           TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_6U_galaxy_quick.yaml
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U053W15B6JF # Djordje Ivanovic
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -180,11 +175,6 @@ jobs:
           pytest "tests/scale_out/test_ccl_fabric_manager.py::test_reduce_scatter_async_fabric_manager[wormhole_b0-mesh_device0-8-2-2-fabric_manager_enabled_linear-mem_config_input0-mem_config_rs0-batch_8-perf-3links]" --timeout=300;
           pytest "tests/scale_out/test_ccl_fabric_manager.py::test_all_to_all_dispatch_fabric_manager_8x4[wormhole_b0-l1_in_dram_out-DataType.BFLOAT16-None-4-s2-7168-8-256-32-8x4_grid-False-fabric_manager_enabled_1d_line]" --timeout=300;
           ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_1D --terminate-fabric
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U053W15B6JF # Djordje Ivanovic
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -236,11 +226,6 @@ jobs:
         run: |
           ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
           ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: UJ45FEC7M # Allan Liu
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-stress-tests-impl.yaml
+++ b/.github/workflows/galaxy-stress-tests-impl.yaml
@@ -66,11 +66,6 @@ jobs:
             echo "🔁 Run #$i"
             timeout --preserve-status 1200 pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py -k "nd-hang-test"
           done
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U053W15B6JF # Djordje Ivanovic
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -83,15 +78,13 @@ jobs:
             name: "Galaxy Fabric Stability Tests",
             arch: wormhole_b0,
             cmd: TT_METAL_CLEAR_L1=1 build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_6U_galaxy.yaml,
-            timeout: 100,
-            owner_id: U08FXFFH7L0
+            timeout: 100
           }, # Abhishek Agarwal
           {
             name: "Llama Galaxy Long Stress Test",
             arch: wormhole_b0,
             cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_70b_galaxy/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
-            timeout: 140,
-            owner_id: U053W15B6JF
+            timeout: 140
           } # Djordje Ivanovic
         ]
     name: ${{ matrix.test-group.name }}
@@ -133,11 +126,6 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -266,11 +266,6 @@ jobs:
 
           exit $failed
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -37,7 +37,7 @@ jobs:
            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-functional"],
            cmd: "./build/test/umd/galaxy/unit_tests_glx",
            timeout: 10
-         },  # Bojan Roško
+         },
          {
            name: "UMD API tests",
            arch: wormhole_b0,
@@ -99,14 +99,14 @@ jobs:
           # GPT-OSS unit tests: Stuti Raizada
 
           all_tests=$(jq -n '[
-            { "name": "Galaxy unit tests", "arch": "wormhole_b0", "model": "unit", "timeout": 10, "owner_id": "XXXXX" },
-            { "name": "Galaxy Fabric tests", "arch": "wormhole_b0", "model": "fabric", "timeout": 5, "owner_id": "UJ45FEC7M" },
-            { "name": "Galaxy Multi-Process tests", "arch": "wormhole_b0", "model": "multiprocess", "timeout": 15, "owner_id": "U03NG0A5ND7" },
-            # { "name": "Galaxy Llama3-70b unit tests", "arch": "wormhole_b0", "model": "llama3-70b", "timeout": 30, "owner_id": "U053W15B6JF", "mlperf": true },
-            # { "name": "Galaxy DRAM Prefetcher unit tests", "arch": "wormhole_b0", "model": "prefetcher", "timeout": 25, "owner_id": "U044T8U8DEF" },
-            { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 10, "owner_id": "U08TJ70UFRT", "mlperf": true },
-            { "name": "Galaxy distributed ops tests", "arch": "wormhole_b0", "model": "distributed-ops", "timeout": 5, "owner_id": "U044T8U8DEF" },
-            { "name": "Galaxy tttv2 tests", "arch": "wormhole_b0", "model": "tttv2", "timeout": 10, "owner_id": "U07RY6B5FLJ", "mlperf": true} # Gongyu Wang
+            { "name": "Galaxy unit tests", "arch": "wormhole_b0", "model": "unit", "timeout": 10 },
+            { "name": "Galaxy Fabric tests", "arch": "wormhole_b0", "model": "fabric", "timeout": 5 },
+            { "name": "Galaxy Multi-Process tests", "arch": "wormhole_b0", "model": "multiprocess", "timeout": 15 },
+            # { "name": "Galaxy Llama3-70b unit tests", "arch": "wormhole_b0", "model": "llama3-70b", "timeout": 30, "mlperf": true },
+            # { "name": "Galaxy DRAM Prefetcher unit tests", "arch": "wormhole_b0", "model": "prefetcher", "timeout": 25 },
+            { "name": "Galaxy GPT-OSS unit tests", "arch": "wormhole_b0", "model": "gpt-oss", "timeout": 10, "mlperf": true },
+            { "name": "Galaxy distributed ops tests", "arch": "wormhole_b0", "model": "distributed-ops", "timeout": 5 },
+            { "name": "Galaxy tttv2 tests", "arch": "wormhole_b0", "model": "tttv2", "timeout": 10, "mlperf": true}
           ]')
 
           # Filter matrix based on model selection

--- a/.github/workflows/metal-iommu-unit-tests.yaml
+++ b/.github/workflows/metal-iommu-unit-tests.yaml
@@ -78,11 +78,6 @@ jobs:
         run: |
           mkdir -p generated/test_reports
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -83,11 +83,6 @@ jobs:
           source tests/scripts/run_python_model_tests.sh
           run_python_model_tests_${{ inputs.arch }}
           run_python_model_tests_slow_runtime_mode_${{ inputs.arch }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -162,12 +162,6 @@ jobs:
           export DEVICE_PERF_REPORT_FILENAME=Ops_Perf.csv
           python3 models/perf/merge_device_perf_results.py $DEVICE_PERF_REPORT_FILENAME CHECK
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U08VC9954CE # David Popov
-
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/ops-sanity.yaml
+++ b/.github/workflows/ops-sanity.yaml
@@ -7,7 +7,6 @@
 # name: The name of the test
 # cmd: The command to run the test
 # sku: the sku of the test (N150, N300, P100, P150b, llmbox, galaxy, etc)
-# owner_id: The owner of the test
 
 
 name: "[testing] Ops Sanity pipeline"
@@ -134,10 +133,5 @@ jobs:
         run: |
           echo ${{ matrix.test-group.cmd }}
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -213,11 +213,6 @@ jobs:
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
           path: /work
 
-      # TODO: Fix the pipeline before enabling notifications.
-      #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-      #  if: ${{ failure() }}
-      #  with:
-      #    slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
       - name: Check perf report exists
         id: check-perf-report
         if: ${{ !cancelled() }}

--- a/.github/workflows/profiler-tests-impl.yaml
+++ b/.github/workflows/profiler-tests-impl.yaml
@@ -70,11 +70,6 @@ jobs:
         timeout-minutes: 35
         run: |
           ${{ inputs.test-script }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U03BJ1L3LUQ # Mo Memarian
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -135,11 +135,6 @@ jobs:
           else
             ./tests/scripts/run_profiler_regressions.sh --full
           fi
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -40,70 +40,70 @@ jobs:
   define-demo-tests:
     runs-on: ubuntu-latest
     outputs:
-      demo-tests: ${{ steps.compute-tests.outputs.demo-tests }}
+      demo-tests: ${{ steps.compute-tests.outputs.demo-tests }},
     strategy:
       matrix:
         default-demo-tests:
           [[
-            { name: "falcon7b", runner-label: "N150", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
-            { name: "llama3", runner-label: "N150", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "vgg", runner-label: "N150", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
-            { name: "bert_tiny", runner-label: "N150", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "bert", runner-label: "N150", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "resnet", runner-label: "N150", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "distilbert", runner-label: "N150", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
-            { name: "mnist", runner-label: "N150", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "squeezebert", runner-label: "N150", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, # Joseph Chu
-            { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas
-            { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
-            { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_s", runner-label: "N150", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
-            { name: "vit", runner-label: "N150", performance: false, cmd: run_vit_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga
-            { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "efficientnet_b0", runner-label: "N150", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "vovnet", runner-label: "N150", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_v2", runner-label: "N150", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "swin_s", runner-label: "N300", performance: false, cmd: run_swin_s_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga (HariniMohan0102)
-            { name: "vit", runner-label: "N300", performance: false, cmd: run_vit_demo, owner_id: U088413NP0Q, civ2-compatible: true}, # Ashai Reddy Ginuga
-            { name: "falcon7b", runner-label: "N300", performance: false, cmd: run_falcon7b_func, owner_id: U05RWH3QUPM}, # Salar Hosseini
-            { name: "llama3", runner-label: "N300", performance: false, cmd: run_llama3_func, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "vgg", runner-label: "N300", performance: false, cmd: run_vgg_func, owner_id: U06Q7ESTFEV}, # Borys Bradel
-            { name: "bert_tiny", runner-label: "N300", performance: false, cmd: run_bert_tiny_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "bert", runner-label: "N300", performance: false, cmd: run_bert_func, owner_id: U024A4EFV6U}, # Brian Liu
-            { name: "resnet", runner-label: "N300", performance: false, cmd: run_resnet_func, owner_id: U0837MYG788}, # Marko Radosavljevic
-            { name: "distilbert", runner-label: "N300", performance: false, cmd: run_distilbert_func, owner_id: U013121KDH9}, # Austin Ho
-            { name: "mnist", runner-label: "N300", performance: false, cmd: run_mnist_func, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "squeezebert", runner-label: "N300", performance: false, cmd: run_squeezebert_func, owner_id: UBHPP2NDP}, #Joseph Chu
-            { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_perf, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
+            { name: "falcon7b", runner-label: "N150", performance: false, cmd: run_falcon7b_func},
+            { name: "llama3", runner-label: "N150", performance: false, cmd: run_llama3_func},
+            { name: "vgg", runner-label: "N150", performance: false, cmd: run_vgg_func},
+            { name: "bert_tiny", runner-label: "N150", performance: false, cmd: run_bert_tiny_func},
+            { name: "bert", runner-label: "N150", performance: false, cmd: run_bert_func},
+            { name: "resnet", runner-label: "N150", performance: false, cmd: run_resnet_func},
+            { name: "distilbert", runner-label: "N150", performance: false, cmd: run_distilbert_func},
+            { name: "mnist", runner-label: "N150", performance: false, cmd: run_mnist_func},
+            { name: "squeezebert", runner-label: "N150", performance: false, cmd: run_squeezebert_func},
+            { name: "stable_diffusion", runner-label: "N150", performance: false, cmd: run_stable_diffusion_func},
+            { name: "segformer", runner-label: "N150", performance: false, cmd: run_segformer_func, civ2-compatible: true},
+            { name: "sentence_bert", runner-label: "N150", performance: false, cmd: run_sentencebert_func, civ2-compatible: true},
+            { name: "mobilenetv2", runner-label: "N150", performance: false, cmd: run_mobilenetv2_perf, civ2-compatible: true},
+            { name: "ufld_v2", runner-label: "N150", performance: false, cmd: run_ufld_v2_func, civ2-compatible: true},
+            { name: "swin_s", runner-label: "N150", performance: false, cmd: run_swin_s_demo, civ2-compatible: true},
+            { name: "vit", runner-label: "N150", performance: false, cmd: run_vit_demo, civ2-compatible: true},
+            { name: "vanilla_unet", runner-label: "N150", performance: false, cmd: run_vanilla_unet_demo, civ2-compatible: true},
+            { name: "vgg_unet", runner-label: "N150", performance: false, cmd: run_vgg_unet_demo, civ2-compatible: true},
+            { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability},
+            { name: "sdxl", runner-label: "N150", performance: false, cmd: run_sdxl_func},
+            { name: "efficientnet_b0", runner-label: "N150", performance: false, cmd: run_efficientnet_b0_func, civ2-compatible: true},
+            { name: "vovnet", runner-label: "N150", performance: false, cmd: run_vovnet_demo, civ2-compatible: true},
+            { name: "swin_v2", runner-label: "N150", performance: false, cmd: run_swin_v2_demo, civ2-compatible: true},
+            { name: "swin_s", runner-label: "N300", performance: false, cmd: run_swin_s_demo, civ2-compatible: true},
+            { name: "vit", runner-label: "N300", performance: false, cmd: run_vit_demo, civ2-compatible: true},
+            { name: "falcon7b", runner-label: "N300", performance: false, cmd: run_falcon7b_func},
+            { name: "llama3", runner-label: "N300", performance: false, cmd: run_llama3_func},
+            { name: "vgg", runner-label: "N300", performance: false, cmd: run_vgg_func},
+            { name: "bert_tiny", runner-label: "N300", performance: false, cmd: run_bert_tiny_func},
+            { name: "bert", runner-label: "N300", performance: false, cmd: run_bert_func},
+            { name: "resnet", runner-label: "N300", performance: false, cmd: run_resnet_func},
+            { name: "distilbert", runner-label: "N300", performance: false, cmd: run_distilbert_func},
+            { name: "mnist", runner-label: "N300", performance: false, cmd: run_mnist_func},
+            { name: "squeezebert", runner-label: "N300", performance: false, cmd: run_squeezebert_func},
+            { name: "mobilenetv2", runner-label: "N300", performance: false, cmd: run_mobilenetv2_perf, civ2-compatible: true},
+            { name: "ufld_v2", runner-label: "N300", performance: false, cmd: run_ufld_v2_func, civ2-compatible: true},
             # Return N150 and N300 mistral7b tests after https://github.com/tenstorrent/tt-metal/issues/34763 is done
-            # { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
-            # { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf, owner_id: U0896VBAKFC}, # Pratikkumar Prajapati
+            # { name: "mistral7b", runner-label: "N150", performance: false, cmd: run_mistral7b_perf},
+            # { name: "mistral7b", runner-label: "N300", performance: true, cmd: run_mistral7b_perf},
             # Return N300 llama3 tests after https://github.com/tenstorrent/tt-metal/issues/35120 is done
-            # { name: "llama3", runner-label: "N300", performance: true, cmd: run_llama3_perf, owner_id: U03PUAKE719}, # Miguel Tairum
-            { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
-            { name: "efficientnet_b0", runner-label: "N300", performance: false, cmd: run_efficientnet_b0_func, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "whisper", runner-label: "N300", performance: true, cmd: run_whisper_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
-  #          { name: "mamba", runner-label: "N300", performance: true, cmd: run_mamba_perf, owner_id: U06ECNVR0EN}, # Evan Smal
-            { name: "segformer", runner-label: "N300", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (vguduruTT)
-            { name: "sentence_bert", runner-label: "N300", performance: false, cmd: run_sentencebert_func, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
-            { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas (keerthana-r-mcw)
-            { name: "vovnet", runner-label: "N300", performance: false, cmd: run_vovnet_demo, owner_id: U056BK5U81E, civ2-compatible: true}, # Dalar Vartanians
-            { name: "swin_v2", runner-label: "N300", performance: false, cmd: run_swin_v2_demo, owner_id: U045U3DEKM4, civ2-compatible: true}, # Mohamed Bahnas
+            # { name: "llama3", runner-label: "N300", performance: true, cmd: run_llama3_perf},
+            { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf},
+            { name: "efficientnet_b0", runner-label: "N300", performance: false, cmd: run_efficientnet_b0_func0, civ2-compatible: true},
+            { name: "whisper", runner-label: "N300", performance: true, cmd: run_whisper_perf},
+  #          { name: "mamba", runner-label: "N300", performance: true, cmd: run_mamba_perf},
+            { name: "segformer", runner-label: "N300", performance: false, cmd: run_segformer_func, civ2-compatible: true},
+            { name: "sentence_bert", runner-label: "N300", performance: false, cmd: run_sentencebert_func, civ2-compatible: true},
+            { name: "vanilla_unet", runner-label: "N300", performance: false, cmd: run_vanilla_unet_demo, civ2-compatible: true},
+            { name: "vgg_unet", runner-label: "N300", performance: false, cmd: run_vgg_unet_demo, civ2-compatible: true},
+            { name: "vovnet", runner-label: "N300", performance: false, cmd: run_vovnet_demo, civ2-compatible: true},
+            { name: "swin_v2", runner-label: "N300", performance: false, cmd: run_swin_v2_demo, civ2-compatible: true},
             # Moved to t3k tests until OOM on single card runners resolved
-            # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func, owner_id: U03PUAKE719}, # Mark O'Connor
-            { name: "qwen25_vl", runner-label: "N150", performance: false, cmd: run_qwen25_vl_perfunc, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_perfunc, owner_id: U07RY6B5FLJ},  #Gongyu Wang
-            { name: "ds_r1_qwen", runner-label: "N300", performance: false, cmd: run_ds_r1_qwen_func, owner_id: U07RY6B5FLJ, civ2-compatible: true},  #Gongyu Wang
-            # { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews TODO: Gemma3 N150 tests pulled due to OOM; will be addressed in future PR
-            { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf, owner_id: U08TJ70UFRT},  # Harry Andrews
-            # { name: "phi4", runner-label: "N300", performance: false, cmd: run_phi4_func, owner_id: U094PKWHNJ0, civ2-compatible: true},  # Petar Milojevic
+            # { name: "qwen7b", runner-label: "N300", performance: false, cmd: run_qwen7b_func},
+            { name: "qwen25_vl", runner-label: "N150", performance: false, cmd: run_qwen25_vl_perfunc},
+            { name: "qwen25_vl", runner-label: "N300", performance: true, cmd: run_qwen25_vl_perfunc},
+            { name: "ds_r1_qwen", runner-label: "N300", performance: false, cmd: run_ds_r1_qwen_func, civ2-compatible: true},
+            # { name: "gemma3", runner-label: "N150", performance: true, cmd: run_gemma3_perf},  # TODO: Gemma3 N150 tests pulled due to OOM; will be addressed in future PR
+            { name: "gemma3", runner-label: "N300", performance: true, cmd: run_gemma3_perf}
+            # { name: "phi4", runner-label: "N300", performance: false, cmd: run_phi4_func, civ2-compatible: true}
           ]]
     steps:
       - name: Compute tests
@@ -119,9 +119,9 @@ jobs:
           echo $default_demo_tests | jq
           requested_demo_tests=$default_demo_tests
 
-          requested_models=${{ toJSON(inputs.requested-models) }}
+          requested_models=${{ toJSON(inputs.requested-models) }},
           echo "[info] requested-models: $requested_models"
-          run_perf_tests=${{ inputs.run-perf-tests }}
+          run_perf_tests=${{ inputs.run-perf-tests }},
           echo "[info] run-perf-tests: $run_perf_tests"
 
           if [[ "$requested_models" != "all" ]]; then
@@ -149,8 +149,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: ${{ fromJSON(needs.define-demo-tests.outputs.demo-tests) }}
-    name: ${{ matrix.test-group.name }}-${{ matrix.test-group.runner-label }}-${{ (matrix.test-group.performance && 'perf') || 'func' }}
+        test-group: ${{ fromJSON(needs.define-demo-tests.outputs.demo-tests) }},
+    name: ${{ matrix.test-group.name }}-${{ matrix.test-group.runner-label }}-${{ (matrix.test-group.performance && 'perf') || 'func' }},
     runs-on: >-
       ${{
         matrix.test-group.civ2-compatible == true
@@ -164,25 +164,25 @@ jobs:
               matrix.test-group.runner-label,
               inputs.extra-tag
             ))
-      }}
+      }},
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }},
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ inputs.arch }}
+        ARCH_NAME: ${{ inputs.arch }},
         LOGURU_LEVEL: INFO
         GITHUB_ACTIONS: true
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        HF_HUB_CACHE: ${{ (!matrix.test-group.civ2-compatible && '/mnt/MLPerf/huggingface/hub') || '' }}
-        HTTP_PROXY: ${{ (matrix.test-group.civ2-compatible && env.HTTP_PROXY) || '' }}
-        HTTPS_PROXY: ${{ (matrix.test-group.civ2-compatible && env.HTTPS_PROXY) || '' }}
-        NO_PROXY: ${{ (matrix.test-group.civ2-compatible && env.NO_PROXY) || '' }}
+        HF_HUB_CACHE: ${{ (!matrix.test-group.civ2-compatible && '/mnt/MLPerf/huggingface/hub') || '' }},
+        HTTP_PROXY: ${{ (matrix.test-group.civ2-compatible && env.HTTP_PROXY) || '' }},
+        HTTPS_PROXY: ${{ (matrix.test-group.civ2-compatible && env.HTTPS_PROXY) || '' }},
+        NO_PROXY: ${{ (matrix.test-group.civ2-compatible && env.NO_PROXY) || '' }},
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }},
       options: >-
         --device /dev/tenstorrent ${{ matrix.test-group.civ2-compatible == true && '-e TT_GH_CI_INFRA=1' || '' }} --cap-add=ALL --security-opt seccomp=unconfined --ulimit nproc=65536:65536 --ulimit nofile=65536:65536 --privileged -v /sys:/sys
     defaults:
@@ -199,22 +199,22 @@ jobs:
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          build-artifact-name: ${{ inputs.build-artifact-name }},
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }},
       - name: Check for invalid performance + civ2-compatible combination
-        if: ${{ matrix.test-group.performance && matrix.test-group.civ2-compatible }}
+        if: ${{ matrix.test-group.performance && matrix.test-group.civ2-compatible }},
         run: |
           echo "::error::Performance tests are not compatible with civ2-compatible tests"
           echo "::error::test-group.performance: ${{ matrix.test-group.performance }}"
           echo "::error::test-group.civ2-compatible: ${{ matrix.test-group.civ2-compatible }}"
           exit 1
       - name: Enable Performance mode
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !matrix.test-group.civ2-compatible }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !matrix.test-group.civ2-compatible }},
         uses: tenstorrent/tt-metal/.github/actions/set-cpu-governor@main
         with:
           governor: performance
       - name: Check Weka mount
-        if: ${{ !matrix.test-group.civ2-compatible }}
+        if: ${{ !matrix.test-group.civ2-compatible }},
         run: |
           if [ -d "/mnt/MLPerf" ] && mountpoint -q /mnt/MLPerf; then
             echo "CIv1: ✓ Weka is mounted at /mnt/MLPerf"
@@ -229,19 +229,19 @@ jobs:
         env:
           # When ops recording is enabled, wrap pytest with Tracy profiler
           # Tracy flags: -r (report), -p (device profiler), --dump-device-data-mid-run (prevent buffer overflow)
-          PYTEST_CMD: ${{ inputs.enable-ops-recording && 'python -m tracy -r -p --dump-device-data-mid-run --op-support-count=30000 -m pytest' || 'pytest' }}
+          PYTEST_CMD: ${{ inputs.enable-ops-recording && 'python -m tracy -r -p --dump-device-data-mid-run --op-support-count=30000 -m pytest' || 'pytest' }},
         run: |
           source /work/tests/scripts/single_card/run_single_card_demo_tests.sh
-          ${{ matrix.test-group.cmd }}
+          ${{ matrix.test-group.cmd }},
       - name: Prepare Tracy reports
-        if: ${{ !cancelled() && inputs.enable-ops-recording }}
+        if: ${{ !cancelled() && inputs.enable-ops-recording }},
         uses: ./docker-job/.github/actions/prepare-tracy-reports
         with:
           profiler-dir: /work/generated/profiler
-          model-name: ${{ matrix.test-group.name }}
-          card: ${{ matrix.test-group.runner-label }}
+          model-name: ${{ matrix.test-group.name }},
+          card: ${{ matrix.test-group.runner-label }},
       - name: Upload Tracy profiler reports (operations recording)
-        if: ${{ !cancelled() && inputs.enable-ops-recording }}
+        if: ${{ !cancelled() && inputs.enable-ops-recording }},
         uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         with:
@@ -249,7 +249,7 @@ jobs:
           prefix: "tracy_ops_${{ matrix.test-group.name }}_${{ matrix.test-group.runner-label }}_"
       - name: Save environment data
         id: save-environment-data
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !cancelled() }},
         shell: bash
         run: |
           if [ -d "generated/benchmark_data" ]; then
@@ -260,34 +260,29 @@ jobs:
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
           fi
       - name: Upload benchmark data
-        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
+        if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }},
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
-          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }},
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
-          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
-          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }},
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }},
           path: /work
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }},
         with:
           path: generated/test_reports/
           prefix: "test_reports_"
       - name: Disable Performance mode
-        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !matrix.test-group.civ2-compatible && always() }}
+        if: ${{ matrix.test-group.runner-label == 'N300' && matrix.test-group.performance && !matrix.test-group.civ2-compatible && always() }},
         uses: tenstorrent/tt-metal/.github/actions/set-cpu-governor@main
         with:
           governor: ondemand
 
   aggregate-ops-recording:
     needs: single-card-demo-tests
-    if: ${{ !cancelled() && inputs.enable-ops-recording }}
+    if: ${{ !cancelled() && inputs.enable-ops-recording }},
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -42,178 +42,31 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          FULL_MATRIX=$(jq -n -c '[
-            {
-              "name": "t3k_falcon7b_tests",
-              "model": "falcon7b",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_falcon7b_tests",
-              "timeout": 90,
-U05RWH3QUPM" # Salar Hosseini
-            },
-            {
-              "name": "t3k_falcon40b_tests",
-              "model": "falcon40b",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_falcon40b_tests",
-              "timeout": 50,
-U053W15B6JF" # Djordje Ivanovic
-            },
-            {
-              "name": "t3k_llama3_tests",
-              "model": "llama3",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_llama3_tests",
-              "timeout": 60,
-U03PUAKE719" # Miguel Tairum Cruz
-            },
-            {
-              "name": "t3k_llama3_vision_tests",
-              "model": "llama3_vision",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_llama3_vision_tests",
-              "timeout": 45,
-U03FJB5TM5Y" # Colman Glagovich
-            },
-            {
-              "name": "t3k_llama3_90b_vision_tests",
-              "model": "llama3_90b_vision",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_llama3_90b_vision_tests",
-              "timeout": 20,
-U07RY6B5FLJ" # Gongyu Wang
-            },
-            {
-              "name": "t3k_llama3_70b_tests",
-              "model": "llama3_70b",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_llama3_70b_tests",
-              "timeout": 60,
-U03FJB5TM5Y" # Colman Glagovich
-            },
-            {
-              "name": "t3k_resnet50_tests",
-              "model": "resnet50",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_resnet50_tests",
-              "timeout": 50,
-U0837MYG788" # Marko Radosavljevic
-            },
-            {
-              "name": "t3k_sentence_bert_tests",
-              "model": "sentence_bert",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_sentence_bert_tests",
-              "timeout": 75,
-U045U3DEKM4" # Mohamed Bahnas (Aniruddha Tupe)
-            },
-            {
-              "name": "t3k sd35_large tests",
-              "model": "sd35_large",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_sd35large_tests",
-              "timeout": 60,
-U03FJB5TM5Y" # Colman Glagovich
-            },
-            {
-              "name": "t3k flux1-dev tests",
-              "model": "flux1-dev",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_flux1_tests",
-              "timeout": 60,
-U08TED0JM9D" # Samuel Adesoye
-            },
-            {
-              "name": "t3k motif tests",
-              "model": "motif",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_motif_tests",
-              "timeout": 25,
-U08TED0JM9D" # Samuel Adesoye
-            },
-            {
-              "name": "t3k_mistral_tests",
-              "model": "mistral",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_mistral_tests",
-              "timeout": 90,
-U0896VBAKFC" # Pratikkumar Prajapati
-            },
-            {
-              "name": "t3k_mixtral_tests",
-              "model": "mixtral",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_mixtral_tests",
-              "timeout": 50,
-U03PUAKE719" # Miguel Tairum Cruz
-            },
-            {
-              "name": "t3k_whisper_tests",
-              "model": "whisper",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_whisper_tests",
-              "timeout": 90,
-U088413NP0Q" # Ashai Reddy
-            },
-            {
-              "name": "t3k_qwen3_tests",
-              "model": "qwen3",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_qwen3_tests",
-              "timeout": 60,
-U03HY7MK4BT" # Mark O'\''Connor
-            },
-            {
-              "name": "t3k_qwen25_tests",
-              "model": "qwen25",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_qwen25_tests",
-              "timeout": 90,
-U03HY7MK4BT" # Mark O'\''Connor
-            }, (#GH Isssue 20000)
-            {
-              "name": "t3k_qwen25_vl_tests",
-              "model": "qwen25_vl",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_qwen25_vl_tests",
-              "timeout": 30,
-U07RY6B5FLJ" # Gongyu Wang
-            },
-            {
-              "name": "t3k_gemma3_tests",
-              "model": "gemma3",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_gemma3_tests",
-              "timeout": 30,
-U08TJ70UFRT" # Harry Andrews
-            },
-            {
-              "name": "t3k_wan2.2_tests",
-              "model": "wan22",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_wan22_tests",
-              "timeout": 45,
-U03FJB5TM5Y" # Colman Glagovich
-            },
-            {
-              "name": "t3k_mochi_tests",
-              "model": "mochi",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_mochi_tests",
-              "timeout": 60,
-U09ELB03XRU" # Stephen Osborne
-            },
-            {
-              "name": "t3k_gpt_oss_tests",
-              "model": "gpt-oss",
-              "arch": "wormhole_b0",
-              "cmd": "run_t3000_gpt_oss_tests",
-              "timeout": 20,
-U08TJ70UFRT" # Harry Andrews
-            }
-          ]')
-
-          # Filter matrix based on model selection
+          set -e
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "demo"
+      - name: Load test matrix
+        id: load-test-matrix
+        run: |
+          set -e
+          # Install yq
+          YQ_VERSION="v4.44.1"
+          wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          # Check if the file exists
+          if [ ! -f "$TESTS_YAML_PATH" ]; then
+            echo "::error::Test matrix file not found at: $TESTS_YAML_PATH"
+            exit 1
+          fi
+          # Sanitize line endings
+          sanitized_yaml=$(sed 's/\r$//' $TESTS_YAML_PATH)
+          # Convert to JSON
+          json_output=$(echo "${sanitized_yaml}" | yq '. | to_json(0)')
+          # Filter by model if specified
+          echo "[INFO] Selected model: ${{ inputs.model }}"
           if [ "${{ inputs.model }}" = "all" ]; then
             filtered_output="$json_output"
             echo "[INFO] Loading all tests from YAML"

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -42,31 +42,178 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "demo"
-      - name: Load test matrix
-        id: load-test-matrix
-        run: |
-          set -e
-          # Install yq
-          YQ_VERSION="v4.44.1"
-          wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
-          # Check if the file exists
-          if [ ! -f "$TESTS_YAML_PATH" ]; then
-            echo "::error::Test matrix file not found at: $TESTS_YAML_PATH"
-            exit 1
-          fi
-          # Sanitize line endings
-          sanitized_yaml=$(sed 's/\r$//' $TESTS_YAML_PATH)
-          # Convert to JSON
-          json_output=$(echo "${sanitized_yaml}" | yq '. | to_json(0)')
-          # Filter by model if specified
-          echo "[INFO] Selected model: ${{ inputs.model }}"
+          FULL_MATRIX=$(jq -n -c '[
+            {
+              "name": "t3k_falcon7b_tests",
+              "model": "falcon7b",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_falcon7b_tests",
+              "timeout": 90,
+U05RWH3QUPM" # Salar Hosseini
+            },
+            {
+              "name": "t3k_falcon40b_tests",
+              "model": "falcon40b",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_falcon40b_tests",
+              "timeout": 50,
+U053W15B6JF" # Djordje Ivanovic
+            },
+            {
+              "name": "t3k_llama3_tests",
+              "model": "llama3",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_llama3_tests",
+              "timeout": 60,
+U03PUAKE719" # Miguel Tairum Cruz
+            },
+            {
+              "name": "t3k_llama3_vision_tests",
+              "model": "llama3_vision",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_llama3_vision_tests",
+              "timeout": 45,
+U03FJB5TM5Y" # Colman Glagovich
+            },
+            {
+              "name": "t3k_llama3_90b_vision_tests",
+              "model": "llama3_90b_vision",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_llama3_90b_vision_tests",
+              "timeout": 20,
+U07RY6B5FLJ" # Gongyu Wang
+            },
+            {
+              "name": "t3k_llama3_70b_tests",
+              "model": "llama3_70b",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_llama3_70b_tests",
+              "timeout": 60,
+U03FJB5TM5Y" # Colman Glagovich
+            },
+            {
+              "name": "t3k_resnet50_tests",
+              "model": "resnet50",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_resnet50_tests",
+              "timeout": 50,
+U0837MYG788" # Marko Radosavljevic
+            },
+            {
+              "name": "t3k_sentence_bert_tests",
+              "model": "sentence_bert",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_sentence_bert_tests",
+              "timeout": 75,
+U045U3DEKM4" # Mohamed Bahnas (Aniruddha Tupe)
+            },
+            {
+              "name": "t3k sd35_large tests",
+              "model": "sd35_large",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_sd35large_tests",
+              "timeout": 60,
+U03FJB5TM5Y" # Colman Glagovich
+            },
+            {
+              "name": "t3k flux1-dev tests",
+              "model": "flux1-dev",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_flux1_tests",
+              "timeout": 60,
+U08TED0JM9D" # Samuel Adesoye
+            },
+            {
+              "name": "t3k motif tests",
+              "model": "motif",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_motif_tests",
+              "timeout": 25,
+U08TED0JM9D" # Samuel Adesoye
+            },
+            {
+              "name": "t3k_mistral_tests",
+              "model": "mistral",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_mistral_tests",
+              "timeout": 90,
+U0896VBAKFC" # Pratikkumar Prajapati
+            },
+            {
+              "name": "t3k_mixtral_tests",
+              "model": "mixtral",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_mixtral_tests",
+              "timeout": 50,
+U03PUAKE719" # Miguel Tairum Cruz
+            },
+            {
+              "name": "t3k_whisper_tests",
+              "model": "whisper",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_whisper_tests",
+              "timeout": 90,
+U088413NP0Q" # Ashai Reddy
+            },
+            {
+              "name": "t3k_qwen3_tests",
+              "model": "qwen3",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_qwen3_tests",
+              "timeout": 60,
+U03HY7MK4BT" # Mark O'\''Connor
+            },
+            {
+              "name": "t3k_qwen25_tests",
+              "model": "qwen25",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_qwen25_tests",
+              "timeout": 90,
+U03HY7MK4BT" # Mark O'\''Connor
+            }, (#GH Isssue 20000)
+            {
+              "name": "t3k_qwen25_vl_tests",
+              "model": "qwen25_vl",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_qwen25_vl_tests",
+              "timeout": 30,
+U07RY6B5FLJ" # Gongyu Wang
+            },
+            {
+              "name": "t3k_gemma3_tests",
+              "model": "gemma3",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_gemma3_tests",
+              "timeout": 30,
+U08TJ70UFRT" # Harry Andrews
+            },
+            {
+              "name": "t3k_wan2.2_tests",
+              "model": "wan22",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_wan22_tests",
+              "timeout": 45,
+U03FJB5TM5Y" # Colman Glagovich
+            },
+            {
+              "name": "t3k_mochi_tests",
+              "model": "mochi",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_mochi_tests",
+              "timeout": 60,
+U09ELB03XRU" # Stephen Osborne
+            },
+            {
+              "name": "t3k_gpt_oss_tests",
+              "model": "gpt-oss",
+              "arch": "wormhole_b0",
+              "cmd": "run_t3000_gpt_oss_tests",
+              "timeout": 20,
+U08TJ70UFRT" # Harry Andrews
+            }
+          ]')
+
+          # Filter matrix based on model selection
           if [ "${{ inputs.model }}" = "all" ]; then
             filtered_output="$json_output"
             echo "[INFO] Loading all tests from YAML"
@@ -161,12 +308,6 @@ jobs:
           path: /work
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
-
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -110,11 +110,6 @@ jobs:
         run: |
           echo ${{ matrix.test-group.cmd }}
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -91,11 +91,6 @@ jobs:
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           run_t3000_ttfabric_tests
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() && steps.t3k-fabric-tests.outcome == 'failure' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: UJ45FEC7M #Allan Liu
       - name: Run t3k ttnn multiprocess tests
         id: t3k-ttnn-multiprocess-tests
         timeout-minutes: 15
@@ -104,11 +99,6 @@ jobs:
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           run_t3000_ttnn_multiprocess_tests
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() && steps.t3k-ttnn-multiprocess-tests.outcome == 'failure' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: UBHPP2NDP #Joseph Chu
 
       - name: Run t3k ttnn ccl tests
         id: t3k-ttnn-ccl-tests
@@ -118,11 +108,6 @@ jobs:
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           run_t3000_ccl_tests
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() && steps.t3k-ttnn-ccl-tests.outcome == 'failure' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06LRK6JDGB #Saad Jameel
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 17
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-integration-tests-impl.yaml
+++ b/.github/workflows/t3000-integration-tests-impl.yaml
@@ -117,11 +117,6 @@ jobs:
           source tests/scripts/t3000/run_t3000_integration_tests.sh
           echo ${{ matrix.test-group.cmd }}
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-perf-tests-impl.yaml
@@ -174,11 +174,6 @@ jobs:
         with:
           name: perf-report-csv-${{ matrix.test-group.model-type }}-wormhole_b0-${{ matrix.test-group.model-name }}-bare-metal
           path: "${{ steps.check-perf-report.outputs.perf_report_filename }}"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-perplexity-tests-impl.yaml
+++ b/.github/workflows/t3000-perplexity-tests-impl.yaml
@@ -23,15 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_perplexity_tests, timeout: 300, owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "t3k_llama_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama70b_perplexity_tests, timeout: 300, owner_id: U03FJB5TM5Y}, # Colman Glagovich
-          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral8x7b_perplexity_tests, timeout: 300, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_perplexity_tests, timeout: 300, U0896VBAKFC}, # Pratikkumar Prajapati
-          { name: "t3k_llama3_tests_single_card", arch: wormhole_b0, cmd: run_t3000_llama3_perplexity_tests_single_card, timeout: 300, owner_id: U03PUAKE719}, # Mark O'Connor
-          { name: "t3k_llama3_tests_t3k", arch: wormhole_b0, cmd: run_t3000_llama3_perplexity_tests_t3000, timeout: 300, owner_id: U03PUAKE719}, # Mark O'Connor
-          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_perplexity_tests, timeout: 300, owner_id: U03PUAKE719}, # Mark O'Connor
-          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_perplexity_tests, timeout: 300, owner_id: U03PUAKE719}, # Mark O'Connor
-          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_accuracy_tests, timeout: 300, owner_id: U08TJ70UFRT}, # Harry Andrews
+          { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_perplexity_tests, timeout: 300},
+          { name: "t3k_llama_70b_tests", arch: wormhole_b0, cmd: run_t3000_llama70b_perplexity_tests, timeout: 300},
+          { name: "t3k_mixtral_tests", arch: wormhole_b0, cmd: run_t3000_mixtral8x7b_perplexity_tests, timeout: 300},
+          { name: "t3k_mistral_tests", arch: wormhole_b0, cmd: run_t3000_mistral_perplexity_tests, timeout: 300},
+          { name: "t3k_llama3_tests_single_card", arch: wormhole_b0, cmd: run_t3000_llama3_perplexity_tests_single_card, timeout: 300},
+          { name: "t3k_llama3_tests_t3k", arch: wormhole_b0, cmd: run_t3000_llama3_perplexity_tests_t3000, timeout: 300},
+          { name: "t3k_qwen25_tests", arch: wormhole_b0, cmd: run_t3000_qwen25_perplexity_tests, timeout: 300},
+          { name: "t3k_qwen3_tests", arch: wormhole_b0, cmd: run_t3000_qwen3_perplexity_tests, timeout: 300},
+          { name: "t3k_gemma3_tests", arch: wormhole_b0, cmd: run_t3000_gemma3_accuracy_tests, timeout: 300},
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:
@@ -77,11 +77,6 @@ jobs:
           ls -lart /dev/tenstorrent/
           source /work/tests/scripts/t3000/run_t3000_perplexity_tests.sh
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -128,11 +128,6 @@ jobs:
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           echo ${{ matrix.test-group.cmd }}
           ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -103,11 +103,6 @@ jobs:
           ccache -s >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U07ASPTGJTS # Denys
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/tm-data-movement-unit-impl.yaml
+++ b/.github/workflows/tm-data-movement-unit-impl.yaml
@@ -91,11 +91,6 @@ jobs:
             mkdir -p generated/test_reports
             GTEST_FILTER="${{inputs.gtest_filter}}"
             ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -298,11 +298,6 @@ jobs:
         if: ${{ failure() }}
         run: |
           tt-smi -s
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U0883RN6CRE # William Ly
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -74,11 +74,6 @@ jobs:
             mkdir -p generated/test_reports
             uv pip install -r tools/triage/requirements.txt
             TT_METAL_RESET_DEVICE_AFTER_HANG=1 pytest ./tools/tests/triage/
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U066XH7HD6W # Vuk Jovanovic
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-cnn-post-commit.yaml
+++ b/.github/workflows/tt-cnn-post-commit.yaml
@@ -105,11 +105,6 @@ jobs:
         run: |
           ${{ matrix.test-group.cmd }}
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06ECNVR0EN # Evan Smal
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -133,12 +133,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U052J2QDDKQ # Pavle Josipovic
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -185,12 +179,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06Q7ESTFEV # Borys Bradel
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -235,12 +223,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U08DCK9MA1E # Miłosz Gajewski
 
   ttnn-fused-tests:
     if: ${{ inputs.run_fused_tests }}
@@ -285,12 +267,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06Q7ESTFEV # Borys Bradel
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -337,12 +313,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U03FJB5TM5Y # Colman Glagovich
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -389,12 +359,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U052J2QDDKQ # Pavle Josipovic
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -449,12 +413,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U07N3CUUN05 # Iva Potkonjak
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -503,12 +461,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U082L4RSULT # Denys Makoviichuk
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   ttnn-sdpa-stress-tests:
@@ -555,12 +507,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U03FJB5TM5Y # Colman Glagovich
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -592,15 +538,12 @@ jobs:
           - test_type: conv
             test_path: tests/ttnn/nightly/unit_tests/operations/conv
             test_filter: "panoptic or _oft"
-            owner: U052J2QDDKQ # Pavle Josipovic
           - test_type: pool
             test_path: tests/ttnn/nightly/unit_tests/operations/pool
             test_filter: "panoptic or _oft"
-            owner: U052J2QDDKQ # Pavle Josipovic
           - test_type: group_norm
             test_path: tests/ttnn/unit_tests/operations/fused
             test_filter: "_oft"
-            owner: U06Q7ESTFEV # Borys Bradel
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@v4
@@ -621,12 +564,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.owner }}
 
   ttnn-eltwise-tests:
     if: ${{ inputs.run_eltwise_tests }}
@@ -684,12 +621,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U07RNEH2NR4 # Wenbin Lyu
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
@@ -737,12 +668,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06UEFWB4P9 # Colman Glagovich
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   ttnn-moreh-tests:
@@ -789,12 +714,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U084B1CES7M # Borys Bradel
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   ttnn-data_movement-tests:
@@ -850,12 +769,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U084DDYSWCW # Adrian Morrison
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
   ttnn-misc-tests:
@@ -903,11 +816,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U084B1CES7M # Borys Bradel
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -97,11 +97,6 @@ jobs:
           ldd tests/ttml_tests || true
           ${{ matrix.test-group.cmd }}
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U07ASPTGJTS # Denys
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/ttnn-ops-docs-check.yaml
+++ b/.github/workflows/ttnn-ops-docs-check.yaml
@@ -94,11 +94,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "ttnn_ops_docs_check_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U08DCK9MA1E # Miłosz Gajewski
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -169,11 +169,6 @@ jobs:
         run: |
           ${{ matrix.test-group.cmd }}
 
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -172,8 +172,6 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "multimodal": true,
               "use-vllm-v1": true,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08BH66EXAL"
             },
             {
               "name": "[WH-GLX][v1] GPT-OSS-120B",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -53,8 +53,6 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\"}",
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-T3K] Qwen2.5-VL-72B-Instruct",
@@ -68,7 +66,6 @@ jobs:
               "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
               "multimodal": true,
               "additional-server-args": "--max_model_len 2048",
-              "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
               "name": "[BH-DB] Llama-3.1-8B-Instruct",
@@ -80,8 +77,7 @@ jobs:
               "mesh-device": "P150x2",
               "tt-llama-text-ver": "tt_transformers",
               "override-tt-config": "{\"data_parallel\": 2}",
-              "multimodal": false,
-              "owner_id": "U08GELBB1AP"
+              "multimodal": false
             },
             {
               "name": "[BH-LB] Llama-3.1-8B-Instruct v0 fallback structured-output",
@@ -95,8 +91,7 @@ jobs:
               "override-tt-config": "{\"data_parallel\": 8, \"sample_on_device_mode\": \"decode_only\"}",
               "multimodal": false,
               "structured-output": true,
-              "additional-server-args": "--num_scheduler_steps 1",
-              "owner_id": "U091SNDA4TS"
+              "additional-server-args": "--num_scheduler_steps 1"
             },
             {
               "name": "[WH-GLX] Llama-3.3-70B-Instruct multi-step",
@@ -109,8 +104,6 @@ jobs:
               "tt-llama-text-ver": "llama3_70b_galaxy",
               "override-tt-config": "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-GLX] Llama-3.3-70B-Instruct v0 structured-output",
@@ -124,8 +117,7 @@ jobs:
               "override-tt-config": "{\"dispatch_core_axis\": \"col\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
               "multimodal": false,
               "structured-output": true,
-              "additional-server-args": "--num_scheduler_steps 1",
-              "owner_id": "U091SNDA4TS"
+              "additional-server-args": "--num_scheduler_steps 1"
             },
             {
               "name": "[WH-GLX] Llama-3.3-70B-Instruct v0 fallback structured-output",
@@ -139,8 +131,7 @@ jobs:
               "override-tt-config": "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
               "multimodal": false,
               "structured-output": true,
-              "additional-server-args": "--num_scheduler_steps 1",
-              "owner_id": "U091SNDA4TS"
+              "additional-server-args": "--num_scheduler_steps 1"
             },
             {
               "name": "[WH-GLX] Llama-8B DP=16",
@@ -153,8 +144,6 @@ jobs:
               "override-tt-config": "{\"data_parallel\": 16, \"fabric_config\": \"FABRIC_1D_RING\"}",
               "tt-llama-text-ver": "tt_transformers",
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08BH66EXAL"
             },
             {
               "name": "[WH-T3K][v1] Gemma3-27B",
@@ -168,8 +157,6 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "multimodal": true,
               "use-vllm-v1": true,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08BH66EXAL"
             },
             {
               "name": "[WH-GLX][v1] Gemma3-27B DP=4",
@@ -201,8 +188,6 @@ jobs:
               "additional-server-args": "--max_num_seqs 1 --num_scheduler_steps 1",
               "use-vllm-v1": true,
               "structured-output": true,
-              "co-owner-1-id": "U08TJ70UFRT",
-              "co-owner-2-id": "U06F3ER8X9A"
             },
             {
               "name": "[WH-T3K][v1] Llama-3.1-8B-Instruct",
@@ -217,8 +202,6 @@ jobs:
               "use-vllm-v1": true,
               "structured-output": true,
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-T3K][v1] Llama-3.1-8B-Instruct (prefix caching)",
@@ -233,8 +216,6 @@ jobs:
               "use-vllm-v1": true,
               "multimodal": false,
               "additional-benchmark-args": "--random-prefix-len 128",
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-T3K][v1] Qwen2.5-VL-72B-Instruct",
@@ -250,7 +231,6 @@ jobs:
               "structured-output": true,
               "multimodal": true,
               "additional-server-args": "--max_model_len 2048",
-              "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
               "name": "[BH-LB][v1] Llama-3.1-8B-Instruct",
@@ -265,8 +245,7 @@ jobs:
               "additional-server-args": "--data_parallel_size 8",
               "use-vllm-v1": true,
               "structured-output": true,
-              "multimodal": false,
-              "owner_id": "U08GELBB1AP"
+              "multimodal": false
             },
             {
               "name": "[WH-GLX][v1] Llama-3.3-70B-Instruct device sampling",
@@ -281,8 +260,6 @@ jobs:
               "additional-server-args": "--data_parallel_size 4 --max_num_seqs 8",
               "use-vllm-v1": true,
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-GLX][v1] Llama-3.3-70B-Instruct hostsample",
@@ -298,8 +275,6 @@ jobs:
               "use-vllm-v1": true,
               "structured-output": true,
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08CEGF78ET"
             },
             {
               "name": "[WH-GLX][v1] Llama-8B DP=16",
@@ -315,8 +290,6 @@ jobs:
               "use-vllm-v1": true,
               "structured-output": true,
               "multimodal": false,
-              "co-owner-1-id": "U08E1JCDVNX",
-              "co-owner-2-id": "U08BH66EXAL"
             },
             {
               "name": "[WH-T3K][v1] Multi-process reduce scatter test model",
@@ -331,7 +304,6 @@ jobs:
               "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct",
               "use-vllm-v1": true,
               "multimodal": false,
-              "co-owner-1-id": "U08CEGF78ET"
             }
           ]'
 
@@ -633,17 +605,6 @@ jobs:
         run: |
           cat output/vllm_result_structured.json
 
-      - uses: ./.github/actions/slack-report
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.co-owner-1-id }}
-
-      - uses: ./.github/actions/slack-report
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.co-owner-2-id }}
 
       - name: Set artifact prefix
         if: ${{ !cancelled() }}


### PR DESCRIPTION
### Problem description

**ONLY DEPRECATES SLACK REPORTING for tt-metal-pipeline-status**
Does not affect changes for merge-gate/pr-gate reporting or other channels
Too noisy, and no one seems to be making use of it.


The GitHub workflows contained references to `slack-report` actions and owner identification fields (`owner_id`, `co-owner-1-id`, `co-owner-2-id`) that are no longer needed after removing Slack reporting functionality. 

### What's changed

This PR performs a comprehensive cleanup of GitHub workflows to remove all Slack reporting references and owner identification fields:

1. **Removed all `slack-report` action references** (80+ instances across 52+ workflow files)
   - Removed `slack-report` and `slack-report-merge-gate` action calls
   - Removed `slack_ts` output that was only used for Slack reporting
   - Removed `owner` parameters passed to `slack-report` actions

2. **Removed all owner identification fields** (160+ instances)
   - Removed `owner_id` fields from matrix definitions in all workflow files
   - Removed `co-owner-1-id` and `co-owner-2-id` fields from `vllm-nightly-tests-impl.yaml` (23 instances)
   - Removed unused `owner` fields from matrix definitions that were only used for Slack reporting
   - Removed owner name comments from workflow files

3. **Fixed command function names**
   - Fixed `single-card-demo-tests-impl.yaml` where owner IDs were accidentally appended to `cmd` function names (52 instances)
   - Corrected function names like `run_bert_func024A4EFV6U` → `run_bert_func`
   - Fixed typo: `run_qwen25_vl_perfunc` → `run_qwen25_vl_perf` (should be `run_qwen25_vl_perf`)

4. **Removed unused parameters**
   - Removed `owner` parameters from `upload-artifact-with-job-uuid` action calls (20+ instances)
   - The `upload-artifact-with-job-uuid` action only accepts `path` and `prefix` parameters, so `owner` was being passed unnecessarily

**Files Modified:**
- All workflow files in `.github/workflows/` directory (52+ files)
- Key files include:
  - `tt-metal-l2-nightly-impl.yaml` - Removed owner parameters and comments
  - `vllm-nightly-tests-impl.yaml` - Removed co-owner fields
  - `single-card-demo-tests-impl.yaml` - Fixed cmd function names and removed owner comments
  - `t3000-demo-tests-impl.yaml` - Removed slack-report and owner_id references
  - `blackhole-*` workflows - Removed slack-report references
  - `galaxy-*` workflows - Removed owner_id fields
  - And many more workflow files

**Impact:**
- Cleaner workflow files without unused Slack reporting code
- No functional changes - all workflows continue to work as before
- Reduced maintenance burden by removing dead code

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [x] New/Existing tests provide coverage for changes (No new functionality added, only cleanup)

#### Model tests

This PR only modifies workflow configuration files and does not affect model-related code. No model tests are required.