### PR TITLE
#34137: add check for out_subblock_h dividing m in matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -833,10 +833,10 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
                 if (batch_size_a > 1 && batch_size_b > 1) {
                     TT_FATAL(
-                        program_config.out_subblock_h % M == 0,
+                        M % program_config.out_subblock_h == 0,
                         "out_subblock_h ({}) needs to divide M ({}) evenly and does not. "
                         "Please update your program config.",
-                        program_config.out_subblock_h % M,
+                        program_config.out_subblock_h,
                         M);
                 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -831,6 +831,14 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 const auto batch_size_b = get_batch_size(b_shape_padded);
                 bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
                 TT_FATAL(!broadcast_batch, "Batch broadcasting is not supported for the chosen program config");
+                if (batch_size_a > 1 && batch_size_b > 1) {
+                    TT_FATAL(
+                        program_config.out_subblock_h % M == 0,
+                        "out_subblock_h ({}) needs to divide M ({}) evenly and does not. "
+                        "Please update your program config.",
+                        program_config.out_subblock_h % M,
+                        M);
+                }
 
                 if (input_tensor_b.is_sharded()) {
                     TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");


### PR DESCRIPTION
### Ticket
Link to Github Issue #34137

### Problem description
Someone created a non-supported program config for matmul that resulted in incorrect output. Validation was missing to catch the program config.

### What's changed
Add validation to check for the specific scenario that was encountered.

Verified in local testing.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-34137_mm_check) https://github.com/tenstorrent/tt-metal/actions/runs/21094545898
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-34137_mm_check)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-34137_mm_check)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-34137_mm_check)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-34137_mm_check)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-34137_mm_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-34137_mm_check)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs