### PR TITLE
[skip ci] Fix previous mistake in code-analysis.yaml

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -225,6 +225,9 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
+      - name: Configure git safe.directory
+        run: git config --global --add safe.directory /work
+
       - name: 🔧 CMake configure
         run: cmake --preset clang-static-analyzer
 


### PR DESCRIPTION
Configure git safe.directory in workflow

This is required for git describe to work, when we don't use the `docker-job` workaround that was previously removed.