### PR TITLE
Adjust Qwen2.5 perf/TTFT targets and demo timeout

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -100,4 +100,4 @@ models:
   perf:
     wh_llmbox: 685
   demo:
-    wh_llmbox: 1100
+    wh_llmbox: 1070

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -100,4 +100,4 @@ models:
   perf:
     wh_llmbox: 685
   demo:
-    wh_llmbox: 1070
+    wh_llmbox: 1100

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1475,10 +1475,12 @@ def test_demo_text(
                 "N150_Llama-3.1-8B": 120,
                 "N150_Mistral-7B": 106,
                 # N300 targets
-                "N300_Qwen2.5-7B": (95, 1.20),  # (value, high_tolerance_ratio)
+                # Faster-than-expected TTFT observed in CI; lower target and widen tolerance to avoid false failures.
+                "N300_Qwen2.5-7B": (90, 1.25),  # (value, high_tolerance_ratio)
                 # T3K targets
                 "T3K_Llama-3.1-70B": (205, 1.25),
-                "T3K_Qwen2.5-72B": (290, 1.35),  # (value, high_tolerance_ratio)
+                # Faster-than-expected TTFT observed in CI; lower target and widen tolerance to avoid false failures.
+                "T3K_Qwen2.5-72B": (240, 1.40),  # (value, high_tolerance_ratio)
                 # Faster-than-expected TTFT observed in CI; lower the target and keep tolerance to avoid false failures.
                 "T3K_Qwen2.5-Coder-32B": (100, 1.27),  # (value, high_tolerance_ratio)
                 "T3K_Qwen3-32B": (100, 1.1),  # Issue: Perf regression being tracked on issue #29834

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1491,7 +1491,7 @@ def test_demo_text(
                 "N150_Mistral-7B": 23,
                 # N300 targets
                 # Slightly relaxed to accommodate normal variance in CI while still flagging regressions
-                "N300_Qwen2.5-7B": 22.0,
+                "N300_Qwen2.5-7B": 21.0,
                 # T3K targets
                 "T3K_Llama-3.1-70B": 15,
                 "T3K_Qwen2.5-72B": 13.25,

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -39,7 +39,7 @@
   sku: wh_llmbox
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
-  timeout: 55
+  timeout: 90
   model-name: qwen25
 
 - name: t3k_llama3_vision_tests

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -39,7 +39,7 @@
   sku: wh_llmbox
   owner_id: U03HY7MK4BT # Mark O'Connor
   team: models
-  timeout: 90
+  timeout: 78
   model-name: qwen25
 
 - name: t3k_llama3_vision_tests


### PR DESCRIPTION
## Summary
- relax Qwen2.5-7B decode perf target in demo CI
- tighten Qwen2.5-7B + Qwen2.5-72B TTFT targets to match faster runs
- set t3k_qwen25 demo timeout to 78 minutes (measured 64m24s + 20% buffer)

## Evidence
- t3000-demo-tests (qwen25) run 21138568105: job ran 64m24s (13:21:24Z → 14:25:48Z); timeout set to 78 minutes
  https://github.com/tenstorrent/tt-metal/actions/runs/21138568105
- models/demo budget remains within .github/time_budget.yaml (sum 568 <= budget 1070); no update needed

## Testing
- `t3000-demo-tests` (qwen25, branch)

[![t3000-demo-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=perf/relax-qwen25-7b-ci-target&event=workflow_dispatch&cachebust=21138568105)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch%3Aperf/relax-qwen25-7b-ci-target)