### PR TITLE
PDL: Replace old SHA-pinned setup-job action in CI 

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -152,8 +152,9 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         PYTHONPATH: /work
+        TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ inputs.arch_name }}
+        ARCH_NAME: blackhole
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -152,7 +152,6 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         PYTHONPATH: /work
-        TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: blackhole
         LOGURU_LEVEL: INFO

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -165,8 +165,13 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -117,8 +117,13 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -103,7 +103,6 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         PYTHONPATH: /work
-        TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ inputs.arch_name }}
         LOGURU_LEVEL: INFO

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -103,8 +103,9 @@ jobs:
       image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
         PYTHONPATH: /work
+        TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ inputs.arch_name }}
+        ARCH_NAME: blackhole
         LOGURU_LEVEL: INFO
         TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "10,9"
       volumes:

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -105,7 +105,7 @@ jobs:
         PYTHONPATH: /work
         TT_METAL_HOME: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: blackhole
+        ARCH_NAME: ${{ inputs.arch_name }}
         LOGURU_LEVEL: INFO
         TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE: "10,9"
       volumes:


### PR DESCRIPTION
### Problem description
`ModuleNotFoundError` in BH nightly and BH demo tests for panoptic-deeplab.
```
ImportError while loading conftest '/work/conftest.py'.
conftest.py:24: in <module>
    from models.tt_transformers.demo.trace_region_config import get_supported_trace_region_size
models/tt_transformers/demo/trace_region_config.py:11: in <module>
    from models.common.utility_functions import is_blackhole, is_wormhole_b0
models/common/utility_functions.py:15: in <module>
    from ttnn.device import Arch
E   ModuleNotFoundError: No module named 'ttnn.device'
Error: Process completed with exit code 4.
```
Failing [P150 Blackhole nightly tests on main for PDL 110 cores](https://github.com/tenstorrent/tt-metal/actions/runs/21121247722/job/60762375560#step:5:1)
Failing [P150 Demo tests on main](https://github.com/tenstorrent/tt-metal/actions/runs/21125168255/job/60745349827#step:5:1)

### What's changed
The https://github.com/tenstorrent/tt-metal/pull/33691 introduced a change that wasn't applied when creating PDL p150 ci-v2 jobs in `.github/workflows/blackhole-demo-tests-impl.yaml `and `.github/workflows/blackhole-nightly-tests-impl.yaml`  so now they are updated in the same way as other jobs in #33691. 
The old SHA-pinned setup-job action was trying to download and install wheels with the old naming pattern, but the recent build changes created wheels with a new naming pattern.
 When setup-job couldn't find/install the wheel properly, the Python environment wasn't set up correctly, causing:
` ModuleNotFoundError: No module named 'ttnn.device'`

### Checklist

- [x] [(Blackhole) Nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/21138948174) PDL PASS
- [x] [(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/21138932822)
