### PR TITLE
Update Panoptic DeepLab 20 core unit tests to match conv and upsample shapes in actual model

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4154,44 +4154,41 @@ def test_conv_sharded_rm_input(
     "batch_size, input_channels, output_channels, input_height, input_width, input_dtype, weights_dtype, output_dtype, kernel, stride, padding, groups, has_bias, frequency_in_model, shard_layout, act_block_h_override",
     # fmt: off
     [
-        (1,  128,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 3, HS, 32 * 4),
-        (1,  128,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 32 * 8), #act_block_h_override 0 fails because of Commit #db1fdd0
-        (1,  128,   32, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 2, HS, 32 * 4),
-        (1,  128,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 4, HS, 0),
-        (1,  160,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 1, HS, 32 * 3),
-        (1,  256,  256,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 0),
-        (1,  256,  256,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 1, HS, 32 * 2),
+        # 3x3 convolutions
         (1,    3,   64, 512, 1024, ttnn.bfloat16,  ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 32 * 41),
-        (1,  320,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 1, HS, 32 * 2),
-        (1,  320,  256,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 1, BS, 32 * 16),
-        (1,  512,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (2, 2), 1, False, 1, BS, 32 * 9),
-        (1,  512,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (4, 4), 1, False, 1, BS, 32 * 7),
-        (1,  512,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (8, 8), 1, False, 1, BS, 32),
-        (1,  512, 1024,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (2, 2), (0, 0), 1, False, 1, BS, 0),
+        (1,   64,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 3, HS, 32 * 4),
+        (1,  128,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 4, HS, 0),
+        (1,   64,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 3, HS, 32 * 4),
+        (1,  128,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 2, HS, 0),
+        (1,  256,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 5, HS, 32 * 2),
+        (1,  128,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 32 * 8),
+        (1,  256,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 5, HS, 32 * 2),
+        (1,  256,  256,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 0),
 
         # Matmul convs
-        (1, 1024, 2048,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
-        (1, 1024,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 5, None, 0),
-        (1, 1024,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
-        (1,  128,  256, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
+        (1,   32,    1, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 1, None, 0),
+        (1,   32,    2, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 1, None, 0),
         (1,  128,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
+        (1,  128,  256, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
         (1,  128,  512,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 4, None, 0),
-        (1, 1280,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
-        (1, 2048,  256,   1,    1, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 2, None, 0),
-        (1, 2048,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
-        (1, 2048,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
-        (1,  256,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
         (1,  256,   19, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 1, None, 0),
         (1,  256,   32, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
         (1,  256,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
+        (1,  256,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
         (1,  256, 1024,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 6, None, 0),
-        (1,   32,    1, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 1, None, 0),
-        (1,   32,    2, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 1, None, 0),
-        (1,  512, 2048,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 3, None, 0),
+        (1,  512,   64,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
         (1,  512,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 3, None, 0),
         (1,  512,  256,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
-        (1,  512,   64,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
+        (1,  512, 1024,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (2, 2), (0, 0), 1, False, 1, BS, 0),
+        (1,  512, 2048,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 3, None, 0),
         (1,   64,  256, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 3, None, 0),
+        (1, 1280,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
+        (1, 1024,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 5, None, 0),
+        (1, 1024,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
+        (1, 1024, 2048,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 1, None, 0),
+        (1, 2048,  256,   1,    1, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1,  True, 2, None, 0),
+        (1, 2048,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
+        (1, 2048,  512,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (1, 1), (1, 1), (0, 0), 1, False, 2, None, 0),
 
     ],
     # fmt: on
@@ -4251,27 +4248,30 @@ def test_conv2d_panoptic(
         enable_act_double_buffer=True,
         enable_weights_double_buffer=True if shard_layout == BS else False,
         config_tensors_in_dram=True,
-
     )
     signpost(header="conv2d_end.")
 
 
-@pytest.mark.parametrize(
-    "input_layout, dtype",
-    [
-        [ttnn.TILE_LAYOUT, ttnn.bfloat8_b],
-    ],
-)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": PDL_L1_SMALL_SIZE}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity, shard_layout, frequency_in_model",
+    "input_layout, input_dtype, output_dtype, batch_size, input_channels, output_channels, input_height, input_width, slice_type, num_slices, weights_dtype, kernel, stride, padding, dilation, act_block_h_override,  math_fidelity, shard_layout, frequency_in_model",
     # fmt: off
     (
-        (1, 256, 256,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, HS, 3), # Panoptic
-        (1, 256, 512,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (1, 1), (2, 2), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, HS, 1), # Panoptic
-        (1, 288, 256,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 32,  ttnn.MathFidelity.LoFi, HS, 1), # Panoptic
-        (1,  64, 128,  256,    512,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, HS, 1), # Panoptic
-        (1,  64,  64,  256,    512,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, HS, 1), # Panoptic
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1,  64,  64,  256,    512,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, None, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1,  64, 128,  256,    512,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), None,  ttnn.MathFidelity.LoFi, None, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 128,  32,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 2),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 128, 128,   64,    128,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 128, 128,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 3),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 256, 256,   64,    128,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 256, 256,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 3),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 256, 512,  128,    256,   SliceWidth,   0,  ttnn.bfloat8_b,  (1, 1), (2, 2), (0, 0), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 512, 512,   32,     64,   SliceWidth,   2,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (2, 2), 0,  ttnn.MathFidelity.LoFi, BS, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 512, 512,   32,     64,   SliceWidth,   2,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (4, 4), 0,  ttnn.MathFidelity.LoFi, BS, 1),
+        (ttnn.TILE_LAYOUT, ttnn.bfloat8_b, ttnn.bfloat8_b, 1, 512, 512,   32,     64,   SliceWidth,   2,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (8, 8), 0,  ttnn.MathFidelity.LoFi, BS, 1),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, ttnn.bfloat8_b, 1,  160,  128, 128,  256,   SliceWidth,    4,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, ttnn.bfloat8_b, 1,  288,  256, 128,  256,   SliceWidth,    8,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, ttnn.bfloat8_b, 1,  320,  128,  64,  128,   SliceHeight,   3,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
+        (ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, ttnn.bfloat8_b, 1,  320,  256,  64,  128,   SliceHeight,   3,  ttnn.bfloat8_b,  (3, 3), (1, 1), (1, 1), (1, 1), 0,  ttnn.MathFidelity.LoFi, HS, 1),
     )
     # fmt: on
 )
@@ -4290,7 +4290,8 @@ def test_conv_dram_panoptic(
     input_width,
     has_bias,
     weights_dtype,
-    dtype,
+    input_dtype,
+    output_dtype,
     slice_type,
     num_slices,
     kernel,
@@ -4317,11 +4318,12 @@ def test_conv_dram_panoptic(
     signpost(
         header=f"dram_slice_conv_{slice_type}_{num_slices}_slices_{input_channels}_{output_channels}_{input_height}_{input_width}; frequency_in_model={frequency_in_model}"
     )
+
     run_conv(
         device,
         torch_tensor_map,
         math_fidelity,
-        dtype,
+        output_dtype,
         weights_dtype,
         batch_size,
         output_channels,
@@ -4337,9 +4339,9 @@ def test_conv_dram_panoptic(
         has_bias=True,
         fp32_accum=fp32_accum,
         packer_l1_acc=packer_l1_acc,
-        input_dtype=dtype,
+        input_dtype=input_dtype,
         input_layout=input_layout,
-        output_layout=input_layout,
+        output_layout=ttnn.TILE_LAYOUT,
         shard_layout=shard_layout,
         slice_config=ttnn.Conv2dSliceConfig(
             slice_type=slice_type,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -4157,8 +4157,6 @@ def test_conv_sharded_rm_input(
         # 3x3 convolutions
         (1,    3,   64, 512, 1024, ttnn.bfloat16,  ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 32 * 41),
         (1,   64,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 3, HS, 32 * 4),
-        (1,  128,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 4, HS, 0),
-        (1,   64,   64, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 3, HS, 32 * 4),
         (1,  128,  128,  64,  128, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 2, HS, 0),
         (1,  256,  256,  32,   64, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (1, 1), (1, 1), 1, False, 5, HS, 32 * 2),
         (1,  128,  128, 128,  256, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, (3, 3), (2, 2), (1, 1), 1, False, 1, HS, 32 * 8),

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -215,16 +215,14 @@ def test_upsample_various(
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 37888}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, num_channels, height, width, scale_h, scale_w, num_slices",
+    "batch_size, num_channels, height, width, scale_h, scale_w",
     (
-        (1, 256, 64, 128, 2, 2, 2),
-        (1, 128, 64, 128, 2, 2, 2),
+        (1, 256, 32, 64, 2, 2),
+        (1, 256, 64, 128, 2, 2),
+        (1, 128, 64, 128, 2, 2),
     ),
 )
-@pytest.mark.parametrize("run_twice", [True])
-def test_panoptic_upsample_sliced(
-    device, batch_size, num_channels, height, width, scale_h, scale_w, num_slices, run_twice
-):
+def test_panoptic_upsample(device, batch_size, num_channels, height, width, scale_h, scale_w):
     input_shape_nchw = [batch_size, num_channels, height, width]
     scale_factor = (scale_h, scale_w)
     mode_pytorch = "nearest"  # we only did nearest in panoptic due to pcc dropping very little and bilinear not being able to fit in memory as of now
@@ -233,10 +231,10 @@ def test_panoptic_upsample_sliced(
     dtype_ttnn = ttnn.bfloat16
 
     batch_size, channels, input_h, input_w = input_shape_nchw
-    assert channels % num_slices == 0, "Channels must be divisible by num_slices"
-    slice_channels = channels // num_slices
 
-    logger.info(f"Running Panoptic Upsample with Channel Slicing (slices={num_slices})")
+    logger.info(
+        f"Running Panoptic Upsample: {channels} ch @ {input_h}x{input_w}, scale={scale_factor}, mode={mode_ttnn}"
+    )
 
     torch.manual_seed(0)
     torch_input_nchw = torch.rand(input_shape_nchw, dtype=dtype_torch)
@@ -248,40 +246,14 @@ def test_panoptic_upsample_sliced(
         torch_input_nchw.permute(0, 2, 3, 1), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=dtype_ttnn
     )
 
-    sliced_results = []
-    for slice_idx in range(num_slices):
-        start_ch = slice_idx * slice_channels
-        end_ch_exclusive = (slice_idx + 1) * slice_channels
-
-        x_slice_nhwc = ttnn.slice(
-            ttnn_input_nhwc, [0, 0, 0, start_ch], [batch_size, input_h, input_w, end_ch_exclusive]
-        )
-
-        x_slice_upsampled = ttnn.upsample(
-            x_slice_nhwc,
-            scale_factor=scale_factor,
-            mode=mode_ttnn,
-        )
-
-        if run_twice:
-            ttnn.deallocate(x_slice_upsampled, True)
-            x_slice_upsampled = ttnn.upsample(
-                x_slice_nhwc,
-                scale_factor=scale_factor,
-                mode=mode_ttnn,
-            )
-
-        x_slice_upsampled = ttnn.to_memory_config(x_slice_upsampled, ttnn.DRAM_MEMORY_CONFIG)
-        sliced_results.append(x_slice_upsampled)
-
-        ttnn.deallocate(x_slice_nhwc)
+    ttnn_output_nhwc = ttnn.upsample(
+        ttnn_input_nhwc,
+        scale_factor=scale_factor,
+        mode=mode_ttnn,
+    )
+    ttnn_output_nhwc = ttnn.to_memory_config(ttnn_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
 
     ttnn.deallocate(ttnn_input_nhwc)
-
-    ttnn_output_nhwc = ttnn.concat(sliced_results, dim=3, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-
-    for slice_result in sliced_results:
-        ttnn.deallocate(slice_result)
 
     torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1)
 

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_upsample.py
@@ -222,7 +222,8 @@ def test_upsample_various(
         (1, 128, 64, 128, 2, 2),
     ),
 )
-def test_panoptic_upsample(device, batch_size, num_channels, height, width, scale_h, scale_w):
+@pytest.mark.parametrize("run_twice", [True])
+def test_panoptic_upsample(device, batch_size, num_channels, height, width, scale_h, scale_w, run_twice):
     input_shape_nchw = [batch_size, num_channels, height, width]
     scale_factor = (scale_h, scale_w)
     mode_pytorch = "nearest"  # we only did nearest in panoptic due to pcc dropping very little and bilinear not being able to fit in memory as of now
@@ -251,6 +252,15 @@ def test_panoptic_upsample(device, batch_size, num_channels, height, width, scal
         scale_factor=scale_factor,
         mode=mode_ttnn,
     )
+
+    if run_twice:
+        ttnn.deallocate(ttnn_output_nhwc, True)
+        ttnn_output_nhwc = ttnn.upsample(
+            ttnn_input_nhwc,
+            scale_factor=scale_factor,
+            mode=mode_ttnn,
+        )
+
     ttnn_output_nhwc = ttnn.to_memory_config(ttnn_output_nhwc, ttnn.DRAM_MEMORY_CONFIG)
 
     ttnn.deallocate(ttnn_input_nhwc)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/29513)

### Problem description
During development, the convs and upsamples in Panoptic Deeplab changed from originally written unit tests.

### What's changed
Unit tests updated to match actual shapes.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ianastasijevic/update_pdl_tests)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/update_pdl_tests)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/update_pdl_tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/update_pdl_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/update_pdl_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/update_pdl_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/update_pdl_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs