### PR TITLE
Make ops work when some ranks are inactive

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -163,6 +163,7 @@ run_t3000_ttnn_multiprocess_tests() {
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/unit_tests_ttnn --gtest_filter="*LaunchOperation*"
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_data_parallel_example.py
+  tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_all_gather_async.py::test_all_gather_async_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_2x4
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" pytest -svv tests/nightly/t3000/ccl/test_new_all_broadcast.py::test_all_broadcast_sharded_2x4

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/distributed/mesh_device_impl.hpp"
+#include "tt_metal/distributed/dummy_mesh_command_queue.hpp"
 
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 
@@ -214,6 +215,12 @@ TEST_F(BigMeshDualRankTest2x4, SubmeshCreationSingleSubmesh) {
     auto submesh = mesh_device_->create_submesh(MeshShape(2, 2));
     ASSERT_NE(submesh, nullptr);
     EXPECT_EQ(submesh->shape(), MeshShape(2, 2));
+
+    // Make sure the inactive rank returns a DummyMeshCommandQueue
+    if (submesh->get_view().get_devices().empty()) {
+        auto& cq = submesh->mesh_command_queue();
+        EXPECT_TRUE(dynamic_cast<DummyMeshCommandQueue*>(&cq) != nullptr);
+    }
 }
 
 TEST_F(BigMeshDualRankTest2x4, SubmeshCreationMultipleSubmeshes) {

--- a/tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py
+++ b/tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+
+
+# This test is meant to run on a T3000 system, with devices split across two ranks.
+def test_submesh_not_spanning_all_ranks_T3000():
+    if not ttnn.using_distributed_env():
+        pytest.skip("This test only makes sense in a distributed environment")
+
+    # Create a mesh device that fits on one rank
+    mesh_shape = ttnn.MeshShape(2, 2)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    # Allocate tensors on the mesh device, confirming that allocation works on active and inactive ranks
+    a_0 = ttnn.from_torch(torch.randn(1024, 1024), layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=mesh_device)
+    b_0 = ttnn.from_torch(torch.randn(1024, 1024), layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=mesh_device)
+
+    # Perform any simple operation on the tensors, the operation should execute on the active ranks and be a nop on the
+    # inactive ranks
+    res = ttnn.experimental.minimal_matmul(a_0, b_0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Perform another simple operation using the result of the first operation. The operation is a nop on the inactive
+    # ranks, but it needs to return a result that can be used by following operations (they'll also be a nop on the
+    # inactive ranks).
+    ttnn.experimental.minimal_matmul(res, res)

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -3,6 +3,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_coordinate_translator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_command_queue_base.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dummy_mesh_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fd_mesh_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sd_mesh_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mesh_device.cpp

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/distributed_context.hpp>
 #include "mesh_device_impl.hpp"
 #include "mesh_command_queue.hpp"
 #include "fd_mesh_command_queue.hpp"
@@ -30,6 +31,11 @@ DispatchContext& DispatchContext::get() {
 }
 
 void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_device) {
+    // If the mesh device is inactive, do not attempt to initialize fast dispatch.
+    if (mesh_device->impl().view_->get_devices().empty()) {
+        return;
+    }
+
     fast_dispatch_enabled_ = MetalContext::instance().rtoptions().get_fast_dispatch();
     const auto& cluster = MetalContext::instance().get_cluster();
     TT_FATAL(
@@ -69,13 +75,19 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
             mesh_device_impl.dispatch_thread_pool_,
             mesh_device_impl.reader_thread_pool_,
             cq_shared_state,
-            std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl)));
+            std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl),
+            mesh_device_impl.active_distributed_context_));
     }
     fast_dispatch_enabled_ = true;
     num_fd_inits_++;
 }
 
 void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_device) {
+    // If the mesh device is inactive, do not attempt to terminate fast dispatch.
+    if (mesh_device->impl().view_->get_devices().empty()) {
+        return;
+    }
+
     TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
     TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch can only be manually terminated and torn down once.");
 
@@ -86,9 +98,13 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
     mesh_device_impl.mesh_command_queues_.reserve(num_hw_cqs);
+
     for (std::size_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         mesh_device_impl.mesh_command_queues_.push_back(std::make_unique<distributed::SDMeshCommandQueue>(
-            mesh_device, cq_id, std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl)));
+            mesh_device,
+            cq_id,
+            std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl),
+            mesh_device_impl.active_distributed_context_));
     }
     for (const auto& dev : active_devices) {
         for (int cq_id = 0; cq_id < dev->num_hw_cqs(); cq_id++) {

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -16,6 +16,10 @@
 namespace tt::tt_metal::distributed {
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking) {
+    // Short-circuit for inactive MeshDevices (no-op)
+    if (mesh_cq.device()->get_view().get_devices().empty()) {
+        return;
+    }
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
         mesh_workload.impl().compile(mesh_cq.device());
         mesh_workload.impl().load_binaries(mesh_cq);

--- a/tt_metal/distributed/dummy_mesh_command_queue.cpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dummy_mesh_command_queue.hpp"
+#include "tt_metal/common/thread_pool.hpp"
+#include <mesh_device.hpp>
+#include <mesh_event.hpp>
+#include <mesh_workload.hpp>
+
+namespace tt::tt_metal::distributed {
+
+DummyMeshCommandQueue::DummyMeshCommandQueue(
+    MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function) :
+    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), std::move(lock_api_function)) {}
+
+std::optional<MeshTraceId> DummyMeshCommandQueue::trace_id() const { return std::nullopt; }
+
+WorkerConfigBufferMgr& DummyMeshCommandQueue::get_config_buffer_mgr(uint32_t /*index*/) {
+    TT_THROW("get_config_buffer_mgr() not supported for DummyMeshCommandQueue (inactive rank)");
+}
+
+bool DummyMeshCommandQueue::write_shard_to_device(
+    const MeshBuffer& /*buffer*/,
+    const MeshCoordinate& /*device_coord*/,
+    const void* /*src*/,
+    const std::optional<BufferRegion>& /*region*/,
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/,
+    std::shared_ptr<experimental::PinnedMemory> /*pinned_memory*/) {
+    // No-op for inactive rank; no pinned memory used
+    return false;
+}
+
+void DummyMeshCommandQueue::read_shard_from_device(
+    const MeshBuffer& /*buffer*/,
+    const MeshCoordinate& /*device_coord*/,
+    void* /*dst*/,
+    std::shared_ptr<experimental::PinnedMemory> /*pinned_memory*/,
+    const std::optional<BufferRegion>& /*region*/,
+    std::unordered_map<IDevice*, uint32_t>& /*num_txns_per_device*/,
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
+    // No-op for inactive rank
+}
+
+void DummyMeshCommandQueue::submit_memcpy_request(
+    std::unordered_map<IDevice*, uint32_t>& /*num_txns_per_device*/, bool /*blocking*/) {
+    // No-op for inactive rank
+}
+
+void DummyMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
+    // No-op for inactive rank
+}
+
+MeshEvent DummyMeshCommandQueue::enqueue_record_event_to_host_nolock(
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/, const std::optional<MeshCoordinateRange>& device_range) {
+    // Return dummy event for inactive rank
+    return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
+}
+
+void DummyMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& /*mesh_workload*/, bool /*blocking*/) {
+    // No-op for inactive rank
+}
+
+MeshEvent DummyMeshCommandQueue::enqueue_record_event(
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/, const std::optional<MeshCoordinateRange>& device_range) {
+    // Return dummy event for inactive rank
+    return MeshEvent(0, mesh_device_, id_, device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
+}
+
+MeshEvent DummyMeshCommandQueue::enqueue_record_event_to_host(
+    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
+    // Call the no-lock version since we don't need synchronization for inactive rank
+    return this->enqueue_record_event_to_host_nolock(sub_device_ids, device_range);
+}
+
+void DummyMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& /*sync_event*/) {
+    // No-op for inactive rank
+}
+
+void DummyMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
+    // No-op for inactive rank
+}
+
+void DummyMeshCommandQueue::reset_worker_state(
+    bool /*reset_launch_msg_state*/,
+    uint32_t /*num_sub_devices*/,
+    const vector_aligned<uint32_t>& /*go_signal_noc_data*/,
+    const std::vector<std::pair<CoreRangeSet, uint32_t>>& /*core_go_message_mapping*/) {
+    // No-op for inactive rank
+}
+
+void DummyMeshCommandQueue::record_begin(
+    const MeshTraceId& /*trace_id*/, const std::shared_ptr<MeshTraceDescriptor>& /*ctx*/) {
+    TT_THROW("Trace operations not supported for DummyMeshCommandQueue (inactive rank)");
+}
+
+void DummyMeshCommandQueue::record_end() {
+    TT_THROW("Trace operations not supported for DummyMeshCommandQueue (inactive rank)");
+}
+
+void DummyMeshCommandQueue::enqueue_trace(const MeshTraceId& /*trace_id*/, bool /*blocking*/) {
+    TT_THROW("Trace operations not supported for DummyMeshCommandQueue (inactive rank)");
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/dummy_mesh_command_queue.hpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,11 +8,7 @@
 
 namespace tt::tt_metal::distributed {
 
-class SDMeshCommandQueue final : public MeshCommandQueueBase {
-private:
-    // Distributed context used to synchronize operations done by all active ranks on the given mesh device.
-    std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
-
+class DummyMeshCommandQueue final : public MeshCommandQueueBase {
 protected:
     bool write_shard_to_device(
         const MeshBuffer& buffer,
@@ -36,12 +32,9 @@ protected:
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
 
 public:
-    SDMeshCommandQueue(
-        MeshDevice* mesh_device,
-        uint32_t id,
-        std::function<std::lock_guard<std::mutex>()> lock_api_function,
-        std::shared_ptr<distributed::multihost::DistributedContext> distributed_context);
-    ~SDMeshCommandQueue() override = default;
+    DummyMeshCommandQueue(
+        MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function);
+    ~DummyMeshCommandQueue() override = default;
 
     std::optional<MeshTraceId> trace_id() const override;
 
@@ -64,16 +57,6 @@ public:
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
-
-    void enable_asynchronous_slow_dispatch();
-    void disable_asynchronous_slow_dispatch();
-
-private:
-    void wait_for_cores_idle();
-
-    std::unordered_map<ChipId, std::vector<std::vector<CoreCoord>>> logical_cores_for_previous_workload_;
-
-    bool asynchronous_slow_dispatch_enabled_ = false;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -198,6 +198,9 @@ private:
     // so the main thread can handle the exception
     std::atomic<bool> thread_exception_state_ = false;
 
+    // Distributed context used to synchronize operations done by all active ranks on the given mesh device.
+    std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
+
 protected:
     bool write_shard_to_device(
         const MeshBuffer& buffer,
@@ -227,7 +230,8 @@ public:
         std::shared_ptr<ThreadPool>& dispatch_thread_pool,
         std::shared_ptr<ThreadPool>& reader_thread_pool,
         std::shared_ptr<CQSharedState>& cq_shared_state,
-        std::function<std::lock_guard<std::mutex>()> lock_api_function);
+        std::function<std::lock_guard<std::mutex>()> lock_api_function,
+        std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context);
 
     ~FDMeshCommandQueue() override;
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -90,6 +90,13 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
             }},
         mesh_buffer_config);
 
+    if (mesh_device->get_view().get_devices().empty()) {
+        auto mesh_buffer =
+            std::shared_ptr<MeshBuffer>(new MeshBuffer(mesh_buffer_config, device_local_config, 0, 0, mesh_device));
+        mesh_buffer->initialize_device_buffers();
+        return mesh_buffer;
+    }
+
     std::shared_ptr<MeshBuffer> mesh_buffer;
     if (!address.has_value()) {
         // Rely on the MeshDevice allocator to provide the address for the entire mesh buffer.

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -58,6 +58,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "mesh_device_view_impl.hpp"
+#include "dummy_mesh_command_queue.hpp"
 
 namespace tt::tt_metal {
 class SystemMemoryManager;
@@ -629,6 +630,11 @@ tt_fabric::FabricNodeId MeshDeviceImpl::get_fabric_node_id(const MeshCoordinate&
 MeshCommandQueue& MeshDeviceImpl::mesh_command_queue(std::optional<uint8_t> cq_id) const {
     auto id = cq_id.value_or(GetCurrentCommandQueueIdForThread());
 
+    // If the mesh device has no local devices, return the dummy mesh command queue.
+    if (this->get_view().get_devices().empty()) {
+        return *mesh_command_queues_[0];
+    }
+
     TT_FATAL(id < mesh_command_queues_.size(), "cq_id {} is out of range", id);
     const auto& command_queue = mesh_command_queues_[id];
     TT_FATAL(id == command_queue->id(), "MeshCommandQueue id mismatch, expected {}, got {}", id, command_queue->id());
@@ -1152,8 +1158,15 @@ bool MeshDeviceImpl::initialize_impl(
 
     // If the mesh device has no local devices, do not attempt to initialize it.
     if (view_->get_devices().empty()) {
+        active_distributed_context_ = distributed_context_->split(
+            distributed::multihost::Color(1), distributed::multihost::Key(*distributed_context_->rank()));
+        mesh_command_queues_.push_back(
+            std::make_unique<DummyMeshCommandQueue>(pimpl_wrapper, 0, std::bind(&MeshDeviceImpl::lock_api, this)));
         return false;
     }
+
+    active_distributed_context_ = distributed_context_->split(
+        distributed::multihost::Color(0), distributed::multihost::Key(*distributed_context_->rank()));
 
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
@@ -1181,12 +1194,13 @@ bool MeshDeviceImpl::initialize_impl(
                 dispatch_thread_pool_,
                 reader_thread_pool_,
                 cq_shared_state,
-                std::bind(&MeshDeviceImpl::lock_api, this)));
+                std::bind(&MeshDeviceImpl::lock_api, this),
+                active_distributed_context_));
         }
     } else {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
-            mesh_command_queues_.push_back(
-                std::make_unique<SDMeshCommandQueue>(pimpl_wrapper, cq_id, std::bind(&MeshDeviceImpl::lock_api, this)));
+            mesh_command_queues_.push_back(std::make_unique<SDMeshCommandQueue>(
+                pimpl_wrapper, cq_id, std::bind(&MeshDeviceImpl::lock_api, this), active_distributed_context_));
         }
     }
     Inspector::mesh_device_initialized(this);

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -157,6 +157,8 @@ private:
 
     // Distributed context used to synchronize operations done by all ranks on the given mesh device.
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
+    // Active distributed context used by mesh command queues (split from distributed_context_).
+    std::shared_ptr<distributed::multihost::DistributedContext> active_distributed_context_;
 
     friend class ::tt::tt_metal::experimental::DispatchContext;
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -48,8 +48,12 @@ bool logical_cores_intersect(
 namespace tt::tt_metal::distributed {
 
 SDMeshCommandQueue::SDMeshCommandQueue(
-    MeshDevice* mesh_device, uint32_t id, std::function<std::lock_guard<std::mutex>()> lock_api_function) :
-    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), std::move(lock_api_function)) {}
+    MeshDevice* mesh_device,
+    uint32_t id,
+    std::function<std::lock_guard<std::mutex>()> lock_api_function,
+    std::shared_ptr<distributed::multihost::DistributedContext> distributed_context) :
+    MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool(), std::move(lock_api_function)),
+    active_distributed_context_(std::move(distributed_context)) {}
 
 std::optional<MeshTraceId> SDMeshCommandQueue::trace_id() const {
     TT_THROW("Trace not supported for slow dispatch");
@@ -220,10 +224,8 @@ void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     }
 
-    // Barrier across all hosts of the mesh
-    auto distributed_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(
-        mesh_device_->get_view().mesh_id());
-    distributed_context->barrier();
+    // Barrier across all active hosts of the mesh
+    active_distributed_context_->barrier();
 }
 
 void SDMeshCommandQueue::finish_nolock(tt::stl::Span<const SubDeviceId>) {}

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -560,6 +560,14 @@ typename device_operation_t::tensor_return_value_t launch(
 
     ttnn::MeshDevice* mesh_device = detail::get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
 
+    // TODO: #37267 - Remove this short-circuit once we have a better way to handle inactive MeshDevices.
+    // Short-circuit for inactive MeshDevices (no-op). It is important this happens before any validation an op may
+    // perform, as most of the MeshDevice calls will fail for inactive MeshDevices.
+    if (mesh_device->get_view().get_devices().empty()) {
+        tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
+        return tensor_return_value;
+    }
+
     if (!mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
         tensor_return_value = mesh_device_operation_utils::filter_tensor_shards(
             mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device), tensor_return_value);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33901

### Problem description
Currently when a MeshDevice does not span all ranks in a distributed
set-up running ops (or creating buffers) for it will fail. Instead, in
such cases, the "inactive" ranks should execute nop's and let the
"active" ranks carry out their work.

### What's changed
This patch is the first step towards supporting ops on meshes and/or
sub-meshes which do not span all ranks in a distributed system. It aims
to unlock running basic ops, by short-circuiting their launch at the
ttnn level for "inactive" MeshDevice instances. A large portion of the
MeshDevice interface will remain broken for "inactive" meshes.
Eventually, the MeshDevice class should be reworked in a way that will
make it safe to use on "inactive" ranks, and allow ttnn not to care
about whether a MeshDevice is "active" or "inactive".

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=p1-0tr/33901-run-op-with-inactive-ranks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:p1-0tr/33901-run-op-with-inactive-ranks)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs