### PR TITLE
Fix Mochi VAE test

### DIFF
--- a/models/experimental/tt_dit/tests/models/mochi/test_vae_mochi.py
+++ b/models/experimental/tt_dit/tests/models/mochi/test_vae_mochi.py
@@ -40,7 +40,7 @@ def vae_device_config(func):
     )(func)
     func = pytest.mark.parametrize(
         "device_params",
-        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 20000000}],
+        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 20000000}],
         indirect=True,
     )(func)
     return func


### PR DESCRIPTION
### Problem description

Mochi broke after a recent update from main. This removes the `l1_small_size` from the fabric config to fix it. The Mochi test [passes](https://github.com/tenstorrent/tt-metal/actions/runs/21146528024/job/60813857254) after the fix.