### PR TITLE
[build-system] Fix install_dependencies.sh to install clang-20

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -322,18 +322,24 @@ install_llvm() {
         return
     fi
 
-    LLVM_VERSION="17"
-    echo "[INFO] Checking if LLVM $LLVM_VERSION is already installed..."
-    if command -v clang-$LLVM_VERSION &> /dev/null; then
-        echo "[INFO] LLVM $LLVM_VERSION is already installed. Skipping installation."
-    else
-        echo "[INFO] Installing LLVM $LLVM_VERSION..."
-        TEMP_DIR=$(mktemp -d)
-        wget -P $TEMP_DIR https://apt.llvm.org/llvm.sh
-        chmod u+x $TEMP_DIR/llvm.sh
-        $TEMP_DIR/llvm.sh $LLVM_VERSION
-        rm -rf "$TEMP_DIR"
-    fi
+    # Install both LLVM 17 and 20:
+    # - clang-17: required by tt-train
+    # - clang-20: default toolchain for tt-metal (build_metal.sh)
+    TEMP_DIR=$(mktemp -d)
+    wget -P $TEMP_DIR https://apt.llvm.org/llvm.sh
+    chmod u+x $TEMP_DIR/llvm.sh
+
+    for LLVM_VERSION in 17 20; do
+        echo "[INFO] Checking if LLVM $LLVM_VERSION is already installed..."
+        if command -v clang-$LLVM_VERSION &> /dev/null; then
+            echo "[INFO] LLVM $LLVM_VERSION is already installed. Skipping installation."
+        else
+            echo "[INFO] Installing LLVM $LLVM_VERSION..."
+            $TEMP_DIR/llvm.sh $LLVM_VERSION
+        fi
+    done
+
+    rm -rf "$TEMP_DIR"
 }
 
 install_sfpi() {


### PR DESCRIPTION
### Ticket
Fixes #36098

### Problem description
The default toolchain was changed from clang-17 to clang-20 in PR #35887, but `install_dependencies.sh` was not updated to install clang-20.

This causes builds to fail on fresh systems after running the dependencies script:

```
clang++-20 is not a full path and was not found in the PATH.
```

### What's changed
Updated `install_llvm()` to install **both** LLVM 17 and LLVM 20:
- **clang-17**: Required by tt-train (see `tt-train/cmake/compilers.cmake`)
- **clang-20**: Default toolchain for tt-metal (`build_metal.sh`)

The function now loops over both versions, checking if each is already installed before installing.

### Checklist
- [x] New/Existing tests provide coverage for changes