### PR TITLE
#35573: Add support for WH/batching to deepseek_moe_gate

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -137,7 +137,7 @@ inline void bitonic_topk_store8_even_cols_single_face() {
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_even_cols_split_indices_single_face() {
-    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be true");
+    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
     // Store 8 consecutive numbers
     TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
     TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -107,7 +107,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
 }
 
 template <uint32_t num_tiles = 1, bool is_32bit>
-inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop() {
+inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     load_replay_buf(
         ckernel::math::replay_buf_offset,  // replay buffer offset
@@ -151,7 +151,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_()
 // Initialize for single face transpose
 template <bool is_32bit = false>
 inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_() {
-    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop<2, is_32bit>();
+    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop<2, is_32bit>();
 }
 
 template <bool is_fp32_dest_acc_en, bool is_32bit = false>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -137,7 +137,7 @@ inline void bitonic_topk_store8_even_cols_single_face() {
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_even_cols_split_indices_single_face() {
-    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be true");
+    static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
     // Store 8 consecutive numbers
     TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
     TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -28,154 +28,154 @@ constexpr uint32_t interm_offset = bias_offset + dst_tile_offset;
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_load16_single_face() {
     // Load 16 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
-    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 12);
 
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_offset + 8);
-    TTI_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_offset + 12);
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, indices_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, indices_offset + 12);
 }
 
 template <bool is_fp32_dest_acc_en, uint32_t offset = 0>
 inline void bitonic_topk_load16_concat_indices_single_face() {
     // Load 16 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 12 + offset);
 
     static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 8 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 12 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 8 + offset);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 12 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 12 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 12 + offset);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_load16_concatted_indices_single_face() {
     // Load 16 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
-    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 12);
 
     static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be false");
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 8);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 12);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 8);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 12);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store16_concatted_indices_single_face() {
     // Store 16 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
-    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 12);
 
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 8);
-    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 12);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 12);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store16_single_face() {
     // Store 16 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 8);
-    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 12);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 12);
 
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_7, indices_offset + 8);
-    TTI_SFPSTORE(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_7, indices_offset + 12);
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, instr_mod_index, ADDR_MOD_3, indices_offset + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, instr_mod_index, ADDR_MOD_3, indices_offset + 12);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_load8_even_cols_single_face() {
     // Load 8 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
 
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_offset + 4);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_load8_even_cols_concatted_indices_single_face() {
     // Load 8 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
 
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 4);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_even_cols_single_face() {
     // Store 8 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
 
     constexpr uint8_t instr_mod_index = is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, instr_mod_index, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, instr_mod_index, ADDR_MOD_3, indices_offset + 4);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_even_cols_split_indices_single_face() {
     static_assert(!is_fp32_dest_acc_en, "is_fp32_dest_acc_en must be true");
     // Store 8 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
 
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 4);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_even_cols_concatted_indices_single_face() {
     // Store 8 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
 
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 4);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_load8_odd_cols_concatted_indices_single_face() {
     // Load 8 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 2);
-    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 6);
 
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 2);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 6);
 }
 
 template <bool is_fp32_dest_acc_en>
 inline void bitonic_topk_store8_odd_cols_concatted_indices_single_face() {
     // Store 8 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 2);
-    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 6);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 2);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 6);
 
-    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 2);
-    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, interm_offset + 6);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 2);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, interm_offset + 6);
 }
 
 template <bool start_transpose, bool end_transpose>
@@ -360,8 +360,8 @@ inline void _deepseek_moe_gate_sum_top2() {
     // TODO: Evaluate compared to broadcast using MOVB2D in FPU
     TTI_SFPCONFIG(0, p_sfpu::LREG14, 0);
     TTI_SFPMOV(0, p_sfpu::LREG14, p_sfpu::LREG0, 0);
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset);
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 4);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
@@ -369,26 +369,26 @@ inline void _deepseek_moe_gate_sort_top4_groups() {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     // Sort top4
     // Load the top2 sums and concat indices
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, interm_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, interm_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, interm_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 4);
 
     // Load the top2 sums (again) and bias scores
     TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
     TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
-    TTI_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_7, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_3, bias_offset + 4);
 
     // Sort 8 groups (not bitonic)
     bitonic_topk_ph0_st1_to_1_single_face<true, false>();
     bitonic_topk_ph1_st2_to_1_single_face<false, true>();
     bitonic_topk_ph2_st3_to_1_single_face<true, false>();
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_7, bias_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_3, bias_offset + 0);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
@@ -400,20 +400,20 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Reverse order of sort for top8 values in odd columns
-    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, bias_offset + 6);
-    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, bias_offset + 2);
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 6);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 2);
-    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 6);
-    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, bias_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, bias_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 6);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 2);
     reverse_sort_order();
 
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, bias_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, bias_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, bias_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, bias_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 4);
     bitonic_top8_ph3_st4_to_1<idir, true>();
 
     bitonic_topk_store8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
@@ -436,25 +436,29 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
     // Step 4 Only, we need top8 but it doesn't have to be sorted
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, indices_offset + 4);
-    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, scores_offset + 4);
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_3, scores_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, scores_offset + 4);
 
     // Reduce the top8 values to 1 value
     TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
     TTI_SFPTRANSP(0, 0, 0, 0);
     TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
     TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+    TTI_SFPNOP;
     TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
 
     // Calculate 1 / (sum + eps) * scale
     // Store the value in lreg0 and reload later since the following instructions overwrite it
-    // Note: This is done for safety since registers used by recip are chosen by the compiler
-    // For BH, it was safe to skip this since recip didn't use the registers affected by the bug requiring us to disable
     TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 0);
+    // Technically we only need to reprogram a single constant here, instead of all 3 used by reciprocal init
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
     _sfpu_load_config32_(0xF, 0x0, 0x0);
     TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 0);
 
@@ -469,17 +473,20 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
 
     // Broadcast to all rows and multiply by the top8 values
     TTI_SFPCONFIG(0, p_sfpu::LREG14, 0);
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, scores_offset + 4);
     TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
-    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, scores_offset + 4);
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void _init_deepseek_moe_gate_topk() {
-    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+    // Note: For BH there is no conflict with reg usage between the gate and reciprocal
+    // For WH, since we use reg 14 to broadcast, this would overwrite the recip value, so we init within the top8 fn
+    // instead of ahead of time
+    // sfpu_reciprocal_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+enum class DeepseekMoeGateEltwiseBinaryMode {
+    COPY,
+    RELOAD,
+};
+
+// local function declarations
+template <EltwiseBinaryType eltwise_binary_type>
+inline void deepseek_moe_gate_eltwise_binary_configure_addrmod() {
+    // Use srcA for data movement
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        addr_mod_t{
+            .srca = {.incr = 8},
+            .srcb = {.incr = 8},
+            .dest = {.incr = 8},
+        }
+            .set(ADDR_MOD_0);
+        addr_mod_t{
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_1);
+    }
+}
+
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src() {
+    if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCA_VLD);  // MOVD2A for a whole face assumes unpacker will set a dummy
+                                                      // data_valid, so we want to wait on that
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 4);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 8);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 12, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 12);
+    } else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB) {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCB_VLD);  // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                      // data_valid, so we want to wait on that
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DstSync Dst, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_(
+    const std::uint32_t num_faces, uint dst_index, const bool clear_fp32_dst_acc) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    constexpr uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    static_assert(!(eltwise_binary_type == ELWMUL && high_fidelity), "High fidelity is not supported for ELWMUL");
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        ckernel_template::run();
+    }
+    math::clear_dst_reg_addr();
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+inline void deepseek_moe_gate_eltwise_binary_configure_mop(
+    const std::uint32_t acc_to_dest = 0, const std::uint32_t num_faces = 4) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity = (NUM_FIDELITY_PHASES > 0);
+    const uint addr_mod = ADDR_MOD_0;
+    constexpr uint innerloop = 16 >> 3;  // 8 rows per eltwise op at a time.
+    uint outerloop = num_faces;
+    auto broadcast_type = p_elwise::SRCB_NO_BCAST;
+
+    constexpr uint32_t dst_tile_offset = 64;  // 1 tile x 64 rows per tile
+    constexpr uint32_t dst_math_offset = 2 * dst_tile_offset;
+
+    uint math_op;
+
+    // TODO: Probably not worth it to use a replay buffer/mop for this
+    // Just hardcode the math ops in _llk_math_deepseek_moe_gate_eltwise_binary_ since we only have 1 face
+    if constexpr (eltwise_binary_type == ELWADD) {
+        math_op = TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+
+    } else if constexpr (eltwise_binary_type == ELWSUB) {
+        math_op = TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+    } else if constexpr (eltwise_binary_type == ELWMUL) {
+        static_assert(!high_fidelity, "High fidelity is not supported for ELWMUL");
+        math_op = TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, dst_math_offset);
+    }
+    if constexpr (mode == DeepseekMoeGateEltwiseBinaryMode::RELOAD) {
+        lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 5);
+        deepseek_moe_gate_eltwise_binary_reuse_dest_as_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>();
+        uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 5);
+        ckernel_template tmp(outerloop, innerloop, math_op);
+        tmp.set_start_op(replay_instr);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    } else {
+        ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 0), math_op);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int MATH_FIDELITY_DESC = 0>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_init_(
+    const std::uint32_t num_faces, const std::uint32_t acc_to_dest) {
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
+
+    deepseek_moe_gate_eltwise_binary_configure_addrmod<eltwise_binary_type>();
+
+    if constexpr (
+        (eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB) || (eltwise_binary_type == ELWMUL)) {
+        deepseek_moe_gate_eltwise_binary_configure_mop<eltwise_binary_type, mode, MATH_FIDELITY_PHASES>(
+            acc_to_dest, num_faces);
+    }
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -100,7 +100,7 @@ inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
 }
 
 template <uint32_t num_tiles = 1, bool is_32bit>
-inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop() {
+inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop() {
     static_assert(!is_32bit, "32-bit is not supported for single face transpose");
     lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 4);
     // Move 8 rows from DEST to SrcB (4 rows at a time)
@@ -140,7 +140,7 @@ inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_()
 // Initialize for single face transpose
 template <bool is_32bit = false>
 inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_() {
-    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop<2, is_32bit>();
+    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop<2, is_32bit>();
 }
 
 template <bool is_fp32_dest_acc_en, bool is_32bit = false>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_globals.h"
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+namespace ckernel {
+
+constexpr uint32_t transpose_dest_tile_offset = 64;  // 1 tile x 64 rows per tile
+
+// Configure address modifiers for single face transpose
+template <bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_configure_addrmod() {
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = transpose_dest_tile_offset},
+    }
+        .set(ADDR_MOD_2);
+
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_3);
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    // For 16-bit data, simple single-pass transpose
+    // Load replay buffer with the transpose sequence for one 16x16 face (face 0: rows 0-15)
+    lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 16);
+    // Move 8 rows from DEST to SrcB interleaved (1 row at a time)
+    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0);
+    TTI_MOVD2B(0, 18, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 1);
+    TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 2);
+    TTI_MOVD2B(0, 22, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 3);
+    TTI_MOVD2B(0, 24, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 4);
+    TTI_MOVD2B(0, 26, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 5);
+    TTI_MOVD2B(0, 28, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 6);
+    TTI_MOVD2B(0, 30, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 7);
+
+    // Move 8 rows from SrcB back to DEST interleaved (1 row at a time)
+    TTI_MOVB2D(0, 16, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 0);
+    TTI_MOVB2D(0, 18, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 1);
+    TTI_MOVB2D(0, 20, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 2);
+    TTI_MOVB2D(0, 22, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 3);
+    TTI_MOVB2D(0, 24, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 4);
+    TTI_MOVB2D(0, 26, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 5);
+    TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
+    TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
+
+    uint d2b_instr = lltt::replay_insn(math::replay_buf_offset, 8);
+    uint b2d_instr = lltt::replay_insn(math::replay_buf_offset + 8, 8);
+
+    ckernel_template tmp(num_tiles, 1, d2b_instr, TT_OP_TRNSPSRCB);
+    tmp.set_end_op(b2d_instr);
+    tmp.program();
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    // For 16-bit data, simple single-pass transpose
+    // Load replay buffer with the transpose sequence for one 16x16 face (face 0: rows 0-15)
+    lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 11);
+    // Move 4 rows from DEST to SrcB (4 rows at a time)
+    // This will place the first 2 rows in the first 2 columns, and the last 2 rows in the last 2 columns
+    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+    TTI_MOVD2B(0, 28, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+
+    TTI_TRNSPSRCB;
+
+    // Move 8 rows from SrcB back to DEST interleaved (1 row at a time)
+    TTI_MOVB2D(0, 16, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 0);
+    TTI_MOVB2D(0, 18, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 1);
+    TTI_MOVB2D(0, 20, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 2);
+    TTI_MOVB2D(0, 22, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 3);
+    TTI_MOVB2D(0, 24, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 4);
+    TTI_MOVB2D(0, 26, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 5);
+    TTI_MOVB2D(0, 28, ADDR_MOD_3, p_movb2d::MOV_1_ROW, 6);
+    TTI_MOVB2D(0, 30, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 7);
+    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 11);
+
+    ckernel_template tmp(num_tiles, 1, replay_instr);
+    tmp.program();
+}
+
+template <uint32_t num_tiles = 1, bool is_32bit>
+inline void deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop() {
+    static_assert(!is_32bit, "32-bit is not supported for single face transpose");
+    lltt::record<lltt::NoExec>(ckernel::math::replay_buf_offset, 4);
+    // Move 8 rows from DEST to SrcB (4 rows at a time)
+    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 0);
+    TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 4);
+
+    TTI_TRNSPSRCB;
+
+    // Move 1 row from SrcB back to DEST
+    TTI_MOVB2D(0, 16, ADDR_MOD_2, p_movb2d::MOV_1_ROW, 0);
+    uint replay_instr = lltt::replay_insn(math::replay_buf_offset, 4);
+
+    ckernel_template tmp(num_tiles, 1, replay_instr);
+    tmp.program();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_configure_addrmod<is_32bit>();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step0_configure_mop<4, is_32bit>();
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    // TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step1_configure_mop<3, is_32bit>();
+}
+
+// Initialize for single face transpose
+template <bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_() {
+    deepseek_moe_gate_transpose_dest_single_face_step2_configure_mop_configure_mop<2, is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    // Run the 16-bit single-face transpose MOP
+    ckernel_template::run();
+}
+
+// Perform in-place transpose on face 0 (rows 0-15) of a single tile in DEST
+// dst_index: The tile index in DEST register buffer (0, 1, 2, ...)
+//            The function transposes face 0 of the specified tile
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    // Run the 16-bit single-face transpose MOP
+    ckernel_template::run();
+}
+
+// Perform in-place transpose on face 0 (rows 0-15) of a single tile in DEST
+// dst_index: The tile index in DEST register buffer (0, 1, 2, ...)
+//            The function transposes face 0 of the specified tile
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_() {
+    static_assert(
+        !(is_32bit || is_fp32_dest_acc_en),
+        "32-bit and fp32 dest accum enable are not supported for single face transpose");
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // Wait for SFPU and SrcB to be available
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCB_VLD);
+
+    ckernel_template::run();
+
+    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "../../../../../../tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_eltwise_binary.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY
+ *************************************************************************/
+
+// Version with operands
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, NUM_FIDELITY_PHASES>(
+        num_faces, acc_to_dest);
+}
+
+template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_deepseek_moe_gate_eltwise_binary(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_<
+        eltwise_binary_type,
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        NUM_FIDELITY_PHASES>(num_faces, dst_index, clear_fp32_dst_acc);
+}

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_common_api.h"
+#include "../../../../../../tt_llk/tt_llk_wormhole_b0/llk_lib/llk_math_deepseek_moe_gate_transpose_dest_single_face.h"
+
+namespace ckernel {
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_common_init_<is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step0() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step0_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step1() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step1_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+template <bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_init_<is_32bit>();
+}
+
+template <bool is_fp32_dest_acc_en, bool is_32bit = false>
+inline void llk_math_deepseek_moe_gate_transpose_dest_single_face_step2() {
+    _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_<is_fp32_dest_acc_en, is_32bit>();
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "../../../../../../../tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_sum_top2() {
+    _deepseek_moe_gate_sum_top2<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_sort_top4_groups() {
+    _deepseek_moe_gate_sort_top4_groups<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
+    _deepseek_moe_gate_top8<APPROXIMATION_MODE, is_fp32_dest_acc_en>(eps, scale);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void deepseek_moe_gate_topk_init() {
+    _init_deepseek_moe_gate_topk<APPROXIMATION_MODE, is_fp32_dest_acc_en>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_deepseek_moe_gate_topk_single_face.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_topk_init() {
+    // Don't need the second addrmod so set type to unused
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>(
+        sfpu::deepseek_moe_gate_topk_init<APPROXIMATE, is_fp32_dest_acc_en>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_sum_top2(uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_sum_top2<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_sort_top4_groups(
+    uint dst_index, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_sort_top4_groups<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
+inline void llk_math_sfpu_deepseek_moe_gate_top8(
+    uint dst_index, uint32_t eps, uint32_t scale, int vector_mode = (int)VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::deepseek_moe_gate_top8<APPROXIMATE, is_fp32_dest_acc_en>, dst_index, vector_mode, eps, scale);
+}
+
+}  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h
@@ -8,9 +8,15 @@
 #include "compute_kernel_api/common.h"
 #include "compute_kernel_api/transpose_wh.h"
 #ifdef TRISC_MATH
+#ifdef ARCH_BLACKHOLE
 #include "../../hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h"
 #include "../../hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h"
 #include "../../hw/ckernels/blackhole/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h"
+#else
+#include "../../hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_deepseek_moe_gate_topk_single_face.h"
+#include "../../hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_eltwise_binary_api.h"
+#include "../../hw/ckernels/wormhole_b0/metal/llk_api/llk_math_deepseek_moe_gate_transpose_dest_single_face_api.h"
+#endif
 #endif
 
 namespace ckernel {

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
@@ -33,22 +33,24 @@ class DeepseekMoeGateSingleCore:
             Top8 normalized scores tensor (torch.Tensor) of shape [1, 8]
             Top8 indices tensor (torch.Tensor) of shape [1, 8]
         """
+        row_offsets = torch.arange(input_tensor.shape[-2]) * input_tensor.shape[-1]
+        batch_idx = torch.arange(input_tensor.shape[0]).unsqueeze(-1)
+
         scores = torch.sigmoid(input_tensor) if enable_sigmoid else input_tensor
         bias_scores = scores + bias_tensor
         sorted_bias, sorted_indices = torch.sort(bias_scores, dim=-1, descending=True)
-        sorted_scores = scores.clone()
-        for i in range(sorted_indices.shape[0]):
-            sorted_scores[i] = scores[i][sorted_indices[i]]
-            sorted_indices[i] += i * sorted_indices.shape[1]
-        top2_sum = sorted_bias[:, 0] + sorted_bias[:, 1]
-        sorted_top2_sum, sorted_top2_indices = torch.sort(top2_sum, descending=True)
-        top4_values = sorted_bias[sorted_top2_indices[:4]].flatten()
-        sorted_scores = sorted_scores[sorted_top2_indices[:4]].flatten()
-        sorted_indices = sorted_indices[sorted_top2_indices[:4]].flatten()
+        sorted_scores = torch.gather(scores, dim=-1, index=sorted_indices)
+        sorted_indices = sorted_indices + row_offsets.view(1, -1, 1)
+
+        top2_sum = sorted_bias[:, :, 0] + sorted_bias[:, :, 1]
+        sorted_top2_sum, sorted_top2_indices = torch.sort(top2_sum, dim=-1, descending=True)
+        top4_values = sorted_bias[batch_idx, sorted_top2_indices[:, :4]].flatten(1)
+        top4_scores = sorted_scores[batch_idx, sorted_top2_indices[:, :4]].flatten(1)
+        top4_indices = sorted_indices[batch_idx, sorted_top2_indices[:, :4]].flatten(1)
         top8_values, top8_indices = torch.topk(top4_values, 8, dim=-1, sorted=True)
-        top8_values = sorted_scores[top8_indices]
-        top8_indices = sorted_indices[top8_indices]
-        denominator = torch.sum(top8_values, dim=-1) + eps
+        top8_values = torch.gather(top4_scores, dim=-1, index=top8_indices)
+        top8_indices = torch.gather(top4_indices, dim=-1, index=top8_indices)
+        denominator = torch.sum(top8_values, dim=-1, keepdim=True) + eps
         normalized_scores = top8_values / denominator * scaling_factor
         return normalized_scores, top8_indices
 
@@ -92,15 +94,32 @@ class DeepseekMoeGateSingleCore:
         assert bias_shape == input_shape, "Bias and input tensors must have the same shape"
         assert input_indices_shape == input_shape, "Input indices and input tensors must have the same shape"
         assert output_indices_shape == input_shape, "Output indices and input tensors must have the same shape"
-        assert input_shape[0] == 16, f"Height must be 16 for Deepseek Moe Gate, got {input_shape[0]}"
-        assert input_shape[1] == 16, f"Width must be 16 for Deepseek Moe Gate, got {input_shape[1]}"
+
+        # Get core grid from input tensor (single core)
+        input_shard_spec = input_tensor.memory_config().shard_spec
+        all_cores = input_shard_spec.grid
+        assert input_shard_spec == bias_tensor.memory_config().shard_spec
+        assert input_shard_spec == output_tensor.memory_config().shard_spec
+        assert input_shard_spec == input_indices_tensor.memory_config().shard_spec
+        assert input_shard_spec == output_indices_tensor.memory_config().shard_spec
 
         # Get tile info from input tensor
         input_tile = input_tensor.tile
         input_tile_height, input_tile_width = input_tile.tile_shape
         input_tile_size = input_tile.get_tile_size(input_tensor.dtype)
-        assert input_tile_height == 16, f"Height must be 16 for Deepseek Moe Gate, got {input_tile_height}"
-        assert input_tile_width == 16, f"Width must be 16 for Deepseek Moe Gate, got {input_tile_width}"
+        expected_tile_size = (16, 16)
+        assert input_tile == bias_tensor.tile
+        assert input_tile == output_tensor.tile
+        assert input_tile == input_indices_tensor.tile
+        assert input_tile == output_indices_tensor.tile
+        assert input_tile_height == expected_tile_size[0]
+        assert input_tile_width == expected_tile_size[1]
+        assert input_shard_spec == bias_tensor.memory_config().shard_spec
+        assert input_shard_spec == output_tensor.memory_config().shard_spec
+        assert input_shard_spec == input_indices_tensor.memory_config().shard_spec
+        assert input_shard_spec == output_indices_tensor.memory_config().shard_spec
+        assert input_shard_spec.shape[0] == expected_tile_size[0]
+        assert input_shard_spec.shape[1] == expected_tile_size[1]
 
         # Get tile info from bias tensor
         bias_tile = bias_tensor.tile
@@ -117,14 +136,6 @@ class DeepseekMoeGateSingleCore:
         # Get tile info from output indices tensor
         output_indices_tile = output_indices_tensor.tile
         output_indices_tile_size = output_indices_tile.get_tile_size(output_indices_tensor.dtype)
-
-        # Get core grid from input tensor (single core)
-        all_cores = input_tensor.memory_config().shard_spec.grid
-        assert all_cores.num_cores() == 1, f"Only single core is supported"
-        assert all_cores == bias_tensor.memory_config().shard_spec.grid
-        assert all_cores == output_tensor.memory_config().shard_spec.grid
-        assert all_cores == input_indices_tensor.memory_config().shard_spec.grid
-        assert all_cores == output_indices_tensor.memory_config().shard_spec.grid
 
         # CB indices
         cb_index = 0

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/op.py
@@ -94,7 +94,7 @@ class DeepseekMoeGateSingleCore:
         assert input_indices_shape == input_shape, "Input indices and input tensors must have the same shape"
         assert output_indices_shape == output_shape, "Output indices and output tensors must have the same shape"
 
-        # Get core grid from input tensor (single core)
+        # Get core grid from input tensor
         input_shard_spec = input_tensor.memory_config().shard_spec
         output_shard_spec = output_tensor.memory_config().shard_spec
         all_cores = input_shard_spec.grid
@@ -119,9 +119,6 @@ class DeepseekMoeGateSingleCore:
         assert input_tile_width == expected_input_tile_size[1]
         assert output_tile_height == expected_output_tile_size[0]
         assert output_tile_width == expected_output_tile_size[1]
-        assert input_shard_spec == bias_tensor.memory_config().shard_spec
-        assert input_shard_spec == input_indices_tensor.memory_config().shard_spec
-        assert output_shard_spec == output_indices_tensor.memory_config().shard_spec
         assert input_shard_spec.shape[0] == expected_input_tile_size[0]
         assert input_shard_spec.shape[1] == expected_input_tile_size[1]
         assert output_shard_spec.shape[0] == expected_output_tile_size[0]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_deepseek_moe_gate.py
@@ -10,9 +10,9 @@ import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.deepseek_moe_gate.op import DeepseekMoeGateSingleCore
 
 
-@pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("enable_sigmoid", [True])
-@pytest.mark.parametrize("seed", [42])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("enable_sigmoid", [True, False])
+@pytest.mark.parametrize("seed", [42, 201, 512])
 def test_deepseek_moe_gate(device, batch_size, enable_sigmoid, seed):
     """Test TTNN Deepseek Moe Gate operation on a 16x16 tile"""
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35573

### Problem description
High batch deepseek implementation requires batch > 1 support and WH support for deepseek_moe_gate. For batch support, we parallelize batch across cores, so each core runs batch 1.

### What's changed
Add WH support + batch support for high batch deepseek.
Differences between WH and BH are:
- Different code to load the replay buffers in the LLKs
- Adding some nops
- Use addr mod 3 instead of 7 for wh
- We cannot init recip ahead of time on WH since we would clobber the registers during earlier stages of the sorting algorithm, so we init recip right before executing recip. BH recip does not use those registers so it's safe to init ahead of time.
- There is a hardware bug affecting lregs4-7 when index tracking is enabled for certain instructions. We need to disable it during the reciprocal call since compiler could select these registers. For BH this did not happen but we apply the same change there for safety

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/wh-gate)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/wh-gate)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/wh-gate)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/wh-gate)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/wh-gate)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/wh-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/wh-gate)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs