### PR TITLE
Fix UDM tests

### DIFF
--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -97,6 +97,56 @@ jobs:
       run-multiprocess-tests: 'false'
       run-ccl-tests: 'false'
 
+  # Wormhole T3K - UDM tests (separate from t3000-fast-tests to avoid affecting other pipelines)
+  wh-t3k-udm-tests:
+    if: ${{ inputs.run-wh-t3k-fabric-tests }}
+    runs-on:
+      - tt-ubuntu-2204-N300-llmbox-stable
+    container:
+      image: harbor.ci.tenstorrent.net/${{ inputs.docker-image || 'docker-image-unresolved!'}}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: wormhole_b0
+        LOGURU_LEVEL: INFO
+        GTEST_OUTPUT: xml:/work/generated/test_reports/
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: --device /dev/tenstorrent
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    name: Wormhole T3K UDM tests
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run UDM tests
+        timeout-minutes: 30
+        run: |
+          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
+          ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
+          ./build/test/ttnn/unit_tests_ttnn_udm
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: U06MJ6CVCGZ # Yu Gao
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - name: Generate gtest annotations on failure
+        uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
+        if: ${{ failure() }}
+
   # Wormhole 6U - Galaxy Quick Health (most of quick-6u-health, skipping 2 tests)
   wh-6u-fabric-tests:
     if: ${{ inputs.run-wh-6u-fabric-tests }}
@@ -238,6 +288,14 @@ jobs:
           - name: fabric 2D fixture unit tests
             cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
             timeout: 15
+          - name: fabric UDM mode unit tests
+            cmd: |
+              ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
+              ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
+            timeout: 30
+          - name: ttnn UDM unit tests
+            cmd: ./build/test/ttnn/unit_tests_ttnn_udm
+            timeout: 30
           - name: fabric system health tests
             cmd: ./build/test/tt_metal/tt_fabric/test_system_health
             timeout: 15

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -292,10 +292,10 @@ jobs:
             cmd: |
               ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
               ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
-            timeout: 30
+            timeout: 15
           - name: ttnn UDM unit tests
             cmd: ./build/test/ttnn/unit_tests_ttnn_udm
-            timeout: 30
+            timeout: 10
           - name: fabric system health tests
             cmd: ./build/test/tt_metal/tt_fabric/test_system_health
             timeout: 15

--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -38,3 +38,11 @@ echo "Running fabric sanity tests now...";
 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
 
 ./build/test/tt_metal/tt_fabric/fabric_elastic_channels_host_test 8 2 16 4352 1 4096 10000 4 4
+
+#############################################
+# UDM MODE TESTS                            #
+#############################################
+echo "Running UDM mode tests now...";
+
+# UDM fabric API tests (basic tests that work with N300 2-chip config)
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"

--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -38,11 +38,3 @@ echo "Running fabric sanity tests now...";
 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
 
 ./build/test/tt_metal/tt_fabric/fabric_elastic_channels_host_test 8 2 16 4352 1 4096 10000 4 4
-
-#############################################
-# UDM MODE TESTS                            #
-#############################################
-echo "Running UDM mode tests now...";
-
-# UDM fabric API tests (basic tests that work with N300 2-chip config)
-./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -211,9 +211,10 @@ void FabricTensixDatamoverConfig::track_missing_directions_for_udm(
     }
 
     // For each active routing plane, check which of the 4 directions (E, W, N, S) are missing
+    // Skip Z direction - it's for 3D routing and not relevant for missing directions on a chip
     std::set<std::pair<routing_plane_id_t, eth_chan_directions>> missing_plane_dirs;
     for (auto routing_plane_id : active_routing_planes) {
-        for (uint8_t dir_idx = 0; dir_idx < eth_chan_directions::COUNT; dir_idx++) {
+        for (uint8_t dir_idx = 0; dir_idx < eth_chan_directions::Z; dir_idx++) {
             auto dir = static_cast<eth_chan_directions>(dir_idx);
             if (!active_plane_directions.contains({routing_plane_id, dir})) {
                 missing_plane_dirs.insert({routing_plane_id, dir});

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -423,12 +423,6 @@ std::vector<MuxConnectionInfo> FabricTensixDatamoverMuxConfig::get_all_mux_conne
         return std::vector<MuxConnectionInfo>();
     }
 
-    // Z direction muxes don't participate in inter-mux forwarding
-    // MUX_TO_MUX channels only support mesh directions (E/W/N/S)
-    if (direction == eth_chan_directions::Z) {
-        return std::vector<MuxConnectionInfo>();
-    }
-
     // UDM mode - collect downstream mux connection info
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
     const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
@@ -669,11 +663,6 @@ MuxConnectionInfo FabricTensixDatamoverRelayConfig::get_mux_connection_info(
 std::array<MuxConnectionInfo, FabricTensixDatamoverRelayConfig::NUM_MUX_CONNECTIONS>
 FabricTensixDatamoverRelayConfig::get_all_mux_connection_infos(
     const FabricNodeId& fabric_node_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
-    // Z direction relays don't have mux connections (perpendicular directions not defined for Z)
-    if (direction == eth_chan_directions::Z) {
-        return std::array<MuxConnectionInfo, NUM_MUX_CONNECTIONS>{};
-    }
-
     const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
     const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
 
@@ -1025,11 +1014,6 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
             // Relay-to-Mux channels: check if relays exist in perpendicular directions (UDM mode only)
             TT_FATAL(num_channels == 3, "RELAY_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
 
-            // Z direction muxes don't have relay connections (perpendicular directions not defined for Z)
-            if (direction_ == eth_chan_directions::Z) {
-                break;
-            }
-
             // Channel 0: Local relay (not persistent for non-active tensix core)
             const auto* noc_coords =
                 tensix_config.get_active_tensix_noc_coords(local_fabric_node_id_, link_idx_, direction_);
@@ -1056,12 +1040,6 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_persistent_channels_f
         case ChannelTypes::MUX_TO_MUX_CHANNEL: {
             // Mux-to-Mux channels: check if muxes exist in other directions (UDM mode only)
             TT_FATAL(num_channels == 3, "MUX_TO_MUX_CHANNEL should have exactly 3 channels (got {})", num_channels);
-
-            // Z direction muxes don't have inter-mux connections
-            // MUX_TO_MUX channels only support mesh directions (E/W/N/S)
-            if (direction_ == eth_chan_directions::Z) {
-                break;
-            }
 
             // Exclude Z direction - MUX mode only supports mesh directions (E/W/N/S)
             auto upstream_mux_dirs = builder::get_all_other_directions(direction_, /*exclude_z=*/true);


### PR DESCRIPTION
### Ticket
no ticket

### Problem description
main is broken for UDM tests, due to recent change of adding Z direction to eth channels, fix it by removing the Z direction when we build the missing directions for tensix builder.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yugao/fabric-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:yugao/fabric-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/fabric-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/fabric-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/fabric-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/fabric-fix)
- [ ] New/Existing tests provide coverage for changes