### PR TITLE
Fix Quasar JIT build so that kernels can compile on all DM cores

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -303,7 +303,9 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     env_(env),
     is_fw_(build_config.is_fw),
     process_defines_at_compile_(true),
-    dispatch_message_addr_(build_config.dispatch_message_addr),
+    core_type_(build_config.core_type),
+    processor_class_(build_config.processor_class),
+    processor_id_(build_config.processor_id),
     out_path_(build_config.is_fw ? env_.out_firmware_root_ : env_.out_kernel_root_),
     cflags_(env.cflags_),
     defines_(env.defines_),
@@ -326,10 +328,7 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     }
 
     HalJitBuildQueryInterface::Params params{
-        this->is_fw_,
-        build_config.core_type,
-        build_config.processor_class,
-        static_cast<uint32_t>(build_config.processor_id)};
+        this->is_fw_, this->core_type_, this->processor_class_, this->processor_id_};
     const auto& jit_build_query = tt_metal::MetalContext::instance().hal().get_jit_build_query();
 
     this->target_name_ = jit_build_query.target_name(params);
@@ -346,7 +345,7 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
         for (const auto& define : jit_build_query.defines(params)) {
             fmt::format_to(it, "-D{} ", define);
         }
-        fmt::format_to(it, "-DDISPATCH_MESSAGE_ADDR={} ", this->dispatch_message_addr_);
+        fmt::format_to(it, "-DDISPATCH_MESSAGE_ADDR={} ", build_config.dispatch_message_addr);
     }
     if (this->is_fw_) {
         this->defines_ += "-DFW_BUILD ";
@@ -582,8 +581,16 @@ void JitBuildState::weaken(const string& out_dir) const {
 }
 
 std::string JitBuildState::weakened_firmware_name() const {
+    const auto& jit_build_query = tt_metal::MetalContext::instance().hal().get_jit_build_query();
+    const std::string weakened_firmware_target_name = jit_build_query.weakened_firmware_target_name(
+        {this->is_fw_, this->core_type_, this->processor_class_, this->processor_id_});
     std::string_view name = this->firmware_is_kernel_object_ ? "object.o" : "weakened.elf";
-    return fmt::format("{}{}/{}_{}", this->env_.out_firmware_root_, this->target_name_, this->target_name_, name);
+    return fmt::format(
+        "{}{}/{}_{}",
+        this->env_.out_firmware_root_,
+        weakened_firmware_target_name,
+        weakened_firmware_target_name,
+        name);
 }
 
 void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const {

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -94,7 +94,10 @@ protected:
     bool is_fw_;
     bool process_defines_at_compile_{};
     bool firmware_is_kernel_object_{};
-    uint32_t dispatch_message_addr_;
+
+    HalProgrammableCoreType core_type_;
+    HalProcessorClassType processor_class_;
+    uint32_t processor_id_;
 
     std::string out_path_;
     std::string target_name_;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -267,6 +267,9 @@ public:
     // implementation of build, to avoid breaking users / tools.
     // We can migrate build to use arch-independent target names, and then this can be removed.
     virtual std::string target_name(const Params& params) const = 0;
+    // Returns the target name for the weakened firmware.
+    // This is usually the same as the target name, but in some cases, the target name for
+    // the weakened firmware may be different.
     virtual std::string weakened_firmware_target_name(const Params& params) const = 0;
 };
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -267,6 +267,7 @@ public:
     // implementation of build, to avoid breaking users / tools.
     // We can migrate build to use arch-independent target names, and then this can be removed.
     virtual std::string target_name(const Params& params) const = 0;
+    virtual std::string weakened_firmware_target_name(const Params& params) const = 0;
 };
 
 class Hal {

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -155,4 +155,8 @@ std::string HalJitBuildQueryBase::target_name(const HalJitBuildQueryInterface::P
     }
 }
 
+std::string HalJitBuildQueryBase::weakened_firmware_target_name(const HalJitBuildQueryInterface::Params& params) const {
+    return target_name(params);
+}
+
 }  // namespace tt::tt_metal::hal_1xx

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.hpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.hpp
@@ -15,6 +15,7 @@ public:
     std::vector<std::string> defines(const Params& params) const override;
     std::vector<std::string> srcs(const Params& params) const override;
     std::string target_name(const Params& params) const override;
+    std::string weakened_firmware_target_name(const Params& params) const override;
 };
 
 }  // namespace tt::tt_metal::hal_1xx

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -128,4 +128,8 @@ std::string HalJitBuildQueryBase::target_name(const HalJitBuildQueryInterface::P
     }
 }
 
+std::string HalJitBuildQueryBase::weakened_firmware_target_name(const HalJitBuildQueryInterface::Params&) const {
+    return "dm0";
+}
+
 }  // namespace tt::tt_metal::hal_2xx

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.hpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.hpp
@@ -13,6 +13,7 @@ public:
     std::vector<std::string> defines(const Params& params) const override;
     std::vector<std::string> srcs(const Params& params) const override;
     std::string target_name(const Params& params) const override;
+    std::string weakened_firmware_target_name(const Params& params) const override;
 };
 
 }  // namespace tt::tt_metal::hal_2xx


### PR DESCRIPTION
This PR fixes a bug with JIT build for Quasar that was only allowing kernels to be compiled for DM0; compilation was failing for the other DM cores. With this fix, kernels can be built for all DM cores.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sagarwal/quasar_fix_fw_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sagarwal/quasar_fix_fw_build)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/quasar_fix_fw_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/quasar_fix_fw_build)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/quasar_fix_fw_build)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/quasar_fix_fw_build)
- [x] New/Existing tests provide coverage for changes