### PR TITLE
Remove batched matmul from prefetcher unit tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -35,7 +35,6 @@ def run_prefetcher_mm(
     dtypes,
     is_functional_test=False,
     enable_performance_mode=False,
-    batch_weights=False,
 ):
     logger.info(f"Running test_run_prefetcher with num_tensors={num_tensors}, num_layers={num_layers}")
     assert len(input_shapes) == len(dtypes)
@@ -271,9 +270,6 @@ def run_prefetcher_mm(
     prev_in0 = torch.randn(prev_shape)
     for shape, shard_shape in zip(in0_shapes, shard_shapes):
         in0 = torch.randn(shape)
-        if batch_weights and prev_shape == shape:
-            in0 = prev_in0
-            prev_shape = shape
         in0_tensors.append(in0)
 
         _, _, M, _ = shape
@@ -341,33 +337,18 @@ def run_prefetcher_mm(
             t = 0
             while t < num_tensors:
                 idx = l * num_tensors + t
-                if batch_weights and t < num_tensors - 1 and in0_t_tensors[t].shape == in0_t_tensors[t + 1].shape:
-                    logger.info(f"running matmul_batched_weights for layer {l}, tensor {t} and tensor {t+1}")
-                    [output_t1, output_t2] = ttnn.matmul_batched_weights(
-                        in0_t_tensors[t],
-                        [tt_tensors_all[idx], tt_tensors_all[idx + 1]],
-                        program_config=program_configs[t],
-                        memory_config=output_mem_configs[t],
-                        compute_kernel_config=compute_kernel_config,
-                        global_cb=global_circular_buffer,
-                        sub_device_id=worker_sub_device_id,
-                    )
-                    outputs_l1.append(output_t1)
-                    outputs_l1.append(output_t2)
-                    t += 2
-                else:
-                    logger.info(f"running normal matmul for layer {l}, tensor {t}")
-                    output_t = ttnn.matmul(
-                        in0_t_tensors[t],
-                        tt_tensors_all[idx],
-                        program_config=program_configs[t],
-                        memory_config=output_mem_configs[t],
-                        compute_kernel_config=compute_kernel_config,
-                        global_cb=global_circular_buffer,
-                        sub_device_id=worker_sub_device_id,
-                    )
-                    outputs_l1.append(output_t)
-                    t += 1
+                logger.info(f"running normal matmul for layer {l}, tensor {t}")
+                output_t = ttnn.matmul(
+                    in0_t_tensors[t],
+                    tt_tensors_all[idx],
+                    program_config=program_configs[t],
+                    memory_config=output_mem_configs[t],
+                    compute_kernel_config=compute_kernel_config,
+                    global_cb=global_circular_buffer,
+                    sub_device_id=worker_sub_device_id,
+                )
+                outputs_l1.append(output_t)
+                t += 1
             # Send outputs to DRAM to so that we don't run out of L1 memory when testing for large number of layers
             for t in range(num_tensors):
                 outputs_dram.append(ttnn.to_memory_config(outputs_l1[t], ttnn.DRAM_MEMORY_CONFIG))

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
@@ -91,17 +91,16 @@ def test_run_prefetcher(
 
 
 @pytest.mark.parametrize(
-    "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers, batch_weights",
+    "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers",
     [
-        (2, 2, [(128, 128), (128, 128)], [ttnn.bfloat4_b] * 2, 2, True),
-        (2, 2, [(256, 1024), (256, 1024)], [ttnn.bfloat4_b] * 2, 5, True),
+        (2, 2, [(128, 128), (128, 128)], [ttnn.bfloat4_b] * 2, 2),
+        (2, 2, [(256, 1024), (256, 1024)], [ttnn.bfloat4_b] * 2, 5),
         (
             12,
             5,
             [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
             [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
             5,
-            True,
         ),  # qkv + do + ff1 + ff3 + ff2
         # Takes really long to set up
         (
@@ -110,7 +109,6 @@ def test_run_prefetcher(
             [(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)],
             [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
             80,
-            True,
         ),  # qkv + do + ff1 + ff3 + ff2
     ],
 )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py
@@ -90,61 +90,6 @@ def test_run_prefetcher(
     )
 
 
-@pytest.mark.parametrize(
-    "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers",
-    [
-        (2, 2, [(128, 128), (128, 128)], [ttnn.bfloat4_b] * 2, 2),
-        (2, 2, [(256, 1024), (256, 1024)], [ttnn.bfloat4_b] * 2, 5),
-        (
-            12,
-            5,
-            [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
-            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
-            5,
-        ),  # qkv + do + ff1 + ff3 + ff2
-        # Takes really long to set up
-        (
-            12,
-            5,
-            [(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)],
-            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
-            80,
-        ),  # qkv + do + ff1 + ff3 + ff2
-    ],
-)
-@pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
-@pytest.mark.parametrize(
-    "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
-    indirect=True,
-)
-def test_run_prefetcher_batched_weights(
-    mesh_device,
-    num_tensors,
-    input_shapes,
-    num_layers,
-    batch_weights,
-    num_reader_cores,
-    dtypes,
-    function_level_defaults,
-):
-    device = mesh_device
-    # Only run these tests on unharvested TG
-    device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
-    if device_grid != (7, 10):
-        pytest.skip("Skipping test_run_prefetcher because it only works with a 7x10 grid")
-
-    run_prefetcher_mm(
-        mesh_device,
-        num_tensors,
-        input_shapes,
-        num_layers,
-        num_reader_cores,
-        dtypes,
-        batch_weights=batch_weights,
-    )
-
-
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
 @pytest.mark.parametrize(
     "device_params",


### PR DESCRIPTION
### Ticket
Prefetcher unit tests were failing in upstream container because of this error: 
```
FAILED tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py::test_run_prefetcher_batched_weights[silicon_arch_name=wormhole_b0-device_params={'dispatch_core_axis': DispatchCoreAxis.COL, 'trace_region_size': 23887872}-2x2_grid-num_reader_cores=12-num_tensors=5-input_shapes=[(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)]-dtypes=[DataType.BFLOAT8_B, DataType.BFLOAT8_B, DataType.BFLOAT4_B, DataType.BFLOAT4_B, DataType.BFLOAT8_B]-num_layers=80-batch_weights=True] - RuntimeError: TT_FATAL @ /project/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp:121: optional_input_tensors.size() == 1
info:
Must have exactly 1 optional input tensor, got: 0
```

### Problem description
This is because the op batched weights matmul no longer expects multiple in1 weights and doesnt seem to exist anymore, further more we do not run the model with this setting so we just remove this codepath.
 
### What's changed
- remove usage of this op

### Checklist
- [ ] [Galaxy unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21153459005)