### PR TITLE
allgather start barrier uses both ring directions instead of just one

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -355,8 +355,8 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         sender_device_coord,
         forward_coord,
         backward_coord,
-        topology == ccl::Topology::Linear ? num_targets_forward : ring_size - 1,
-        topology == ccl::Topology::Linear ? num_targets_backward : ring_size - 1,
+        num_targets_forward,
+        num_targets_backward,
         mesh_device);
 
     TT_FATAL(


### PR DESCRIPTION
Additionally, would improve the latency of the barrier.

Based on inspection, the prior barrier implementation looks like it may be double incrementing semaphores and rather than doing exact `wait` does `wait_min`. The bad practice of using `wait_min` in the op kernel for this barrier purpose is not addressed in this PR.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/34895#issuecomment-3746768360

### Checklist
- [ ] All Post CommitL: https://github.com/tenstorrent/tt-metal/actions/runs/21153789626
- [ ] Blackhole Post Commit: https://github.com/tenstorrent/tt-metal/actions/runs/21153792671