### PR TITLE
Support batch broadcasting for mask in SDPA

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -163,6 +163,7 @@ def run_sdpa_noncausal(
     sk=None,
     use_mask=True,
     rmse_threshold=None,
+    bcast_mask_batch_dim=False,
     bcast_mask_head_dim=True,
 ):
     torch.manual_seed(1234)
@@ -193,7 +194,7 @@ def run_sdpa_noncausal(
         mask = torch.bernoulli(
             torch.full(
                 (
-                    b,
+                    1 if bcast_mask_batch_dim else b,
                     1 if bcast_mask_head_dim else nh,
                     sq,
                     sk,
@@ -478,8 +479,21 @@ def test_sdpa_noncausal_unequal_seqlen(device, b, nh, nkv, sq, sk, d, q_chunk_si
         [1, 16, 16, 128, 64],  # Boltz
     ),
 )
+@pytest.mark.parametrize("bcast_mask_batch_dim", [True, False], ids=["bcast-mask-batch-dim", "no-bcast-mask-batch-dim"])
 @pytest.mark.parametrize("bcast_mask_head_dim", [True, False], ids=["bcast-mask-head-dim", "no-bcast-mask-head-dim"])
-def test_sdpa_noncausal_mask(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, bcast_mask_head_dim):
+def test_sdpa_noncausal_mask(
+    device,
+    b,
+    nh,
+    nkv,
+    s,
+    d,
+    q_chunk_size,
+    k_chunk_size,
+    dtype,
+    bcast_mask_batch_dim,
+    bcast_mask_head_dim,
+):
     rmse_threshold = 0.007
     run_sdpa_noncausal(
         device,
@@ -493,6 +507,7 @@ def test_sdpa_noncausal_mask(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_siz
         dtype,
         rmse_threshold=rmse_threshold,
         use_mask=True,
+        bcast_mask_batch_dim=bcast_mask_batch_dim,
         bcast_mask_head_dim=bcast_mask_head_dim,
     )
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -23,14 +23,15 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_compile_time_arg_val(13);
     constexpr uint32_t is_causal = get_compile_time_arg_val(14) == 1;
     constexpr uint32_t use_provided_mask = get_compile_time_arg_val(15) == 1;
-    constexpr uint32_t broadcast_provided_mask_heads = get_compile_time_arg_val(16) == 1;
-    constexpr uint32_t use_padded_mask = get_compile_time_arg_val(17) == 1;
-    constexpr uint32_t is_chunked = get_compile_time_arg_val(18) == 1;
-    constexpr uint32_t block_size_t = get_compile_time_arg_val(19);
-    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(20);
-    constexpr uint32_t use_attention_sink = get_compile_time_arg_val(21) == 1;
+    constexpr uint32_t broadcast_provided_mask_batch = get_compile_time_arg_val(16) == 1;
+    constexpr uint32_t broadcast_provided_mask_heads = get_compile_time_arg_val(17) == 1;
+    constexpr uint32_t use_padded_mask = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t is_chunked = get_compile_time_arg_val(19) == 1;
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(20);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(21);
+    constexpr uint32_t use_attention_sink = get_compile_time_arg_val(22) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<22>();
+    constexpr auto q_args = TensorAccessorArgs<23>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -130,9 +131,18 @@ void kernel_main() {
                 page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
             }
 
-            uint32_t mask_batch_offset = nb * Sqt * Skt;
-            if constexpr (!broadcast_provided_mask_heads) {
-                mask_batch_offset *= NQH;
+            // Calculate mask batch offset based on broadcasting:
+            // - If batch is broadcasted [1 x ...]: always use batch=0, so offset = 0
+            // - If batch is not broadcasted [b x ...]: use actual batch nb
+            uint32_t mask_batch_offset = 0;
+            if constexpr (!broadcast_provided_mask_batch) {
+                if constexpr (broadcast_provided_mask_heads) {
+                    // [b x 1 x s x s]: batch offset without head factor
+                    mask_batch_offset = nb * Sqt * Skt;
+                } else {
+                    // [b x h x s x s]: batch offset with all heads
+                    mask_batch_offset = nb * Sqt * Skt * NQH;
+                }
             }
             for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
                 // Read attention sink for this Q chunk if enabled

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -263,6 +263,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         num_cores,
         true,                  //(std::uint32_t)is_causal,
         false,                 //(std::uint32_t)use_provided_mask,
+        false,                 //(std::uint32_t)broadcast_provided_mask_batch,
         false,                 //(std::uint32_t)broadcast_provided_mask_heads,
         false,                 //(std::uint32_t)use_padded_mask,
         (uint32_t)is_chunked,  //(uint32_t)is_chunked,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -101,7 +101,10 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
             const auto q_shape = q.logical_shape();
             const auto k_shape = k.logical_shape();
 
-            TT_FATAL(mask_shape[0] == q_shape[0], "Mask batch dim must match Q batch dim");
+            TT_FATAL(
+                mask_shape[0] == 1 || mask_shape[0] == q_shape[0],
+                "Mask batch dim must either be 1 (to be broadcasted across all batches) or must match Q batch "
+                "dimension");
             TT_FATAL(
                 mask_shape[1] == 1 || mask_shape[1] == q_shape[1],
                 "Mask num_heads must either be 1 (to be broadcasted across all heads) or must match Q heads dimension");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -93,7 +93,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t q_num_chunks = padded_Sq / q_chunk_size;
     const uint32_t k_num_chunks = padded_Sk / k_chunk_size;
     const bool use_provided_mask = attn_mask.has_value();
-    const bool broadcast_provided_mask_heads = use_provided_mask ? (attn_mask.value().logical_shape()[1] == 1) : true;
+    const bool broadcast_provided_mask_batch = use_provided_mask ? (attn_mask.value().logical_shape()[0] == 1) : false;
+    const bool broadcast_provided_mask_heads = use_provided_mask ? (attn_mask.value().logical_shape()[1] == 1) : false;
 
     // log_debug all of the above
     log_debug(tt::LogOp, "B: {}", B);
@@ -363,6 +364,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                                                       num_cores,
                                                       (std::uint32_t)is_causal,
                                                       (std::uint32_t)use_provided_mask,
+                                                      (std::uint32_t)broadcast_provided_mask_batch,
                                                       (std::uint32_t)broadcast_provided_mask_heads,
                                                       (std::uint32_t)use_padded_mask,
                                                       (uint32_t)is_chunked,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -34,7 +34,7 @@ void bind_sdpa(nb::module_& mod) {
             input_tensor_v (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
 
         Keyword args:
-            attn_mask (ttnn.Tensor, optional): Defaults to `None`. Either [b x 1 x s x s] with head broadcasting implied or [b x nqh x s x s].
+            attn_mask (ttnn.Tensor, optional): Defaults to `None`. Shape [b x nqh x s x s] where batch and head dims can each be 1 for broadcasting.
             is_causal (bool): Defaults to `true`.
             scale (float, optional): Defaults to `None`.
             sliding_window_size (int, optional): Defaults to `None`. Size of sliding window for attention. If provided && is_causal, only attends to the last `sliding_window_size` tokens. If provided && !is_causal, attends to a window of size `sliding_window_size` centered at the current position.


### PR DESCRIPTION
### Ticket
Closes #36088

### Problem description
The current `ttnn.transformer.scaled_dot_product_attention` op restricts attn_mask to either `[b x 1 x s x s]` or `[b x nqh x s x s]`. This adds support for batch broadcasting (`[1 x nqh x s x s]`) . This is required in TT-Boltz.

### What's changed

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moritztng/36088_sdpa-mask-batch-broadcasting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moritztng/36088_sdpa-mask-batch-broadcasting)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs