### PR TITLE
Add sub-mesh tests for galaxy didt/power tests

### DIFF
--- a/tests/didt/test_duty_cycle.py
+++ b/tests/didt/test_duty_cycle.py
@@ -206,6 +206,9 @@ def test_duty_cycle(
         pytest.param((4, 2), id="4x2"),
         pytest.param((8, 1), id="8x1"),
         pytest.param((8, 2), id="8x2"),
+        pytest.param((8, 3), id="8x3"),
+        pytest.param((6, 4), id="6x4"),
+        pytest.param((8, 4), id="8x4"),
     ],
 )
 @pytest.mark.parametrize(
@@ -249,8 +252,11 @@ def test_mesh_size_duty_cycle(
     non_mm_loops,
     wl_loops,
 ):
-    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
-        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
+        pytest.skip(
+            f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"
+        )
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
     test_duty_cycle(sub_mesh_device, didt_workload_iterations, determinism_check_interval, non_mm_loops, wl_loops)

--- a/tests/didt/test_duty_cycle.py
+++ b/tests/didt/test_duty_cycle.py
@@ -5,6 +5,7 @@ import os
 from loguru import logger
 import pytest
 import torch
+import random
 
 from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
@@ -189,3 +190,109 @@ def test_duty_cycle(
 
     # Run test
     duty_cycle_test.run_op_test()
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "sub_mesh_shape",
+    [
+        pytest.param((4, 1), id="4x1"),
+        pytest.param((4, 2), id="4x2"),
+        pytest.param((8, 1), id="8x1"),
+        pytest.param((8, 2), id="8x2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_coordinate",
+    [
+        pytest.param((0, 0), id="0-0"),
+        pytest.param((4, 0), id="4-0"),
+        pytest.param((0, 1), id="0-1"),
+        pytest.param((4, 1), id="4-1"),
+        pytest.param((0, 2), id="0-2"),
+        pytest.param((4, 2), id="4-2"),
+        pytest.param((0, 3), id="0-3"),
+        pytest.param((4, 3), id="4-3"),
+    ],
+)
+# number of workload repetitions (of alternating mm/non-mm workloads)
+@pytest.mark.parametrize(
+    "wl_loops",
+    [100, 1000, 10000],
+    ids=["rep-100x", "rep-1000x", "rep-10000x"],
+)
+# the number of non-mm loops within each iteration (increasing this lowers the duty cycle)
+@pytest.mark.parametrize(
+    "non_mm_loops",
+    [
+        (1),
+        (2),
+        (3),
+        (4),
+        (5),
+        (6),
+    ],
+    ids=["duty-1", "duty-2", "duty-3", "duty-4", "duty-5", "duty-6"],
+)
+def test_mesh_size_duty_cycle(
+    mesh_device,
+    sub_mesh_shape,
+    mesh_coordinate,
+    didt_workload_iterations,
+    determinism_check_interval,
+    non_mm_loops,
+    wl_loops,
+):
+    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
+        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_duty_cycle(sub_mesh_device, didt_workload_iterations, determinism_check_interval, non_mm_loops, wl_loops)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+# number of workload repetitions (of alternating mm/non-mm workloads)
+@pytest.mark.parametrize(
+    "wl_loops",
+    [100, 1000, 10000],
+    ids=["rep-100x", "rep-1000x", "rep-10000x"],
+)
+# the number of non-mm loops within each iteration (increasing this lowers the duty cycle)
+@pytest.mark.parametrize(
+    "non_mm_loops",
+    [
+        (1),
+        (2),
+        (3),
+        (4),
+        (5),
+        (6),
+    ],
+    ids=["duty-1", "duty-2", "duty-3", "duty-4", "duty-5", "duty-6"],
+)
+def test_random_mesh_size_duty_cycle(
+    mesh_device, didt_workload_iterations, determinism_check_interval, non_mm_loops, wl_loops
+):
+    # generate random sub-mesh shape and mesh coordinate
+    valid_sub_mesh_shapes = [(x, y) for x in range(1, MESH_X + 1) for y in range(1, MESH_Y + 1)]
+    sub_mesh_shape = random.choice(valid_sub_mesh_shapes)
+    valid_mesh_coordinates = [
+        (x, y) for x in range(0, MESH_X + 1 - sub_mesh_shape[0]) for y in range(0, MESH_Y + 1 - sub_mesh_shape[1])
+    ]
+    mesh_coordinate = random.choice(valid_mesh_coordinates)
+
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_duty_cycle(sub_mesh_device, didt_workload_iterations, determinism_check_interval, non_mm_loops, wl_loops)

--- a/tests/didt/test_duty_cycle.py
+++ b/tests/didt/test_duty_cycle.py
@@ -252,7 +252,7 @@ def test_mesh_size_duty_cycle(
     non_mm_loops,
     wl_loops,
 ):
-    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate can fit within the parent mesh of MESH_X by MESH_Y
     if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
         pytest.skip(
             f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"

--- a/tests/didt/test_ff1_matmul.py
+++ b/tests/didt/test_ff1_matmul.py
@@ -235,12 +235,7 @@ def test_specific_board_ff1_matmul(
     determinism_check_interval,
 ):
     test_ff1_matmul(
-        t3k_single_board_mesh_device,
-        gelu,
-        math_fidelity,
-        didt_workload_iterations,
-        determinism_check_interval,
-        False,
+        t3k_single_board_mesh_device, gelu, math_fidelity, didt_workload_iterations, determinism_check_interval
     )
 
 
@@ -274,7 +269,6 @@ def test_grid_size_ff1_matmul(
         math_fidelity,
         didt_workload_iterations,
         determinism_check_interval,
-        False,
         grid_size=grid_size,
     )
 
@@ -310,7 +304,6 @@ def test_blackhole_grid_size_ff1_matmul(
         math_fidelity,
         didt_workload_iterations,
         determinism_check_interval,
-        False,
         grid_size=grid_size,
     )
 
@@ -361,7 +354,7 @@ def test_mesh_size_ff1_matmul(
     didt_workload_iterations,
     determinism_check_interval,
 ):
-    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate can fit within the parent mesh of MESH_X by MESH_Y
     if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
         pytest.skip(
             f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"

--- a/tests/didt/test_ff1_matmul.py
+++ b/tests/didt/test_ff1_matmul.py
@@ -334,6 +334,9 @@ def test_blackhole_grid_size_ff1_matmul(
         pytest.param((4, 2), id="4x2"),
         pytest.param((8, 1), id="8x1"),
         pytest.param((8, 2), id="8x2"),
+        pytest.param((8, 3), id="8x3"),
+        pytest.param((6, 4), id="6x4"),
+        pytest.param((8, 4), id="8x4"),
     ],
 )
 @pytest.mark.parametrize(
@@ -358,8 +361,11 @@ def test_mesh_size_ff1_matmul(
     didt_workload_iterations,
     determinism_check_interval,
 ):
-    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
-        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
+        pytest.skip(
+            f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"
+        )
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
     test_ff1_matmul(sub_mesh_device, gelu, math_fidelity, didt_workload_iterations, determinism_check_interval)

--- a/tests/didt/test_ff1_matmul.py
+++ b/tests/didt/test_ff1_matmul.py
@@ -5,6 +5,7 @@ import os
 from loguru import logger
 import pytest
 import torch
+import random
 
 from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
@@ -312,3 +313,81 @@ def test_blackhole_grid_size_ff1_matmul(
         False,
         grid_size=grid_size,
     )
+
+
+@pytest.mark.parametrize(
+    "gelu, math_fidelity",
+    GELU_FIDELITY_PARAMETRIZATION,
+    ids=GELU_FIDELITY_PARAMETRIZATION_IDS,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "sub_mesh_shape",
+    [
+        pytest.param((4, 1), id="4x1"),
+        pytest.param((4, 2), id="4x2"),
+        pytest.param((8, 1), id="8x1"),
+        pytest.param((8, 2), id="8x2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_coordinate",
+    [
+        pytest.param((0, 0), id="0-0"),
+        pytest.param((4, 0), id="4-0"),
+        pytest.param((0, 1), id="0-1"),
+        pytest.param((4, 1), id="4-1"),
+        pytest.param((0, 2), id="0-2"),
+        pytest.param((4, 2), id="4-2"),
+        pytest.param((0, 3), id="0-3"),
+        pytest.param((4, 3), id="4-3"),
+    ],
+)
+def test_mesh_size_ff1_matmul(
+    mesh_device,
+    sub_mesh_shape,
+    mesh_coordinate,
+    gelu,
+    math_fidelity,
+    didt_workload_iterations,
+    determinism_check_interval,
+):
+    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
+        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_ff1_matmul(sub_mesh_device, gelu, math_fidelity, didt_workload_iterations, determinism_check_interval)
+
+
+@pytest.mark.parametrize(
+    "gelu, math_fidelity",
+    GELU_FIDELITY_PARAMETRIZATION,
+    ids=GELU_FIDELITY_PARAMETRIZATION_IDS,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_random_mesh_size_ff1_matmul(
+    mesh_device, gelu, math_fidelity, didt_workload_iterations, determinism_check_interval
+):
+    # generate random sub-mesh shape and mesh coordinate
+    valid_sub_mesh_shapes = [(x, y) for x in range(1, MESH_X + 1) for y in range(1, MESH_Y + 1)]
+    sub_mesh_shape = random.choice(valid_sub_mesh_shapes)
+    valid_mesh_coordinates = [
+        (x, y) for x in range(0, MESH_X + 1 - sub_mesh_shape[0]) for y in range(0, MESH_Y + 1 - sub_mesh_shape[1])
+    ]
+    mesh_coordinate = random.choice(valid_mesh_coordinates)
+
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_ff1_matmul(sub_mesh_device, gelu, math_fidelity, didt_workload_iterations, determinism_check_interval)

--- a/tests/didt/test_lm_head_matmul.py
+++ b/tests/didt/test_lm_head_matmul.py
@@ -236,6 +236,9 @@ def test_blackhole_grid_size_lm_head_matmul(
         pytest.param((4, 2), id="4x2"),
         pytest.param((8, 1), id="8x1"),
         pytest.param((8, 2), id="8x2"),
+        pytest.param((8, 3), id="8x3"),
+        pytest.param((6, 4), id="6x4"),
+        pytest.param((8, 4), id="8x4"),
     ],
 )
 @pytest.mark.parametrize(
@@ -254,8 +257,11 @@ def test_blackhole_grid_size_lm_head_matmul(
 def test_mesh_size_lm_head_matmul(
     mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
 ):
-    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
-        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
+        pytest.skip(
+            f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"
+        )
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
     test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval, False)

--- a/tests/didt/test_lm_head_matmul.py
+++ b/tests/didt/test_lm_head_matmul.py
@@ -162,7 +162,6 @@ def test_specific_chip_lm_head_matmul(
         mesh_device.get_device(logical_chip_id),
         didt_workload_iterations,
         determinism_check_interval,
-        False,
     )
 
 
@@ -176,7 +175,7 @@ def test_specific_chip_lm_head_matmul(
 def test_specific_board_lm_head_matmul(
     t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval
 ):
-    test_lm_head_matmul(t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval, False)
+    test_lm_head_matmul(t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval)
 
 
 @skip_for_blackhole("Use test_blackhole_grid_size_lm_head_matmul test for blackhole!")
@@ -196,7 +195,7 @@ def test_specific_board_lm_head_matmul(
     indirect=["mesh_device"],
 )
 def test_grid_size_lm_head_matmul(mesh_device, grid_size, didt_workload_iterations, determinism_check_interval):
-    test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, False, grid_size=grid_size)
+    test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, grid_size=grid_size)
 
 
 @skip_for_wormhole_b0("Use test_grid_size_lm_head_matmul for blackhole!")
@@ -219,7 +218,7 @@ def test_grid_size_lm_head_matmul(mesh_device, grid_size, didt_workload_iteratio
 def test_blackhole_grid_size_lm_head_matmul(
     mesh_device, grid_size, didt_workload_iterations, determinism_check_interval
 ):
-    test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, False, grid_size=grid_size)
+    test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, grid_size=grid_size)
 
 
 @pytest.mark.parametrize(
@@ -257,14 +256,14 @@ def test_blackhole_grid_size_lm_head_matmul(
 def test_mesh_size_lm_head_matmul(
     mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
 ):
-    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate can fit within the parent mesh of MESH_X by MESH_Y
     if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
         pytest.skip(
             f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"
         )
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
-    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval, False)
+    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval)
 
 
 @pytest.mark.parametrize(
@@ -285,4 +284,4 @@ def test_random_mesh_size_lm_head_matmul(mesh_device, didt_workload_iterations, 
 
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
-    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval, False)
+    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval)

--- a/tests/didt/test_lm_head_matmul.py
+++ b/tests/didt/test_lm_head_matmul.py
@@ -5,6 +5,7 @@ import os
 from loguru import logger
 import pytest
 import torch
+import random
 
 from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
@@ -219,3 +220,63 @@ def test_blackhole_grid_size_lm_head_matmul(
     mesh_device, grid_size, didt_workload_iterations, determinism_check_interval
 ):
     test_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval, False, grid_size=grid_size)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "sub_mesh_shape",
+    [
+        pytest.param((4, 1), id="4x1"),
+        pytest.param((4, 2), id="4x2"),
+        pytest.param((8, 1), id="8x1"),
+        pytest.param((8, 2), id="8x2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_coordinate",
+    [
+        pytest.param((0, 0), id="0-0"),
+        pytest.param((4, 0), id="4-0"),
+        pytest.param((0, 1), id="0-1"),
+        pytest.param((4, 1), id="4-1"),
+        pytest.param((0, 2), id="0-2"),
+        pytest.param((4, 2), id="4-2"),
+        pytest.param((0, 3), id="0-3"),
+        pytest.param((4, 3), id="4-3"),
+    ],
+)
+def test_mesh_size_lm_head_matmul(
+    mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
+):
+    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
+        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval, False)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_random_mesh_size_lm_head_matmul(mesh_device, didt_workload_iterations, determinism_check_interval):
+    # generate random sub-mesh shape and mesh coordinate
+    valid_sub_mesh_shapes = [(x, y) for x in range(1, MESH_X + 1) for y in range(1, MESH_Y + 1)]
+    sub_mesh_shape = random.choice(valid_sub_mesh_shapes)
+    valid_mesh_coordinates = [
+        (x, y) for x in range(0, MESH_X + 1 - sub_mesh_shape[0]) for y in range(0, MESH_Y + 1 - sub_mesh_shape[1])
+    ]
+    mesh_coordinate = random.choice(valid_mesh_coordinates)
+
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_lm_head_matmul(sub_mesh_device, didt_workload_iterations, determinism_check_interval, False)

--- a/tests/didt/test_resnet_conv.py
+++ b/tests/didt/test_resnet_conv.py
@@ -267,12 +267,7 @@ def test_resnet_conv(mesh_device, didt_workload_iterations, determinism_check_in
 def test_specific_chip_resnet_conv(mesh_device, logical_chip_id, didt_workload_iterations, determinism_check_interval):
     assert len(mesh_device.get_device_ids()) > logical_chip_id, "Not enough devices!"
 
-    test_resnet_conv(
-        mesh_device.get_device(logical_chip_id),
-        didt_workload_iterations,
-        determinism_check_interval,
-        False,
-    )
+    test_resnet_conv(mesh_device.get_device(logical_chip_id), didt_workload_iterations, determinism_check_interval)
 
 
 @skip_for_blackhole("Multi-board Blackhole has not been tested")
@@ -323,7 +318,7 @@ def test_specific_board_resnet_conv(t3k_single_board_mesh_device, didt_workload_
 def test_mesh_size_resnet_conv(
     mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
 ):
-    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate can fit within the parent mesh of MESH_X by MESH_Y
     if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
         pytest.skip(
             f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"

--- a/tests/didt/test_resnet_conv.py
+++ b/tests/didt/test_resnet_conv.py
@@ -302,6 +302,9 @@ def test_specific_board_resnet_conv(t3k_single_board_mesh_device, didt_workload_
         pytest.param((4, 2), id="4x2"),
         pytest.param((8, 1), id="8x1"),
         pytest.param((8, 2), id="8x2"),
+        pytest.param((8, 3), id="8x3"),
+        pytest.param((6, 4), id="6x4"),
+        pytest.param((8, 4), id="8x4"),
     ],
 )
 @pytest.mark.parametrize(
@@ -320,8 +323,11 @@ def test_specific_board_resnet_conv(t3k_single_board_mesh_device, didt_workload_
 def test_mesh_size_resnet_conv(
     mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
 ):
-    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
-        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    # check that sub-mesh with sub_mesh_shape and mesh_coordinate is can fit within the parent mesh of MESH_X by MESH_Y
+    if mesh_coordinate[0] + sub_mesh_shape[0] > MESH_X or mesh_coordinate[1] + sub_mesh_shape[1] > MESH_Y:
+        pytest.skip(
+            f"Sub-mesh {sub_mesh_shape} at mesh coordinate {mesh_coordinate} does not fit within parent mesh-device: {MESH_X} by {MESH_Y}"
+        )
     sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
     logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
     test_resnet_conv(sub_mesh_device, didt_workload_iterations, determinism_check_interval)

--- a/tests/didt/test_resnet_conv.py
+++ b/tests/didt/test_resnet_conv.py
@@ -6,6 +6,7 @@ import os
 from loguru import logger
 import pytest
 import torch
+import random
 
 from tests.didt.op_test_base import OpTestBase, get_blackhole_grid_size
 import ttnn
@@ -283,4 +284,66 @@ def test_specific_chip_resnet_conv(mesh_device, logical_chip_id, didt_workload_i
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_specific_board_resnet_conv(t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval):
-    test_resnet_conv(t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval, False)
+    test_resnet_conv(t3k_single_board_mesh_device, didt_workload_iterations, determinism_check_interval)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "sub_mesh_shape",
+    [
+        pytest.param((4, 1), id="4x1"),
+        pytest.param((4, 2), id="4x2"),
+        pytest.param((8, 1), id="8x1"),
+        pytest.param((8, 2), id="8x2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_coordinate",
+    [
+        pytest.param((0, 0), id="0-0"),
+        pytest.param((4, 0), id="4-0"),
+        pytest.param((0, 1), id="0-1"),
+        pytest.param((4, 1), id="4-1"),
+        pytest.param((0, 2), id="0-2"),
+        pytest.param((4, 2), id="4-2"),
+        pytest.param((0, 3), id="0-3"),
+        pytest.param((4, 3), id="4-3"),
+    ],
+)
+def test_mesh_size_resnet_conv(
+    mesh_device, sub_mesh_shape, mesh_coordinate, didt_workload_iterations, determinism_check_interval
+):
+    if mesh_coordinate[0] == 4 and sub_mesh_shape[0] == 8:
+        pytest.skip("Sub-mesh x coordinate cannot be 4 if sub-mesh x dimension is 8")
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_resnet_conv(sub_mesh_device, didt_workload_iterations, determinism_check_interval)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((MESH_X, MESH_Y), id="all"),
+    ],
+    indirect=["mesh_device"],
+)
+def test_random_mesh_size_resnet_conv(mesh_device, didt_workload_iterations, determinism_check_interval):
+    # generate random sub-mesh shape and mesh coordinate
+    valid_sub_mesh_shapes = [(x, y) for x in range(1, MESH_X + 1) for y in range(1, MESH_Y + 1)]
+    sub_mesh_shape = random.choice(valid_sub_mesh_shapes)
+    valid_mesh_coordinates = [
+        (x, y) for x in range(0, MESH_X + 1 - sub_mesh_shape[0]) for y in range(0, MESH_Y + 1 - sub_mesh_shape[1])
+    ]
+    mesh_coordinate = random.choice(valid_mesh_coordinates)
+
+    sub_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(sub_mesh_shape), ttnn.MeshCoordinate(mesh_coordinate))
+    logger.info(f"Running on {sub_mesh_shape} sub-mesh at mesh coordinate {mesh_coordinate}")
+    test_resnet_conv(sub_mesh_device, didt_workload_iterations, determinism_check_interval)


### PR DESCRIPTION
### Problem description
Tests used for Galaxy need ability to target sub-meshes of cores.

### What's changed
Added that ability. Example test call for "bursty":
`TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_duty_cycle.py::test_mesh_size_duty_cycle -k '4x2 and 0-0 and rep-100x and duty-5' --didt-workload-iterations 1`,
where `4x2` represents the sub-mesh size and `0-0` represents the offset within the whole Galaxy mesh grid (8x4 total size)

Other available options are:
- for sub-meshes: `4x1, 4x2, 8x1, 8x2, 6x4, 8x3` - **I THINK THAT 4x2 CORRESPONDS TO ONE UBB**
- for coordinate offset: `0-0, 4-0, 0-1, 4-1, 0-2, 4-2, 0-3, 4-3`

There is also a "random" test which randomizes the sub-mesh within the range: `1x1` to `8x4` (x dim from 1 to 8, y dim from 1 to 4) as well as randomizing the core coordinate offset of the sub-mesh within the valid range of possibilities (such that the mesh can fit within 8x4 galaxy mesh).

Example test call:
`TT_MM_THROTTLE_PERF=5 pytest tests/didt/test_duty_cycle.py::test_random_mesh_size_ff1_matmul -k 'rep-100x and duty-5' --didt-workload-iterations 1`

**Both these tests have also been added for FF1, LM Head, and Conv tests**

### Checklist

- [x] New/Existing tests provide coverage for changes
- [x] APC - https://github.com/tenstorrent/tt-metal/actions/runs/21528531043