### PR TITLE
Fix dead store in interm0_data_format assignment

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -205,7 +205,6 @@ create_program_dram_sharded(
     // unnecessary overhead for reconfigs are added
     bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
 
-    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = tt::DataFormat::Float16_b;
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -206,10 +206,7 @@ create_program_dram_sharded(
     bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
-    tt::DataFormat interm0_data_format = packer_l1_acc_en
-                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
-                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
-    interm0_data_format = tt::DataFormat::Float16_b;
+    tt::DataFormat interm0_data_format = tt::DataFormat::Float16_b;
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);


### PR DESCRIPTION
## Summary
This PR fixes a dead store warning caught by clang static analyzer in `matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp`.

https://blozano-tt.github.io/clangsa-results/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp_clangsa_c80ccad753f8e3bddc7e8a90db2c14ae.plist.html#reportHash=72028f5a947a4d301da16370138b5816

## Changes
- Removed dead store where `interm0_data_format` was assigned a conditional value (lines 209-211) but immediately overwritten with `Float16_b` on line 212
- Variable now directly assigns `tt::DataFormat::Float16_b` without the unnecessary intermediate assignment

## Context
The clang static analyzer detected that the initial conditional assignment to `interm0_data_format` was never read before being overwritten, making it a dead store.

## Testing
- Pre-commit hooks passed
- No linter errors introduced
- Follows the same pattern as recent dead store fixes (e.g., #36053)