### PR TITLE
[WATCHER] Skip profiler and triage tests with watcher

### DIFF
--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -228,7 +228,7 @@ jobs:
 
   run-profiler-regression:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'run-profiler-regression') }}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'run-profiler-regression') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts}}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -285,7 +285,7 @@ jobs:
 
   triage-tests:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'triage-tests') }}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'triage-tests') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts}}
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/apc-select-tests.yaml
+++ b/.github/workflows/apc-select-tests.yaml
@@ -228,7 +228,7 @@ jobs:
 
   run-profiler-regression:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'run-profiler-regression') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts}}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'run-profiler-regression') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts }}
     secrets: inherit
     strategy:
       fail-fast: false
@@ -285,7 +285,7 @@ jobs:
 
   triage-tests:
     needs: [parse-tests-json, build-artifact]
-    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'triage-tests') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts}}
+    if: ${{ contains(needs.parse-tests-json.outputs.tests-to-run, 'triage-tests') && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts }}
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Ticket
[27840](https://github.com/tenstorrent/tt-metal/issues/27840)

### Problem description
There is a need for a scheduled run of APC Select pipeline with watcher enabled. This asks for failing tests skips in order to have green status of the first run. This PR is first in line achieving that.

### What's changed
This PR skips profiler regression tests and triage tests with watcher or soft asserts enabled. These tests shouldn't be tested with watcher therefore they should be skipped.

### Checklist
Run given below is over following jobs of the APC Select pipeline: run-profiler-regression; test-ttnn-tutorials; triage-tests
- [x] [All post commit select with watcher enabled](https://github.com/tenstorrent/tt-metal/actions/runs/21168940862)