### PR TITLE
allow noc selection for senders in fabric test infra

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -537,3 +537,26 @@ Tests:
 
     patterns:
       - type: all_to_all
+
+  - name: "SimpleNOCSelect"
+    fabric_setup:
+      topology: Linear
+
+    defaults:
+      size: 1024
+      ftype: unicast
+      ntype: unicast_write
+      num_packets: 100
+
+    senders:
+      - noc_id: 0
+        device: [0, 0]
+        patterns:
+          - destination:
+              device: [0, 1]
+
+      - noc_id: 1
+        device: [0, 0]
+        patterns:
+          - destination:
+              device: [0, 1]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_features.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_features.yaml
@@ -52,7 +52,7 @@ Tests:
   #   - AllToAll_size_256_num_packets_100
   #   - AllToAll_size_512_num_packets_50
   #   - ... and so on.
-  # =================================C=====================================================
+  # =======================================================================================
   - name: "ParametrizedAllToAll"
     fabric_setup:
       topology: Mesh
@@ -346,3 +346,23 @@ Tests:
             num_packets: 100
             destination:
               device: 1 # Destination is physical chip 1
+
+  # ======================================================================================
+  # Test 14: NOC ID Selection
+  # This demonstrates how to explicitly select which NOC (0 or 1) to use by worker cores.
+  # By default, NOC 0 is used. This test uses NOC 1.
+  # ======================================================================================
+  - name: "NocIdSelection"
+    fabric_setup:
+      topology: Linear
+
+    senders:
+      - device: [0, [0, 0]]
+        noc_id: 1 # Explicitly select NOC 1 for this sender
+        patterns:
+          - ftype: unicast
+            ntype: unicast_write
+            size: 1024
+            num_packets: 100
+            destination:
+              device: [0, [0, 1]]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -63,6 +63,7 @@ struct ParsedTrafficPatternConfig {
 struct ParsedSenderConfig {
     DeviceIdentifier device = FabricNodeId(MeshId{0}, 0);
     std::optional<CoreCoord> core;
+    std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<ParsedTrafficPatternConfig> patterns;
     std::optional<uint32_t> link_id;  // Link ID for multi-link tests
 };
@@ -100,6 +101,7 @@ struct TrafficPatternConfig {
 struct SenderConfig {
     FabricNodeId device = FabricNodeId(MeshId{0}, 0);
     std::optional<CoreCoord> core;
+    std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<TrafficPatternConfig> patterns;
     uint32_t link_id = 0;  // Link ID for multi-link tests
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -135,6 +135,13 @@ ParsedSenderConfig YamlConfigParser::parse_sender_config(
     if (sender_yaml["core"]) {
         config.core = parse_core_coord(sender_yaml["core"]);
     }
+    if (sender_yaml["noc_id"]) {
+        config.noc_id = static_cast<tt::tt_metal::NOC>(parse_scalar<uint8_t>(sender_yaml["noc_id"]));
+        TT_FATAL(
+            config.noc_id == 0 || config.noc_id == 1,
+            "Expected NOC ID 0 or 1, got: {}",
+            static_cast<uint8_t>(config.noc_id.value()));
+    }
     if (sender_yaml["link_id"]) {
         config.link_id = parse_scalar<uint32_t>(sender_yaml["link_id"]);
     }
@@ -938,6 +945,7 @@ SenderConfig TestConfigBuilder::resolve_sender_config(const ParsedSenderConfig& 
     SenderConfig resolved_sender;
     resolved_sender.device = resolve_device_identifier(parsed_sender.device, device_info_provider_);
     resolved_sender.core = parsed_sender.core;
+    resolved_sender.noc_id = parsed_sender.noc_id;
     resolved_sender.link_id = parsed_sender.link_id.value_or(0);  // Default to link 0 if not specified
 
     resolved_sender.patterns.reserve(parsed_sender.patterns.size());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -552,6 +552,7 @@ void TestContext::process_traffic_config(TestConfig& config) {
                 .target_address = dest.target_address,
                 .atomic_inc_address = dest.atomic_inc_address,
                 .link_id = sender.link_id,
+                .noc_id = sender.noc_id,
                 .sender_credit_info = pattern.sender_credit_info,
                 .credit_return_batch_size = pattern.credit_return_batch_size,
             };
@@ -612,7 +613,8 @@ void TestContext::add_traffic_config(const TestTrafficConfig& traffic_config) {
         .atomic_inc_address = atomic_inc_address,
         .dst_noc_encoding = dst_noc_encoding,
         .payload_buffer_size = payload_buffer_size,
-        .link_id = traffic_config.link_id};
+        .link_id = traffic_config.link_id,
+        .noc_id = traffic_config.noc_id};
 
     TestTrafficReceiverConfig receiver_config = {
         .parameters = traffic_config.parameters,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -959,10 +959,8 @@ void TestDevice::create_sender_kernels() {
 
         tt::tt_metal::NOC noc_id = tt::tt_metal::NOC::RISCV_0_default;
         // Each sender will have the same NOC used for every pattern when parsing, take the one defined in the first config
-        if (!sender.configs_.empty()) {
-            if (sender.configs_[0].first.noc_id.has_value()) {
-                noc_id = sender.configs_[0].first.noc_id.value();
-            }
+        if (sender.configs_[0].first.noc_id.has_value()) {
+            noc_id = sender.configs_[0].first.noc_id.value();
         }
 
         sender.create_kernel(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -958,15 +958,12 @@ void TestDevice::create_sender_kernels() {
         }
 
         tt::tt_metal::NOC noc_id = tt::tt_metal::NOC::RISCV_0_default;
-        // Each sender will have the same NOC used for every pattern when parsing, take the one defined in the first
-        // config
-        if (sender.configs_.size() > 0) {
+        // Each sender will have the same NOC used for every pattern when parsing, take the one defined in the first config
+        if (!sender.configs_.empty()) {
             if (sender.configs_[0].first.noc_id.has_value()) {
                 noc_id = sender.configs_[0].first.noc_id.value();
             }
         }
-
-        log_info(tt::LogTest, "Using NOC {} for sender", static_cast<uint32_t>(noc_id));
 
         sender.create_kernel(
             coord_,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -335,14 +335,15 @@ void TestWorker::create_kernel(
     const std::vector<uint32_t>& rt_args,
     const std::vector<uint32_t>& local_args,
     uint32_t local_args_address,
-    const std::vector<std::pair<size_t, size_t>>& addresses_and_size_to_clear) const {
+    const std::vector<std::pair<size_t, size_t>>& addresses_and_size_to_clear,
+    tt::tt_metal::NOC noc_id) const {
     auto kernel_handle = tt::tt_metal::CreateKernel(
         this->test_device_ptr_->get_program_handle(),
         this->kernel_src_,
         {this->logical_core_},
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .noc = noc_id,
             .compile_args = ct_args,
             .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
 
@@ -956,13 +957,25 @@ void TestDevice::create_sender_kernels() {
                  sender_memory_map_->get_mux_termination_sync_size()});
         }
 
+        tt::tt_metal::NOC noc_id = tt::tt_metal::NOC::RISCV_0_default;
+        // Each sender will have the same NOC used for every pattern when parsing, take the one defined in the first
+        // config
+        if (sender.configs_.size() > 0) {
+            if (sender.configs_[0].first.noc_id.has_value()) {
+                noc_id = sender.configs_[0].first.noc_id.value();
+            }
+        }
+
+        log_info(tt::LogTest, "Using NOC {} for sender", static_cast<uint32_t>(noc_id));
+
         sender.create_kernel(
             coord_,
             ct_args,
             rt_args,
             local_args,
             sender_memory_map_->get_local_args_address(),
-            addresses_and_size_to_clear);
+            addresses_and_size_to_clear,
+            noc_id);
 
         log_debug(tt::LogTest, "Created sender kernel on core {}", core);
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.hpp
@@ -199,7 +199,8 @@ public:
         const std::vector<uint32_t>& rt_args,
         const std::vector<uint32_t>& local_args,
         uint32_t local_args_address,
-        const std::vector<std::pair<size_t, size_t>>& addresses_and_size_to_clear) const;
+        const std::vector<std::pair<size_t, size_t>>& addresses_and_size_to_clear,
+        tt::tt_metal::NOC noc_id = tt::tt_metal::NOC::RISCV_0_default) const;
     void collect_results();
     virtual bool validate_results(std::vector<uint32_t>& data) const = 0;
     void dump_results();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_traffic.hpp
@@ -257,6 +257,7 @@ struct TestTrafficConfig {
     std::optional<uint32_t> target_address;
     std::optional<uint32_t> atomic_inc_address;
     uint32_t link_id = 0;  // Link ID for multi-link tests
+    std::optional<tt::tt_metal::NOC> noc_id;
 
     // Credit info (copied from pattern if populated by allocator)
     std::optional<SenderCreditInfo> sender_credit_info;
@@ -291,6 +292,7 @@ struct TestTrafficSenderConfig {
     uint32_t dst_noc_encoding;  // TODO: decide if we should keep it here or not
     uint32_t payload_buffer_size;  // Add payload buffer size field
     uint32_t link_id = 0;          // Link ID for multi-link tests
+    std::optional<tt::tt_metal::NOC> noc_id;
 
     // Credit flow info (when enable_flow_control is true)
     std::optional<SenderCreditInfo> sender_credit_info;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35635

### Problem description
Allow test configuration for fabric tests to specify the NOC ID used by worker senders. Currently hardcoded to use NOC 0. 

### What's changed
Describe the approach used to solve the problem.
Adjust parser to consume the `noc_id` field and store the field in the the configs used for each sender. Allowing NOC ID selection _per pattern_ seemed like too intrusive of a change, as NOC selection is exposed as part of the `DataMovementConfig` and is configured once per sender, limiting NOC selection to the sender level. A field is added to the parsing of the test configuration `yaml` files. It is stored as a configuration per sender. When the sender creates each kernel, it checks this field. The call to kernel creation now exposes an additional field to pass the NOC ID to. The function to create a kernel is adjusted to include a default field for the NOC ID being used, so current calls do not need to be changed. Only the sender currently checks the config to override this default.

**TDLR**
Fabric tests may now specify the NOC ID being used by the sender workers cores.
### Checklist
Similar failures on other branches
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=nzhao/fabric-test-worker-write-noc-selection)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:nzhao/fabric-test-worker-write-noc-selection)