### PR TITLE
fix(clangsa): Fixed Clang Static Analyzer Issue - Uninitialized Field

Issue Fixed:
- Checker: core.uninitialized.Assign
- File: tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.hpp
- Line: 13
- Severity: HIGH

Description:
The shared_variables_t struct had uninitialized KernelHandle and CoreRangeSet member fields. When this struct was used with implicit construction, fields could contain garbage or undefined values. This fix adds default initialization ({}) to all member fields to ensure they are properly initialized, consistent with other similar structs in the codebase.

Fields initialized:
- layernorm_fw_reader_kernel_id
- layernorm_fw_writer_kernel_id
- layernorm_fw_kernel_group_1_id
- layernorm_fw_kernel_group_2_id
- core_group_1
- core_group_2

This is a safe fix that ensures deterministic behavior and prevents undefined behavior during implicit construction.

### DIFF
--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.hpp
@@ -11,12 +11,12 @@ namespace ttml::metal::ops::layernorm_fw::device {
 
 struct LayerNormForwardProgramFactory {
     struct shared_variables_t {
-        tt::tt_metal::KernelHandle layernorm_fw_reader_kernel_id;
-        tt::tt_metal::KernelHandle layernorm_fw_writer_kernel_id;
-        tt::tt_metal::KernelHandle layernorm_fw_kernel_group_1_id;
-        tt::tt_metal::KernelHandle layernorm_fw_kernel_group_2_id;
-        tt::tt_metal::CoreRangeSet core_group_1;
-        tt::tt_metal::CoreRangeSet core_group_2;
+        tt::tt_metal::KernelHandle layernorm_fw_reader_kernel_id{};
+        tt::tt_metal::KernelHandle layernorm_fw_writer_kernel_id{};
+        tt::tt_metal::KernelHandle layernorm_fw_kernel_group_1_id{};
+        tt::tt_metal::KernelHandle layernorm_fw_kernel_group_2_id{};
+        tt::tt_metal::CoreRangeSet core_group_1{};
+        tt::tt_metal::CoreRangeSet core_group_2{};
         uint32_t num_cores{};
         uint32_t num_cores_y{};
     };


### PR DESCRIPTION
## Automated Clang Static Analyzer Fix

Generated by GitHub Copilot. Please review carefully.