### PR TITLE
TTML module: import ttnn in python code instead of C++ code

### DIFF
--- a/tt-train/sources/ttml/nanobind/__init__.cpp
+++ b/tt-train/sources/ttml/nanobind/__init__.cpp
@@ -29,10 +29,6 @@ namespace ttml::nanobind {
 using namespace ::nanobind;
 
 NB_MODULE(_ttml, m) {
-    // Import ttnn first to ensure all shared types (Layout, DataType, etc.) are registered
-    // before _ttml uses them in function signatures
-    nb::module_::import_("ttnn");
-
     // Bind NamedParameters as a proper map type at the top level
     nb::bind_map<ttml::serialization::NamedParameters>(m, "NamedParameters");
 

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -10,6 +10,7 @@ taking precedence when they exist.
 """
 
 import sys
+import ttnn
 from . import _ttml
 from ._recursive_import import _recursive_import_from_ttml
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Import errors like 'failed to find ttnncpp.so' or 'bad_cast' would occur when importing ttml.  Importing ttnn prior to ttml fixes this.

### What's changed
Move ttnn import to ttml's `__init__.py` from ttml's `__init__.cpp`

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=athompson/ttml_ttnn_import_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:athompson/ttml_ttnn_import_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=athompson/ttml_ttnn_import_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:athompson/ttml_ttnn_import_fix)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=athompson/ttml_ttnn_import_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:athompson/ttml_ttnn_import_fix)


- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=athompson/ttml_ttnn_import_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:athompson/ttml_ttnn_import_fix)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs