### PR TITLE
#36161 Removed incorrect assignment

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -209,7 +209,6 @@ create_program_dram_sharded(
     tt::DataFormat interm0_data_format = packer_l1_acc_en
                                              ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
                                              : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
-    interm0_data_format = tt::DataFormat::Float16_b;
 
     uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);


### PR DESCRIPTION
### Ticket
#36161

### Problem description
An assignment seems to have been added while debugging and then forgotten

### What's changed
Removed incorrect assignment that was 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fplavec-36161_fix_incorrect_format)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec-36161_fix_incorrect_format)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec-36161_fix_incorrect_format)
   Failing [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184579871), but failures are either timeouts, or the same failures that have been seen in other runs (example https://github.com/tenstorrent/tt-metal/actions/runs/21089611809/job/60659162636) 


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec-36161_fix_incorrect_format)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
     Failing [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184770033), but the number of failures is the same as in somebody else's [unrelated run](https://github.com/tenstorrent/tt-metal/actions/runs/21145782964) around the same time
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
     Failing [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184792279), but the number of failures is the same as in somebody else's [unrelated run](https://github.com/tenstorrent/tt-metal/actions/runs/21171421011) around the same time
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec-36161_fix_incorrect_format)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
     Failing [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184837990), but the failures are a subset of failures in somebody else's [unrelated run](https://github.com/tenstorrent/tt-metal/actions/runs/21183746863) around the same time
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
     Failing [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184856575), but the failures are similar to failures in other people's unrelated recent runs (see https://github.com/tenstorrent/tt-metal/actions/runs/21125748426 and https://github.com/tenstorrent/tt-metal/actions/runs/21188371798)
  - [ ] other selection - specify runs

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec-36161_fix_incorrect_format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec-36161_fix_incorrect_format)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
     Passes: https://github.com/tenstorrent/tt-metal/actions/runs/21184713203
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests).
     Fails [here](https://github.com/tenstorrent/tt-metal/actions/runs/21184740096/job/60955711233) but the failure is the [same as on main](https://github.com/tenstorrent/tt-metal/actions/runs/21210134998/job/61016880068) 
  - [ ] other selection - specify runs