### PR TITLE
Allowing intermesh routing through Z port automatically

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2489,14 +2489,6 @@ std::vector<PortDescriptor> ControlPlane::assign_logical_ports_to_exit_nodes(
                 auto port_direction = port_id.first;
                 auto logical_chan_id = port_id.second;
 
-                // Blackhole Z-channels must be assigned the Z Routing Direction.
-                // All other channels must avoid using the Z-direction (they are used for routing along the X/Y
-                // directions). This is to ensure that logical and physical channel assignments are consistent.
-                bool is_z_direction = (port_direction == RoutingDirection::Z);
-                if (should_assign_z != is_z_direction) {
-                    continue;
-                }
-
                 // Override direction to Z BEFORE creating port_id if needed
                 RoutingDirection final_direction = (should_assign_z) ? RoutingDirection::Z : port_direction;
                 port_id_t port_id = {final_direction, logical_chan_id};


### PR DESCRIPTION
When auto-assigning ports in control plane for routing table, include Z ports in consideration along with XY for port directions.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ridvan/remove-z-special-casing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ridvan/remove-z-special-casing)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/remove-z-special-casing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/remove-z-special-casing)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/remove-z-special-casing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/remove-z-special-casing)
- [ ] New/Existing tests provide coverage for changes
- [x] [Galaxy Quick](https://github.com/tenstorrent/tt-metal/actions/runs/21188407174)

