### PR TITLE
Fix unit_tests_api

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/banked_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/banked_reader.cpp
@@ -6,6 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr std::uint32_t cb_id = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/banked_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/banked_writer.cpp
@@ -6,6 +6,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/circular_buffer.h"
+#include "experimental/tensor.h"
 
 void kernel_main() {
     constexpr std::uint32_t cb_id = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_wrapping_test_non_blocking_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_wrapping_test_non_blocking_reader.cpp
@@ -17,6 +17,7 @@ void core_agnostic_main();
 
 #ifdef COMPILE_FOR_BRISC
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/circular_buffer.h"
 
 void kernel_main() { core_agnostic_main(); }
 #else

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -637,11 +637,13 @@ uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) c
     TT_THROW("Virtual core {} is not a DRAM core", virtual_core.str());
 }
 
-std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const { return std::nullopt; }
+std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const {
+    return default_allocator_->get_lowest_occupied_l1_address(0);
+}
 
 std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(
     tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) const {
-    return std::nullopt;
+    return default_allocator_->get_lowest_occupied_l1_address(0);
 }
 
 CommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {


### PR DESCRIPTION
### Problem description
unit_tests_api isn't in APC, so it's bitrotted. Several tests were failing due to missing headers and one was failing because lowest_occupied_compute_l1_address isn't implemented anymore.

### What's changed
Add includes of "experimental/tensor.h" so tests that use TensorAccessor with the new NoC APIs work.

Add back in an implementation of lowest_occupied_compute_l1_address to Device, since it's called when launching a program doing slow dispatch, as MeshDeviceFixture.TensixTestCircularBuffersAndL1BuffersCollision does.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fixsdunittests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixsdunittests)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixsdunittests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixsdunittests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixsdunittests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fixsdunittests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixsdunittests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs