### PR TITLE
Revert "added check and recalculation for block sharded tensors before interleaved to sharded is invoked in reshape op"

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -12,8 +12,6 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-from models.common.utility_functions import torch_random
-
 
 @pytest.mark.parametrize(
     "input_shape, output_shape",
@@ -70,95 +68,6 @@ def test_tensor_reshape_with_cache(device, enable_cache, input_shape, output_sha
     assert torch.allclose(b, ttnn.to_torch(tt_b))
 
 
-@pytest.mark.parametrize("shape", [[1, 1, 1024, 1], [1, 1024, 1]])
-def test_reshape_block_shard(device, shape):
-    input_torch = torch.randn(shape, dtype=torch.bfloat16)
-    shard_shape = shape.copy()
-    shard_shape[-1] = 32
-
-    block_sharded_config = ttnn.create_sharded_memory_config(
-        shape=shard_shape,
-        core_grid=ttnn.CoreGrid(x=1, y=8),
-        strategy=ttnn.ShardStrategy.BLOCK,
-        use_height_and_width_as_shard_shape=False,
-    )
-    input_ttnn = ttnn.from_torch(
-        input_torch,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=block_sharded_config,
-    )
-    output_tensor = ttnn.reshape(input_ttnn, [1, 1024])
-
-    expected_output = input_torch.reshape([1, 1024])
-    actual_output = ttnn.to_torch(output_tensor)
-    assert torch.allclose(expected_output, actual_output)
-
-
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_reshape_height_shard(device, layout):
-    input_shape = [1, 1, 256, 32]
-    output_shape = [1, 1, 32, 256]
-    input_torch = torch.randn(input_shape, dtype=torch.bfloat16)
-
-    height_sharded_config = ttnn.create_sharded_memory_config(
-        shape=input_shape,
-        core_grid=ttnn.CoreGrid(y=8, x=1),
-        strategy=ttnn.ShardStrategy.HEIGHT,
-        use_height_and_width_as_shard_shape=False,
-    )
-    input_ttnn = ttnn.from_torch(
-        input_torch,
-        dtype=ttnn.bfloat16,
-        layout=layout,
-        device=device,
-        memory_config=height_sharded_config,
-    )
-    output_tensor = ttnn.reshape(input_ttnn, output_shape)
-
-    expected_output = input_torch.reshape(output_shape)
-    actual_output = ttnn.to_torch(output_tensor)
-    assert torch.allclose(expected_output, actual_output)
-
-
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-def test_reshape_width_shard(device, layout):
-    input_shape = [1, 1, 256, 256]
-    output_shape = [1, 1, 64, 1024]
-    input_torch = torch.randn(input_shape, dtype=torch.bfloat16)
-
-    width_sharded_config = ttnn.create_sharded_memory_config(
-        shape=input_shape,
-        core_grid=ttnn.CoreGrid(y=1, x=8),
-        strategy=ttnn.ShardStrategy.WIDTH,
-        use_height_and_width_as_shard_shape=False,
-    )
-    input_ttnn = ttnn.from_torch(
-        input_torch,
-        dtype=ttnn.bfloat16,
-        layout=layout,
-        device=device,
-        memory_config=width_sharded_config,
-    )
-    output_tensor = ttnn.reshape(input_ttnn, output_shape)
-
-    expected_output = input_torch.reshape(output_shape)
-    actual_output = ttnn.to_torch(output_tensor)
-    assert torch.allclose(expected_output, actual_output)
-
-
-@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-@pytest.mark.parametrize(
-    "input_shape,output_shape,shard_shape",
-    [
-        # Simple ND sharding test - matches pattern from test_reduce_on_batch
-        # NOTE: Currently reshape with ND sharding returns interleaved output
-        # This test verifies the data correctness even though memory layout changes
-        ([5, 4, 32 * 8, 32 * 8], [5, 4, 8, 32, 8, 32], [5, 1, 32, 32]),
-        ([4, 2, 32 * 4, 32 * 4], [4, 2, 4, 32, 4, 32], [4, 1, 32, 32]),
-    ],
-)
 @pytest.mark.parametrize("n", [16])
 @pytest.mark.parametrize("c", [4])
 @pytest.mark.parametrize("h", [64])
@@ -773,50 +682,3 @@ def test_reshape_oob(device):
         ttnn.deallocate(tt_output_tensor)
         ttnn.deallocate(pre_tensor)
         ttnn.deallocate(post_tensor)
-
-
-@pytest.mark.parametrize(
-    "shape,shard_shape,output_shape",
-    [
-        # Batch sharding
-        # Batch dims are equal for shape and shard_shape, all other dims of shard shape are 1 (or tile size for the lower two dims, or other combinations)
-        ((10, 4, 32 * 17, 32 * 17), (10, 1, 32, 32), (10, 4 * 17 * 17, 32, 32)),
-        ((5, 7, 32 * 11, 32 * 11), (5, 1, 32, 32), (5, 7, 32 * 11 * 11, 32)),
-        ((10, 4, 32 * 16, 32 * 16), (5, 2, 32, 64), (10 * 16 * 16, 4, 32, 32)),  # half batch sharding
-        (
-            (10, 5, 32 * 11, 32 * 11),
-            (10, 2, 64, 64),
-            (10 * 11, 5 * 11, 32, 32),
-        ),  # tensor dimensions not evenly divided by shard dimensions
-    ],
-)
-@pytest.mark.parametrize("dim", [0, 1])
-@pytest.mark.parametrize("interleaved", [False])
-def test_reshape_nd_sharded(shape, shard_shape, output_shape, dim, interleaved, device):
-    pytest.skip("skipped but must be resolved later - issue 36172")
-    torch.manual_seed(0)
-
-    torch_input_tensor = torch_random(shape, -100, 100, dtype=torch.bfloat16)
-
-    grid_size = device.compute_with_storage_grid_size()
-    core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
-    grid = ttnn.CoreRangeSet([core_range])
-
-    torch_output_tensor = torch_input_tensor.reshape(output_shape)
-
-    memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, ttnn.NdShardSpec(ttnn.Shape(shard_shape), grid))
-    output_shard_shape = list(shard_shape)
-    output_shard_shape[0] = 1
-    memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, ttnn.NdShardSpec(ttnn.Shape(shard_shape), grid))
-    output_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, ttnn.NdShardSpec(ttnn.Shape(output_shard_shape), grid))
-    if interleaved:
-        memory_config = None
-        output_memory_config = None
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
-    )
-
-    output_tensor = ttnn.reshape(input_tensor, output_shape)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.995)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -52,30 +52,7 @@ ttnn::Tensor perform_reshape_on_2D_RM(
 
     if (memory_config.is_sharded()) {
         TT_FATAL(!sub_core_grid.has_value(), "Sharded reshape does not support sub core grid specification\n");
-
-        // Recompute the shard spec for the output tensor shape
-        auto output_mem_config = memory_config;
-        if (memory_config.shard_spec().has_value()) {
-            const auto& input_shard_spec = memory_config.shard_spec().value();
-            const auto& output_shape = temp_tensor2.tensor_spec();
-
-            // Update specs for output tensor
-            auto core_range = input_shard_spec.grid.bounding_box();
-            auto orientation = input_shard_spec.orientation;
-
-            if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-                auto updated_spec = output_shape.block_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                auto updated_spec = output_shape.height_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-                auto updated_spec = output_shape.width_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            }
-        }
-
-        return ttnn::interleaved_to_sharded(temp_tensor2, output_mem_config, std::nullopt);
+        return ttnn::interleaved_to_sharded(temp_tensor2, memory_config, std::nullopt);
     }
     return temp_tensor2;
 }
@@ -245,30 +222,7 @@ ttnn::Tensor reshape_tiled(
 
     if (memory_config.is_sharded()) {
         TT_FATAL(!sub_core_grid.has_value(), "Sharded reshape does not support sub core grid specification\n");
-
-        // Recompute the shard spec for the output tensor shape
-        auto output_mem_config = memory_config;
-        if (memory_config.shard_spec().has_value()) {
-            const auto& input_shard_spec = memory_config.shard_spec().value();
-            const auto& output_shape = output_tensor_3d.tensor_spec();
-
-            // Update specs for output tensor
-            auto core_range = input_shard_spec.grid.bounding_box();
-            auto orientation = input_shard_spec.orientation;
-
-            if (memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-                auto updated_spec = output_shape.block_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                auto updated_spec = output_shape.height_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            } else if (memory_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
-                auto updated_spec = output_shape.width_sharded(core_range, orientation);
-                output_mem_config = updated_spec.memory_config();
-            }
-        }
-
-        output_tensor_3d = ttnn::interleaved_to_sharded(output_tensor_3d, output_mem_config, std::nullopt);
+        output_tensor_3d = ttnn::interleaved_to_sharded(output_tensor_3d, memory_config, std::nullopt);
     }
 
     if (tensor.dtype() == DataType::BFLOAT8_B) {


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#36015

APC run after revert: https://github.com/tenstorrent/tt-metal/actions/runs/21191817328

This PR seems to have broken APC: 

FULL REPORT: [full_report_link #2194](https://github.com/tenstorrent/tt-metal/actions/runs/21191462713)
FAILING WORKFLOW: all-post-commit-workflows
FAILING JOB: ttnn-unit-tests (wormhole_b0, N300) / core ttnn unit test group wormhole_b0 N300
FAILING TEST: test_reshape_sharded_rm
FAILING RUN: [Run #21187946099 (latest failure)](https://github.com/tenstorrent/tt-metal/actions/runs/21187946099/job/60957741758)
SCENARIO: Deterministic failure with identified commit
FAILURE MESSAGE:
ERROR collecting tests/ttnn/unit_tests/base_functionality/test_reshape.py - In test_reshape_sharded_rm: function uses no argument 'input_shape'
Pytest collection error in test_reshape_sharded_rm caused by commit 4914f845. The commit added parametrize decorators for 'input_shape', 'output_shape', and 'shard_shape' to an existing test that doesn't accept those parameters. Fix: Remove the incorrectly added decorators (lines 105-115) from the test. This entire analysis is done by AI and is prone to false positives, especially for performance regressions and timeouts.
COMMITS:
- HASH: [4914f845](https://github.com/tenstorrent/tt-metal/commit/4914f84554bdcca1ab1a58c57b5bb6e6d9bf18f7)
  AUTHOR: [@Sam Meydanshahi](https://tenstorrent.enterprise.slack.com/team/U09SQRDLQGJ)
  APPROVERS: Borys Bradel, Juan Camilo Vega
  RELEVANT DEVELOPERS: metalium-developers-ops-data-movement
  RELEVANT FILES:
tests/ttnn/unit_tests/base_functionality/test_reshape.py