### PR TITLE
ci: Single source of truth for ttnn test definitions

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -73,38 +73,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
-    strategy:
-      matrix:
-        default-ttnn-tests:
-          [[
-            { name: "ttnn example tests", cmd: "./tests/scripts/run_ttnn_examples.sh", merge_gate: true },
-            { name: "ttnn eltwise group 1", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn eltwise group 2", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn eltwise group 3", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn eltwise group 4", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn eltwise group 5", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn conv group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn pool group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn matmul group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn fused group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn transformers group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "ttnn reduce and misc ops group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            { name: "core ttnn unit test group", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"', merge_gate: false },
-            # { name: "ttnn fast runtime off", cmd: 'pytest -n auto --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off', merge_gate: false, fast_runtime_mode_off: true },
-          ]]
     steps:
+      - name: Checkout test definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/ttnn-tests.json
+          sparse-checkout-cone-mode: false
+
       - name: Compute tests
         shell: bash
         id: compute-tests
         run: |
           set -euo pipefail
-          echo "[info] Outputing default values"
-          default_ttnn_tests='${{ toJSON(matrix.default-ttnn-tests) }}'
-          echo $default_ttnn_tests
-          echo $default_ttnn_tests | jq
-          requested_ttnn_tests=$default_ttnn_tests
+          # Read test definitions from shared JSON file (single source of truth)
+          # Flags in ttnn-tests.json:
+          #   merge_gate: true/false - runs in merge gate workflow
+          #   ttsim: true/false - runs in ttsim simulator workflow
+          echo "[info] Reading test definitions from ttnn-tests.json"
+          default_ttnn_tests=$(cat .github/workflows/ttnn-tests.json)
+          echo "$default_ttnn_tests" | jq
 
-          requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$requested_ttnn_tests")
+          # Filter based on merge_gate flag (for post-commit workflow)
+          requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$default_ttnn_tests")
           echo "[info] after filtering for requested workflow tests: $requested_ttnn_tests"
 
           # Check that we have a valid test list that's not empty

--- a/.github/workflows/ttnn-tests.json
+++ b/.github/workflows/ttnn-tests.json
@@ -1,0 +1,15 @@
+[
+  { "name": "ttnn example tests", "cmd": "./tests/scripts/run_ttnn_examples.sh", "merge_gate": true, "ttsim": false },
+  { "name": "ttnn eltwise group 1", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": true },
+  { "name": "ttnn eltwise group 2", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn eltwise group 3", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn eltwise group 4", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn eltwise group 5", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn conv group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn pool group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn matmul group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn fused group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn transformers group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "ttnn reduce and misc ops group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false },
+  { "name": "core ttnn unit test group", "cmd": "pytest -n auto --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m \"not disable_fast_runtime_mode\"", "merge_gate": false, "ttsim": false }
+]

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -36,6 +36,48 @@ on:
         default: false
 
 jobs:
+  # Reads test definitions from shared JSON file and filters for ttsim: true
+  # SINGLE SOURCE OF TRUTH: .github/workflows/ttnn-tests.json
+  # Flip ttsim: false -> true in the JSON as simulator support is added
+  define-ttsim-tests:
+    if: ${{ inputs.run-ttsim-integration-tests }}
+    runs-on: ubuntu-latest
+    outputs:
+      ttsim-tests: ${{ steps.compute-tests.outputs.ttsim-tests }}
+      has-tests: ${{ steps.compute-tests.outputs.has-tests }}
+    steps:
+      - name: Checkout test definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/ttnn-tests.json
+          sparse-checkout-cone-mode: false
+
+      - name: Compute ttsim tests
+        shell: bash
+        id: compute-tests
+        run: |
+          set -euo pipefail
+          # Read test definitions from shared JSON file (single source of truth)
+          echo "[info] Reading test definitions from ttnn-tests.json"
+          default_ttnn_tests=$(cat .github/workflows/ttnn-tests.json)
+          echo "$default_ttnn_tests" | jq
+
+          # Filter for ttsim-compatible tests only
+          ttsim_tests=$(jq '[.[] | select(.ttsim == true)]' <<< "$default_ttnn_tests")
+          echo "[info] after filtering for ttsim tests: $ttsim_tests"
+
+          # Check if we have any tests
+          test_count=$(echo "$ttsim_tests" | jq 'length')
+          if [[ "$test_count" -eq 0 ]]; then
+            echo "[info] No ttsim-enabled tests found (all tests have ttsim: false)"
+            echo "has-tests=false" >> "$GITHUB_OUTPUT"
+            echo "ttsim-tests=[]" >> "$GITHUB_OUTPUT"
+          else
+            echo "[info] Found $test_count ttsim-enabled tests"
+            echo "has-tests=true" >> "$GITHUB_OUTPUT"
+            echo "ttsim-tests=$(echo $ttsim_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          fi
+
   ttsim-integration:
     if: ${{ inputs.run-ttsim-integration-tests }}
     runs-on: tt-ubuntu-2204-small-stable
@@ -146,26 +188,28 @@ jobs:
             fi
           done
   ttnn-pytests:
-    if: ${{ inputs.run-ttsim-integration-tests }}
-    runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.job-timeout }}
-    name: "TTNN Pytests - ${{ matrix.arch }}"
+    needs: define-ttsim-tests
+    if: ${{ inputs.run-ttsim-integration-tests && needs.define-ttsim-tests.outputs.has-tests == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - arch: wormhole_b0
+        arch:
+          - name: wormhole_b0
             build_suffix: release_wh
             soc_desc: wormhole_b0_80_arch.yaml
-          - arch: blackhole
+          - name: blackhole
             build_suffix: release_bh
             soc_desc: blackhole_140_arch.yaml
+        test-group: ${{ fromJSON(needs.define-ttsim-tests.outputs.ttsim-tests) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.job-timeout }}
+    name: "${{ matrix.test-group.name }} - ${{ matrix.arch.name }}"
     container:
       image: ${{ inputs.test-docker-image || 'docker-image-unresolved!'}}
       volumes:
         - ${{ github.workspace }}:/work
       env:
-        ARCH_NAME: ${{ matrix.arch }}
+        ARCH_NAME: ${{ matrix.arch.name }}
         TT_METAL_SIMULATOR_HOME: /work/sim
         TT_METAL_SIMULATOR: /work/sim/libttsim.so
         TT_METAL_SLOW_DISPATCH_MODE: 1
@@ -191,7 +235,7 @@ jobs:
       - name: Compute ttsim asset name
         id: ttsim-asset
         run: |
-          asset_suffix="${{ matrix.build_suffix }}"
+          asset_suffix="${{ matrix.arch.build_suffix }}"
           asset_suffix="${asset_suffix#release_}"
           echo "asset_name=libttsim_${asset_suffix}.so" >> "$GITHUB_OUTPUT"
 
@@ -208,92 +252,12 @@ jobs:
           set -euo pipefail
           mkdir -p $TT_METAL_SIMULATOR_HOME
           mv /tmp/ttsim/${{ steps.ttsim-asset.outputs.asset_name }} $TT_METAL_SIMULATOR_HOME/libttsim.so
-          cp /work/tt_metal/soc_descriptors/${{ matrix.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
+          cp /work/tt_metal/soc_descriptors/${{ matrix.arch.soc_desc }} $TT_METAL_SIMULATOR_HOME/soc_descriptor.yaml
 
-      - name: Run TTNN Pytests
+      - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 5
         run: |
-          pytest \
-            tests/ttnn/unit_tests/operations/ccl/blackhole_CI/ \
-            tests/ttnn/unit_tests/operations/ccl/test_ag_rs_llama_prefill_TG.py \
-            tests/nightly/tg/ccl/test_all_reduce_async.py \
-            tests/nightly/tg/ccl/test_all_to_all_combine_6U.py \
-            tests/nightly/t3000/ccl/test_all_to_all_combine.py \
-            tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py \
-            tests/nightly/t3000/ccl/test_all_to_all_dispatch.py \
-            tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py \
-            tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops.py \
-            tests/ttnn/unit_tests/operations/ccl/test_llama_prefill_ccl_ops_perf_nightly_TG.py \
-            tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_6U.py \
-            tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py \
-            tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_create_heads_async_TG.py \
-            tests/nightly/tg/ccl/test_mesh_partition_6U.py \
-            tests/nightly/t3000/ccl/test_mesh_partition.py \
-            tests/ttnn/unit_tests/operations/ccl/test_minimals.py \
-            tests/nightly/t3000/ccl/test_moe_ccl_end_to_end.py\
-            tests/nightly/t3000/ccl/test_new_all_broadcast.py \
-            tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py \
-            tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py \
-            tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py \
-            tests/nightly/t3000/ccl/test_send_recv_async.py \
-            tests/nightly/t3000/ccl/test_moe_expert_token_remap.py \
-            tests/nightly/t3000/ccl/test_apply_device_delay.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/complex_ops/test_backward_complex_add.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/complex_ops/test_backward_complex_mul.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/complex_ops/test_backward_conj.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/complex_ops/test_backward_imag.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/complex_ops/test_backward_real.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_abs.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_addalpha.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_addcmul.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_assign.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_ceil.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_clamp.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_clip.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_concat.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_deg2rad.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_fill.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_fill_zero.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_floor.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_frac.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_i0.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_lerp.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_max.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_min.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_neg.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rad2deg.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_relu.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_repeat.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_round.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rsub.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_sign.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_square.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_squared_difference.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_subalpha.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_trunc.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/test_complex_tensor.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_eltwise_logical_and_.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_inplace.py \
-            tests/ttnn/nightly/unit_tests/operations/eltwise/test_mul_bcast.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_signbit.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_sub.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_unary_uint16.py \
-            tests/ttnn/unit_tests/operations/point_to_point/test_moe_p2p.py \
-            tests/nightly/t3000/ccl/test_point_to_point.py \
-            tests/ttnn/unit_tests/operations/transformers/test_concatenate_heads.py \
-            tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py \
-            tests/ttnn/unit_tests/operations/debug/test_examples.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_full.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_full_like.py \
-            tests/ttnn/unit_tests/operations/debug/test_generic_op.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_hardtanh.py \
-            tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_non_zero_indices.py \
-            tests/ttnn/unit_tests/operations/transformers/test_paged_cache_mask.py \
-            tests/ttnn/unit_tests/operations/eltwise/test_polyval.py \
-            tests/ttnn/unit_tests/operations/transformers/test_prefetcher_TG.py \
-            tests/ttnn/unit_tests/operations/data_movement/test_reallocate.py
+          ${{ matrix.test-group.cmd }}
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}
     runs-on: tt-ubuntu-2204-small-stable


### PR DESCRIPTION
### Ticket
N/A - Infrastructure improvement

### Problem description
The ttnn test definitions were duplicated between `ttnn-post-commit.yaml` and `ttsim.yaml`. This made it difficult to:
- Keep test definitions in sync
- Enable tests on the simulator incrementally as support is added
- Have a clear view of which tests run where

### What's changed
Created a shared JSON file (`.github/workflows/ttnn-tests.json`) that serves as the **single source of truth** for ttnn test definitions.

**Changes:**
- Add `ttnn-tests.json` with test definitions including `name`, `cmd`, `merge_gate`, and `ttsim` flags
- Update `ttnn-post-commit.yaml` to read tests from the shared JSON file
- Update `ttsim.yaml` to read tests from the shared JSON file and filter for `ttsim: true` tests
- Add `has-tests` output to gracefully skip `ttnn-pytests` when no tests are simulator-enabled

**How to enable a test on the simulator:**
Simply change `"ttsim": false` to `"ttsim": true` in the JSON file. The change automatically propagates to both workflows.

**Example:**
```json
{ "name": "ttnn eltwise group 1", "cmd": "...", "merge_gate": false, "ttsim": true }
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=single-source-of-truth-ttnn-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:single-source-of-truth-ttnn-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=single-source-of-truth-ttnn-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:single-source-of-truth-ttnn-tests)
- [x] New/Existing tests provide coverage for changes (CI workflow changes - tested by running the workflows)