### PR TITLE
#24136 binary op output mem config half config

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -64,6 +64,42 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
 bool is_quant_op(const BinaryOpType val) {
     return (val == BinaryOpType::QUANT) || (val == BinaryOpType::DEQUANT) || (val == BinaryOpType::REQUANT);
 }
+
+ShardSpec generate_shard_spec_all_cores(
+    const Tensor& input_tensor_a, const Shape& padded_out_shape, const TensorMemoryLayout& memory_layout) {
+    // Generate shard spec using all worker cores
+    auto* device = input_tensor_a.device();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    auto all_cores = CoreRangeSet(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    uint32_t num_cores = all_cores.num_cores();
+
+    // Calculate squeezed tensor height (all dims except last) and width (last dim)
+    uint32_t tensor_height = 1;
+    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= padded_out_shape[i];
+    }
+    uint32_t tensor_width = padded_out_shape[-1];
+
+    // Calculate shard shape based on memory layout (must be tile-aligned for TILE layout)
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        auto height_padded = tt::round_up(tensor_height, num_cores * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), tt::constants::TILE_HEIGHT);
+        shard_shape = {shard_height, tensor_width};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), tt::constants::TILE_WIDTH);
+        shard_shape = {tensor_height, shard_width};
+    } else {
+        // BLOCK_SHARDED
+        CoreCoord grid_size = all_cores.bounding_box().grid_size();
+        auto height_padded = tt::round_up(tensor_height, grid_size.y * tt::constants::TILE_HEIGHT);
+        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), tt::constants::TILE_HEIGHT);
+        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
+        shard_shape = {shard_height, shard_width};
+    }
+    log_debug(tt::LogOp, "BinaryNgDeviceOperation: Generated shard spec using all {} worker cores", num_cores);
+    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+}
 }  // namespace utils
 
 CoreRangeSet get_worker_grid(
@@ -373,22 +409,21 @@ BinaryNgDeviceOperation::spec_return_value_t BinaryNgDeviceOperation::compute_ou
 
         // If no shard spec is provided, inherit from input tensor
         if (!shard_spec_opt.has_value()) {
+            const auto& padded_out_shape =
+                input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
             if (input_tensor_a.is_sharded()) {
                 // Adjust shard spec from input A to match output shape
                 const auto& padded_a_shape = input_tensor_a.padded_shape();
-                const auto& padded_out_shape =
-                    input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+
                 shard_spec_opt = ttnn::operations::binary_ng::adjust_to_shape(
                     *input_tensor_a.memory_config().shard_spec(), padded_a_shape, padded_out_shape);
             } else if (tensor_b.has_value() && tensor_b->is_sharded()) {
                 // Adjust shard spec from input B to match output shape
                 const auto& padded_b_shape = tensor_b->padded_shape();
-                const auto& padded_out_shape =
-                    tensor_b->tensor_spec().tensor_layout().compute_padded_shape(output_shape);
                 shard_spec_opt = ttnn::operations::binary_ng::adjust_to_shape(
                     *tensor_b->memory_config().shard_spec(), padded_b_shape, padded_out_shape);
             } else {
-                TT_THROW("Output memory config is sharded but has no shard spec, and no input tensors are sharded");
+                shard_spec_opt = utils::generate_shard_spec_all_cores(input_tensor_a, padded_out_shape, memory_layout);
             }
         }
 
@@ -539,7 +574,16 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
                     operations::binary_ng::compute_mem_config_actual(input_tensor_b, input_tensor_a.logical_shape());
                 log_debug(tt::LogOp, "BinaryNgDeviceOperation: Inheriting shard spec from input tensor B");
             } else {
-                TT_THROW("Output memory config is sharded but has no shard spec, and no input tensors are sharded");
+                auto memory_layout = mem_config_actual.memory_layout();
+                auto output_shape = operations::binary_ng::compute_broadcasted_output(
+                    input_tensor_a.logical_shape(), input_tensor_b.logical_shape());
+                const auto& padded_out_shape =
+                    input_tensor_a.tensor_spec().tensor_layout().compute_padded_shape(output_shape);
+                mem_config_actual = MemoryConfig(
+                    memory_layout,
+                    mem_config_actual.buffer_type(),
+                    operations::binary_ng::utils::generate_shard_spec_all_cores(
+                        input_tensor_a, padded_out_shape, memory_layout));
             }
         } else {
             log_debug(tt::LogOp, "BinaryNgDeviceOperation: Using provided memory config from function argument");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -620,14 +620,15 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     uint32_t from_volume_except_width = 1;
     uint32_t to_volume_except_width = 1;
 
-    const int rank = std::max(from_shape.rank(), to_shape.rank());
+    const int from_rank = static_cast<int>(from_shape.rank());
+    const int to_rank = static_cast<int>(to_shape.rank());
 
-    // Accumulate all dimensions except the last
-    for (int i = 0; i < rank - 1; ++i) {
-        uint32_t from_dim = (i < from_shape.rank()) ? from_shape[i] : 1;
-        uint32_t to_dim = (i < to_shape.rank()) ? to_shape[i] : 1;
-        from_volume_except_width *= from_dim;
-        to_volume_except_width *= to_dim;
+    for (int i = 0; i < from_rank - 1; ++i) {
+        from_volume_except_width *= from_shape[i];
+    }
+
+    for (int i = 0; i < to_rank - 1; ++i) {
+        to_volume_except_width *= to_shape[i];
     }
 
     // Get width dimensions

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -620,8 +620,8 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     uint32_t from_volume_except_width = 1;
     uint32_t to_volume_except_width = 1;
 
-    const int from_rank = static_cast<int>(from_shape.rank());
-    const int to_rank = static_cast<int>(to_shape.rank());
+    const auto from_rank = static_cast<int>(from_shape.rank());
+    const auto to_rank = static_cast<int>(to_shape.rank());
 
     for (int i = 0; i < from_rank - 1; ++i) {
         from_volume_except_width *= from_shape[i];


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/24316)

### Problem description
Finishing up the feature where both input tensors are interleaved

### What's changed
Compute shard spec to use all cores

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dchen/24316-half_mem_config)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/24316-half_mem_config)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/24316-half_mem_config)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/24316-half_mem_config)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/24316-half_mem_config)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/24316-half_mem_config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/24316-half_mem_config)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs