### PR TITLE
Fixing PCC failure in PR #35888

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -176,7 +176,7 @@ void TransposeWHShardedProgramFactory::override_runtime_arguments(
             num_tiles_per_shard * shared_variables.dst_single_tile_size);
     }
 
-    auto padded_shape = output_tensor.padded_shape();
+    auto padded_shape = src_tensor.padded_shape();
     auto shard_shape = shard_spec.shape;
 
     uint32_t H = padded_shape[2];


### PR DESCRIPTION
### Ticket
N/A
### Problem description
PCC failure seen on https://github.com/tenstorrent/tt-metal/actions/runs/21128592428/job/60755068376#step:6:1116 after commit https://github.com/tenstorrent/tt-metal/commit/c83c151d8396171a223f4f4dc24614fac1be1eec.

### What's changed
There was a bug introduced in the `override_runtime_arguments` function in the `ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp` program factory. This PR corrects that bug.

### Checklist

- [ ] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21196466781)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/21196478931)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/21196495243)
- [ ] [L2-Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/21196518903)
- [x] New/Existing tests provide coverage for changes