### PR TITLE
Update eltwise kernels to sync with updated format

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_h.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_h.cpp
@@ -5,8 +5,7 @@
 #include <cstdint>
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
@@ -40,4 +39,3 @@ void MAIN {
         }
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -5,8 +5,7 @@
 #include <cstdint>
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t NC = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
@@ -39,4 +38,3 @@ void MAIN {
     cb_pop_front(tt::CBIndex::c_0, Wt * Ht);
     cb_push_back(tt::CBIndex::c_2, Wt * Ht);
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_hw.cpp
@@ -6,8 +6,7 @@
 
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     constexpr uint32_t onetile = 1;
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
@@ -44,4 +43,3 @@ void MAIN {
         }
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_w.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/bcast_w.cpp
@@ -6,8 +6,7 @@
 
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t w = 0;
     constexpr uint32_t onetile = 1;
     uint32_t B = get_arg_val<uint32_t>(0);
@@ -37,4 +36,3 @@ void MAIN {
         }
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -10,8 +10,7 @@
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
 
@@ -139,4 +138,3 @@ void MAIN {
         cb_push_back(cb_out0, per_core_block_size);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -26,8 +26,7 @@
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
 
@@ -175,4 +174,3 @@ void MAIN {
         cb_push_back(cb_out0, per_core_block_size);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary.cpp
@@ -10,8 +10,6 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
     tt::CBIndex cb_post_lhs,
@@ -62,7 +60,7 @@ ALWI void process_tile(
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -109,4 +107,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast.cpp
@@ -9,8 +9,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -57,4 +56,3 @@ void MAIN {
         cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar.cpp
@@ -9,8 +9,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -56,4 +55,3 @@ void MAIN {
         cb_push_back(cb_out, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -25,8 +25,6 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
     tt::CBIndex cb_post_lhs,
@@ -91,7 +89,7 @@ ALWI void process_tile(
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -138,4 +136,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -26,8 +26,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -89,4 +88,3 @@ void MAIN {
         cb_pop_front(cb_post_rhs, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -22,8 +22,7 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -83,4 +82,3 @@ void MAIN {
         cb_push_back(cb_out, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_no_bcast.cpp
@@ -10,8 +10,7 @@
 #include "eltwise_utils_sfpu.hpp"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t scalar_value = get_arg_val<uint32_t>(3);
     const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
@@ -79,4 +78,3 @@ void MAIN {
         cb_pop_front(cb_in1, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu.cpp
@@ -10,8 +10,6 @@
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_in0,
     tt::CBIndex cb_in1,
@@ -86,7 +84,7 @@ ALWI void process_tile(
     cb_pop_front(CB_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -126,4 +124,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_where_sfpu_scalar.cpp
@@ -10,8 +10,7 @@
 #include "eltwise_utils_sfpu.hpp"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t scalar_value = get_arg_val<uint32_t>(3);
     const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
@@ -80,4 +79,3 @@ void MAIN {
         cb_push_back(cb_out, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast.cpp
@@ -11,8 +11,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -81,4 +80,3 @@ void MAIN {
         cb_pop_front(cb_right, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_col_bcast.cpp
@@ -11,8 +11,6 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
     tt::CBIndex cb_post_lhs,
@@ -81,7 +79,7 @@ ALWI void process_tile(
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -123,4 +121,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -16,8 +16,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
@@ -107,4 +106,3 @@ void MAIN {
         cb_pop_front(cb_right, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -26,8 +26,6 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_pre_lhs,
     tt::CBIndex cb_post_lhs,
@@ -111,7 +109,7 @@ ALWI void process_tile(
     cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -157,4 +155,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_bcast.cpp
@@ -11,8 +11,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t scalar_value = get_arg_val<uint32_t>(3);
     const auto scalar_val = reinterpret_cast<const float*>(&scalar_value);
@@ -110,4 +109,3 @@ void MAIN {
         cb_pop_front(cb_right, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_where_sfpu_row_col_bcast.cpp
@@ -12,8 +12,6 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "compute_kernel_api/bcast.h"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_in0,
     tt::CBIndex cb_in1,
@@ -116,7 +114,7 @@ ALWI void process_tile(
     cb_pop_front(CB_BCAST, num_tiles_per_cycle);
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -153,4 +151,3 @@ void MAIN {
             num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu.cpp
@@ -8,8 +8,7 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/addcmul.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
 
@@ -67,4 +66,3 @@ void MAIN {
         cb_pop_front(cb_in0, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_bcast.cpp
@@ -10,8 +10,6 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_in0,
     tt::CBIndex cb_in1,
@@ -104,7 +102,7 @@ ALWI void process_tile(
 #endif
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -135,4 +133,3 @@ void MAIN {
         process_tile(cb_in0, cb_in1, cb_in2, cb_out, remaining_iterations, tile_start, num_tiles_per_cycle, scalar_arg);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_rowbcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_fpu_rowbcast.cpp
@@ -10,8 +10,7 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/eltwise_unary/addcmul.h"
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
 
@@ -131,4 +130,3 @@ void MAIN {
         cb_pop_front(cb_eff_c, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_sfpu.cpp
@@ -11,8 +11,7 @@
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #include "compute_kernel_api/eltwise_unary/addcmul.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t scalar_arg = get_arg_val<uint32_t>(3);
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
@@ -58,4 +57,3 @@ void MAIN {
         cb_pop_front(cb_in2, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_sfpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_sfpu_bcast.cpp
@@ -8,8 +8,6 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/addcmul.h"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex cb_in0,
     tt::CBIndex cb_in1,
@@ -96,7 +94,7 @@ ALWI void process_tile(
 #endif
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -126,4 +124,3 @@ void MAIN {
         process_tile(cb_in0, cb_in1, cb_in2, cb_out, remaining_iterations, tile_start, num_tiles_per_cycle, scalar_arg);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
@@ -10,8 +10,6 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex predicate_cb,
     tt::CBIndex tensor_cb,
@@ -113,7 +111,7 @@ ALWI void process_tile(
 #endif
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -144,4 +142,3 @@ void MAIN {
             predicate_cb, tensor_cb, cb_out, remaining_iterations, tile_start, num_tiles_per_cycle, scalar_value);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
@@ -9,8 +9,6 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 
-namespace NAMESPACE {
-
 ALWI void process_tile(
     tt::CBIndex predicate_cb,
     tt::CBIndex true_cb,
@@ -95,7 +93,7 @@ ALWI void process_tile(
 #endif
 }
 
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     uint32_t tile_freq = get_arg_val<uint32_t>(1);
     uint32_t tile_start = get_arg_val<uint32_t>(2);
@@ -124,4 +122,3 @@ void MAIN {
         process_tile(predicate_cb, true_cb, false_cb, cb_out, remaining_iterations, tile_start, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
@@ -10,8 +10,7 @@
 #include "compute_kernel_api/eltwise_unary/where.h"
 #include "compute_kernel_api/eltwise_unary/fill.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     const uint32_t scalar_value = get_arg_val<uint32_t>(3);
 
@@ -81,4 +80,3 @@ void MAIN {
         cb_pop_front(cb_pre_in2, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
@@ -9,8 +9,7 @@
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/where.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
@@ -56,4 +55,3 @@ void MAIN {
         cb_pop_front(cb_pre_in3, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -20,8 +20,7 @@
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // typically 1
@@ -155,4 +154,3 @@ void MAIN {
         cb_pop_front(cb_eff_c, num_tiles_per_cycle);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/cbrt_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/cbrt_kernel.cpp
@@ -12,8 +12,7 @@
 #include "compute_kernel_api/eltwise_unary/cbrt.h"
 #include "compute_kernel_api.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -79,4 +78,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_identity_kernel.cpp
@@ -7,8 +7,7 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -38,4 +37,3 @@ void MAIN {
         cb_push_back(tt::CBIndex::c_2, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
@@ -13,8 +13,7 @@
 #include "compute_kernel_api/eltwise_unary/rpow.h"
 #include "compute_kernel_api/eltwise_unary/rdiv.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -46,4 +45,3 @@ void MAIN {
         cb_push_back(tt::CBIndex::c_2, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel.cpp
@@ -13,8 +13,7 @@
 #include "compute_kernel_api/eltwise_unary/fill.h"
 #include "compute_kernel_api/eltwise_unary/comp.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
     const auto lambd = reinterpret_cast<const float*>(&packed_scalar);
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -78,4 +77,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardshrink_kernel_sfpu.cpp
@@ -14,8 +14,7 @@
 #include "compute_kernel_api/eltwise_unary/fill.h"
 #include "compute_kernel_api/eltwise_unary/comp.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     const uint32_t packed_scalar = get_arg_val<uint32_t>(0);
     const auto lambd = reinterpret_cast<const float*>(&packed_scalar);
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -82,4 +81,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel.cpp
@@ -12,8 +12,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/eltwise_unary/activations.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -52,4 +51,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/hardswish_kernel_sfpu.cpp
@@ -12,8 +12,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/eltwise_unary/activations.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -52,4 +51,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logit_kernel.cpp
@@ -16,8 +16,7 @@
 #include "compute_kernel_api/copy_dest_values.h"
 #include "compute_kernel_api.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     const uint32_t packed_scalar1 = get_arg_val<uint32_t>(0);
     const uint32_t packed_scalar2 = get_arg_val<uint32_t>(1);
 
@@ -102,4 +101,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
@@ -11,8 +11,7 @@
 #include "compute_kernel_api/logsigmoid.h"
 #include "compute_kernel_api/eltwise_unary/negative.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     // Compile-time arguments
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
@@ -59,4 +58,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -14,8 +14,7 @@
 #include "compute_kernel_api/eltwise_unary/log1p.h"
 #include "compute_kernel_api.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -64,4 +63,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_kernel.cpp
@@ -10,8 +10,7 @@
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -49,4 +48,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/tanhshrink_sfpu_kernel.cpp
@@ -12,8 +12,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/copy_dest_values.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
@@ -52,4 +51,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
@@ -12,8 +12,7 @@
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api/eltwise_unary/fill.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     const uint32_t packed_scalar1 = get_arg_val<uint32_t>(0);
     const uint32_t packed_scalar2 = get_arg_val<uint32_t>(1);
     const auto true_value = reinterpret_cast<const float*>(&packed_scalar1);
@@ -54,4 +53,3 @@ void MAIN {
         cb_push_back(cb_output, per_core_block_dim);
     }
 }
-}  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
NA

### Problem description
device kernels structure has been updated and simplified
`2026-01-21 04:27:21.345 | warning  |    BuildKernels | Compute kernel 'eltwise_sfpu/13872637564034646659/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)`

### What's changed
Reflect the changes to use new syntax in eltwise kernels

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/simplified_kernels)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/simplified_kernels)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/simplified_kernels)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/simplified_kernels)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/simplified_kernels)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/simplified_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/simplified_kernels)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs