### PR TITLE
[Quasar only]: Adding experimental DataflowBuffer support to enable multiple DM threads streaming data into a Neo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@ tt_metal/tools/profiler/noc_event_profiler.hpp @bgrady-tt @sohaibnadeemTT @mo-te
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @bgrady-tt @sohaibnadeemTT @mo-tenstorrent @tenstorrent/codeowner-bypass
 tt_metal/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
 tt_metal/hw/inc/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-bypass
+tt_metal/experimental/dataflow_buffer/ @abhullar-tt @tenstorrent/codeowner-bypass
 
 # metal misc
 tt_metal/sfpi-info.sh @nathan-TT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass

--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
         core_coord/test_CoreRangeSet_contains.cpp
         core_coord/test_CoreRangeSet_intersects.cpp
         core_coord/test_CoreRangeSet_merge.cpp
+        dataflow_buffer/test_dataflow_buffer_configs.cpp
         distribution_spec/test_buffer_distribution_spec.cpp
         test_banked.cpp
         test_bit_utils.cpp

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp"
+
+namespace tt::tt_metal {
+
+void run_dfb_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const experimental::dfb::DataflowBufferConfig& dfb_config) {
+    Program program = CreateProgram();
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    uint32_t buffer_size = dfb_config.entry_size * dfb_config.num_entries;
+    distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+    auto in_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
+    auto out_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
+
+    log_info(tt::LogTest, "In Buffer: [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
+    log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
+
+    CoreCoord logical_core = CoreCoord(0, 0);
+    /*auto logical_dfb_id = */ experimental::dfb::CreateDataflowBuffer(program, logical_core, dfb_config);
+
+    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address()};
+    tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
+    /*auto producer_kernel = */ CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        logical_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = producer_cta});
+
+    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address()};
+    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
+    /*auto consumer_kernel = */ CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
+        logical_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_0, .compile_args = consumer_cta});
+
+    // SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)in_buffer->address()});
+    // SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)out_buffer->address()});
+
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, buffer_size / sizeof(uint32_t));
+    distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
+
+    // Execute using slow dispatch (DFBs not yet supported in MeshWorkload path)
+    IDevice* device = mesh_device->get_devices()[0];
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    std::vector<uint32_t> output;
+    distributed::ReadShard(mesh_device->mesh_command_queue(), output, out_buffer, zero_coord, true);
+
+    EXPECT_EQ(input, output);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+}  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+#include "api/debug/dprint.h"
+
+void kernel_main() {
+    const uint32_t dst_addr_base = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+
+    experimental::DataflowBuffer dfb(0);
+    experimental::Noc noc;
+
+    // uint32_t dst_addr_base = get_arg_val<uint32_t>(0);
+    uint32_t entry_size = dfb.get_entry_size();
+    const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
+
+    for (uint32_t tile_id = 0; tile_id < 16; tile_id++) {
+        dfb.wait_front(1);
+        noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = tile_id});
+        dfb.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "experimental/dataflow_buffer.h"
+#include "experimental/noc.h"
+#include "experimental/tensor.h"
+#include "api/debug/dprint.h"
+
+void kernel_main() {
+    const uint32_t src_addr_base = get_compile_time_arg_val(0);
+    constexpr auto src_args = TensorAccessorArgs<1>();
+
+    experimental::DataflowBuffer dfb(0);
+    experimental::Noc noc;
+
+    // uint32_t src_addr_base = get_arg_val<uint32_t>(0);
+    uint32_t entry_size = dfb.get_entry_size();
+    const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
+
+    for (uint32_t tile_id = 0; tile_id < 16; tile_id++) {
+        dfb.reserve_back(1);
+        noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id}, {});
+        noc.async_read_barrier();
+        dfb.push_back(1);
+    }
+    dfb.finish();
+}

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -251,6 +251,7 @@ target_link_libraries(
         detail
         distributed
         fabric
+        dfb
         FlatBuffers::FlatBuffers
         TT::Metalium::Logging
         TT::ScaleoutTools
@@ -302,6 +303,7 @@ add_subdirectory(detail)
 add_subdirectory(distributed)
 add_subdirectory(fabric)
 add_subdirectory(experimental/udm)
+add_subdirectory(experimental/dataflow_buffer)
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(test)
 endif()

--- a/tt_metal/experimental/dataflow_buffer/CMakeLists.txt
+++ b/tt_metal/experimental/dataflow_buffer/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(dfb OBJECT dataflow_buffer.cpp)
+
+target_link_libraries(
+    dfb
+    PRIVATE
+        common
+        TT::Metalium::HostDevCommon
+)

--- a/tt_metal/experimental/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/experimental/dataflow_buffer/dataflow_buffer.cpp
@@ -1,0 +1,426 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp"
+#include "tt_metal/impl/allocator/allocator.hpp"
+#include "tt_metal/impl/program/program_impl.hpp"
+
+namespace tt::tt_metal::experimental::dfb {
+
+uint32_t CreateDataflowBuffer(
+    Program& program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const DataflowBufferConfig& config) {
+    auto core_range_set = std::visit(
+        ttsl::overloaded{
+            [](const CoreCoord& core_spec) { return CoreRangeSet(CoreRange(core_spec, core_spec)); },
+            [](const CoreRange& core_spec) { return CoreRangeSet(core_spec); },
+            [](const CoreRangeSet& core_spec) { return core_spec; },
+        },
+        core_spec);
+
+    return program.impl().add_dataflow_buffer(core_range_set, config);
+}
+
+namespace detail {
+
+::experimental::PackedTileCounter TileCounterAllocator::allocate(uint8_t tensix_id) {
+    // 16 exposed to overlay
+    // TODO: Update for remapper
+    TT_FATAL(next_tc_id_ < 16, "Out of tile counters for tensix {}", (uint32_t)tensix_id);
+    uint8_t tc_id = next_tc_id_++;
+    return static_cast<::experimental::PackedTileCounter>((tensix_id << 5) | tc_id);
+}
+
+uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
+    if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+        return is_producer ? config.num_consumers : 1;
+    }
+    return (config.num_consumers + config.num_producers - 1) / config.num_producers;
+}
+
+::experimental::PackedTileCounter get_shared_tc_for_consumer(
+    const DataflowBufferImpl* dfb, uint8_t consumer_idx, uint8_t tc_idx) {
+    // In strided mode, consumers share TCs with producers (unless remapper is used and we have diff 1:1 remappings)
+    // TODO: this needs to be updated when remapper is added
+    uint8_t producer_idx = (consumer_idx * dfb->config.num_producers) / dfb->config.num_consumers;
+    return dfb->risc_configs[producer_idx].config.packed_tile_counter[tc_idx];
+}
+
+uint32_t DataflowBufferImpl::serialized_size() const {
+    // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc
+    return sizeof(::experimental::dfb_initializer_t) +
+           (risc_configs.size() * sizeof(::experimental::dfb_initializer_per_risc_t));
+}
+
+std::vector<uint8_t> DataflowBufferImpl::serialize() const {
+    std::vector<uint8_t> data;
+    data.reserve(serialized_size());
+
+    ::experimental::dfb_initializer_t init = {};
+    init.logical_id = this->id;
+    init.entry_size = this->entry_size;
+    init.stride_size = this->stride_size;
+    init.capacity = this->capacity;
+    init.risc_mask_bits.dm_mask = this->risc_mask & 0xFF;
+    init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
+    init.risc_mask_bits.reserved = 0;
+    init.risc_mask_bits.tc_initialized = 0;  // set by device after init
+    init.remapper_pair_index = this->remapper_pair_index;
+    init.num_txn_ids = this->num_txn_ids;
+    for (int i = 0; i < 4; i++) {
+        init.txn_ids[i] = this->txn_ids[i];
+    }
+    init.num_entries_per_txn_id = this->num_entries_per_txn_id;
+    init.num_entries_per_txn_id_per_tc = this->num_entries_per_txn_id_per_tc;
+
+    log_info(
+        tt::LogMetal,
+        "Serializing DFB {} with {} producers and {} consumers. risc_mask: 0x{:x}",
+        this->id,
+        this->config.num_producers,
+        this->config.num_consumers,
+        this->risc_mask);
+
+    const auto* init_bytes = reinterpret_cast<const uint8_t*>(&init);
+    data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
+
+    // Write one dfb_initializer_per_risc_t per risc
+    for (const auto& rc : risc_configs) {
+        ::experimental::dfb_initializer_per_risc_t per_risc = {};
+
+        // Copy per-risc arrays
+        for (int i = 0; i < 4; i++) {
+            per_risc.base_addr[i] = rc.config.base_addr[i];
+            per_risc.limit[i] = rc.config.limit[i];
+            per_risc.packed_tile_counter[i] = rc.config.packed_tile_counter[i];
+        }
+        per_risc.num_tcs_to_rr = rc.config.num_tcs_to_rr;
+        per_risc.should_init_tc = rc.config.should_init_tc ? 1 : 0;
+
+        log_info(
+            tt::LogMetal,
+            "\tRisc {}: base_addr[0]={}, limit[0]={}, num_tcs_to_rr={}",
+            rc.risc_id,
+            rc.config.base_addr[0],
+            rc.config.limit[0],
+            rc.config.num_tcs_to_rr);
+
+        const auto* cfg_bytes = reinterpret_cast<const uint8_t*>(&per_risc);
+        data.insert(data.end(), cfg_bytes, cfg_bytes + sizeof(per_risc));
+    }
+
+    log_info(tt::LogMetal, "Serialized DFB {} size: {}", this->id, data.size());
+
+    return data;
+}
+
+uint32_t finalize_dfbs(
+    uint32_t /*programmable_core_type_index*/,
+    std::vector<std::shared_ptr<tt::tt_metal::KernelGroup>>& kernel_groups,
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dataflow_buffers,
+    uint32_t base_offset,
+    uint32_t& dfb_offset,
+    uint32_t& dfb_size) {
+    if (dataflow_buffers.empty()) {
+        return base_offset;
+    }
+
+    const auto& hal = MetalContext::instance().hal();
+
+    dfb_offset = base_offset;
+    dfb_size = 0;
+
+    for (auto& kg : kernel_groups) {
+        auto kernel_config = kg->launch_msg.view().kernel_config();
+        kernel_config.local_cb_offset() = base_offset;
+
+        // Calculate total DFB size for this kernel group
+        uint32_t kg_dfb_size = 0;
+        for (const auto& dfb : dataflow_buffers) {
+            // Check if this DFB overlaps with any core in the kernel group
+            bool dfb_on_kg = false;
+            for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
+                if (dfb->core_ranges.intersects(kg_range)) {
+                    dfb_on_kg = true;
+                    break;
+                }
+            }
+            if (dfb_on_kg) {
+                kg_dfb_size += dfb->serialized_size();
+            }
+        }
+
+        // Track max across all kernel groups
+        dfb_size = std::max(dfb_size, kg_dfb_size);
+    }
+
+    dfb_size = tt::align(
+        dfb_size, 64);  // workaround where non-64 byte aligned writes on sim seem to get zero padded to 64 bytes
+
+    log_info(
+        tt::LogMetal,
+        "Finalize dfb: dfb_offset == base_offset: {}, dfb size: {}, return value: {}",
+        base_offset,
+        dfb_size,
+        tt::align(base_offset + dfb_size, hal.get_alignment(HalMemType::L1)));
+
+    return tt::align(base_offset + dfb_size, hal.get_alignment(HalMemType::L1));
+}
+
+}  // namespace detail
+
+}  // namespace tt::tt_metal::experimental::dfb
+
+namespace tt::tt_metal::detail {
+
+using namespace tt::tt_metal::experimental::dfb;
+using namespace tt::tt_metal::experimental::dfb::detail;
+
+uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, const DataflowBufferConfig& config) {
+    TT_FATAL(this->compiled_.empty(), "Cannot add dataflow buffer to an already compiled program {}", this->id);
+
+    TT_FATAL(this->circular_buffers_.empty(), "Cannot add dataflow buffer to a program with circular buffers");
+
+    TT_FATAL(config.entry_size > 0, "Entry size must be > 0");
+    TT_FATAL(config.num_entries > 0, "Num entries must be > 0");
+    TT_FATAL(config.producer_risc_mask != 0, "producer_risc_mask must have at least one bit set");
+    TT_FATAL(config.consumer_risc_mask != 0, "consumer_risc_mask must have at least one bit set");
+    TT_FATAL((config.producer_risc_mask & 0xFF00) == 0, "producer cannot be a Tensix yet");
+    TT_FATAL((config.consumer_risc_mask & 0xFF00) == 0, "consumer cannot be a Tensix yet");
+    TT_FATAL(
+        (config.producer_risc_mask & config.consumer_risc_mask) == 0,
+        "producer_risc_mask and consumer_risc_mask must not overlap");
+    TT_FATAL(config.num_producers == 1, "DFB only supports one producer for now");
+    TT_FATAL(config.num_consumers == 1, "DFB only supports one consumer for now");
+    TT_FATAL(config.pap != ::experimental::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
+    TT_FATAL(config.cap != ::experimental::AccessPattern::BLOCKED, "Blocked consumer pattern not supported yet");
+    TT_FATAL(!config.enable_implicit_sync, "Implicit sync not supported yet");
+    TT_FATAL(
+        core_range_set.num_cores() == 1,
+        "DFB only supports single core, but CoreRangeSet contains {} cores: {}",
+        core_range_set.num_cores(),
+        core_range_set.str());
+
+    auto dfb = std::make_shared<DataflowBufferImpl>();
+
+    // Assign logical ID (0, 1, 2, ...)
+    dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
+    dfb->core_ranges = core_range_set.merge_ranges();
+    dfb->config = config;
+
+    // Use risc_mask from config
+    dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
+
+    // Set shared config fields
+    dfb->entry_size = config.entry_size;
+    dfb->stride_size = config.entry_size * std::max(config.num_producers, config.num_consumers);
+
+    log_info(
+        tt::LogMetal,
+        "Creating DFB {} with {} producers (mask 0x{:x}) and {} consumers (mask 0x{:x})",
+        dfb->id,
+        config.num_producers,
+        config.producer_risc_mask,
+        config.num_consumers,
+        config.consumer_risc_mask);
+
+    uint32_t capacity;
+    switch (config.cap) {
+        case ::experimental::AccessPattern::STRIDED:
+            TT_FATAL(
+                config.num_entries % std::max(config.num_producers, config.num_consumers) == 0,
+                "Num entries in DFB {} must be divisible by max of num producers and consumers {}",
+                config.num_entries,
+                std::max(config.num_producers, config.num_consumers));
+            capacity = config.num_entries / std::max(config.num_producers, config.num_consumers);
+            break;
+        case ::experimental::AccessPattern::BLOCKED:
+            TT_FATAL(
+                config.num_entries % config.num_producers == 0,
+                "Num entries in DFB {} must be divisible by num producers {}",
+                config.num_entries,
+                config.num_producers);
+            capacity = config.num_entries / config.num_producers;
+            break;
+        default: TT_FATAL(false, "Invalid access pattern", (uint32_t)config.cap);
+    }
+    dfb->capacity = capacity;
+
+    uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
+    uint8_t num_consumer_tcs = calculate_num_tile_counters(config, false);
+
+    // Iterate over producer_risc_mask to create producer risc_configs
+    for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
+        if (!(config.producer_risc_mask & (1 << risc_id))) {
+            continue;
+        }
+
+        DFBRiscConfig risc_config;
+        risc_config.risc_id = risc_id;
+        risc_config.is_producer = true;
+        risc_config.config.should_init_tc = true;  // producer is responsible for initializing tile counters
+
+        log_info(tt::LogMetal, "Producer risc {} uses {} TCs", risc_id, num_producer_tcs);
+
+        // Fill arrays for round-robin TCs
+        for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
+            risc_config.config.packed_tile_counter[tc] = tile_counter_allocator_.allocate(risc_id);
+            log_info(tt::LogMetal, "\tAssigned TC[{}]: {}", tc, (uint32_t)risc_config.config.packed_tile_counter[tc]);
+        }
+        risc_config.config.num_tcs_to_rr = num_producer_tcs;
+
+        dfb->risc_configs.push_back(risc_config);
+    }
+
+    // Iterate over consumer_risc_mask to create consumer risc_configs
+    uint8_t consumer_count = 0;
+    for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
+        if (!(config.consumer_risc_mask & (1 << risc_id))) {
+            continue;
+        }
+
+        DFBRiscConfig risc_config;
+        risc_config.risc_id = risc_id;
+        risc_config.is_producer = false;
+
+        log_info(tt::LogMetal, "Consumer risc {} uses {} TCs", risc_id, num_consumer_tcs);
+
+        // Fill arrays for round-robin TCs
+        for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
+            if (config.cap == ::experimental::AccessPattern::STRIDED) {
+                risc_config.config.packed_tile_counter[tc] = get_shared_tc_for_consumer(dfb.get(), consumer_count, tc);
+                log_info(
+                    tt::LogMetal, "\tAssigned TC[{}]: {}", tc, (uint32_t)risc_config.config.packed_tile_counter[tc]);
+            } else {
+                TT_FATAL(false, "Need to implement blocked consumer access pattern");
+            }
+        }
+        risc_config.config.num_tcs_to_rr = num_consumer_tcs;
+        consumer_count++;
+
+        dfb->risc_configs.push_back(risc_config);
+    }
+
+    log_info(tt::LogMetal, "DFB {} risc_mask: 0x{:x}", dfb->id, dfb->risc_mask);
+
+    this->dataflow_buffers_.push_back(dfb);
+    this->dataflow_buffer_by_id_.insert({dfb->id, dfb});
+
+    for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                CoreCoord logical_core(x, y);
+                per_core_num_dfbs_[logical_core]++;
+            }
+        }
+    }
+
+    this->local_dataflow_buffer_allocation_needed_ = true;
+
+    return dfb->id;
+}
+
+void ProgramImpl::invalidate_dataflow_buffer_allocation() {
+    if (this->local_dataflow_buffer_allocation_needed_) {
+        return;
+    }
+    for (CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+        dfb_allocator.reset_available_addresses();
+    }
+    this->local_dataflow_buffer_allocation_needed_ = true;
+}
+
+// Same as allocate_circular_buffers
+void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
+    if (not this->local_dataflow_buffer_allocation_needed_) {
+        return;
+    }
+
+    uint64_t base_dfb_address = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    for (auto& dfb : this->dataflow_buffers_) {
+        uint64_t computed_addr = base_dfb_address;
+        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+            // Need the max available address across all cores dataflow buffer is placed on
+            for (const CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+                if (dfb_allocator.core_range == core_range) {
+                    computed_addr = std::max(computed_addr, dfb_allocator.get_cb_region_end());
+                    break;
+                }
+            }
+        }
+        computed_addr = align(computed_addr, device->allocator()->get_alignment(BufferType::DRAM));
+        for (const CoreRange& core_range : dfb->core_ranges.ranges()) {
+            for (CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+                if (dfb_allocator.core_range.intersects(core_range)) {
+                    if (dfb_allocator.core_range != core_range and computed_addr < dfb_allocator.get_cb_region_end()) {
+                        // Intersecting core range has already been marked to have allocation at this address. This
+                        // could have been marked by a dataflow buffer on a core range disjoint from current
+                        // `core_range` but also intersecting `dfb_allocator.core_range`
+                        continue;
+                    }
+                    dfb_allocator.mark_address(computed_addr, dfb->total_size(), base_dfb_address);
+                }
+            }
+        }
+        dfb->allocated_address = computed_addr;
+
+        // Populate base_addr[] and limit[] arrays for each risc config
+        uint32_t entry_size = dfb->config.entry_size;
+        uint32_t max_prod_cons = std::max(dfb->config.num_producers, dfb->config.num_consumers);
+
+        for (auto& rc : dfb->risc_configs) {
+            for (uint8_t tc = 0; tc < rc.config.num_tcs_to_rr; tc++) {
+                rc.config.base_addr[tc] = static_cast<uint32_t>(computed_addr) + (tc * entry_size);
+                rc.config.limit[tc] =
+                    rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
+            }
+        }
+    }
+    this->local_dataflow_buffer_allocation_needed_ = false;
+}
+
+// Same as validate_circular_buffer_region
+void ProgramImpl::validate_dataflow_buffer_region(const IDevice* device) {
+    std::optional<DeviceAddr> lowest_address =
+        device->lowest_occupied_compute_l1_address(this->determine_sub_device_ids(device));
+    uint32_t max_l1_size = device->l1_size_per_core();
+
+    for (const CircularBufferAllocator& dfb_allocator : this->dfb_allocators_) {
+        if (dfb_allocator.l1_regions.empty()) {
+            continue;
+        }
+        uint64_t dfb_region_end = dfb_allocator.l1_regions.back().second;
+        if (dfb_region_end > max_l1_size) {
+            TT_THROW(
+                "Statically allocated dataflow buffers on core range {} grow to {} B which is beyond max L1 size of {} "
+                "B",
+                dfb_allocator.core_range.str(),
+                dfb_region_end,
+                max_l1_size);
+        }
+        if (lowest_address.has_value() and lowest_address.value() < dfb_region_end) {
+            TT_THROW(
+                "Statically allocated dataflow buffers in program {} clash with L1 buffers on core range {}. L1 buffer "
+                "allocated at {} and static dataflow buffer region ends at {}",
+                this->id,
+                dfb_allocator.core_range.str(),
+                lowest_address.value(),
+                dfb_region_end);
+        }
+    }
+}
+
+std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
+ProgramImpl::dataflow_buffers_on_core(const CoreCoord& core) const {
+    std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dfbs_on_core;
+    for (const auto& dfb : dataflow_buffers_) {
+        if (dfb->core_ranges.intersects(core)) {
+            dfbs_on_core.push_back(dfb);
+        }
+    }
+    return dfbs_on_core;
+}
+
+}  // namespace tt::tt_metal::detail

--- a/tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/core_coord.hpp>
+// #include <tt-metalium/program.hpp>
+
+#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+
+namespace tt::tt_metal {
+class Program;
+struct KernelGroup;
+}
+
+namespace tt::tt_metal::experimental::dfb {
+
+struct DataflowBufferConfig {
+    uint32_t entry_size = 0;
+    uint32_t num_entries = 0;
+    uint16_t producer_risc_mask = 0x0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
+    uint8_t num_producers = 1;
+    ::experimental::AccessPattern pap = ::experimental::AccessPattern::STRIDED;
+    uint16_t consumer_risc_mask = 0x0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
+    uint8_t num_consumers = 1;
+    ::experimental::AccessPattern cap = ::experimental::AccessPattern::STRIDED;
+    bool enable_implicit_sync = false;
+};
+
+// Returns logical DFB id
+uint32_t CreateDataflowBuffer(
+    Program& program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const DataflowBufferConfig& config);
+
+namespace detail {
+
+// Per-risc config matching dfb_initializer_per_risc_t (40 bytes)
+struct LocalDFBInterfaceHost {
+    std::array<uint32_t, 4> base_addr = {0};
+    std::array<uint32_t, 4> limit = {0};
+    std::array<::experimental::PackedTileCounter, 4> packed_tile_counter = {0};
+    uint8_t num_tcs_to_rr = 1;
+    bool should_init_tc = false;
+};
+
+struct DFBRiscConfig {
+    uint8_t risc_id = 0xFF;
+    bool is_producer{};
+    LocalDFBInterfaceHost config;
+};
+
+struct DataflowBufferImpl {
+    uint32_t id{};
+    CoreRangeSet core_ranges;
+    DataflowBufferConfig config;
+
+    uint16_t risc_mask = 0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
+    uint16_t capacity = 0;
+    std::vector<DFBRiscConfig> risc_configs;
+
+    // Shared config fields (written to dfb_initializer_t)
+    uint32_t entry_size = 0;
+    uint32_t stride_size = 0;
+    std::array<uint8_t, 4> txn_ids = {0};
+    uint8_t num_entries_per_txn_id = 0;
+    uint8_t num_entries_per_txn_id_per_tc = 0;
+    uint8_t remapper_pair_index = 0xFF;
+    uint8_t num_txn_ids = 0;
+
+    std::optional<uint32_t> allocated_address;
+
+    uint32_t total_size() const { return config.entry_size * config.num_entries; }
+    uint32_t serialized_size() const;
+    std::vector<uint8_t> serialize() const;  // returns config to write to device
+};
+
+class TileCounterAllocator {
+public:
+    ::experimental::PackedTileCounter allocate(uint8_t tensix_id);
+    void reset() { next_tc_id_ = 0; }
+
+private:
+    uint8_t next_tc_id_ = 0;
+};
+
+uint32_t finalize_dfbs(
+    uint32_t programmable_core_type_index,
+    std::vector<std::shared_ptr<tt::tt_metal::KernelGroup>>& kernel_groups,
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dataflow_buffers,
+    uint32_t base_offset,
+    uint32_t& dfb_offset,
+    uint32_t& dfb_size);
+
+}  // namespace detail
+
+}  // namespace tt::tt_metal::experimental::dfb

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -539,6 +539,7 @@ target_sources(
             inc/experimental/lock.h
             inc/experimental/noc.h
             inc/experimental/circular_buffer.h
+            inc/experimental/dataflow_buffer.h
             inc/experimental/noc_semaphore.h
             inc/experimental/endpoints.h
             inc/experimental/core_local_mem.h
@@ -552,6 +553,8 @@ target_sources(
             inc/internal/bit_utils.h
             inc/internal/circular_buffer_interface.h
             inc/internal/circular_buffer_init.h
+            inc/internal/dataflow_buffer_interface.h
+            inc/internal/dataflow_buffer_init.h
             inc/internal/firmware_common.h
             inc/internal/mod_div_lib.h
             inc/internal/risc_attribs.h

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -8,8 +8,11 @@
 #include "internal/debug/watcher_common.h"
 #include "api/debug/waypoint.h"
 #include "api/debug/dprint.h"
+#include "internal/dataflow_buffer_init.h"
 #include "internal/debug/stack_usage.h"
 #include "internal/debug/sanitize.h"
+#include "internal/dataflow_buffer_interface.h"
+#include "hostdev/dev_msgs.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 uint8_t noc_index;
@@ -41,6 +44,9 @@ int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(UNCACHED_MEM_MAILBOX_BASE);
 tt_l1_ptr subordinate_map_t* const subordinate_sync = (subordinate_map_t*)mailboxes->subordinate_sync.map;
+
+// Definition of the global DFB interface array (declared extern in dataflow_buffer_init.h)
+thread_local ::experimental::LocalDFBInterface g_dfb_interface[32] __attribute__((used));
 
 void device_setup() {
     // instn_buf
@@ -177,7 +183,7 @@ extern "C" uint32_t _start1() {
                 //     { subordinate_sync.dm1 = RUN_SYNC_MSG_LOAD;
                 // }
                 // Copies from L1 to IRAM on chips where NCRISC has IRAM
-                uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
+                uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
                 // Invalidate the i$ now the kernels have loaded and before running
                 // volatile tt_reg_ptr uint32_t* cfg_regs = core.cfg_regs_base(0);
                 // cfg_regs[RISCV_IC_INVALIDATE_InvalidateAll_ADDR32] =
@@ -206,27 +212,20 @@ extern "C" uint32_t _start1() {
                 // }
                 // prev_noc_mode = noc_mode;
 
-                // uint32_t tt_l1_ptr* cb_l1_base =
-                //     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.local_cb_offset);
+                uint32_t tt_l1_ptr* dfb_l1_base =
+                    (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg_address->kernel_config.local_cb_offset);
                 start_subordinate_kernel_run_early(enables);
 
                 // Run the kernel
                 WAYPOINT("R");
                 int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
                 if (enables & (1u << index)) {
-                    uint32_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
-                    // TODO: setup DataFlowBuffers
-                    // setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
-                    // cb_l1_base =
-                    //     (uint32_t tt_l1_ptr*)(kernel_config_base +
-                    //     launch_msg_address->kernel_config.remote_cb_offset);
-                    // uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
-                    // experimental::setup_remote_cb_interfaces<true>(
-                    //     cb_l1_base, end_cb_index, noc_index, noc_mode, true, cmd_buf);
-                    // barrier_remote_cb_interface_setup(noc_index, end_cb_index);
+                    uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
+                    experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
                     uint32_t kernel_lma =
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
                     asm("FENCE.i");
+                    uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
                     auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
                     record_stack_usage(stack_free);
                 } else {
@@ -319,15 +318,11 @@ extern "C" uint32_t _start1() {
 
         uint32_t kernel_lma = kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
 
-        uint32_t tt_l1_ptr* cb_l1_base =
+        uint32_t tt_l1_ptr* dfb_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
-        // setup_local_cb_read_write_interfaces<true, true, false>(cb_l1_base, 0, local_cb_mask);
+        uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
 
-        // cb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.remote_cb_offset);
-        // uint32_t end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
-        // NOC argument is unused
-        // experimental::setup_remote_cb_interfaces<false>(cb_l1_base, end_cb_index, 0, 0, 0, 0);
+        experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -316,12 +316,14 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args,
         const size_t bank_base_address_in,
         const uint32_t page_size_in = 0) :
-        InterleavedAddrGen<IsDram>({.bank_base_address = bank_base_address_in, .page_size = page_size_in}) {}
+        InterleavedAddrGen<IsDram>(
+            {.bank_base_address = static_cast<uint32_t>(bank_base_address_in), .page_size = page_size_in}) {}
 
     template <typename DSpec_ = DSpec, std::enable_if_t<std::is_same_v<std::decay_t<DSpec_>, DSpec>, int> = 0>
     constexpr explicit TensorAccessor(
         DSpec_&& dspec, const size_t bank_base_address_in, const uint32_t page_size_in = 0) :
-        InterleavedAddrGen<IsDram>({.bank_base_address = bank_base_address_in, .page_size = page_size_in}) {}
+        InterleavedAddrGen<IsDram>(
+            {.bank_base_address = static_cast<uint32_t>(bank_base_address_in), .page_size = page_size_in}) {}
 
     // Locality APIs
     FORCE_INLINE

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/dataflow_buffer_interface.h"
+#include "internal/dataflow_buffer_init.h"  // For g_dfb_interface extern declaration
+#include "api/debug/assert.h"
+
+// TODO: make this the top level api header but then separate out 1xx and 2xx implementations
+
+#ifndef COMPILE_FOR_TRISC
+#include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
+#include "experimental/noc.h"
+#endif
+
+#include "experimental/lock.h"
+
+namespace experimental {
+
+class DataflowBuffer {
+public:
+    DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {
+        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id];
+        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[0];
+        uint8_t tc_id = get_counter_id(packed_tc);
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+    }
+
+    uint32_t get_entry_size() const { return g_dfb_interface[logical_dfb_id_].entry_size; }
+
+    // Explicit sync APIs
+    void reserve_back(uint16_t num_entries) {
+        ASSERT(num_entries == 1);
+        PackedTileCounter packed_tc = g_dfb_interface[logical_dfb_id_].packed_tile_counter[counter_idx_];
+        uint8_t tc_id = get_counter_id(packed_tc);
+#ifdef COMPILE_FOR_TRISC
+#error "Not implemented"
+#else
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
+#endif
+    }
+
+    void push_back(uint16_t num_entries) {
+        ASSERT(num_entries == 1);
+        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
+        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[counter_idx_];
+        uint8_t tc_id = get_counter_id(packed_tc);
+#ifdef COMPILE_FOR_TRISC
+#error "Not implemented"
+#else
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        llk_intf_inc_posted(tensix_id, tc_id, num_entries);
+#endif
+
+        local_dfb_interface.wr_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
+        if (local_dfb_interface.wr_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
+            local_dfb_interface.wr_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
+        }
+
+        counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
+    }
+
+    void wait_front(uint16_t num_entries) {
+        ASSERT(num_entries == 1);
+        PackedTileCounter packed_tc = g_dfb_interface[logical_dfb_id_].packed_tile_counter[counter_idx_];
+        uint8_t tc_id = get_counter_id(packed_tc);
+#ifdef COMPILE_FOR_TRISC
+#error "Not implemented"
+#else
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
+#endif
+    }
+
+    void pop_front(uint16_t num_entries) {
+        ASSERT(num_entries == 1);
+        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
+        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[counter_idx_];
+        uint8_t tc_id = get_counter_id(packed_tc);
+#ifdef COMPILE_FOR_TRISC
+#error "Not implemented"
+#else
+        uint8_t tensix_id = get_tensix_id(packed_tc);
+        llk_intf_inc_acked(tensix_id, tc_id, num_entries);
+#endif
+
+        local_dfb_interface.rd_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
+        if (local_dfb_interface.rd_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
+            local_dfb_interface.rd_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
+        }
+        counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
+    }
+    // Explicit sync APIs end
+
+    // Implicit sync APIs
+    void read_in() {}
+
+    void write_out() {}
+    // Implicit sync APIs end
+
+    // from pov of producer need to make sure all the entries get posted (check the raw posted per TC == raw acked per
+    // TC)
+    // also that there are no interrupts remaining...
+    void finish() {
+        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
+#ifndef COMPILE_FOR_TRISC
+        bool all_acked = false;
+        while (!all_acked) {
+            all_acked = true;
+            for (uint8_t i = 0; i < local_dfb_interface.num_tcs_to_rr; i++) {
+                PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[i];
+                uint8_t tc_id = get_counter_id(packed_tc);
+                uint8_t tensix_id = get_tensix_id(packed_tc);
+                all_acked &=
+                    (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
+            }
+        }
+#endif
+    }
+
+    uint32_t get_write_ptr() const {
+        // return byte address (wr_ptr is 16B address on Gen1XX)
+        uint32_t wr_ptr_bytes = g_dfb_interface[logical_dfb_id_].wr_ptr[counter_idx_];
+        return wr_ptr_bytes;
+    }
+
+    uint32_t get_read_ptr() const {
+        // return byte address (rd_ptr is 16B address on Gen1XX)
+        uint32_t rd_ptr_bytes = g_dfb_interface[logical_dfb_id_].rd_ptr[counter_idx_];
+        return rd_ptr_bytes;
+    }
+
+    [[nodiscard]] auto scoped_lock() {
+        // TODO: Register with the debugger to track the lock
+        return Lock([this]() { release_scoped_lock(); });
+    }
+
+private:
+    void release_scoped_lock() {
+        // TODO: Unregister with the debugger
+    }
+
+    uint16_t logical_dfb_id_;
+    uint8_t counter_idx_ = 0;
+
+    // TODO: update txn id isr handling
+    uint8_t txn_id_index_ = 0;
+    uint32_t txn_id_loop_cnt_ = 0;  // try to remove this
+};
+
+#ifndef COMPILE_FOR_TRISC
+
+template <>
+struct noc_traits_t<DataflowBuffer> {
+    struct src_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_type {
+        uint32_t offset_bytes{};
+    };
+    struct dst_args_mcast_type {
+        uint32_t noc_x_start{};
+        uint32_t noc_y_start{};
+        uint32_t noc_x_end{};
+        uint32_t noc_y_end{};
+        uint32_t offset_bytes{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const DataflowBuffer& src, const Noc&, const src_args_type& args) {
+        static_assert(
+            address_type == Noc::AddressType::LOCAL_L1,
+            "DataflowBuffer without mcast range can only be used as L1 source");
+        return src.get_read_ptr() + args.offset_bytes;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const DataflowBuffer& dst, const Noc& noc, const dst_args_type& args) {
+        static_assert(
+            address_type == Noc::AddressType::LOCAL_L1,
+            "DataflowBuffer without mcast range can only be used as L1 source");
+        return dst.get_write_ptr() + args.offset_bytes;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr_mcast(const DataflowBuffer& dst, const Noc& noc, const dst_args_mcast_type& args) {
+        static_assert(
+            address_type == Noc::AddressType::NOC, "DataflowBuffer with mcast range cannot be used as L1 source");
+        auto local_addr = dst.get_write_ptr() + args.offset_bytes;
+        return ::get_noc_multicast_addr(
+            args.noc_x_start, args.noc_y_start, args.noc_x_end, args.noc_y_end, local_addr, noc.get_noc_id());
+    }
+};
+
+#endif
+
+}  // namespace experimental

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace experimental {
+
+enum AccessPattern : uint8_t {  // this should be put into experimental/hostdev or should it be a host file???
+    STRIDED,
+    BLOCKED,
+    UNKNOWN,
+};
+
+using PackedTileCounter = uint8_t;  // top 2 bits identify tensix id, bottom 5 bits for counter id
+
+// NOLINTBEGIN(readability-redundant-inline-specifier)
+inline __attribute__((always_inline)) constexpr uint8_t get_tensix_id(const PackedTileCounter& p) {
+    return (p >> 5) & 0x03;
+}
+
+inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(const PackedTileCounter& p) { return p & 0x1F; }
+// NOLINTEND(readability-redundant-inline-specifier)
+
+// move configs and LocalDFBInterface structs to hw/inc/hostdev
+
+/*
+    tensix + dm or tensix + tensix via remapper dfb
+    LogicalDFB 0:
+    | dfb_initializer_t |
+    | dfb_initializer_per_risc_t | risc 0
+    | dfb_initializer_per_risc_t | risc 1
+    ...
+    | dfb_initializer_per_risc_t | risc 11
+    LogicalDFB 1:
+    | dfb_initializer_t |
+    | dfb_initializer_per_risc_t | risc 0
+    | dfb_initializer_per_risc_t | risc 1
+    ...
+    (24 + (40 * 12)) * 16 = 8064 bytes
+*/
+struct dfb_initializer_t {  // 24 bytes
+    uint32_t logical_id;
+    uint32_t entry_size;
+    uint32_t stride_size;
+    uint16_t capacity;
+    struct {
+        uint16_t dm_mask : 8;         // bits 0-7: DM RISC mask
+        uint16_t tensix_mask : 4;     // bits 8-11: Tensix RISC mask
+        uint16_t reserved : 3;        // bits 12-14: unused
+        uint16_t tc_initialized : 1;  // bit 15: tile counter initialized flag
+    } risc_mask_bits;
+    uint8_t remapper_pair_index;
+    uint8_t num_txn_ids;
+    uint8_t txn_ids[4];
+    uint8_t num_entries_per_txn_id;
+    uint8_t num_entries_per_txn_id_per_tc;
+} __attribute__((packed));
+
+struct dfb_initializer_per_risc_t {  // 40 bytes
+    uint32_t base_addr[4];
+    uint32_t limit[4];
+    PackedTileCounter packed_tile_counter[4];
+    uint8_t num_tcs_to_rr;
+    uint8_t should_init_tc;  // 1 = this RISC should initialize tile counters
+    uint8_t padding[2];
+} __attribute__((packed));
+
+// intra tensix dfb
+// (24 * 16) * 4 = 1,536 bytes
+struct dfb_initializer_intra_tensix_t {  // 24 bytes
+    uint32_t logical_id;
+    uint32_t entry_size;
+    uint32_t stride_size;
+    uint32_t base_addr;
+    uint32_t limit;
+    uint16_t capacity;
+    PackedTileCounter packed_tile_counter;
+    uint8_t tensix_mask;
+} __attribute__((packed));
+
+// on WH/BH arrays will be sized to 1
+struct LocalDFBInterface {
+    uint32_t rd_ptr[4];
+    uint32_t wr_ptr[4];
+    uint32_t base_addr[4];
+    uint32_t limit[4];
+
+    uint32_t entry_size;   // shared across riscs so can be factored out and put into sep initialization struct
+    uint32_t stride_size;  // shared across riscs so can be factored out and put into sep initialization struct
+
+    PackedTileCounter packed_tile_counter[4];
+    uint8_t txn_ids[4];  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t
+        num_entries_per_txn_id;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t num_entries_per_txn_id_per_tc;  // shared across riscs so can be factored out and put into sep
+                                            // initialization struct
+    uint8_t remapper_pair_index;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t num_tcs_to_rr;
+    uint8_t num_txn_ids;  // shared across riscs so can be factored out and put into sep initialization struct
+
+    uint8_t padding[3];
+
+    // #ifndef ARCH_QUASAR
+    //     // used by packer for in-order packing ... is this still needed on Quasar?
+    //     uint32_t wr_tile_ptr;
+
+    //     // Save a cycle during init by writing 0 to the uint32 below
+    //     union {
+    //         uint32_t tiles_acked_received_init;
+    //         struct {
+    //             uint16_t tiles_acked;
+    //             uint16_t tiles_received;
+    //         };
+    //     };
+    // #endif
+} __attribute__((packed));
+
+}  // namespace experimental

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
@@ -12,7 +12,8 @@
  */
 
 #pragma once
-#include "overlay_reg.h"
+
+#include "meta/registers/overlay_reg.h"
 #include "rocc_instructions.hpp"
 
 #define LLK_REG_SIZE TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_SIZE

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/rocc_instructions.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/rocc_instructions.hpp
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include "xcustom_test.hpp"
-#include "overlay_reg.h"
+#include "meta/registers/overlay_reg.h"
 /////////////////
 // MISC
 /////////////////
@@ -620,5 +620,3 @@
     {                                                    \
         ROCC_INSTRUCTION_S(0, (trid), (64 + 49));        \
     }
-
-#endif

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -154,6 +154,7 @@ private:
     std::vector<uint32_t> mem_map_sizes_;
     std::vector<uint32_t> eth_fw_mailbox_msgs_;
     bool supports_cbs_ = false;
+    bool supports_dfbs_ = false;
     bool supports_receiving_multicast_cmds_ = false;
     dev_msgs::Factory dev_msgs_factory_;
     tt::tt_fabric::fabric_telemetry::Factory fabric_telemetry_factory_;
@@ -169,6 +170,7 @@ public:
         std::vector<uint32_t> eth_fw_mailbox_msgs,
         std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names,
         bool supports_cbs,
+        bool supports_dfbs,
         bool supports_receiving_multicast_cmds,
         dev_msgs::Factory dev_msgs_factory,
         tt::tt_fabric::fabric_telemetry::Factory fabric_telemetry_factory) :
@@ -181,6 +183,7 @@ public:
         mem_map_sizes_(std::move(mem_map_sizes)),
         eth_fw_mailbox_msgs_{std::move(eth_fw_mailbox_msgs)},
         supports_cbs_(supports_cbs),
+        supports_dfbs_(supports_dfbs),
         supports_receiving_multicast_cmds_(supports_receiving_multicast_cmds),
         dev_msgs_factory_(dev_msgs_factory),
         fabric_telemetry_factory_(fabric_telemetry_factory) {}
@@ -456,6 +459,8 @@ public:
 
     bool get_supports_cbs(uint32_t programmable_core_type_index) const;
 
+    bool get_supports_dfbs(uint32_t programmable_core_type_index) const;
+
     bool get_supports_receiving_multicasts(uint32_t programmable_core_type_index) const;
 
     uint32_t get_num_risc_processors(HalProgrammableCoreType programmable_core_type) const;
@@ -642,6 +647,10 @@ inline uint32_t Hal::get_common_alignment_with_pcie(HalMemType memory_type) cons
 
 inline bool Hal::get_supports_cbs(uint32_t programmable_core_type_index) const {
     return this->core_info_[programmable_core_type_index].supports_cbs_;
+}
+
+inline bool Hal::get_supports_dfbs(uint32_t programmable_core_type_index) const {
+    return this->core_info_[programmable_core_type_index].supports_dfbs_;
 }
 
 inline bool Hal::get_supports_receiving_multicasts(uint32_t programmable_core_type_index) const {

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -175,6 +175,7 @@ HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode) {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory(),
         active_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_idle_eth.cpp
@@ -119,6 +119,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory(),
         idle_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_tensix.cpp
@@ -153,6 +153,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         true /*supports_cbs*/,
+        false /*supports_dfbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory(),
         tensix_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_active_eth.cpp
@@ -136,6 +136,7 @@ HalCoreInfoType create_active_eth_mem_map(bool is_base_routing_fw_enabled) {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory(),
         active_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_idle_eth.cpp
@@ -114,6 +114,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory(),
         idle_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal_tensix.cpp
@@ -152,6 +152,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         true /*supports_cbs*/,
+        false /*supports_dfbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory(),
         tensix_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_active_eth.cpp
@@ -137,6 +137,7 @@ HalCoreInfoType create_active_eth_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         active_eth_dev_msgs::create_factory(),
         active_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
@@ -128,6 +128,7 @@ HalCoreInfoType create_idle_eth_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         false /*supports_cbs*/,
+        false /*supports_dfbs*/,
         false /*supports_receiving_multicast_cmds*/,
         idle_eth_dev_msgs::create_factory(),
         idle_eth_fabric_telemetry::create_factory()};

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -194,6 +194,7 @@ HalCoreInfoType create_tensix_mem_map() {
         std::move(fw_mailbox_addr),
         std::move(processor_classes_names),
         true /*supports_cbs*/,
+        true /*supports_dfbs*/,
         true /*supports_receiving_multicast_cmds*/,
         tensix_dev_msgs::create_factory(),
         tensix_fabric_telemetry::create_factory()};

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -828,6 +828,8 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
 
     program.impl().allocate_circular_buffers(device);
     program.impl().validate_circular_buffer_region(device);
+    program.impl().allocate_dataflow_buffers(device);
+    program.impl().validate_dataflow_buffer_region(device);
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
     const auto& hal = MetalContext::instance().hal();
@@ -840,7 +842,10 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
             ConfigureKernelGroup(program, index, kernel_group, device, logical_core);
             // TODO: add support for CB for ethernet cores
             if (core_type == CoreType::WORKER) {
+                uint64_t kernel_config_base =
+                    hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
                 const auto& cbs_on_core = program.impl().circular_buffers_on_core(logical_core);
+                const auto& dfbs_on_core = program.impl().dataflow_buffers_on_core(logical_core);
                 if (!cbs_on_core.empty()) {
                     // CircularBufferConfigVec -- common across all kernels, so written once to the core
                     std::vector<uint32_t> circular_buffer_config_vec(
@@ -869,11 +874,32 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                             circular_buffer_config_vec[base_index + 1] = circular_buffer->page_size(buffer_index);
                         }
                     }  // PROF_END("CBS")
-                    uint64_t kernel_config_base =
-                        hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
                     uint64_t addr = kernel_config_base + program.impl().get_program_config(index).cb_offset;
                     MetalContext::instance().get_cluster().write_core(
                         device_id, physical_core, circular_buffer_config_vec, addr);
+                }
+
+                if (!dfbs_on_core.empty()) {
+                    log_info(tt::LogMetal, "DFB size: {}", program.impl().get_program_config(index).dfb_size);
+                    std::vector<uint8_t> dfb_config_vec(
+                        program.impl().get_program_config(index).dfb_size / sizeof(uint8_t));
+                    uint32_t offset = 0;
+                    for (const auto& dfb : dfbs_on_core) {
+                        auto serialized = dfb->serialize();
+                        std::memcpy(dfb_config_vec.data() + offset, serialized.data(), serialized.size());
+                        offset += serialized.size();
+                    }
+                    uint64_t addr = kernel_config_base + program.impl().get_program_config(index).dfb_offset;
+                    log_info(
+                        tt::LogMetal,
+                        "Writing DFB config to core {} at addr 0x{:x} (kernel_config_base=0x{:x}, dfb_offset=0x{:x}) "
+                        "size: {}",
+                        physical_core.str(),
+                        addr,
+                        kernel_config_base,
+                        program.impl().get_program_config(index).dfb_offset,
+                        dfb_config_vec.size());
+                    MetalContext::instance().get_cluster().write_core(device_id, physical_core, dfb_config_vec, addr);
                 }
             }
             program.impl().init_semaphores(*device, logical_core, index);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35486

### Problem description
First pr to support [DataflowBuffer](https://docs.google.com/document/d/1J55PCzS1VQKbNoSmKvwgPZ_siu04aqnS5DAsDw0vj1Q/edit?pli=1&tab=t.0) 
Many features are missing but there are a series of follow up prs to bridge the gaps listed below

Note: An existing Quasar related PR introduces experimental::quasar namespace. DFB will move into that as well 

### What's changed
- Added device side DataflowBuffer class and dataflow buffer initialization structs 
- Added support in DM fw to setup dataflow buffer interface
- Modified kernel config ring buffer to support DataflowBuffers (slow dispatch + program only - no meshworkload support)

### TODO
- future pr to uplift support to handle remapper cases + multiple producer/consumer kernel threads
- need to uplift to handle implicit sync 
- need to uplift to run on tensix 
- need to debug why dfb config size needs to be multiple for 64 atm or why adding a rtarg causes misalignment resulting in zero padding overwriting dm0 kernel binary
- clean up dfb device-side header  structure and what is being leaked to host (internal/dataflow_buffer_interface.h)

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/dfb)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb)
- [x] New/Existing tests provide coverage for changes