### PR TITLE
[skip ci] Bump MNIST device perf expected value

### DIFF
--- a/models/demos/mnist/tests/test_perf_mnist.py
+++ b/models/demos/mnist/tests/test_perf_mnist.py
@@ -100,7 +100,7 @@ def test_perf_device_bare_metal(batch_size, reset_seeds):
     subdir = "ttnn_mnist"
     num_iterations = 1
     margin = 0.04
-    expected_perf = 1029400
+    expected_perf = 1071000
 
     command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py::test_mnist"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]


### PR DESCRIPTION
## Problem description
  The `test_perf_device_bare_metal` test for MNIST intermittently fails due to actual performance exceeding the upper threshold of the expected range.
  Examples of recent failures:                                                                                                                          
  - [Run 21200633943](https://github.com/tenstorrent/tt-metal/actions/runs/21200633943) (Jan 21): 1,072,502 samples/s (threshold: 1,070,576)            
  - [Run 21190639762](https://github.com/tenstorrent/tt-metal/actions/runs/21190639762) (Jan 20): 1,078,912 samples/s (threshold: 1,070,576)            
                                                                                                
  ## What's changed
  Updated `expected_perf` from 1,029,400 to 1,071,000 samples/s based on analysis of the last 11 runs on main.

  With 4% margin, the new acceptable range is [1,028,160 - 1,113,840] samples/s.