### PR TITLE
Reduce hang detection timeout

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -106,7 +106,6 @@ runs:
       shell: bash
 
     - name: Set up env vars for auto-triage
-      if: ${{ inputs.auto-triage == 'true' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -106,6 +106,7 @@ runs:
       shell: bash
 
     - name: Set up env vars for auto-triage
+      if: ${{ inputs.auto-triage == 'true' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -35,7 +35,7 @@ inputs:
     type: boolean
   hang-detection-timeout:
     description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
-    default: 1.0
+    default: 5.0
     type: float
 runs:
   using: "composite"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -106,7 +106,7 @@ runs:
       shell: bash
 
     - name: Set up env vars for auto-triage
-      if: ${{ inputs.auto-triage == 'true' && inputs.enable-watcher != 'true' }}
+      if: ${{ inputs.auto-triage == 'true' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -33,9 +33,9 @@ inputs:
     description: 'Enable detection of timeout on fast dispatch and automatically call tt-triage'
     default: true
     type: boolean
-  slow-dispatch-timeout:
-    description: 'Timeout in seconds to consider a dispatch as slow for auto-triage'
-    default: 60.0
+  hang-detection-timeout:
+    description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
+    default: 1.0
     type: float
 runs:
   using: "composite"
@@ -111,6 +111,6 @@ runs:
       run: |
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress 1>&2" >> $GITHUB_ENV
-        echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.slow-dispatch-timeout }}" >> $GITHUB_ENV
+        echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
         echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -134,7 +134,6 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           auto-triage: ${{ !inputs.enable-watcher && matrix.test-group.auto-triage }}
-          slow-dispatch-timeout: 10
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167
         if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -139,7 +139,6 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
           auto-triage: ${{ !inputs.enable-watcher }}
-          slow-dispatch-timeout: 10.0
 
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -157,7 +157,6 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
           auto-triage: ${{ !inputs.enable-watcher }}
-          slow-dispatch-timeout: 10.0
 
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,3 @@ endif()
 if(TT_INSTALL)
     include(packaging)
 endif()
-
-# Adding something to trigger all merge gate runs
-message(STATUS "CMake configuration complete.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,3 +313,6 @@ endif()
 if(TT_INSTALL)
     include(packaging)
 endif()
+
+# Adding something to trigger all merge gate runs
+message(STATUS "CMake configuration complete.")


### PR DESCRIPTION
With new slow progressing dispatch hang detection, we are able to detect hangs more precisely.
Here, we reduce timeouts to 5 seconds (that was originally planned).

Passing APC Select: https://github.com/tenstorrent/tt-metal/actions/runs/21208893607.

I tried reducing timeout to 1 second, but there are tests that have kernels running longer than 1 second: https://github.com/tenstorrent/tt-metal/actions/runs/21204109186.
4 second difference in timeout detection won't impact CI that much, so lets go with 5 seconds.

Merge gate with change to CMakeLists.txt: https://github.com/tenstorrent/tt-metal/actions/runs/21212542904

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vjovanovic/lower_hang_detection_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vjovanovic/lower_hang_detection_timeout)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/lower_hang_detection_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/lower_hang_detection_timeout)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/lower_hang_detection_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/lower_hang_detection_timeout)