### PR TITLE
Fix DeepSeekV3 multi-host tests

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -175,7 +175,7 @@ jobs:
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run tests on multiple hosts
         uses: ./.github/actions/docker-run
-        timeout-minutes: 200
+        timeout-minutes: 160
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -175,7 +175,7 @@ jobs:
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run tests on multiple hosts
         uses: ./.github/actions/docker-run
-        timeout-minutes: 140
+        timeout-minutes: 200
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -302,14 +302,54 @@ def run_test_forward_pass_decoder2d(
 @pytest.mark.parametrize(
     "DecoderBlockClass, module_path, reference_layer_idx, test_closure",
     [
-        (DecoderBlock1D, None, 0, run_test_forward_pass_decoder1d),
-        (MoEDecoderBlock1D, None, 3, run_test_forward_pass_decoder1d),
-        (DecoderBlock1D, "model.layers.0", 0, run_test_forward_pass_decoder1d),
-        (MoEDecoderBlock1D, "model.layers.3", 3, run_test_forward_pass_decoder1d),
-        (DecoderBlock2D, None, 0, run_test_forward_pass_decoder2d),
-        (MoEDecoderBlock2D, None, 3, run_test_forward_pass_decoder2d),
-        (DecoderBlock2D, "model.layers.0", 0, run_test_forward_pass_decoder2d),
-        (MoEDecoderBlock2D, "model.layers.3", 3, run_test_forward_pass_decoder2d),
+        pytest.param(
+            DecoderBlock1D, None, 0, run_test_forward_pass_decoder1d, marks=pytest.mark.requires_device(["TG"])
+        ),
+        pytest.param(
+            MoEDecoderBlock1D, None, 3, run_test_forward_pass_decoder1d, marks=pytest.mark.requires_device(["TG"])
+        ),
+        pytest.param(
+            DecoderBlock1D,
+            "model.layers.0",
+            0,
+            run_test_forward_pass_decoder1d,
+            marks=pytest.mark.requires_device(["TG"]),
+        ),
+        pytest.param(
+            MoEDecoderBlock1D,
+            "model.layers.3",
+            3,
+            run_test_forward_pass_decoder1d,
+            marks=pytest.mark.requires_device(["TG"]),
+        ),
+        pytest.param(
+            DecoderBlock2D,
+            None,
+            0,
+            run_test_forward_pass_decoder2d,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
+        pytest.param(
+            MoEDecoderBlock2D,
+            None,
+            3,
+            run_test_forward_pass_decoder2d,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
+        pytest.param(
+            DecoderBlock2D,
+            "model.layers.0",
+            0,
+            run_test_forward_pass_decoder2d,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
+        pytest.param(
+            MoEDecoderBlock2D,
+            "model.layers.3",
+            3,
+            run_test_forward_pass_decoder2d,
+            marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -34,22 +34,40 @@ from models.demos.deepseek_v3.utils.test_utils import (
 @pytest.mark.parametrize(
     "EmbeddingClass,mode,batch_size_or_seq_len",
     [
-        (Embedding1D, "decode", 32),
-        (Embedding2D, "decode", 128),
+        pytest.param(Embedding1D, "decode", 32, marks=pytest.mark.requires_device(["TG"])),
+        pytest.param(Embedding2D, "decode", 128, marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"])),
     ]
     + [
-        (EmbeddingClass, "prefill", seq_len)
+        pytest.param(Embedding1D, "prefill", seq_len, marks=pytest.mark.requires_device(["TG"]))
         if seq_len == 128
         else pytest.param(
-            EmbeddingClass,
+            Embedding1D,
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
-            ),
+            marks=[
+                pytest.mark.requires_device(["TG"]),
+                pytest.mark.skip(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
+            ],
         )
         for seq_len in PREFILL_SEQ_LENS
-        for EmbeddingClass in (Embedding1D, Embedding2D)
+    ]
+    + [
+        pytest.param(Embedding2D, "prefill", seq_len, marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"]))
+        if seq_len == 128
+        else pytest.param(
+            Embedding2D,
+            "prefill",
+            seq_len,
+            marks=[
+                pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
+                pytest.mark.skip(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
+            ],
+        )
+        for seq_len in PREFILL_SEQ_LENS
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -64,6 +64,7 @@ class DeepseekV3LMHead(nn.Module):
         for seq_len in PREFILL_SEQ_LENS
     ],
 )
+@pytest.mark.requires_device(["TG"])
 def test_forward_pass(
     mode: str,
     seq_len: int,

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -52,6 +52,7 @@ class DeepseekV3LMHead(nn.Module):
         ("prefill", 1024),
     ],
 )
+@pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
 def test_forward_pass(
     mode: str,
     batch_size_per_row: int,

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -592,7 +592,10 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
 )
 @pytest.mark.parametrize(
     "test_closure",
-    [run_test_forward_pass_mla1d, run_test_forward_pass_mla2d],
+    [
+        pytest.param(run_test_forward_pass_mla1d, marks=pytest.mark.requires_device(["TG"])),
+        pytest.param(run_test_forward_pass_mla2d, marks=pytest.mark.requires_device(["TG", "DUAL", "QUAD"])),
+    ],
 )
 def test_forward_pass(
     mode,

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -25,6 +25,8 @@ from models.demos.deepseek_v3.utils.test_utils import (
 )
 
 
+# TODO: Doesn't work on multi-host - we should figure out why
+@pytest.mark.requires_device(["TG"])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_device):
     reference_model = DeepseekV3MLP(hf_config).eval()
@@ -40,6 +42,8 @@ def test_convert_weights_for_non_dequantized_mlp(hf_config, tmp_path, mesh_devic
     )
 
 
+# TODO: Doesn't work on multi-host - we should figure out why
+@pytest.mark.requires_device(["TG"])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize(
     "MLPClass,module_path",


### PR DESCRIPTION
### Summary

This change adds skips for tests that are unsupported on the multi-host pipelines.

Test timeout has been updated to reflect worst case time to complete tests.