### PR TITLE
[tt-train] Fix from_vector float to float implementation

### DIFF
--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -202,9 +202,9 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
                                            : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
 
     if (layout == ttnn::Layout::TILE) {
-        // I'd imagine should be tilized on device not on host for performance
-        // ttnn::to_layout doesn't correctly change the layout for fp32
-        // i.e. TestFloatToFromTensorFloat32Precision test fails after putting ttnn::to_layout after ttnn::to_device
+        // NOTE: Layout conversion is currently performed on host.
+        // ttnn::to_layout does not correctly handle FP32 tensors after device transfer.
+        // Performing tilization before to_device avoids precision issues.
         output = ttnn::to_layout(output, ttnn::Layout::TILE, std::nullopt, output_mem_config);
     }
     output = ttnn::to_device(output, device, output_mem_config);

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -291,3 +291,21 @@ TEST_F(TensorUtilsTest, TestBytesToFromTensor) {
         EXPECT_EQ(vec_back[i], test_data[i]);
     }
 }
+
+TEST_F(TensorUtilsTest, TestFloatToFromTensorFloat32Precision) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    // Should preserve full precision
+    std::vector<float> test_data = {0.1f, 0.2f, 0.3f, 0.123456789f};
+
+    auto shape = ttnn::Shape({1, 1, 1, 4});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    EXPECT_EQ(tensor.dtype(), ttnn::DataType::FLOAT32);
+
+    auto vec_back = ttml::core::to_vector(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}


### PR DESCRIPTION
### Ticket
None

### Problem description
This PR fixes an issue where 
`tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>` incorrectly called 
`tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>`.
This caused a conversion to bf16 and resulted in accuracy loss.

The function now correctly transfers float32 vector data to the device without intermediate BF16 conversion.

### What's changed
Fixed data movement from std::vector<float> to device for FLOAT32 tensors
+ **Core change** in `tt-train/sources/ttml/core/tt_tensor_utils.cpp`
+ **Added test** in `tt-train/tests/core/tensor_utils_test.cpp` to validate accuracy preservation

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=zbaczewski/from_vector-float-float)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:zbaczewski/from_vector-float-float)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=zbaczewski/from_vector-float-float)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:zbaczewski/from_vector-float-float)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/from_vector-float-float)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/from_vector-float-float)
- [x] New/Existing tests provide coverage for changes