### PR TITLE
[skip ci] make Analyze-Nd-Failures upload to superset

### DIFF
--- a/.github/actions/upload-data-via-sftp/job_failure_cluster_batchfile.txt
+++ b/.github/actions/upload-data-via-sftp/job_failure_cluster_batchfile.txt
@@ -1,0 +1,2 @@
+put -r generated/job_failure_cluster/*.json
+ls -hal

--- a/.github/scripts/data_analysis/create_job_failure_cluster_json.py
+++ b/.github/scripts/data_analysis/create_job_failure_cluster_json.py
@@ -1,0 +1,109 @@
+"""
+Script to convert job failure cluster data from slack-output-analysis action
+to pydantic model and save as JSON for upload to database.
+
+This script:
+1. Reads error_report.json from workspace root (output by slack-output-analysis action)
+2. Creates JobFailureCluster pydantic model instances
+3. Serializes to JSON and saves to generated/job_failure_cluster/
+"""
+import json
+import pathlib
+from loguru import logger
+
+from infra.data_collection.pydantic_models import JobFailureCluster
+
+
+def find_job_failure_cluster_data():
+    """
+    Find job failure cluster data file.
+
+    The slack-output-analysis action outputs error_report.json in the root
+    of the workspace.
+    """
+    data_file = pathlib.Path("error_report.json")
+
+    if not data_file.exists():
+        raise FileNotFoundError(
+            f"Could not find error_report.json in workspace root ({data_file.absolute()}). "
+            "Make sure the slack-output-analysis action has run successfully."
+        )
+
+    logger.info(f"Found job failure cluster data at: {data_file}")
+    return str(data_file)
+
+
+def create_job_failure_cluster_json():
+    """
+    Main function to create JSON files from job failure cluster data.
+    """
+    # Find the input data file
+    input_data_path = find_job_failure_cluster_data()
+
+    # Read JSON data
+    with open(input_data_path, "r") as f:
+        raw_data = json.load(f)
+
+    # Handle both single object and array of objects
+    if isinstance(raw_data, list):
+        clusters_data = raw_data
+    elif isinstance(raw_data, dict):
+        # If it's a dict, check if it has a key containing the array
+        # Common patterns: "clusters", "data", "results", "failures"
+        for key in ["clusters", "data", "results", "failures", "job_failure_clusters"]:
+            if key in raw_data and isinstance(raw_data[key], list):
+                clusters_data = raw_data[key]
+                break
+        else:
+            # Single object, wrap in list
+            clusters_data = [raw_data]
+    else:
+        raise ValueError(f"Unexpected data format: {type(raw_data)}")
+
+    # Ensure output directory exists
+    output_dir = pathlib.Path("generated/job_failure_cluster")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Process each cluster record
+    created_files = []
+    for idx, cluster_data in enumerate(clusters_data):
+        try:
+            # Create pydantic model instance (validates data)
+            cluster = JobFailureCluster(**cluster_data)
+
+            # Generate output filename
+            github_job_id = cluster_data.get("github_job_id", f"unknown_{idx}")
+            output_filename = output_dir / f"job_failure_cluster_{github_job_id}.json"
+
+            # Serialize to JSON and save
+            json_data = cluster.model_dump_json(indent=2)
+            with open(output_filename, "w") as f:
+                f.write(json_data)
+
+            created_files.append(output_filename)
+            logger.info(f"Created JSON file: {output_filename}")
+
+        except Exception as e:
+            logger.error(f"Failed to process cluster record {idx}: {e}")
+            logger.error(f"Problematic data: {json.dumps(cluster_data, indent=2)}")
+            raise
+
+    # Also create a combined file with all records (useful for batch upload)
+    if len(clusters_data) > 1:
+        combined_file = output_dir / "job_failure_cluster_batch.json"
+        clusters_list = []
+        for cluster_data in clusters_data:
+            cluster = JobFailureCluster(**cluster_data)
+            clusters_list.append(json.loads(cluster.model_dump_json()))
+
+        with open(combined_file, "w") as f:
+            json.dump(clusters_list, f, indent=2)
+        created_files.append(combined_file)
+        logger.info(f"Created combined batch file: {combined_file}")
+
+    logger.info(f"Successfully created {len(created_files)} JSON file(s)")
+    return created_files
+
+
+if __name__ == "__main__":
+    create_job_failure_cluster_json()

--- a/.github/scripts/data_analysis/create_job_failure_cluster_json.py
+++ b/.github/scripts/data_analysis/create_job_failure_cluster_json.py
@@ -20,30 +20,11 @@ def ensure_required_fields(cluster_data: dict) -> dict:
     """
     Ensure all required fields are populated, using fallbacks for None values.
 
-    The pydantic model requires all timestamp fields to be datetime (not Optional),
-    but the source data may have None values. This function provides fallbacks.
+    Timestamp fields can now be None (Optional[datetime] in pydantic model),
+    but we still need to ensure other required fields like job names are populated.
     """
     # Make a copy to avoid modifying the original
     data = cluster_data.copy()
-
-    # Handle None timestamps - use dummy value to indicate missing data
-    # TODO: Ideally, the pydantic model should allow Optional[datetime] for these fields
-    # Using epoch timestamp (1970-01-01) as a clear indicator of missing data
-    DUMMY_TIMESTAMP = "1970-01-01T00:00:00.000Z"
-
-    if data.get("centroid_job_slack_ts") is None:
-        logger.warning(
-            f"centroid_job_slack_ts is None for job {data.get('github_job_id')}, "
-            f"using dummy timestamp {DUMMY_TIMESTAMP} (consider making this field Optional in pydantic model)"
-        )
-        data["centroid_job_slack_ts"] = DUMMY_TIMESTAMP
-
-    if data.get("oldest_job_slack_ts") is None:
-        logger.warning(
-            f"oldest_job_slack_ts is None for job {data.get('github_job_id')}, "
-            f"using dummy timestamp {DUMMY_TIMESTAMP} (consider making this field Optional in pydantic model)"
-        )
-        data["oldest_job_slack_ts"] = DUMMY_TIMESTAMP
 
     # Ensure job_name, centroid_job_name, oldest_job_name are never None
     if data.get("job_name") is None:

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -11,11 +11,6 @@ on:
         options:
           - update
           - rebuild
-      run_maintenance:
-        description: 'Run maintenance (cleanup old runs, ensure sorting)'
-        required: false
-        default: false
-        type: boolean
       start_date:
         description: 'Start date for fetching Slack messages (format: January 1, 2026)'
         required: false
@@ -49,6 +44,5 @@ jobs:
           # channel_id: Slack channel ID to fetch messages from
           channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           update_mode: ${{ inputs.update_mode || 'update' }}
-          run_maintenance: ${{ inputs.run_maintenance || 'false' }}
           start_date: ${{ inputs.start_date || 'January 1, 2026' }}
           end_date: ${{ inputs.end_date || '' }}

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -3,11 +3,24 @@ name: Analyze ND Failures
 on:
   workflow_dispatch:
     inputs:
-      starting_date:
-        description: "Starting date to analyze failures (YYYY-MM-DD)"
-        required: true
+      update_mode:
+        description: 'Mode: update (sync new errors) or rebuild (recreate all issues)'
+        required: false
+        default: 'update'
+        type: choice
+        options:
+          - update
+          - rebuild
+      run_maintenance:
+        description: 'Run maintenance (cleanup old runs, ensure sorting)'
+        required: false
+        default: false
+        type: boolean
+      start_date:
+        description: 'Start date for fetching Slack messages (format: January 1, 2026)'
+        required: false
+        default: 'January 1, 2026'
         type: string
-
 
 jobs:
   analyze-nd-failures:
@@ -24,4 +37,13 @@ jobs:
       - name: Run analyze nd failures
         uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack-output-analysis@main
         with:
-          starting_date: ${{ inputs.starting_date }}
+          # TODO: Configure these secrets in repository settings -> Secrets and variables -> Actions
+          # github_token: Personal Access Token for creating/updating GitHub issues
+          github_token: ${{ secrets.EVAN_PAT }}
+          # slack_token: Slack Bot Token for fetching messages
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # channel_id: Slack channel ID to fetch messages from
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          update_mode: ${{ inputs.update_mode || 'update' }}
+          run_maintenance: ${{ inputs.run_maintenance || 'false' }}
+          start_date: ${{ inputs.start_date || 'January 1, 2026' }}

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -1,6 +1,9 @@
 name: Analyze ND Failures
 
 on:
+  schedule:
+    # Run every hour at minute 0
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       update_mode:

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -46,3 +46,22 @@ jobs:
           update_mode: ${{ inputs.update_mode || 'update' }}
           start_date: ${{ inputs.start_date || 'January 1, 2026' }}
           end_date: ${{ inputs.end_date || '' }}
+
+      - name: Install infra dependencies
+        if: ${{ !cancelled() }}
+        run: pip install -r infra/requirements-infra.txt
+
+      - name: Create job failure cluster JSON
+        if: ${{ !cancelled() }}
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python3 .github/scripts/data_analysis/create_job_failure_cluster_json.py
+
+      - name: Upload job failure cluster data
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/job_failure_cluster_batchfile.txt
+          username: job-failure-cluster-writer
+          hostname: s-dbd4b8a190fa40a4b.server.transfer.us-east-2.amazonaws.com

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         default: 'January 1, 2026'
         type: string
+      end_date:
+        description: "End date (cutoff) for fetching Slack messages (format: 'January 31, 2026'). Messages after this date are ignored. Leave empty for no cutoff."
+        required: false
+        default: ""
 
 jobs:
   analyze-nd-failures:
@@ -47,3 +51,4 @@ jobs:
           update_mode: ${{ inputs.update_mode || 'update' }}
           run_maintenance: ${{ inputs.run_maintenance || 'false' }}
           start_date: ${{ inputs.start_date || 'January 1, 2026' }}
+          end_date: ${{ inputs.end_date || '' }}

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run analyze nd failures
-        uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack-output-analysis@main
+        uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack_output_analysis@main
         with:
           # TODO: Configure these secrets in repository settings -> Secrets and variables -> Actions
           # github_token: Personal Access Token for creating/updating GitHub issues

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -62,7 +62,7 @@ jobs:
           # channel_id: Slack channel ID to fetch messages from
           channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           update_mode: ${{ inputs.update_mode || 'update' }}
-          start_date: ${{ inputs.start_date || steps.calc-date.outputs.start_date }}
+          start_date: ${{ inputs.start_date || steps['calc-date'].outputs.start_date }}
           end_date: ${{ inputs.end_date || '' }}
 
       - name: Install infra dependencies

--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -12,9 +12,8 @@ on:
           - update
           - rebuild
       start_date:
-        description: 'Start date for fetching Slack messages (format: January 1, 2026)'
+        description: 'Start date for fetching Slack messages (format: January 1, 2026). Defaults to 3 days ago if empty.'
         required: false
-        default: 'January 1, 2026'
         type: string
       end_date:
         description: "End date (cutoff) for fetching Slack messages (format: 'January 31, 2026'). Messages after this date are ignored. Leave empty for no cutoff."
@@ -33,6 +32,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Calculate start date (default to 3 days ago)
+        id: calc-date
+        if: ${{ !inputs.start_date }}
+        shell: bash
+        run: |
+          # Calculate date 3 days ago and format as "January 1, 2026"
+          # Remove leading zero from day using sed for portability
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            START_DATE=$(date -d "3 days ago" "+%B %d, %Y" | sed 's/ 0/ /')
+          else
+            # macOS uses different date command
+            START_DATE=$(date -v-3d "+%B %d, %Y" | sed 's/ 0/ /')
+          fi
+          echo "start_date=$START_DATE" >> $GITHUB_OUTPUT
+          echo "Using calculated start date: $START_DATE"
+
       - name: Run analyze nd failures
         uses: tenstorrent-metal/tt-auto-triage/.github/actions/slack_output_analysis@main
         with:
@@ -44,7 +59,7 @@ jobs:
           # channel_id: Slack channel ID to fetch messages from
           channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           update_mode: ${{ inputs.update_mode || 'update' }}
-          start_date: ${{ inputs.start_date || 'January 1, 2026' }}
+          start_date: ${{ inputs.start_date || steps.calc-date.outputs.start_date }}
           end_date: ${{ inputs.end_date || '' }}
 
       - name: Install infra dependencies

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -586,8 +586,9 @@ class JobFailureCluster(BaseModel):
     github_job_link: str = Field(description="Link to the GitHub job for the specific job being analyzed.")
     job_name: str = Field(description="Name of the job being analyzed.")
     job_error_message: str = Field(description="Error message from the job failure.")
-    job_slack_ts: datetime = Field(
-        description="Timestamp with timezone when the Slack message for this specific failure was sent."
+    job_slack_ts: Optional[datetime] = Field(
+        None,
+        description="Timestamp with timezone when the Slack message for this specific failure was sent.",
     )
     job_commit_hash: str = Field(description="Commit hash associated with the job failure.")
     is_nd: bool = Field(description="Non-Deterministic flag indicating if the failure is flaky.")
@@ -600,8 +601,9 @@ class JobFailureCluster(BaseModel):
     centroid_job_error_message: str = Field(
         description="Error message of the representative failure for this cluster group."
     )
-    centroid_job_slack_ts: datetime = Field(
-        description="Timestamp when the Slack message for the representative failure for this cluster group was sent."
+    centroid_job_slack_ts: Optional[datetime] = Field(
+        None,
+        description="Timestamp when the Slack message for the representative failure for this cluster group was sent.",
     )
     centroid_job_commit_hash: str = Field(
         description="Commit hash of the representative failure for this cluster group."
@@ -620,8 +622,9 @@ class JobFailureCluster(BaseModel):
     oldest_job_error_message: str = Field(
         description="Error message of the oldest run that had the same error as the currently failing run."
     )
-    oldest_job_slack_ts: datetime = Field(
-        description="Timestamp when the Slack message for the oldest run that had the same error as the currently failing run was sent."
+    oldest_job_slack_ts: Optional[datetime] = Field(
+        None,
+        description="Timestamp when the Slack message for the oldest run that had the same error as the currently failing run was sent.",
     )
     oldest_job_commit_hash: str = Field(
         description="Commit hash of the oldest run that had the same error as the currently failing run."

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -569,3 +569,60 @@ class OpRun(BaseModel):
     run_end_ts: datetime = Field(description="Timestamp with timezone when the sweeps run ended.")
     status: RunStatus = Field(description="Overall run status aggregated from testcases.")
     tests: List[OpTest] = Field(description="List of tests executed in the run.")
+
+
+class JobFailureCluster(BaseModel):
+    """
+    Contains information about job failure clusters, grouping similar job failures together.
+
+    Each record represents a specific job failure that has been clustered with similar failures.
+    The model includes attributes for the specific job being analyzed, centroid data (representative
+    failure for the group), and oldest job data (the oldest run that had the same error as the
+    currently failing run, tracking regression history).
+    """
+
+    # Attributes for the specific job being analyzed
+    github_job_id: int = Field(description="GitHub job identifier for the specific job being analyzed.")
+    github_job_link: str = Field(description="Link to the GitHub job for the specific job being analyzed.")
+    job_name: str = Field(description="Name of the job being analyzed.")
+    job_error_message: str = Field(description="Error message from the job failure.")
+    job_slack_ts: datetime = Field(
+        description="Timestamp with timezone when the Slack message for this specific failure was sent."
+    )
+    job_commit_hash: str = Field(description="Commit hash associated with the job failure.")
+    is_nd: bool = Field(description="Non-Deterministic flag indicating if the failure is flaky.")
+    slack_message_link: Optional[str] = Field(None, description="URL to the Slack message related to this job failure.")
+
+    # Centroid Data (The representative failure for this group)
+    centroid_job_id: int = Field(description="Job ID of the representative failure for this cluster group.")
+    centroid_job_link: str = Field(description="Link to the representative failure for this cluster group.")
+    centroid_job_name: str = Field(description="Name of the representative failure for this cluster group.")
+    centroid_job_error_message: str = Field(
+        description="Error message of the representative failure for this cluster group."
+    )
+    centroid_job_slack_ts: datetime = Field(
+        description="Timestamp when the Slack message for the representative failure for this cluster group was sent."
+    )
+    centroid_job_commit_hash: str = Field(
+        description="Commit hash of the representative failure for this cluster group."
+    )
+
+    # Oldest Job Data (The oldest run that had the same error as the currently failing run)
+    oldest_job_id: int = Field(
+        description="Job ID of the oldest run that had the same error as the currently failing run."
+    )
+    oldest_job_link: str = Field(
+        description="Link to the oldest run that had the same error as the currently failing run."
+    )
+    oldest_job_name: str = Field(
+        description="Name of the oldest run that had the same error as the currently failing run."
+    )
+    oldest_job_error_message: str = Field(
+        description="Error message of the oldest run that had the same error as the currently failing run."
+    )
+    oldest_job_slack_ts: datetime = Field(
+        description="Timestamp when the Slack message for the oldest run that had the same error as the currently failing run was sent."
+    )
+    oldest_job_commit_hash: str = Field(
+        description="Commit hash of the oldest run that had the same error as the currently failing run."
+    )


### PR DESCRIPTION
### Ticket
NA

### Problem description
Currently regression failure grouping is just stored here: https://github.com/users/ebanerjeeTT/projects/2 
It would be much better for the data to be stored in superset.

### What's changed
Modify the workflow to add the pydantic model and push to the dataflow bucket.

### Checklist

- [x] [![Analyze-ND-Issues](https://github.com/tenstorrent/tt-metal/actions/workflows/analyze-nd-failures.yaml/badge.svg?branch=ebanerjee/moving-grouping-to-superset)](https://github.com/tenstorrent/tt-metal/actions/workflows/analyze-nd-failures.yaml?query=branch:ebanerjee/moving-grouping-to-superset) https://github.com/tenstorrent/tt-metal/actions/runs/21371193642

Note: The name of this workflow is misleading, it's not just analyzing ND failures. I'll change the name in a follow up PR (it's difficult to do it now because then I can't test it).
