### PR TITLE
Pool2D Match Output Layout to Input Layout

### DIFF
--- a/models/tt_cnn/tt/builder.py
+++ b/models/tt_cnn/tt/builder.py
@@ -324,7 +324,7 @@ class MaxPool2dConfiguration:
     reallocate_halo_output: bool = True
 
     dtype: ttnn.DataType = ttnn.bfloat16
-    output_layout: ttnn.Layout = ttnn.ROW_MAJOR_LAYOUT
+    output_layout: Optional[ttnn.Layout] = None  # None means match input layout
 
     slice_strategy: Optional[SliceStrategy] = None
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -841,8 +841,11 @@ std::vector<Tensor> MaxPool2DOp::invoke(
     bool reallocate_halo_output,
     bool return_indices,
     const DataType dtype,
-    const Layout output_layout,
+    const std::optional<Layout> output_layout,
     bool config_tensor_in_dram) {
+    // Default output_layout to match input layout if not specified except MPWI which does not support tiled output
+    Layout resolved_output_layout = return_indices ? Layout::ROW_MAJOR : output_layout.value_or(input_tensor.layout());
+
     return pool2d(
         input_tensor,
         Pool2DType::MAX_POOL2D,
@@ -865,7 +868,7 @@ std::vector<Tensor> MaxPool2DOp::invoke(
         reallocate_halo_output,
         return_indices,
         dtype,
-        output_layout,
+        resolved_output_layout,
         config_tensor_in_dram);
 }
 
@@ -888,8 +891,11 @@ Tensor AvgPool2DOp::invoke(
     bool deallocate_input,
     bool reallocate_halo_output,
     const DataType dtype,
-    const Layout output_layout,
+    const std::optional<Layout> output_layout,
     bool config_tensor_in_dram) {
+    // Default output_layout to match input layout if not specified
+    Layout resolved_output_layout = output_layout.value_or(input_tensor.layout());
+
     auto result = pool2d(
         input_tensor,
         Pool2DType::AVG_POOL2D,
@@ -912,7 +918,7 @@ Tensor AvgPool2DOp::invoke(
         reallocate_halo_output,
         false,  // return_indices
         dtype,
-        output_layout,
+        resolved_output_layout,
         config_tensor_in_dram);
 
     // Average pool always returns just the tensor, never indices

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -42,7 +42,7 @@ struct MaxPool2DOp {
         bool reallocate_halo_output = true,
         bool return_indices = false,
         DataType dtype = DataType::BFLOAT16,
-        Layout output_layout = Layout::ROW_MAJOR,
+        std::optional<Layout> output_layout = std::nullopt,
         bool config_tensor_in_dram = false);
 };
 struct AvgPool2DOp {
@@ -65,7 +65,7 @@ struct AvgPool2DOp {
         bool deallocate_input = false,
         bool reallocate_halo_output = true,
         DataType dtype = DataType::BFLOAT16,
-        Layout output_layout = Layout::ROW_MAJOR,
+        std::optional<Layout> output_layout = std::nullopt,
         bool config_tensor_in_dram = false);
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_nanobind.cpp
@@ -47,9 +47,9 @@ void bind_max_pool2d_operation(nb::module_& mod) {
             applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
-            return_indices (bool, optional): whether to return both values and indices. When True, returns a tuple (values, indices). Defaults to `False`.
+            return_indices (bool, optional): whether to return both values and indices. When True, returns a tuple (values, indices), and returns a ROW_MAJOR layout output tensor. Defaults to `False`.
             dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
-            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. If not specified, matches the input tensor layout. Defaults to `None`.
 
         Returns:
             ttnn.Tensor or tuple[ttnn.Tensor, ttnn.Tensor]: the max pool convolved output tensor, or a tuple of (values, indices) if return_indices is True.
@@ -73,7 +73,7 @@ void bind_max_pool2d_operation(nb::module_& mod) {
                bool reallocate_halo_output,
                bool return_indices,
                const DataType dtype,
-               const Layout output_layout,
+               const std::optional<Layout> output_layout,
                bool config_tensor_in_dram) -> nb::object {
                 auto result = self(
                     input_tensor,
@@ -120,7 +120,7 @@ void bind_max_pool2d_operation(nb::module_& mod) {
             nb::arg("reallocate_halo_output") = true,
             nb::arg("return_indices") = false,
             nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
-            nb::arg("output_layout") = nb::cast(Layout::ROW_MAJOR),
+            nb::arg("output_layout") = nb::none(),
             nb::arg("config_tensor_in_dram") = false});
 }
 
@@ -152,7 +152,7 @@ void bind_avg_pool2d_operation(nb::module_& mod) {
             deallocate_input (bool, optional): whether to deallocate the input tensor after the operation. Defaults to `False`.
             reallocate_halo_output (bool, optional): whether to reallocate the halo output tensor after the operation, ideally used with deallocate_activation = true. Defaults to `True`.
             dtype (ttnn.DataType, optional): the data format for the output tensor. Defaults to `ttnn.bfloat16`.
-            output_layout (ttnn.Layout, optional): the layout for the output tensor. Defaults to `ttnn.ROW_MAJOR_LAYOUT`.
+            output_layout (ttnn.Layout, optional): the layout for the output tensor. If not specified, matches the input tensor layout. Defaults to `None`.
             compute_kernel_config (DeviceComputeKernelConfig, optional): the device compute kernel configuration. Defaults to `None`.
 
         Returns:
@@ -178,7 +178,7 @@ void bind_avg_pool2d_operation(nb::module_& mod) {
                bool deallocate_input,
                bool reallocate_halo_output,
                const DataType dtype,
-               const Layout output_layout,
+               const std::optional<Layout> output_layout,
                bool config_tensor_in_dram) -> ttnn::Tensor {
                 return self(
                     input_tensor,
@@ -221,7 +221,7 @@ void bind_avg_pool2d_operation(nb::module_& mod) {
             nb::arg("deallocate_input") = false,
             nb::arg("reallocate_halo_output") = true,
             nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
-            nb::arg("output_layout") = nb::cast(Layout::ROW_MAJOR),
+            nb::arg("output_layout") = nb::none(),
             nb::arg("config_tensor_in_dram") = false});
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/27903

### Problem description
Currently Pool2D defaults to row major layout output.  It should match the input tensor layout unless the user specifies a layout.

### What's changed
Pool has been updated to default to the input tensor layout for the output tensor layout.

### Checklist
In progress