### PR TITLE
Nhuang/detect l1 errors

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -366,7 +366,7 @@ def test_device_api_debugger_non_dropping():
 
     expected_local_read_count = 2 * NUM_DM_RISCS
     expected_local_write_count = 7 * NUM_DM_RISCS
-    expected_local_read_write_count = 0 * NUM_DM_RISCS
+    expected_local_read_write_count = 1 * NUM_DM_RISCS
 
     for event in noc_trace_data:
         assert isinstance(event, dict), f"noc trace file format error; found event that is not a dict"

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -452,6 +452,50 @@ def test_device_api_debugger_non_dropping():
         write_barrier_end_count == expected_barrier_count
     ), f"Expected {expected_barrier_count} WRITE_BARRIER_END events, found {write_barrier_end_count}"
 
+    # There is a read/write barrier after each noc_async_read/write call.
+    # Verify that the noc counters are being tracked properly
+    NOC_COUNTER_BITS = 12
+    prev_counters = {}  # (proc, noc, type) -> previous counter value
+    read_event_count = 0
+    write_event_count = 0
+
+    for event in noc_trace_data:
+        event_type = event.get("type")
+        if event_type in ["READ", "WRITE_"]:
+            assert (
+                "noc_status_counter" in event
+            ), f"noc_status_counter missing in {event_type} event at timestamp {event.get('timestamp')}"
+            assert "proc" in event, f"proc missing in {event_type} event at timestamp {event.get('timestamp')}"
+            assert "noc" in event, f"noc missing in {event_type} event at timestamp {event.get('timestamp')}"
+
+            noc_status_counter = event.get("noc_status_counter")
+            proc = event.get("proc")
+            noc = event.get("noc")
+
+            assert isinstance(
+                noc_status_counter, int
+            ), f"noc_status_counter must be an integer, found {type(noc_status_counter)} in {event_type} event"
+
+            counter_key = (proc, noc, event_type)
+
+            if counter_key in prev_counters:
+                prev_counter = prev_counters[counter_key]
+                expected_counter = (prev_counter + 1) % (2**NOC_COUNTER_BITS)
+                assert noc_status_counter == expected_counter, (
+                    f"noc_status_counter should increment by 1 for consecutive {event_type} events "
+                    f"for {proc} {noc}. Previous counter: {prev_counter}, current counter: {noc_status_counter}, "
+                    f"expected: {expected_counter} at timestamp {event.get('timestamp')}"
+                )
+
+            prev_counters[counter_key] = noc_status_counter
+
+            if event_type == "READ":
+                read_event_count += 1
+            else:
+                write_event_count += 1
+
+    assert read_event_count > 0 or write_event_count > 0, "No READ or WRITE_ events found to verify noc_status_counter"
+
     # Verify local memory event counts
     assert (
         local_read_count == expected_local_read_count

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1544,13 +1544,22 @@ inline void noc_semaphore_set_multicast_loopback_src(
     bool linked = false,
     uint8_t noc = noc_index) {
     WAYPOINT("NSLW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, 4);
+    // size in bytes
+    constexpr uint32_t size = 4;
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::WRITE_MULTICAST,
+        src_local_l1_addr,
+        dst_noc_addr_multicast,
+        size,
+        NOC_MULTICAST_WRITE_VC,
+        /*posted=*/false);
     ncrisc_noc_fast_write_any_len_loopback_src<noc_mode>(
         noc,
         write_reg_cmd_buf,
         src_local_l1_addr,
         dst_noc_addr_multicast,
-        4 /*size in bytes*/,
+        size,
         NOC_MULTICAST_WRITE_VC,
         true,
         linked,

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -201,6 +201,7 @@ public:
      */
     tt_l1_ptr T* operator->() const {
         DEBUG_SANITIZE_L1_ADDR(address_, sizeof(T));
+        RECORD_LOCAL_MEM_EVENT(KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_READ_WRITE, address_, sizeof(T));
         return get_unsafe_ptr();
     }
 

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -107,10 +107,9 @@ class CoreLocalMem {
             RECORD_LOCAL_MEM_EVENT(
                 KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
             auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
-
-            T temp = *ptr;
-            ++temp;
-            *ptr = temp;
+            T old_val = *ptr;
+            T new_val = old_val + 1;
+            *ptr = new_val;
             return *this;
         }
 
@@ -122,6 +121,16 @@ class CoreLocalMem {
             T new_val = old_val + 1;
             *ptr = new_val;
             return old_val;
+        }
+
+        FORCE_INLINE Proxy& operator--() {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+            T old_val = *ptr;
+            T new_val = old_val - 1;
+            *ptr = new_val;
+            return *this;
         }
 
         FORCE_INLINE T operator--(int) {
@@ -183,7 +192,7 @@ public:
      */
     Proxy operator[](uint32_t index) const {
         DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T));
-        return Proxy(address_ + (index + 1) * sizeof(T));
+        return Proxy(address_ + (index * sizeof(T)));
     }
 
     /** @brief Dereference operator to get reference to the value

--- a/tt_metal/hw/inc/experimental/core_local_mem.h
+++ b/tt_metal/hw/inc/experimental/core_local_mem.h
@@ -6,6 +6,8 @@
 
 #include "experimental/noc.h"
 #include "experimental/lock.h"
+#include "tools/profiler/noc_event_profiler.hpp"
+#include "tt_metal/tools/profiler/event_metadata.hpp"
 
 namespace experimental {
 
@@ -31,6 +33,110 @@ class CoreLocalMem {
     static_assert(
         sizeof(AddressType) >= sizeof(difference_type),
         "AddressType must be large enough to hold difference_type for safe pointer arithmetic");
+
+    // Proxy class to detect if an access to local memory is read or write.
+    class Proxy {
+    public:
+        Proxy(AddressType target_address) : target_address_(target_address) {}
+
+        FORCE_INLINE operator T() const {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_READ, target_address_, sizeof(T));
+            return *reinterpret_cast<tt_l1_ptr T*>(target_address_);
+        }
+
+        FORCE_INLINE operator T() const volatile {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_READ, target_address_, sizeof(T));
+            return *reinterpret_cast<tt_l1_ptr T*>(target_address_);
+        }
+
+        FORCE_INLINE Proxy& operator=(const T& val) {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            *reinterpret_cast<tt_l1_ptr T*>(target_address_) = val;
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator=(const Proxy& other) {
+            if (this != &other) {
+                T val = other;
+                *this = val;
+            }
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator=(const T& val) volatile {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            *reinterpret_cast<tt_l1_ptr T*>(target_address_) = val;
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator=(const Proxy& other) volatile {
+            if (this != &other) {
+                T val = other;
+                const_cast<Proxy&>(*this) = val;
+            }
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator+=(const T& val) {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+            T temp = *ptr;
+            temp += val;
+            *ptr = temp;
+
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator-=(const T& val) {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+
+            T temp = *ptr;
+            temp -= val;
+            *ptr = temp;
+            return *this;
+        }
+
+        FORCE_INLINE Proxy& operator++() {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+
+            T temp = *ptr;
+            ++temp;
+            *ptr = temp;
+            return *this;
+        }
+
+        FORCE_INLINE T operator++(int) {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+            T old_val = *ptr;
+            T new_val = old_val + 1;
+            *ptr = new_val;
+            return old_val;
+        }
+
+        FORCE_INLINE T operator--(int) {
+            RECORD_LOCAL_MEM_EVENT(
+                KernelProfilerNocEventMetadata::NocEventType::LOCAL_MEM_WRITE, target_address_, sizeof(T));
+            auto ptr = reinterpret_cast<tt_l1_ptr T*>(target_address_);
+            T old_val = *ptr;
+            T new_val = old_val - 1;
+            *ptr = new_val;
+            return old_val;
+        }
+
+    private:
+        AddressType target_address_;
+    };
 
 public:
     /** @brief Construct a CoreLocalMem instance from a raw address
@@ -73,20 +179,20 @@ public:
     /** @brief Get the element at the given index
      *
      * @param index The index of the element to get
-     * @return Reference to the element at the given index
+     * @return Proxy to the element at the given index
      */
-    T& operator[](uint32_t index) const {
+    Proxy operator[](uint32_t index) const {
         DEBUG_SANITIZE_L1_ADDR(address_ + (index + 1) * sizeof(T), sizeof(T));
-        return get_unsafe_ptr()[index];
+        return Proxy(address_ + (index + 1) * sizeof(T));
     }
 
     /** @brief Dereference operator to get reference to the value
      *
-     * @return Reference to the value at the address
+     * @return Proxy to the value at the address
      */
-    T& operator*() const {
+    Proxy operator*() const {
         DEBUG_SANITIZE_L1_ADDR(address_, sizeof(T));
-        return get_unsafe_ptr()[0];
+        return Proxy(address_);
     }
 
     /** @brief Arrow operator for struct/class member access

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -201,6 +201,8 @@ void NOCDebugState::push_event(size_t chip_id, uint64_t timestamp, int processor
             } else if constexpr (std::is_same_v<T, NocWriteFlushEvent>) {
                 tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
                 handle_write_flush_event(key, processor_id, timestamp, e);
+            } else if constexpr (std::is_same_v<T, LocalMemWriteEvent>) {
+            } else if constexpr (std::is_same_v<T, LocalMemReadEvent>) {
             }
         },
         event);

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -202,7 +202,9 @@ void NOCDebugState::push_event(size_t chip_id, uint64_t timestamp, int processor
                 tt_cxy_pair key{chip_id, {static_cast<size_t>(e.src_x), static_cast<size_t>(e.src_y)}};
                 handle_write_flush_event(key, processor_id, timestamp, e);
             } else if constexpr (std::is_same_v<T, LocalMemWriteEvent>) {
+                // TODO: handle this case
             } else if constexpr (std::is_same_v<T, LocalMemReadEvent>) {
+                // TODO: handle this case
             }
         },
         event);

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -60,6 +60,20 @@ struct NocWriteFlushEvent {
     uint8_t noc;
 };
 
+struct LocalMemWriteEvent {
+    uint32_t local_start_addr;
+    uint32_t local_end_addr;
+    // Nonposted writes sent counter value
+    uint32_t counter_snapshot;
+};
+
+struct LocalMemReadEvent {
+    uint32_t local_start_addr;
+    uint32_t local_end_addr;
+    // Read received counter value
+    uint32_t counter_snapshot;
+};
+
 struct UnknownNocEvent {};
 
 using NOCDebugEvent = std::variant<
@@ -68,6 +82,8 @@ using NOCDebugEvent = std::variant<
     NocReadBarrierEvent,
     NocWriteBarrierEvent,
     NocWriteFlushEvent,
+    LocalMemWriteEvent,
+    LocalMemReadEvent,
     UnknownNocEvent>;
 
 enum class NOCDebugIssueType : uint8_t {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -66,46 +66,75 @@ kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
 #if defined(TRACY_ENABLE)
 NOCDebugEvent make_noc_debug_event(
     const CoreCoord& src_core,
-    const KernelProfilerNocEventMetadata::LocalNocEvent& event,
+    const KernelProfilerNocEventMetadata& event,
     const KernelProfilerNocEventMetadata::LocalNocEventDstTrailer& trailer) {
     using EMD = KernelProfilerNocEventMetadata;
     int8_t src_x = static_cast<int8_t>(src_core.x);
     int8_t src_y = static_cast<int8_t>(src_core.y);
-    switch (event.noc_xfer_type) {
-        case EMD::NocEventType::READ:
-            return NOCDebugEvent(NocReadEvent{
-                trailer.getDstAddr(),
-                trailer.getSrcAddr(),
-                event.getNumBytes(),
-                static_cast<uint32_t>(trailer.counter_value),
-                event.dst_x,
-                event.dst_y,
-                src_x,
-                src_y,
-                event.noc_type == EMD::NocType::NOC_1});
-        case EMD::NocEventType::WRITE_:
-            return NOCDebugEvent(NocWriteEvent{
-                trailer.getSrcAddr(),
-                trailer.getDstAddr(),
-                event.getNumBytes(),
-                static_cast<uint32_t>(trailer.counter_value),
-                src_x,
-                src_y,
-                event.dst_x,
-                event.dst_y,
-                static_cast<bool>(event.posted),
-                event.noc_type == EMD::NocType::NOC_1});
-        case EMD::NocEventType::READ_BARRIER_END:
-            return NOCDebugEvent(NocReadBarrierEvent{src_x, src_y, event.noc_type == EMD::NocType::NOC_1});
-        case EMD::NocEventType::WRITE_BARRIER_END: [[fallthrough]];
-        case EMD::NocEventType::WRITE_FLUSH:
-            // This event is only being emitted from noc_async_writes_flushed which is non posted
-            // event.posted should always be false; if true, data was corrupted during read
-            TT_ASSERT(!event.posted);
-            return NOCDebugEvent(NocWriteFlushEvent{
-                src_x, src_y, static_cast<bool>(event.posted), event.noc_type == EMD::NocType::NOC_1});
-        default: return NOCDebugEvent(UnknownNocEvent{});
-    }
+
+    const auto handle_local_noc_event = [&](const EMD::LocalNocEvent& event) {
+        switch (event.noc_xfer_type) {
+            case EMD::NocEventType::READ:
+                return NOCDebugEvent(NocReadEvent{
+                    trailer.getDstAddr(),
+                    trailer.getSrcAddr(),
+                    event.getNumBytes(),
+                    static_cast<uint32_t>(trailer.counter_value),
+                    event.dst_x,
+                    event.dst_y,
+                    src_x,
+                    src_y,
+                    event.noc_type == EMD::NocType::NOC_1});
+            case EMD::NocEventType::WRITE_:
+                return NOCDebugEvent(NocWriteEvent{
+                    trailer.getSrcAddr(),
+                    trailer.getDstAddr(),
+                    event.getNumBytes(),
+                    static_cast<uint32_t>(trailer.counter_value),
+                    src_x,
+                    src_y,
+                    event.dst_x,
+                    event.dst_y,
+                    static_cast<bool>(event.posted),
+                    event.noc_type == EMD::NocType::NOC_1});
+            case EMD::NocEventType::READ_BARRIER_END:
+                return NOCDebugEvent(NocReadBarrierEvent{src_x, src_y, event.noc_type == EMD::NocType::NOC_1});
+            case EMD::NocEventType::WRITE_BARRIER_END: [[fallthrough]];
+            case EMD::NocEventType::WRITE_FLUSH:
+                // This event is only being emitted from noc_async_writes_flushed which is non posted
+                // event.posted should always be false; if true, data was corrupted during read
+                TT_ASSERT(!event.posted);
+                return NOCDebugEvent(NocWriteFlushEvent{
+                    src_x, src_y, static_cast<bool>(event.posted), event.noc_type == EMD::NocType::NOC_1});
+            default: return NOCDebugEvent(UnknownNocEvent{});
+        }
+    };
+
+    const auto handle_local_mem_event = [&](const EMD::LocalMemEvent& event) {
+        switch (event.noc_xfer_type) {
+            case EMD::NocEventType::LOCAL_MEM_WRITE:
+                return NOCDebugEvent(LocalMemWriteEvent{
+                    event.getStartAddr(), event.getEndAddr(), static_cast<uint32_t>(event.counter_value)});
+            case EMD::NocEventType::LOCAL_MEM_READ:
+                return NOCDebugEvent(LocalMemReadEvent{
+                    event.getStartAddr(), event.getEndAddr(), static_cast<uint32_t>(event.counter_value)});
+            case EMD::NocEventType::LOCAL_MEM_READ_WRITE: [[fallthrough]];  // TODO: handle this case
+            default: return NOCDebugEvent(UnknownNocEvent{});
+        }
+    };
+
+    return std::visit(
+        [&](auto&& e) {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, EMD::LocalNocEvent>) {
+                return handle_local_noc_event(e);
+            } else if constexpr (std::is_same_v<T, EMD::LocalMemEvent>) {
+                return handle_local_mem_event(e);
+            } else {
+                return NOCDebugEvent(UnknownNocEvent{});
+            }
+        },
+        event.getContents());
 }
 
 uint32_t risc_type_to_control_buffer_dram_address_offset(tracy::RiscType risc_type) {
@@ -170,6 +199,36 @@ DeviceAddr getControlVectorAddress(IDevice* device, const CoreCoord& virtual_cor
                                 dev_msgs::profiler_msg_t::Field::control_vector);
     return control_vector_addr;
 }
+
+void push_data_to_noc_debug_state(
+    int device_id,
+    const CoreCoord& physical_core,
+    tracy::RiscType risc_type,
+    uint64_t timestamp,
+    uint64_t payload,
+    uint64_t trailer) {
+    auto& noc_debug_state = MetalContext::instance().noc_debug_state();
+    if (noc_debug_state) {
+        using EMD = KernelProfilerNocEventMetadata;
+
+        const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
+
+        EMD event_metadata(payload);
+        EMD trailer_metadata(trailer);
+
+        // disable linting here; slicing is __intended__
+        // NOLINTBEGIN
+        const CoreCoord virtual_core =
+            soc_desc.translate_coord_to(physical_core, CoordSystem::NOC0, CoordSystem::TRANSLATED);
+        // NOLINTEND
+        noc_debug_state->push_event(
+            device_id,
+            timestamp,
+            get_processor_id(risc_type),
+            make_noc_debug_event(virtual_core, event_metadata, trailer_metadata.getLocalNocEventDstTrailer()));
+    }
+}
+
 #endif
 
 }  // namespace
@@ -812,6 +871,19 @@ std::unordered_map<experimental::ProgramExecutionUID, nlohmann::json::array_t> c
                     }
 
                     json_events_by_op[program_execution_uid].push_back(data);
+                } else if (std::holds_alternative<EMD::LocalMemEvent>(EMD(device_marker.data).getContents())) {
+                    auto local_memory_event = std::get<EMD::LocalMemEvent>(EMD(device_marker.data).getContents());
+                    json_events_by_op[program_execution_uid].push_back(nlohmann::ordered_json{
+                        {"run_host_id", device_marker.runtime_host_id},
+                        {"op_name", device_marker.op_name},
+                        {"proc", enchantum::to_string(device_marker.risc)},
+                        {"src_device_id", device_marker.chip_id},
+                        {"sx", device_marker.core_x},
+                        {"sy", device_marker.core_y},
+                        {"addr", local_memory_event.addr},
+                        {"type", enchantum::to_string(local_memory_event.noc_xfer_type)},
+                        {"timestamp", device_marker.timestamp},
+                    });
                 }
             } else if (std::holds_alternative<FabricEventMarkers>(marker_it)) {
                 // coalesce fabric event markers into a single logical trace event with extra 'fabric_send' metadata
@@ -1754,6 +1826,10 @@ void DeviceProfiler::readDeviceMarkerData(
         return;
     }
 
+    if (packet_type == kernel_profiler::PacketTypes::TS_DATA) {
+        push_data_to_noc_debug_state(device_id, physical_core, risc_type, timestamp, data, 0);
+    }
+
     device_tracy_contexts.try_emplace({device_id, physical_core}, nullptr);
 
     updateFirstTimestamp(timestamp);
@@ -1827,21 +1903,7 @@ void DeviceProfiler::readTsData16BMarkerData(
         return;
     }
 
-    auto& noc_debug_state = MetalContext::instance().noc_debug_state();
-    if (noc_debug_state) {
-        EMD::LocalNocEvent local_noc_event = std::get<EMD::LocalNocEvent>(event_contents);
-        const metal_SocDescriptor& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
-        // disable linting here; slicing is __intended__
-        // NOLINTBEGIN
-        const CoreCoord virtual_core =
-            soc_desc.translate_coord_to(physical_core, CoordSystem::NOC0, CoordSystem::TRANSLATED);
-        // NOLINTEND
-        noc_debug_state->push_event(
-            device_id,
-            timestamp,
-            get_processor_id(risc_type),
-            make_noc_debug_event(virtual_core, local_noc_event, trailer_metadata.getLocalNocEventDstTrailer()));
-    }
+    push_data_to_noc_debug_state(device_id, physical_core, risc_type, timestamp, data, trailer_data[0]);
 
     device_tracy_contexts.try_emplace({device_id, physical_core}, nullptr);
 

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -40,4 +40,26 @@ void kernel_main() {
             });
         noc.async_write_barrier();
     }
+
+    // Test read
+    [[maybe_unused]] volatile uint32_t rd = local_buffer[0];
+    rd = local_buffer[5];
+
+    // Test write
+    local_buffer[0] = START_DELAY;
+    local_buffer[0]++;
+    local_buffer[1]++;
+    local_buffer[0]--;
+    local_buffer[1]--;
+    local_buffer[0] += 10;
+    local_buffer[0] -= 10;
+
+    // Bypass checks. Nothing reported
+    local_buffer.get_unsafe_ptr()[0] = 1;
+
+    struct MyStruct {
+        uint32_t x;
+    };
+    experimental::CoreLocalMem<MyStruct> struct_mem(L1_BUFFER_ADDR);
+    struct_mem->x = 1;
 }

--- a/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
+++ b/tt_metal/programming_examples/profiler/test_device_api_debugger/kernels/debug_packets.cpp
@@ -57,6 +57,7 @@ void kernel_main() {
     // Bypass checks. Nothing reported
     local_buffer.get_unsafe_ptr()[0] = 1;
 
+    // Read or Write
     struct MyStruct {
         uint32_t x;
     };

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -58,7 +58,11 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         FABRIC_ROUTING_FIELDS_1D = 37,
         FABRIC_ROUTING_FIELDS_2D = 38,
 
-        UNSUPPORTED = 39,
+        LOCAL_MEM_READ_WRITE = 39,
+        LOCAL_MEM_READ = 40,
+        LOCAL_MEM_WRITE = 41,
+
+        UNSUPPORTED = 42,
     };
 
     enum class NocType : unsigned char { UNDEF = 0, NOC_0 = 1, NOC_1 = 2 };
@@ -115,6 +119,31 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         uint32_t getSrcAddr() const { return (src_addr_4b << 2) | (src_addr_offset & 0x3); }
     };
 
+    struct LocalMemEvent {
+        NocEventType noc_xfer_type;
+        uint64_t end_offset : 12;
+        // For read_write or write, contains the nonposted writes sent counter value
+        // For read, contains the reads received counter value
+        // Which noc being used is noc_index
+        uint64_t counter_value : 12;
+        uint32_t addr;
+
+        void setStartAddr(uint32_t address) { addr = address; }
+        uint32_t getStartAddr() const { return static_cast<uint32_t>(addr); }
+
+        void setEndOffset(uint32_t start_addr, uint32_t end_addr) {
+            end_offset = std::min(end_addr - start_addr, uint32_t(4095));
+        }
+        uint32_t getEndAddr() const { return static_cast<uint32_t>(addr + end_offset); }
+
+        void setAddresses(uint32_t start_addr, uint32_t end_addr) {
+            setStartAddr(start_addr);
+            setEndOffset(start_addr, end_addr);
+        }
+
+        uint32_t getSize() const { return static_cast<uint32_t>(end_offset); }
+    };
+
     // represents a fabric NOC event
     enum class FabricPacketType : unsigned char { REGULAR, LOW_LATENCY, LOW_LATENCY_MESH, DYNAMIC_MESH };
     struct FabricNoCEvent {
@@ -161,6 +190,7 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         RawEvent raw_event;
         LocalNocEvent local_event;
         LocalNocEventDstTrailer local_event_dst_trailer;
+        LocalMemEvent local_mem_event;
         FabricNoCEvent fabric_event;
         FabricNoCScatterEvent fabric_scatter_event;
         FabricRoutingFields1D fabric_routing_fields_1d;
@@ -205,8 +235,19 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         return event_type == NocEventType::FABRIC_UNICAST_SCATTER_WRITE;
     }
 
+    static bool isLocalMemEventType(NocEventType event_type) {
+        return event_type == NocEventType::LOCAL_MEM_READ_WRITE || event_type == NocEventType::LOCAL_MEM_READ ||
+               event_type == NocEventType::LOCAL_MEM_WRITE;
+    }
+
     // Getter to return the correct variant based on the tag (noc_xfer_type)
-    std::variant<LocalNocEvent, FabricNoCEvent, FabricNoCScatterEvent, FabricRoutingFields1D, FabricRoutingFields2D>
+    std::variant<
+        LocalNocEvent,
+        FabricNoCEvent,
+        FabricNoCScatterEvent,
+        FabricRoutingFields1D,
+        FabricRoutingFields2D,
+        LocalMemEvent>
     getContents() const {
         if (isFabricEventType(data.raw_event.noc_xfer_type)) {
             if (isFabricScatterEventType(data.raw_event.noc_xfer_type)) {
@@ -219,6 +260,9 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         }
         if (isFabricRoutingFields2D(data.raw_event.noc_xfer_type)) {
             return data.fabric_routing_fields_2d;
+        }
+        if (isLocalMemEventType(data.raw_event.noc_xfer_type)) {
+            return data.local_mem_event;
         }
         return data.local_event;
     }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -801,6 +801,7 @@ __attribute__((noinline)) void trace_only_init() {
 #define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted)
 #define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted)
 #define RECORD_NOC_EVENT(type, posted)
+#define RECORD_LOCAL_MEM_EVENT(event_type, local_addr, access_size)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 
 // null macros when perf counters are disabled


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/detect-l1-errors)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/detect-l1-errors)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/detect-l1-errors)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/detect-l1-errors)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/detect-l1-errors)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/detect-l1-errors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/detect-l1-errors)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs