### PR TITLE
Plumb dynamic noc index into noc_event_profiler

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -500,7 +500,7 @@ FORCE_INLINE void noc_async_read_one_packet(
         Read responses - assigned VCs dynamically
     */
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false, noc);
     }
 
     WAYPOINT("RP2W");
@@ -545,7 +545,7 @@ inline void noc_async_read(
         Read responses - assigned VCs dynamically
     */
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, dst_local_l1_addr, src_noc_addr, size, -1, false, noc);
     }
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
@@ -584,7 +584,7 @@ FORCE_INLINE void noc_async_read_one_packet_set_state(
     */
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ_SET_STATE, 0, src_noc_addr, size, (use_vc) ? static_cast<int8_t>(vc) : -1, false);
+        NocEventType::READ_SET_STATE, 0, src_noc_addr, size, (use_vc) ? static_cast<int8_t>(vc) : -1, false, noc);
 
     WAYPOINT("NASW");
     ncrisc_noc_read_set_state<noc_mode, true /* one_packet */, use_vc>(noc, read_cmd_buf, src_noc_addr, size, vc);
@@ -621,7 +621,8 @@ FORCE_INLINE void noc_async_read_one_packet_with_state(
         static_cast<uint64_t>(src_local_l1_addr),
         0,
         (use_vc) ? static_cast<int8_t>(vc) : -1,
-        false);
+        false,
+        noc);
 
     WAYPOINT("NATW");
 
@@ -660,7 +661,7 @@ void noc_async_read_set_state(uint64_t src_noc_addr, uint8_t noc = noc_index) {
         Read responses - assigned VCs dynamically
     */
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, 0, src_noc_addr, 0, -1, false);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ_SET_STATE, 0, src_noc_addr, 0, -1, false, noc);
 
     WAYPOINT("NAUW");
     ncrisc_noc_read_set_state<noc_mode>(noc, read_cmd_buf, src_noc_addr);
@@ -696,7 +697,13 @@ FORCE_INLINE void noc_async_read_with_state(
         Read responses - assigned VCs dynamically
     */
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::READ_WITH_STATE, dst_local_l1_addr, static_cast<uint64_t>(src_local_l1_addr), size, -1, false);
+        NocEventType::READ_WITH_STATE,
+        dst_local_l1_addr,
+        static_cast<uint64_t>(src_local_l1_addr),
+        size,
+        -1,
+        false,
+        noc);
 
     WAYPOINT("NAVW");
 
@@ -756,7 +763,7 @@ FORCE_INLINE void noc_async_write_one_packet(
     uint8_t noc = noc_index,
     uint32_t vc = NOC_UNICAST_WRITE_VC) {
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted, noc);
     }
 
     WAYPOINT("NWPW");
@@ -810,7 +817,7 @@ inline void noc_async_write(
     uint8_t noc = noc_index,
     uint32_t vc = NOC_UNICAST_WRITE_VC) {
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, src_local_l1_addr, dst_noc_addr, size, vc, posted, noc);
     }
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
@@ -846,7 +853,8 @@ FORCE_INLINE void noc_async_write_multicast_one_packet(
             dst_noc_addr_multicast,
             size,
             NOC_MULTICAST_WRITE_VC,
-            false);
+            false,
+            noc);
     }
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, write_cmd_buf));
@@ -911,7 +919,13 @@ inline void noc_async_write_multicast(
     bool linked = false,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::WRITE_MULTICAST, src_local_l1_addr, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
+        NocEventType::WRITE_MULTICAST,
+        src_local_l1_addr,
+        dst_noc_addr_multicast,
+        size,
+        NOC_MULTICAST_WRITE_VC,
+        false,
+        noc);
 
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
         noc_async_write_multicast_one_packet<false>(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked);
@@ -960,7 +974,7 @@ template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
     uint64_t dst_noc_addr, uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size, vc, posted, noc);
 
     WAYPOINT("NWPW");
     ncrisc_noc_write_set_state<posted, true /* one_packet */>(noc, write_cmd_buf, dst_noc_addr, size, vc);
@@ -989,7 +1003,7 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
 template <bool posted = false>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
     uint32_t src_local_l1_addr, uint32_t dst_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_local_l1_addr, 0ull, 0, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_local_l1_addr, 0ull, 0, -1, posted, noc);
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_local_l1_addr, src_local_l1_addr);
@@ -1039,7 +1053,7 @@ FORCE_INLINE void noc_async_read_page(
         page_size = (1 << addrgen.log_base_2_of_page_size);
     }
     if constexpr (enable_noc_tracing) {
-        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, page_size, -1, false);
+        RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, page_size, -1, false, noc);
     }
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         addrgen.get_noc_addr(id, offset, noc), dst_local_l1_addr, page_size, noc);
@@ -1062,7 +1076,8 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false, noc);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1083,7 +1098,8 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false, noc);
     noc_async_read_page<TensorAccessor<DSpec>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1104,7 +1120,8 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false, noc);
     noc_async_read_page<InterleavedAddrGen<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1131,7 +1148,8 @@ FORCE_INLINE void noc_async_read_tile(
     uint32_t dst_local_l1_addr,
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false);
+    RECORD_NOC_EVENT_WITH_ID(
+        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, addrgen.page_size, -1, false, noc);
     noc_async_read_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1153,7 +1171,15 @@ FORCE_INLINE void noc_async_read_page(
     uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::READ, dst_local_l1_addr, id, addrgen, offset, 1 << addrgen.log_base_2_of_page_size, -1, false);
+        NocEventType::READ,
+        dst_local_l1_addr,
+        id,
+        addrgen,
+        offset,
+        1 << addrgen.log_base_2_of_page_size,
+        -1,
+        false,
+        noc);
     noc_async_read_page<InterleavedPow2AddrGenFast<DRAM>, false>(id, addrgen, dst_local_l1_addr, offset, noc);
 }
 
@@ -1208,7 +1234,8 @@ FORCE_INLINE void noc_async_write_page(
             offset,
             size ? size : page_size,
             NOC_UNICAST_WRITE_VC,
-            posted);
+            posted,
+            noc);
     }
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
         src_local_l1_addr, addrgen.get_noc_addr(id, offset, noc), size ? size : page_size, noc);
@@ -1239,7 +1266,15 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC, false);
+        NocEventType::WRITE_,
+        src_local_l1_addr,
+        id,
+        addrgen,
+        offset,
+        write_size_bytes,
+        NOC_UNICAST_WRITE_VC,
+        false,
+        noc);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1256,7 +1291,7 @@ template <bool DRAM>
 [[deprecated("Use <typename AddrGen> noc_async_write_page instead.")]]
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const InterleavedAddrGen<DRAM>& addrgen, uint32_t src_local_l1_addr, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false, noc);
     noc_async_write_page<InterleavedAddrGen<DRAM>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1282,7 +1317,7 @@ FORCE_INLINE void noc_async_write_tile(
     const InterleavedAddrGenFast<DRAM, tile_hw>& addrgen,
     uint32_t src_local_l1_addr,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false);
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, src_local_l1_addr, id, addrgen, 0 /* offset */, addrgen.page_size, NOC_UNICAST_WRITE_VC, false, noc);
     noc_async_write_page<InterleavedAddrGenFast<DRAM, tile_hw>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1308,7 +1343,8 @@ FORCE_INLINE void noc_async_write_tile(
         0 /* offset */,
         addrgen.page_size,
         NOC_UNICAST_WRITE_VC,
-        false);
+        false,
+        noc);
     noc_async_write_page<TensorAccessor<DSpec>, false>(
         id, addrgen, src_local_l1_addr, addrgen.page_size, 0 /* offset */, noc);
 }
@@ -1339,7 +1375,15 @@ FORCE_INLINE void noc_async_write_page(
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
     RECORD_NOC_EVENT_WITH_ID(
-        NocEventType::WRITE_, src_local_l1_addr, id, addrgen, offset, write_size_bytes, NOC_UNICAST_WRITE_VC, false);
+        NocEventType::WRITE_,
+        src_local_l1_addr,
+        id,
+        addrgen,
+        offset,
+        write_size_bytes,
+        NOC_UNICAST_WRITE_VC,
+        false,
+        noc);
     noc_async_write_page<InterleavedPow2AddrGenFast<DRAM>, false>(
         id, addrgen, src_local_l1_addr, write_size_bytes, offset, noc);
 }
@@ -1370,7 +1414,8 @@ FORCE_INLINE void noc_async_read_shard(
         s.get_shard_noc_addr(shard_id, noc),
         s.page_size * shard_volume,
         -1,
-        false);
+        false,
+        noc);
     noc_async_read<NOC_MAX_BURST_SIZE + 1, false>(
         s.get_shard_noc_addr(shard_id, noc), dst_local_l1_addr, s.page_size * shard_volume, noc);
 }
@@ -1403,7 +1448,8 @@ FORCE_INLINE void noc_async_write_shard(
         s.get_shard_noc_addr(shard_id, noc),
         s.page_size * shard_volume,
         NOC_UNICAST_WRITE_VC,
-        posted);
+        posted,
+        noc);
     noc_async_write<NOC_MAX_BURST_SIZE + 1, false, posted>(
         src_local_l1_addr, s.get_shard_noc_addr(shard_id, noc), s.page_size * shard_volume, noc);
 }
@@ -1588,7 +1634,13 @@ inline void noc_async_write_multicast_loopback_src(
 
     NOC_TRACE_QUICK_PUSH_IF_LINKED(write_cmd_buf, linked);
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::WRITE_MULTICAST, src_local_l1_addr, dst_noc_addr_multicast, size, NOC_MULTICAST_WRITE_VC, false);
+        NocEventType::WRITE_MULTICAST,
+        src_local_l1_addr,
+        dst_noc_addr_multicast,
+        size,
+        NOC_MULTICAST_WRITE_VC,
+        false,
+        noc);
 
     WAYPOINT("NMLW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size);
@@ -1619,7 +1671,7 @@ inline void noc_async_write_multicast_loopback_src(
  * | noc      | Which NOC to query on                | uint8_t  | 0 or 1      | False    |
  */
 void noc_async_read_barrier(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_START, false);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_START, false, noc);
 
     WAYPOINT("NRBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1632,7 +1684,7 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
     invalidate_l1_cache();
     WAYPOINT("NRBD");
 
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_END, false);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_END, false, noc);
 }
 
 /**
@@ -1649,7 +1701,7 @@ void noc_async_read_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_write_barrier(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_START, false);
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_START, false, noc);
 
     WAYPOINT("NWBW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1662,7 +1714,7 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
     invalidate_l1_cache();
     WAYPOINT("NWBD");
 
-    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_END, false);
+    RECORD_NOC_EVENT(NocEventType::WRITE_BARRIER_END, false, noc);
 }
 
 /**
@@ -1678,7 +1730,7 @@ void noc_async_write_barrier(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_writes_flushed(uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH, false);
+    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH, false, noc);
 
     WAYPOINT("NWFW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1731,7 +1783,7 @@ void noc_async_posted_writes_flushed(uint8_t noc = noc_index) {
  */
 FORCE_INLINE
 void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::ATOMIC_BARRIER, false);
+    RECORD_NOC_EVENT(NocEventType::ATOMIC_BARRIER, false, noc_idx);
 
     WAYPOINT("NABW");
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -1756,7 +1808,7 @@ void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
 FORCE_INLINE
 void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
     invalidate_l1_cache();
-    RECORD_NOC_EVENT(NocEventType::FULL_BARRIER, false);
+    RECORD_NOC_EVENT(NocEventType::FULL_BARRIER, false, noc_idx);
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         WAYPOINT("NFBW");
         while (!ncrisc_dynamic_noc_reads_flushed(noc_idx)) {
@@ -1811,7 +1863,7 @@ void noc_async_full_barrier(uint8_t noc_idx = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false, -1);
 
     WAYPOINT("NSW");
     do {
@@ -1837,7 +1889,7 @@ void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_WAIT, false, -1);
 
     WAYPOINT("NSMW");
     do {
@@ -1863,7 +1915,7 @@ void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val)
 // clang-format on
 FORCE_INLINE
 void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET, false);
+    RECORD_NOC_EVENT(NocEventType::SEMAPHORE_SET, false, -1);
 
     // set semaphore value to val
     (*sem_addr) = val;
@@ -2060,7 +2112,7 @@ FORCE_INLINE void noc_inline_dw_write_with_state(
 template <bool posted = false>
 FORCE_INLINE void noc_semaphore_inc(
     uint64_t addr, uint32_t incr, uint8_t noc_id = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC, 0, addr, 0, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::SEMAPHORE_INC, 0, addr, 0, vc, posted, noc_id);
 
     WAYPOINT("NSIW");
     DEBUG_SANITIZE_NOC_ADDR(noc_id, addr, 4);
@@ -2109,7 +2161,7 @@ inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
 template <bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
     uint32_t src_base_addr, uint32_t src_addr, uint32_t dest_addr, uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID, false);
+    RECORD_NOC_EVENT(NocEventType::READ_WITH_STATE_AND_TRID, false, noc);
 
     WAYPOINT("NRDW");
     ncrisc_noc_fast_read_with_transaction_id<noc_mode, skip_ptr_update, skip_cmdbuf_chk>(
@@ -2131,7 +2183,7 @@ FORCE_INLINE void noc_async_read_one_packet_with_state_with_trid(
 // clang-format on
 FORCE_INLINE
 void noc_async_read_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::READ_SET_TRID, false);
+    RECORD_NOC_EVENT(NocEventType::READ_SET_TRID, false, noc);
 
     WAYPOINT("NSTW");
     ncrisc_noc_set_transaction_id(noc, read_cmd_buf, trid);
@@ -2152,7 +2204,7 @@ void noc_async_read_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_async_write_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_SET_TRID, false);
+    RECORD_NOC_EVENT(NocEventType::WRITE_SET_TRID, false, noc);
     WAYPOINT("NWSW");
     ncrisc_noc_set_transaction_id(noc, write_cmd_buf, trid);
     WAYPOINT("NWSD");
@@ -2176,7 +2228,7 @@ void noc_async_write_set_trid(uint32_t trid = 0, uint8_t noc = noc_index) {
 FORCE_INLINE
 void noc_async_read_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
     WAYPOINT("NBTW");
-    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_WITH_TRID, false);
+    RECORD_NOC_EVENT(NocEventType::READ_BARRIER_WITH_TRID, false, noc);
     while (!ncrisc_noc_read_with_transaction_id_flushed(noc, trid)) {
         continue;
     }
@@ -2210,7 +2262,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid(
     uint8_t noc = noc_index,
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, src_local_l1_addr, dst_noc_addr, size, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID, src_local_l1_addr, dst_noc_addr, size, -1, posted, noc);
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc, cmd_buf));
 
@@ -2269,7 +2321,7 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_set_state(
     uint8_t vc = NOC_UNICAST_WRITE_VC) {
     WAYPOINT("NAWW");
     DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc, DEBUG_SANITIZE_NOC_UNICAST);
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, 0, dst_noc_addr, 0, vc, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_SET_STATE, 0, dst_noc_addr, 0, vc, posted, noc);
 
     ncrisc_noc_write_set_state<posted, false /* one_packet */>(noc, cmd_buf, dst_noc_addr, 0 /* len_bytes */, vc);
     WAYPOINT("NAWD");
@@ -2306,7 +2358,8 @@ FORCE_INLINE void noc_async_write_one_packet_with_trid_with_state(
     uint32_t trid,
     uint8_t cmd_buf = write_cmd_buf,
     uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_TRID_WITH_STATE, src_local_l1_addr, 0ull, size, -1, posted);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::WRITE_WITH_TRID_WITH_STATE, src_local_l1_addr, 0ull, size, -1, posted, noc);
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc, dst_local_l1_addr, src_local_l1_addr, size);
@@ -2368,7 +2421,7 @@ void noc_async_write_barrier_with_trid(uint32_t trid, uint8_t noc = noc_index) {
 // clang-format on
 FORCE_INLINE
 void noc_async_write_flushed_with_trid(uint32_t trid, uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH_WITH_TRID, false);
+    RECORD_NOC_EVENT(NocEventType::WRITE_FLUSH_WITH_TRID, false, noc);
     WAYPOINT("NFTW");
     while (!ncrisc_noc_nonposted_write_with_transaction_id_sent(noc, trid)) {
         continue;

--- a/tt_metal/hw/inc/experimental/noc.h
+++ b/tt_metal/hw/inc/experimental/noc.h
@@ -157,7 +157,8 @@ public:
             src_noc_addr,
             size_bytes,
             (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1,
-            false);
+            false,
+            noc_id_);
 
         WAYPOINT("NASW");
         ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, vc_selection == VcSelection::CUSTOM>(
@@ -254,7 +255,7 @@ public:
             auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
             if constexpr (enable_noc_tracing) {
                 RECORD_NOC_EVENT_WITH_ADDR(
-                    NocEventType::WRITE_WITH_TRID, src_addr, dst_noc_addr, size_bytes, -1, posted);
+                    NocEventType::WRITE_WITH_TRID, src_addr, dst_noc_addr, size_bytes, -1, posted, noc_id_);
             }
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, size_bytes);
             constexpr bool one_packet = max_page_size <= NOC_MAX_BURST_SIZE;
@@ -359,7 +360,7 @@ public:
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
         constexpr bool posted = response_mode == ResponseMode::POSTED;
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size_bytes, vc, posted);
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size_bytes, vc, posted, noc_id_);
 
         WAYPOINT("NWPW");
         ncrisc_noc_write_set_state<posted, max_page_size <= NOC_MAX_BURST_SIZE>(
@@ -409,7 +410,7 @@ public:
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_addr =
                 get_dst_ptr<AddressType::NOC>(dst, dst_args);  // NoC target was programmed in set_async_write_state
-            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_addr, 0ull, 0, -1, posted);
+            RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, src_addr, 0ull, 0, -1, posted, noc_id_);
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id_, dst_addr, src_addr);
 
             WAYPOINT("NWPW");

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -798,9 +798,9 @@ __attribute__((noinline)) void trace_only_init() {
 #define DeviceIncrementTraceCount()
 
 // null macros when noc tracing is disabled
-#define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT(type, posted)
+#define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted, noc)
+#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted, noc)
+#define RECORD_NOC_EVENT(type, posted, noc)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 
 // null macros when perf counters are disabled

--- a/tt_metal/tools/profiler/noc_event_profiler.hpp
+++ b/tt_metal/tools/profiler/noc_event_profiler.hpp
@@ -132,60 +132,79 @@ FORCE_INLINE void recordMulticastNocEvent(
 
 template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, bool posted, typename AddrGen, typename NocIDU32>
 FORCE_INLINE void recordNocEventWithID(
-    uint32_t local_addr, NocIDU32 noc_id, AddrGen addrgen, uint32_t offset, uint32_t num_bytes, int8_t vc) {
+    uint32_t local_addr,
+    NocIDU32 noc_id,
+    AddrGen addrgen,
+    uint32_t offset,
+    uint32_t num_bytes,
+    int8_t vc,
+    uint8_t noc) {
     static_assert(std::is_same_v<NocIDU32, uint32_t>);
     static_assert(
         has_required_addrgen_traits_v<AddrGen>,
         "AddrGen must have get_noc_addr() and either page_size or log_base_2_of_page_size member variable");
-    auto [decoded_x, decoded_y] = decode_noc_id_into_coord<addrgen.is_dram>(noc_id);
+    auto [decoded_x, decoded_y] = decode_noc_id_into_coord<addrgen.is_dram>(noc_id, noc);
     if constexpr (kernel_profiler::NON_DROPPING) {
         auto noc_addr_local =
-            decode_noc_addr_to_local_addr(get_noc_addr_from_bank_id<addrgen.is_dram>(noc_id, offset, noc_index));
-        recordNocEvent<noc_event_type, posted>(
-            decoded_x, decoded_y, num_bytes, vc, noc_index, local_addr, noc_addr_local);
+            decode_noc_addr_to_local_addr(get_noc_addr_from_bank_id<addrgen.is_dram>(noc_id, offset, noc));
+        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc, local_addr, noc_addr_local);
     } else {
-        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc_index, 0, 0);
+        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc, 0, 0);
     }
 }
 
 template <KernelProfilerNocEventMetadata::NocEventType noc_event_type, bool posted, typename NocAddrU64>
-FORCE_INLINE void recordNocEventWithAddr(uint32_t local_addr, NocAddrU64 noc_addr, uint32_t num_bytes, int8_t vc) {
+FORCE_INLINE void recordNocEventWithAddr(
+    uint32_t local_addr, NocAddrU64 noc_addr, uint32_t num_bytes, int8_t vc, uint8_t noc) {
     static_assert(std::is_same_v<NocAddrU64, uint64_t>);
     auto [decoded_x, decoded_y] = decode_noc_addr_to_coord(noc_addr);
     if constexpr (kernel_profiler::NON_DROPPING) {
         auto noc_addr_local = decode_noc_addr_to_local_addr(noc_addr);
-        recordNocEvent<noc_event_type, posted>(
-            decoded_x, decoded_y, num_bytes, vc, noc_index, local_addr, noc_addr_local);
+        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc, local_addr, noc_addr_local);
     } else {
-        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc_index, 0, 0);
+        recordNocEvent<noc_event_type, posted>(decoded_x, decoded_y, num_bytes, vc, noc, 0, 0);
     }
 }
 }  // namespace noc_event_profiler
 
-#define RECORD_NOC_EVENT_WITH_ADDR(event_type, local_addr, noc_addr, num_bytes, vc, posted)                         \
-    {                                                                                                               \
-        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                                          \
-        if constexpr (event_type != NocEventType::WRITE_MULTICAST) {                                                \
-            noc_event_profiler::recordNocEventWithAddr<event_type, posted>(local_addr, noc_addr, num_bytes, vc);    \
-        } else {                                                                                                    \
-            auto [mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y] =                         \
-                noc_event_profiler::decode_noc_addr_to_multicast_coord(noc_addr);                                   \
-            noc_event_profiler::recordMulticastNocEvent(                                                            \
-                event_type, mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y, num_bytes, vc); \
-        }                                                                                                           \
+#define RECORD_NOC_EVENT_WITH_ADDR(event_type, local_addr, noc_addr, num_bytes, vc, posted, noc)                      \
+    {                                                                                                                 \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                                            \
+        if constexpr (event_type != NocEventType::WRITE_MULTICAST) {                                                  \
+            noc_event_profiler::recordNocEventWithAddr<event_type, posted>(local_addr, noc_addr, num_bytes, vc, noc); \
+        } else {                                                                                                      \
+            auto [mcast_dst_start_x, mcast_dst_start_y, mcast_dst_end_x, mcast_dst_end_y] =                           \
+                noc_event_profiler::decode_noc_addr_to_multicast_coord(noc_addr);                                     \
+            noc_event_profiler::recordMulticastNocEvent(                                                              \
+                event_type,                                                                                           \
+                mcast_dst_start_x,                                                                                    \
+                mcast_dst_start_y,                                                                                    \
+                mcast_dst_end_x,                                                                                      \
+                mcast_dst_end_y,                                                                                      \
+                num_bytes,                                                                                            \
+                vc,                                                                                                   \
+                noc);                                                                                                 \
+        }                                                                                                             \
     }
 
-#define RECORD_NOC_EVENT_WITH_ID(event_type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted) \
-    {                                                                                                    \
-        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                               \
-        noc_event_profiler::recordNocEventWithID<event_type, posted>(                                    \
-            local_addr, noc_id, addrgen, offset, num_bytes, vc);                                         \
+#define RECORD_NOC_EVENT_WITH_ID(event_type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted, noc) \
+    {                                                                                                         \
+        using NocEventType = KernelProfilerNocEventMetadata::NocEventType;                                    \
+        noc_event_profiler::recordNocEventWithID<event_type, posted>(                                         \
+            local_addr, noc_id, addrgen, offset, num_bytes, vc, noc);                                         \
     }
 
-#define RECORD_NOC_EVENT(event_type, posted)                               \
+#define RECORD_NOC_EVENT(event_type, posted, noc)                          \
     {                                                                      \
         using NocEventType = KernelProfilerNocEventMetadata::NocEventType; \
-        noc_event_profiler::recordNocEvent<event_type, posted>();          \
+        noc_event_profiler::recordNocEvent<event_type, posted>(            \
+            /*dst_x=*/-1,                                                  \
+            /*dst_y=*/-1,                                                  \
+            /*num_bytes=*/0,                                               \
+            /*vc=*/-1,                                                     \
+            /*noc=*/noc,                                                   \
+            /*local_addr=*/0,                                              \
+            /*dst_local_addr=*/0);                                         \
     }
 
 // preemptive quick push if transitioning from unlinked state to linked state
@@ -197,9 +216,9 @@ FORCE_INLINE void recordNocEventWithAddr(uint32_t local_addr, NocAddrU64 noc_add
 #else
 
 // null macros when noc tracing is disabled
-#define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted)
-#define RECORD_NOC_EVENT(type, posted)
+#define RECORD_NOC_EVENT_WITH_ADDR(type, local_addr, noc_addr, num_bytes, vc, posted, noc)
+#define RECORD_NOC_EVENT_WITH_ID(type, local_addr, noc_id, addrgen, offset, num_bytes, vc, posted, noc)
+#define RECORD_NOC_EVENT(type, posted, noc)
 #define NOC_TRACE_QUICK_PUSH_IF_LINKED(cmd_buf, linked)
 
 #endif


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29601

### Problem description
Some kernels use dynamic noc. They pass in a noc index which is not the same as `noc_index` at runtime to the noc async APIs but the event profiler still records them as `noc_index`.

### What's changed
Plumb the correct noc index to the noc event profiler record functions

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/plumb-noc-index)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/plumb-noc-index)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/plumb-noc-index)
- [ ] New/Existing tests provide coverage for changes

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/21266358841

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/plumb-noc-index)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/plumb-noc-index)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/plumb-noc-index)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/plumb-noc-index)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs