### PR TITLE
Record noc event for semaphore APIs

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1554,6 +1554,8 @@ inline void noc_semaphore_set_multicast(
 
     constexpr uint32_t size_bytes = 4;
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size_bytes);
+
+    NOC_TRACE_QUICK_PUSH_IF_LINKED(NOC_MULTICAST_WRITE_VC, linked);
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::SEMAPHORE_SET_MULTICAST,
         src_local_l1_addr,
@@ -1614,6 +1616,8 @@ inline void noc_semaphore_set_multicast_loopback_src(
 
     constexpr uint32_t size_bytes = 4;
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size_bytes);
+
+    NOC_TRACE_QUICK_PUSH_IF_LINKED(NOC_MULTICAST_WRITE_VC, linked);
     RECORD_NOC_EVENT_WITH_ADDR(
         NocEventType::SEMAPHORE_SET_MULTICAST,
         src_local_l1_addr,

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -1490,18 +1490,29 @@ FORCE_INLINE uint32_t get_semaphore(uint32_t semaphore_id) {
 inline void noc_semaphore_set_remote(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, uint8_t noc = noc_index) {
     WAYPOINT("NSSW");
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, 4);
+
+    constexpr uint32_t size_bytes = 4;
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size_bytes);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::SEMAPHORE_SET_REMOTE,
+        src_local_l1_addr,
+        dst_noc_addr,
+        size_bytes,
+        NOC_UNICAST_WRITE_VC,
+        /*posted=*/false,
+        noc);
     ncrisc_noc_fast_write_any_len<noc_mode>(
         noc,
         write_reg_cmd_buf,
         src_local_l1_addr,
         dst_noc_addr,
-        4 /* size in bytes */,
+        size_bytes,
         NOC_UNICAST_WRITE_VC,
         false,
         false,
         1,
-        true);
+        /*multicast_path_reserve=*/true,
+        /*posted=*/false);
     WAYPOINT("NSSD");
 }
 
@@ -1540,18 +1551,29 @@ inline void noc_semaphore_set_multicast(
     bool linked = false,
     uint8_t noc = noc_index) {
     WAYPOINT("NSNW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, 4);
+
+    constexpr uint32_t size_bytes = 4;
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size_bytes);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::SEMAPHORE_SET_MULTICAST,
+        src_local_l1_addr,
+        dst_noc_addr_multicast,
+        size_bytes,
+        NOC_MULTICAST_WRITE_VC,
+        /*posted=*/false,
+        noc);
     ncrisc_noc_fast_write_any_len<noc_mode>(
         noc,
         write_reg_cmd_buf,
         src_local_l1_addr,
         dst_noc_addr_multicast,
-        4 /*size in bytes*/,
+        size_bytes,
         NOC_MULTICAST_WRITE_VC,
         true,
         linked,
         num_dests,
-        true /* multicast_path_reserve */);
+        /*multicast_path_reserve=*/true,
+        /*posted=*/false);
     WAYPOINT("NSND");
 }
 // clang-format off
@@ -1589,18 +1611,28 @@ inline void noc_semaphore_set_multicast_loopback_src(
     bool linked = false,
     uint8_t noc = noc_index) {
     WAYPOINT("NSLW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, 4);
+
+    constexpr uint32_t size_bytes = 4;
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc, dst_noc_addr_multicast, src_local_l1_addr, size_bytes);
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::SEMAPHORE_SET_MULTICAST,
+        src_local_l1_addr,
+        dst_noc_addr_multicast,
+        size_bytes,
+        NOC_MULTICAST_WRITE_VC,
+        /*posted=*/false,
+        noc);
     ncrisc_noc_fast_write_any_len_loopback_src<noc_mode>(
         noc,
         write_reg_cmd_buf,
         src_local_l1_addr,
         dst_noc_addr_multicast,
-        4 /*size in bytes*/,
+        size_bytes,
         NOC_MULTICAST_WRITE_VC,
         true,
         linked,
         num_dests,
-        true /* multicast_path_reserve */);
+        /*multicast_path_reserve=*/true);
     WAYPOINT("NSLD");
 }
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -83,7 +83,10 @@ NOCDebugEvent make_noc_debug_event(
                 src_x,
                 src_y,
                 event.noc_type == EMD::NocType::NOC_1});
-        case EMD::NocEventType::WRITE_:
+        case EMD::NocEventType::WRITE_: [[fallthrough]];
+        case EMD::NocEventType::WRITE_MULTICAST: [[fallthrough]];
+        case EMD::NocEventType::SEMAPHORE_SET_MULTICAST: [[fallthrough]];
+        case EMD::NocEventType::SEMAPHORE_SET_REMOTE:
             return NOCDebugEvent(NocWriteEvent{
                 trailer.getSrcAddr(),
                 trailer.getDstAddr(),

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -46,19 +46,21 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         SEMAPHORE_INC = 27,
         SEMAPHORE_WAIT = 28,
         SEMAPHORE_SET = 29,
+        SEMAPHORE_SET_REMOTE = 30,
+        SEMAPHORE_SET_MULTICAST = 31,
 
         // NOTE: fabric events should be contiguous to allow quick range check!
-        FABRIC_UNICAST_WRITE = 30,
-        FABRIC_UNICAST_INLINE_WRITE = 31,
-        FABRIC_UNICAST_ATOMIC_INC = 32,
-        FABRIC_FUSED_UNICAST_ATOMIC_INC = 33,
-        FABRIC_MULTICAST_WRITE = 34,
-        FABRIC_MULTICAST_ATOMIC_INC = 35,
-        FABRIC_UNICAST_SCATTER_WRITE = 36,
-        FABRIC_ROUTING_FIELDS_1D = 37,
-        FABRIC_ROUTING_FIELDS_2D = 38,
+        FABRIC_UNICAST_WRITE = 32,
+        FABRIC_UNICAST_INLINE_WRITE = 33,
+        FABRIC_UNICAST_ATOMIC_INC = 34,
+        FABRIC_FUSED_UNICAST_ATOMIC_INC = 35,
+        FABRIC_MULTICAST_WRITE = 36,
+        FABRIC_MULTICAST_ATOMIC_INC = 37,
+        FABRIC_UNICAST_SCATTER_WRITE = 38,
+        FABRIC_ROUTING_FIELDS_1D = 39,
+        FABRIC_ROUTING_FIELDS_2D = 40,
 
-        UNSUPPORTED = 39,
+        UNSUPPORTED = 41,
     };
 
     enum class NocType : unsigned char { UNDEF = 0, NOC_0 = 1, NOC_1 = 2 };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29601

### Problem description
Missing barrier after usage of this API was the root cause of https://github.com/tenstorrent/tt-metal/issues/32489

### What's changed
Add calls to record multicast NOC event so we can track it on the host and check if barriers have been issued between calls.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/record-1)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/record-1)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/record-1)
- [ ] New/Existing tests provide coverage for changes

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/21300581438

Manual Testing

I reverted https://github.com/tenstorrent/tt-metal/pull/33710 and ran `TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1 pytest tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py::test_post_allgather_layernorm -vvvv` to confirm the semaphore multicasts are being picked up.

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/record-1)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/record-1)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/record-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/record-1)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs