### PR TITLE
Added Fabric Sparse Multicast Messaging

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_host_kernel_common.hpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_host_kernel_common.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file contains common parameters that are used in both the testbenches and the kernels that they call.
+
+#pragma once
+
+namespace tt::tt_fabric::fabric_router_tests {
+
+// Enum used to specify the fabric packet type used in the test
+enum FabricPacketType {
+    CHIP_UNICAST = 0,
+    CHIP_MULTICAST = 1,
+    CHIP_SPARSE_MULTICAST = 2,
+    COUNT = CHIP_SPARSE_MULTICAST + 1
+};
+
+}  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_atomic_inc_sender.cpp
@@ -17,6 +17,8 @@ using namespace tt::tt_fabric::mesh::experimental;
 #include "test_linear_common.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
+#include "test_host_kernel_common.hpp"
+using tt::tt_fabric::fabric_router_tests::FabricPacketType;
 
 constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
 constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
@@ -26,7 +28,12 @@ uint32_t target_address = get_compile_time_arg_val(3);
 constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
 constexpr uint32_t num_send_dir = get_compile_time_arg_val(5);
 constexpr bool with_state = get_compile_time_arg_val(6) == 1;
-constexpr bool is_chip_multicast = get_compile_time_arg_val(7) == 1;
+constexpr uint32_t raw_fabric_packet_type = get_compile_time_arg_val(7);
+static_assert(
+    raw_fabric_packet_type < static_cast<uint32_t>(FabricPacketType::COUNT),
+    "Compile-time arg 7 (fabric_packet_type) must be 0 (CHIP_UNICAST), 1 (CHIP_MULTICAST), or 2 "
+    "(CHIP_SPARSE_MULTICAST)");
+constexpr FabricPacketType fabric_packet_type = static_cast<FabricPacketType>(raw_fabric_packet_type);
 
 void kernel_main() {
     size_t rt_arg_idx = 0;
@@ -36,12 +43,12 @@ void kernel_main() {
     uint32_t time_seed = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t noc_x_start = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t noc_y_start = get_arg_val<uint32_t>(rt_arg_idx++);
-    auto hop_info = get_hop_info_from_args<is_chip_multicast, num_send_dir>(rt_arg_idx);
+    auto hop_info = get_hop_info_from_args<fabric_packet_type, num_send_dir>(rt_arg_idx);
 
 #ifdef API_TYPE_Mesh
     // Build MeshMcastRange array from hop_info once
     MeshMcastRange ranges[num_send_dir];
-    if constexpr (is_chip_multicast) {
+    if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
         for (uint32_t i = 0; i < num_send_dir; i++) {
             ranges[i].e = hop_info.mcast.e[i];
             ranges[i].w = hop_info.mcast.w[i];
@@ -61,13 +68,16 @@ void kernel_main() {
     uint64_t start_timestamp = get_timestamp();
 
     if constexpr (with_state) {
-        set_state<num_send_dir, is_chip_multicast, noc_send_type>(
+        set_state<num_send_dir, fabric_packet_type, noc_send_type>(
             connections, route_id, hop_info, static_cast<uint16_t>(packet_payload_size_bytes));
     }
 
     for (uint32_t i = 0; i < num_packets; i++) {
 #ifdef API_TYPE_Linear
-        if constexpr (is_chip_multicast) {
+        static_assert(
+            fabric_packet_type != FabricPacketType::CHIP_SPARSE_MULTICAST,
+            "Sparse multicast has not been tested yet with atomic inc");
+        if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
             switch (noc_send_type) {
                 case NOC_UNICAST_ATOMIC_INC: {
                     if constexpr (with_state) {
@@ -169,7 +179,10 @@ void kernel_main() {
             }
         }
 #elif defined(API_TYPE_Mesh)
-        if constexpr (is_chip_multicast) {
+        static_assert(
+            fabric_packet_type != FabricPacketType::CHIP_SPARSE_MULTICAST,
+            "Sparse multicast has not been tested yet with mesh topology");
+        if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
             switch (noc_send_type) {
                 case NOC_UNICAST_ATOMIC_INC: {
                     if constexpr (with_state) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
@@ -17,6 +17,8 @@ using namespace tt::tt_fabric::mesh::experimental;
 #include "test_linear_common.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
+#include "test_host_kernel_common.hpp"
+using tt::tt_fabric::fabric_router_tests::FabricPacketType;
 
 constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(0);
 constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(1);
@@ -26,7 +28,12 @@ uint32_t target_address = get_compile_time_arg_val(3);
 constexpr NocSendType noc_send_type = static_cast<NocSendType>(get_compile_time_arg_val(4));
 constexpr uint32_t num_send_dir = get_compile_time_arg_val(5);
 constexpr bool with_state = get_compile_time_arg_val(6) == 1;
-constexpr bool is_chip_multicast = get_compile_time_arg_val(7) == 1;
+constexpr uint32_t raw_fabric_packet_type = get_compile_time_arg_val(7);
+static_assert(
+    raw_fabric_packet_type < static_cast<uint32_t>(FabricPacketType::COUNT),
+    "Compile-time arg 7 (fabric_packet_type) must be 0 (CHIP_UNICAST), 1 (CHIP_MULTICAST), or 2 "
+    "(CHIP_SPARSE_MULTICAST)");
+constexpr FabricPacketType fabric_packet_type = static_cast<FabricPacketType>(raw_fabric_packet_type);
 
 void kernel_main() {
     size_t rt_arg_idx = 0;
@@ -36,12 +43,12 @@ void kernel_main() {
     uint32_t time_seed = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t noc_x_start = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t noc_y_start = get_arg_val<uint32_t>(rt_arg_idx++);
-    auto hop_info = get_hop_info_from_args<is_chip_multicast, num_send_dir>(rt_arg_idx);
+    auto hop_info = get_hop_info_from_args<fabric_packet_type, num_send_dir>(rt_arg_idx);
 
 #ifdef API_TYPE_Mesh
     // Build MeshMcastRange array from hop_info once
     MeshMcastRange ranges[num_send_dir];
-    if constexpr (is_chip_multicast) {
+    if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
         for (uint32_t i = 0; i < num_send_dir; i++) {
             ranges[i].e = hop_info.mcast.e[i];
             ranges[i].w = hop_info.mcast.w[i];
@@ -61,7 +68,7 @@ void kernel_main() {
     uint64_t start_timestamp = get_timestamp();
 
     if constexpr (with_state) {
-        set_state<num_send_dir, is_chip_multicast, noc_send_type>(
+        set_state<num_send_dir, fabric_packet_type, noc_send_type>(
             connections, route_id, hop_info, static_cast<uint16_t>(packet_payload_size_bytes));
     }
 
@@ -71,7 +78,23 @@ void kernel_main() {
         fill_packet_data(start_addr, packet_payload_size_bytes / 16, time_seed);
 
 #ifdef API_TYPE_Linear
-        if constexpr (is_chip_multicast) {
+        if constexpr (fabric_packet_type == FabricPacketType::CHIP_SPARSE_MULTICAST) {
+            // Currently sparse multicast has only been tested for NoC Unicast Writes
+            switch (noc_send_type) {
+                case NOC_UNICAST_WRITE: {
+                    fabric_sparse_multicast_noc_unicast_write(
+                        connections,
+                        route_id,
+                        source_l1_buffer_address,
+                        packet_payload_size_bytes,
+                        tt::tt_fabric::NocUnicastCommandHeader{get_noc_addr(noc_x_start, noc_y_start, target_address)},
+                        hop_info.sparse_mcast.hop_mask);
+                } break;
+                default: {
+                    ASSERT(false);
+                } break;
+            }
+        } else if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
             switch (noc_send_type) {
                 case NOC_UNICAST_WRITE: {
                     if constexpr (with_state) {
@@ -203,7 +226,10 @@ void kernel_main() {
             }
         }
 #elif defined(API_TYPE_Mesh)
-        if constexpr (is_chip_multicast) {
+        static_assert(
+            fabric_packet_type != FabricPacketType::CHIP_SPARSE_MULTICAST,
+            "Sparse multicast has not been tested yet with mesh topology");
+        if constexpr (fabric_packet_type == FabricPacketType::CHIP_MULTICAST) {
             switch (noc_send_type) {
                 case NOC_UNICAST_WRITE: {
                     if constexpr (with_state) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -16,6 +16,7 @@
 #include <variant>
 #include <vector>
 #include <random>
+#include <bit>
 
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -37,6 +38,7 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include "kernels/test_host_kernel_common.hpp"
 
 namespace tt::tt_fabric::fabric_router_tests {
 std::random_device rd;  // Non-deterministic seed source
@@ -2184,8 +2186,7 @@ void FabricUnicastCommon(
         noc_send_type,
         static_cast<uint32_t>(dir_configs.size()),
         with_state,
-        0  // is_chip_multicast = 0
-    };
+        static_cast<uint32_t>(FabricPacketType::CHIP_UNICAST)};
 
     if (noc_send_type == NOC_UNICAST_INLINE_WRITE) {
         worker_mem_map.packet_payload_size_bytes = 4;
@@ -3277,8 +3278,7 @@ void Fabric2DMulticastCommon(
         noc_send_type,
         num_connections,  // Number of connections (multicast routes)
         with_state,
-        1  // is_chip_multicast = 1
-    };
+        static_cast<uint32_t>(FabricPacketType::CHIP_MULTICAST)};
 
     std::vector<uint32_t> sender_runtime_args = {
         worker_mem_map.source_l1_buffer_address,
@@ -3423,6 +3423,9 @@ void FabricMulticastCommon(
     auto sender_device = fixture->get_device(src_physical_device_id);
     auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
 
+    // Preserve original lists for connection setup
+    auto original_end_fabric_node_ids_by_dir = end_fabric_node_ids_by_dir;
+
     // Adjust lists to start from start_distance for each direction
     std::vector<FabricNodeId> dest_fabric_node_ids;
     for (auto [dir, start_distance, range] : dir_configs) {
@@ -3431,7 +3434,11 @@ void FabricMulticastCommon(
             physical_end_device_ids_by_dir[dir].end());
         end_fabric_node_ids_by_dir[dir] = std::vector(
             end_fabric_node_ids_by_dir[dir].begin() + (start_distance - 1), end_fabric_node_ids_by_dir[dir].end());
-        dest_fabric_node_ids.push_back(end_fabric_node_ids_by_dir[dir][0]);
+
+        // Connect only to first hop (direct neighbor), regardless of start_distance
+        if (!original_end_fabric_node_ids_by_dir[dir].empty()) {
+            dest_fabric_node_ids.push_back(original_end_fabric_node_ids_by_dir[dir][0]);
+        }
     }
 
     // Choose a receiver device to compute RX core coords (use last device from first configured dir)
@@ -3455,8 +3462,7 @@ void FabricMulticastCommon(
         noc_send_type,
         static_cast<uint32_t>(dir_configs.size()),
         with_state,
-        1  // is_chip_multicast = 1
-    };
+        static_cast<uint32_t>(FabricPacketType::CHIP_MULTICAST)};
 
     std::vector<uint32_t> sender_runtime_args = {
         worker_mem_map.source_l1_buffer_address,
@@ -3641,6 +3647,177 @@ TEST_F(NightlyFabric1DFixture, TestLinearFabricUnicastNocFusedAtomicIncWithState
         true);
 }
 
+void FabricSparseMulticastCommon(
+    BaseFabricFixture* fixture, const std::vector<std::tuple<RoutingDirection, uint16_t>>& pair_ordered_dir_configs) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+    uint32_t num_packets = 10;
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+
+    // Limit directions per cluster (T3K: up to 3, TG: up to 4)
+    const auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    size_t max_dirs = (cluster_type == tt::tt_metal::ClusterType::T3K) ? 3 : 4;
+    std::vector<std::tuple<RoutingDirection, uint16_t>> dir_configs = pair_ordered_dir_configs;
+    if (dir_configs.size() > max_dirs) {
+        dir_configs.resize(max_dirs);
+    }
+
+    FabricNodeId src_fabric_node_id(MeshId{0}, 0);
+    // Identify the maximum hop distance (most significant set bit) for each direction
+    std::unordered_map<RoutingDirection, uint32_t> fabric_hops;
+    for (auto [dir, hops] : dir_configs) {
+        fabric_hops[dir] = std::bit_width(hops);
+    }
+
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> end_fabric_node_ids_by_dir;
+    ChipId src_physical_device_id;
+    std::unordered_map<RoutingDirection, std::vector<ChipId>> physical_end_device_ids_by_dir;
+    if (!find_device_with_neighbor_in_multi_direction(
+            fixture,
+            src_fabric_node_id,
+            end_fabric_node_ids_by_dir,
+            src_physical_device_id,
+            physical_end_device_ids_by_dir,
+            fabric_hops)) {
+        GTEST_SKIP() << "No sparse multicast destinations found for requested directions";
+    }
+
+    // Preserve original lists for connection setup (like FabricMulticastCommon)
+    auto original_physical_end_device_ids_by_dir = physical_end_device_ids_by_dir;
+    auto original_end_fabric_node_ids_by_dir = end_fabric_node_ids_by_dir;
+
+    // Filter device lists to only include devices that should receive packets (like FabricMulticastCommon range
+    // filtering)
+    for (auto [dir, hops] : dir_configs) {
+        std::vector<ChipId> filtered_physical_devices;
+        std::vector<FabricNodeId> filtered_fabric_nodes;
+
+        for (size_t i = 0; i < physical_end_device_ids_by_dir[dir].size(); i++) {
+            if (hops & (1 << i)) {  // Only include devices where the hop bit is set
+                filtered_physical_devices.push_back(physical_end_device_ids_by_dir[dir][i]);
+                filtered_fabric_nodes.push_back(end_fabric_node_ids_by_dir[dir][i]);
+            }
+        }
+
+        physical_end_device_ids_by_dir[dir] = filtered_physical_devices;
+        end_fabric_node_ids_by_dir[dir] = filtered_fabric_nodes;
+    }
+
+    // Build destination fabric node ID list (for routing plane connection manager)
+    // Like regular multicast, only connect to the first hop in each direction
+    // The sparse routing is handled by packet headers, not direct connections
+    std::vector<FabricNodeId> dest_fabric_node_ids;
+    for (auto [dir, hops] : dir_configs) {
+        // Use original lists for connections (first hop only)
+        if (!original_end_fabric_node_ids_by_dir[dir].empty()) {
+            dest_fabric_node_ids.push_back(original_end_fabric_node_ids_by_dir[dir][0]);
+        }
+    }
+
+    auto sender_device = fixture->get_device(src_physical_device_id);
+    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+
+    tt_metal::Program sender_program = tt_metal::CreateProgram();
+
+    auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
+
+    std::vector<uint32_t> compile_time_args = {
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        worker_mem_map.notification_mailbox_address,
+        worker_mem_map.target_address,
+        NOC_UNICAST_WRITE,  // Only support NOC_UNICAST_WRITE for sparse multicast
+        static_cast<uint32_t>(dir_configs.size()),
+        0,  // with_state = false (not supported for sparse multicast)
+        static_cast<uint32_t>(FabricPacketType::CHIP_SPARSE_MULTICAST)};
+
+    std::vector<uint32_t> sender_runtime_args = {
+        worker_mem_map.source_l1_buffer_address,
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        time_seed,
+        receiver_virtual_core.x,
+        receiver_virtual_core.y,
+    };
+    for (auto [dir, hops] : dir_configs) {
+        sender_runtime_args.push_back(static_cast<uint32_t>(hops));
+    }
+
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    append_routing_plane_connection_manager_rt_args(
+        src_fabric_node_id,
+        dest_fabric_node_ids,
+        {},
+        sender_program,
+        sender_kernel,
+        {sender_logical_core},
+        sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Build and launch receiver programs for all destination devices in all configured directions
+    std::vector<std::pair<std::shared_ptr<tt_metal::distributed::MeshDevice>, tt_metal::Program>> receiver_programs;
+    std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
+    for (auto& [dir, hops] : dir_configs) {
+        for (auto physical_end_device_id : physical_end_device_ids_by_dir[dir]) {
+            auto receiver_device = fixture->get_device(physical_end_device_id);
+            tt_metal::Program receiver_program = tt_metal::CreateProgram();
+            auto receiver_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_receiver.cpp",
+                {receiver_logical_core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_time_args});
+
+            tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+            fixture->RunProgramNonblocking(receiver_device, receiver_program);
+            receiver_programs.emplace_back(receiver_device, std::move(receiver_program));
+        }
+    }
+
+    fixture->RunProgramNonblocking(sender_device, sender_program);
+    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+
+    for (auto& [dev, prog] : receiver_programs) {
+        fixture->WaitForSingleProgramDone(dev, prog);
+    }
+
+    std::vector<uint32_t> sender_status;
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device->get_devices()[0],
+        sender_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    for (auto& [dev, _] : receiver_programs) {
+        std::vector<uint32_t> recv_status;
+        tt_metal::detail::ReadFromDeviceL1(
+            dev->get_devices()[0],
+            receiver_logical_core,
+            worker_mem_map.test_results_address,
+            worker_mem_map.test_results_size_bytes,
+            recv_status,
+            CoreType::WORKER);
+        EXPECT_EQ(recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    }
+}
+
 TEST_F(NightlyFabric1DFixture, TestLinearFabricMulticastNocUnicastWrite) {
     FabricMulticastCommon(this, NOC_UNICAST_WRITE, {std::make_tuple(RoutingDirection::E, 1, 2)});
 }
@@ -3741,6 +3918,24 @@ TEST_F(Fabric1DTensixFixture, TestLinearFabricMulticastNocUnicastWriteMux) {
 
 TEST_F(Fabric1DTensixFixture, TestLinearFabricMulticastNocAtomicIncMux) {
     FabricMulticastCommon(this, NOC_UNICAST_ATOMIC_INC, {std::make_tuple(RoutingDirection::E, 1, 2)});
+}
+
+// Fabric 1D sparse multicast test cases
+TEST_F(NightlyFabric1DFixture, TestLinearFabricSparseMulticastNocUnicastWrite) {
+    FabricSparseMulticastCommon(this, {std::make_tuple(RoutingDirection::E, 0b0101)});  // Write to hops 1 and 3
+}
+
+TEST_F(NightlyFabric1DFixture, TestLinearFabricSparseMulticastNocUnicastWriteSingleHop) {
+    FabricSparseMulticastCommon(this, {std::make_tuple(RoutingDirection::E, 0b0100)});  // Write to hop 3 only
+}
+
+TEST_F(NightlyFabric1DFixture, TestLinearFabricSparseMulticastNocUnicastWriteMultiDir) {
+    FabricSparseMulticastCommon(
+        this,
+        {
+            std::make_tuple(RoutingDirection::E, 0b1),    // Write to hop 1 eastward
+            std::make_tuple(RoutingDirection::W, 0b0011)  // Write to hops 1 and 2 westward
+        });
 }
 
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -133,6 +133,34 @@ struct MulticastRoutingCommandHeader {
 };
 static_assert(sizeof(MulticastRoutingCommandHeader) == 2, "MulticastRoutingCommandHeader size is not 2 bytes");
 
+// Helper to extract maximum number of hops from LowLatencyPacketHeaderT
+// The other helpers are defined further down in this file, after their respective template declarations
+template <typename HEADER_TYPE>
+struct get_max_num_hops {
+    // Use std::is_same_v to ensure this static_assert is only evaluated after template instantiation
+    static_assert(!std::is_same_v<HEADER_TYPE, HEADER_TYPE>, "Unsupported header type in get_max_num_hops");
+};
+
+template <typename HEADER_TYPE>
+struct SparseMulticastRoutingCommandHeader {
+    // Each bit represents a single hop in the target direction
+    // The router will WRITE AND FORWARD at hops set to 1 and FORWARD ONLY at unset hops.
+    // This continues until the last set bit, which will WRITE ONLY and not forward the packet any further.
+    // For example, if we want to write from device 0 to devices 1 and 4 only:
+    // 0 --> 1 --> 2 --> 3 --> 4 --- 5
+    //      [X]               [X]
+    // We would set a hop mask of 0b01001
+
+    static constexpr uint32_t max_num_hops = get_max_num_hops<HEADER_TYPE>::value;
+
+    using HopMaskType = std::conditional_t<
+        max_num_hops <= 8,
+        uint8_t,
+        std::conditional_t<max_num_hops <= 16, uint16_t, std::conditional_t<max_num_hops <= 32, uint32_t, uint64_t>>>;
+
+    HopMaskType hop_mask;
+};
+
 struct NocUnicastCommandHeader {
     uint64_t noc_address;
 };
@@ -333,6 +361,13 @@ public:
         return *static_cast<Derived*>(this);
     }
 
+    // NOTE: Currently only defined for 1D LowLatency packet headers
+    Derived& to_chip_sparse_multicast(
+        const SparseMulticastRoutingCommandHeader<Derived>& sparse_mcast_routing_command_header) {
+        static_cast<Derived*>(this)->to_chip_sparse_multicast_impl(sparse_mcast_routing_command_header);
+        return *static_cast<Derived*>(this);
+    }
+
     Derived& to_noc_unicast_write(
         const NocUnicastCommandHeader& noc_unicast_command_header, size_t payload_size_bytes) {
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
@@ -440,6 +475,16 @@ public:
 
     volatile Derived* to_chip_multicast(const MulticastRoutingCommandHeader& mcast_routing_command_header) volatile {
         static_cast<volatile Derived*>(this)->to_chip_multicast_impl(mcast_routing_command_header);
+        return static_cast<volatile Derived*>(this);
+    }
+
+    // NOTE: Currently only defined for 1D LowLatency packet headers
+    // To use this function, use SparseMulticastRoutingCommandHeader<PACKET_HEADER_TYPE> as the parameter type for the
+    // header PACKET_HEADER_TYPE is defined at the end of this file automatically, depending on the selected routing and
+    // topology
+    volatile Derived* to_chip_sparse_multicast(
+        const SparseMulticastRoutingCommandHeader<Derived>& sparse_mcast_routing_command_header) volatile {
+        static_cast<volatile Derived*>(this)->to_chip_sparse_multicast_impl(sparse_mcast_routing_command_header);
         return static_cast<volatile Derived*>(this);
     }
 
@@ -679,6 +724,13 @@ public:
     }
 };
 
+// Used to get the maximum number of hops that this packet header can support
+template <>
+struct get_max_num_hops<PacketHeader> {
+    static constexpr uint32_t value = ((1 << RoutingFields::START_DISTANCE_FIELD_BIT_WIDTH) - 1) +
+                                      ((1 << RoutingFields::RANGE_HOPS_FIELD_BIT_WIDTH) - 1);
+};
+
 // Primary template for 1D routing fields with route buffer (ExtensionWords >= 1)
 template <uint32_t ExtensionWords = 1>
 struct LowLatencyRoutingFieldsT {
@@ -752,6 +804,18 @@ struct LowLatencyRoutingFieldsT<0> {
     }
 } __attribute__((packed));
 
+// Temporary template function used to restrict sparse multicast to 1D LowLatency Packet headers with ExtensionWords = 0
+// Sparse multicast has not yet been implemented for ExtensionWords > 0
+template <uint32_t ExtensionWords>
+struct is_sparse_multicast_supported {
+    static constexpr bool value = false;
+};
+
+template <>
+struct is_sparse_multicast_supported<0> {
+    static constexpr bool value = true;
+};
+
 // Template for 1D packet headers with variable routing field sizes
 template <uint32_t ExtensionWords = 0>
 struct LowLatencyPacketHeaderT : public PacketHeaderBase<LowLatencyPacketHeaderT<ExtensionWords>> {
@@ -774,6 +838,13 @@ private:
     }
 
     static constexpr size_t padding_size() { return target_size() - unpadded_size(); }
+
+    // Type alias for Sparse Multicast Routing Command Header
+    // To use the Sparse Multicast Functions (eg. to_chip_sparse_multicast), use
+    // SparseMulticastRoutingCommandHeader<PACKET_HEADER_TYPE> as the parameter type PACKET_HEADER_TYPE is defined at
+    // the end of this file automatically
+    using SPARSE_MCAST_ROUTING_CMD_HDR_TYPE =
+        SparseMulticastRoutingCommandHeader<LowLatencyPacketHeaderT<ExtensionWords>>;
 
 public:
     // Explicit padding to reach target size
@@ -810,6 +881,21 @@ public:
         return LowLatencyRoutingFieldsT<ExtensionWords>::from_buffer(buffer);
     }
 
+    // Helper to calculate routing fields for sparse multicast
+    static LowLatencyRoutingFieldsT<ExtensionWords> calculate_chip_sparse_multicast_routing_fields(
+        const SPARSE_MCAST_ROUTING_CMD_HDR_TYPE& chip_sparse_multicast_command_header) {
+        // Delegate to canonical encoder
+        // We currently only support a base packet header, not extension words.
+        static_assert(
+            is_sparse_multicast_supported<ExtensionWords>::value,
+            "Sparse multicast is currently only supported for ExtensionWords = 0");
+
+        uint32_t buffer;
+        routing_encoding::encode_1d_sparse_multicast(chip_sparse_multicast_command_header.hop_mask, buffer);
+        // Unpack using helper
+        return LowLatencyRoutingFieldsT<ExtensionWords>::from_buffer(&buffer);
+    }
+
     // Specialized implementations for LowLatencyPacketHeader
     void set_routing_fields(LowLatencyRoutingFieldsT<ExtensionWords>& fields) { this->routing_fields = fields; }
 
@@ -818,6 +904,9 @@ public:
     }
     void to_chip_multicast_impl(const MulticastRoutingCommandHeader& chip_multicast_command_header) {
         this->routing_fields = calculate_chip_multicast_routing_fields(chip_multicast_command_header);
+    }
+    void to_chip_sparse_multicast_impl(const SPARSE_MCAST_ROUTING_CMD_HDR_TYPE& chip_sparse_multicast_command_header) {
+        this->routing_fields = calculate_chip_sparse_multicast_routing_fields(chip_sparse_multicast_command_header);
     }
 
     void to_chip_unicast_impl(uint8_t distance_in_hops) volatile {
@@ -828,6 +917,11 @@ public:
         auto routing = calculate_chip_multicast_routing_fields(chip_multicast_command_header);
         routing.copy_to(&this->routing_fields);
     }
+    void to_chip_sparse_multicast_impl(
+        const SPARSE_MCAST_ROUTING_CMD_HDR_TYPE& chip_sparse_multicast_command_header) volatile {
+        auto routing = calculate_chip_sparse_multicast_routing_fields(chip_sparse_multicast_command_header);
+        routing.copy_to(&this->routing_fields);
+    }
 };
 
 // Validate expected sizes with detailed checks
@@ -835,6 +929,12 @@ static_assert(sizeof(LowLatencyPacketHeaderT<0>) == 48, "16-hop total must be 48
 static_assert(sizeof(LowLatencyPacketHeaderT<1>) == 64, "32-hop total must be 64B");
 static_assert(sizeof(LowLatencyPacketHeaderT<2>) == 64, "48-hop total must be 64B");  // NEW for 4×64
 static_assert(sizeof(LowLatencyPacketHeaderT<3>) == 64, "64-hop total must be 64B");  // NEW for 4×64
+
+// Used to get the maximum number of hops that this packet header can support
+template <uint32_t ExtensionWords>
+struct get_max_num_hops<LowLatencyPacketHeaderT<ExtensionWords>> {
+    static constexpr uint32_t value = LowLatencyRoutingFieldsT<ExtensionWords>::MAX_NUM_ENCODINGS;
+};
 
 // Conditional type selection based on injected define
 #ifndef FABRIC_1D_PKT_HDR_EXTENSION_WORDS
@@ -908,6 +1008,13 @@ static_assert(sizeof(HybridMeshPacketHeaderT<35>) == 96, "35B buffer must result
 static_assert(sizeof(HybridMeshPacketHeaderT<51>) == 112, "51B buffer must result in 112B header (max capacity)");
 static_assert(sizeof(HybridMeshPacketHeaderT<67>) == 128, "67B buffer must result in 128B header (max capacity)");
 
+// Used to get the maximum number of hops that this packet header can support
+template <int RouteBufferSize>
+struct get_max_num_hops<HybridMeshPacketHeaderT<RouteBufferSize>> {
+    // Each byte in the packet header's route buffer represents a single hop
+    static constexpr uint32_t value = static_cast<uint32_t>(RouteBufferSize);
+};
+
 // Conditional type selection based on injected define
 #ifdef FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE
 using HybridMeshPacketHeader = HybridMeshPacketHeaderT<FABRIC_2D_PKT_HDR_ROUTE_BUFFER_SIZE>;
@@ -931,6 +1038,12 @@ static_assert(
 
 // TODO: When we remove the 32B padding requirement, reduce to 16B size check
 static_assert(sizeof(PacketHeader) == 64, "sizeof(PacketHeader) is not equal to 64B");
+
+// Used to get the maximum number of hops that this packet header can support
+template <>
+struct get_max_num_hops<UDMHybridMeshPacketHeader> {
+    static constexpr uint32_t value = get_max_num_hops<HybridMeshPacketHeader>::value;
+};
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -310,4 +310,15 @@ bool fabric_set_unicast_route(volatile tt_l1_ptr LowLatencyPacketHeader* packet_
         }
     }
 }
+
+// 1D sparse multicast
+template <typename HopMaskType>  // HopMaskType is uint8_t, uint16_t, uint32_t, or uint64_t
+void fabric_set_sparse_multicast_route(volatile tt_l1_ptr LowLatencyPacketHeader* packet_header, HopMaskType hop_mask) {
+    uint32_t temp_routing_fields;
+    routing_encoding::encode_1d_sparse_multicast(hop_mask, temp_routing_fields);
+
+    // Copy to volatile output
+    packet_header->routing_fields.value = temp_routing_fields;
+}
+
 }  // namespace tt::tt_fabric

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -637,4 +637,152 @@ inline void send_init_semaphore_to_configured_targets(
     }
 }
 
+// Send a sparse multicast packet to destinations along a specific direction
+// Currently only supports 1D Ring topology
+// Supply hop mask and direction to the function
+// Hop mask is a bitmask of which destination hops to write to, read from LSb to MSb.
+// For example, if we want to write East from device 0 to devices 1 and 4 only:
+// 0 --> 1 --> 2 --> 3 --> 4 --- 5
+//      [X]               [X]
+// We would set a hop mask of 0b01001 and set direction to eth_chan_directions::EAST.
+template <int32_t FabricMaxPacketSzBytes, typename AddrGenType>
+inline void fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction(
+    // Fabric parameters
+    AddrGenType addrgen,
+    std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4>& fabric_connections,
+    volatile PACKET_HEADER_TYPE* packet_header,
+    uint16_t fabric_mcast_hop_mask,
+    uint32_t fabric_direction,  // eth_chan_directions index
+    // NoC Parameters
+    uint32_t payload_l1_address,
+    uint32_t noc_payload_page,
+    int32_t size_bytes,
+    const uint32_t alignment,
+    uint32_t offset = 0) {
+    // Separate the list of destinations by direction relative to the source chip
+    // Set the sparse multicast fabric route in the packet header
+    fabric_set_sparse_multicast_route((volatile tt_l1_ptr LowLatencyPacketHeader*)packet_header, fabric_mcast_hop_mask);
+
+    // Configure and send the packet
+    fabric_send_noc_unicast<FabricMaxPacketSzBytes>(
+        addrgen,
+        fabric_connections[fabric_direction],
+        packet_header,
+        payload_l1_address,
+        noc_payload_page,
+        size_bytes,
+        alignment,
+        offset);
+}
+
+// Calculate the distance between two mesh coordinates, with the packet travelling in a specific direction.
+// Positive Polarity: Refers to going "forward" (ascending order of coordinates).
+// Eg. Going East (0->3) or South (0->2)
+// Negative Polarity: Refers to going "backward" (descending order of coordinates).
+// Eg. Going West (3->0) or North (2->0)
+template <tt::tt_fabric::Topology Topology, uint32_t AxisSize>
+inline uint32_t calculate_hops_direction_enforced_1D(uint32_t src_coord, uint32_t dest_coord, Polarity polarity) {
+    // Currently this function has only been tested for 1D Ring topology.
+    static_assert(
+        has_wrap_around<Topology>(),
+        "calculate_hops_direction_enforced_1D has only been tested for 1D topologies with wraparound links");
+    return directional_wrap_distance<AxisSize>(src_coord, dest_coord, polarity);
+}
+
+// Given a list of destinations, generates a hop mask relative to the source chip
+// Also determines the direction out of which the source chip should send the packet
+// Assumes that all destinations are along the same axis as the source chip
+template <
+    uint32_t LinearizedSrcMeshCoord,
+    tt::tt_fabric::Topology Topology,
+    uint32_t MeshRows,
+    uint32_t MeshCols,
+    uint32_t MaxNumDestinations>
+inline std::pair<uint16_t, uint32_t> get_fabric_mcast_hop_mask_and_direction(
+    uint32_t linearized_dest_mesh_coords[MaxNumDestinations], uint32_t NumDestinations) {
+    // Guard to make sure the number of destinations is not greater than the maximum number of destinations
+    ASSERT(NumDestinations > 0 && NumDestinations <= MaxNumDestinations);
+
+    // Figure out direction of this multicast packet
+    // Direction will follow the path used for the first destination
+    uint32_t routing_direction =
+        get_route<Topology, MeshRows, MeshCols>(LinearizedSrcMeshCoord, linearized_dest_mesh_coords[0]);
+
+    // Determine polarity of the direction
+    // Positive polarity means going "forward" (ascending order of coordinates). Eg. Going East (0->3) or South (0->2)
+    // Negative polarity means going "backward" (descending order of coordinates). Eg. Going West (3->0) or North (2->0)
+    Polarity direction_polarity =
+        (routing_direction == eth_chan_directions::EAST || routing_direction == eth_chan_directions::SOUTH)
+            ? Polarity::POSITIVE
+            : Polarity::NEGATIVE;
+    bool travelling_ew =
+        (routing_direction == eth_chan_directions::EAST || routing_direction == eth_chan_directions::WEST);
+    // Generate the multicast packet's hop mask
+    auto [src_row, src_col] = get_mesh_coords<MeshRows, MeshCols>(LinearizedSrcMeshCoord);
+    uint16_t fabric_mcast_hop_mask = 0;
+    for (uint32_t i = 0; i < NumDestinations; i++) {
+        auto [dest_row, dest_col] = get_mesh_coords<MeshRows, MeshCols>(linearized_dest_mesh_coords[i]);
+        // Calculate the number of hops between source chip and destination
+        uint32_t num_hops;
+        if (travelling_ew) {
+            num_hops = calculate_hops_direction_enforced_1D<Topology, MeshCols>(src_col, dest_col, direction_polarity);
+        } else {
+            num_hops = calculate_hops_direction_enforced_1D<Topology, MeshRows>(src_row, dest_row, direction_polarity);
+        }
+        // Guard to make sure that num_hops is a valid result
+        ASSERT(num_hops > 0 && num_hops <= 16);  // Currently fabric sparse multicast only supports up to 16 hops
+        // Set the corresponding bit in the fabric multicast hop mask
+        fabric_mcast_hop_mask |= (1 << (num_hops - 1));
+    }
+    return std::make_pair(fabric_mcast_hop_mask, routing_direction);
+}
+
+// Sends a fabric sparse multicast packet to destinations along a specific direction
+// Currently only supports 1D Ring topology
+// Supply the list of destinations and the number of destinations to the function
+template <
+    uint32_t LinearizedSrcMeshCoord,
+    tt::tt_fabric::Topology Topology,
+    uint32_t MeshRows,
+    uint32_t MeshCols,
+    uint32_t FabricMaxNumDestinations,
+    int32_t FabricMaxPacketSzBytes,
+    typename AddrGenType>
+inline void fabric_send_chip_sparse_multicast_noc_unicast_1d(
+    // Fabric parameters
+    AddrGenType addrgen,
+    std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4>& fabric_connections,
+    volatile PACKET_HEADER_TYPE* packet_header,
+    uint32_t linearized_dest_mesh_coords[FabricMaxNumDestinations],
+    uint32_t NumDestinations,
+    // NoC Parameters
+    uint32_t payload_l1_address,
+    uint32_t noc_payload_page,
+    int32_t size_bytes,
+    const uint32_t alignment,
+    uint32_t offset = 0) {
+    // Generate the fabric multicast hop mask and get the direction the packet should be sent
+    uint16_t fabric_mcast_hop_mask;
+    uint32_t routing_direction;
+    std::tie(fabric_mcast_hop_mask, routing_direction) = get_fabric_mcast_hop_mask_and_direction<
+        LinearizedSrcMeshCoord,
+        Topology,
+        MeshRows,
+        MeshCols,
+        FabricMaxNumDestinations>(linearized_dest_mesh_coords, NumDestinations);
+
+    // Send the packet
+    fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction<FabricMaxPacketSzBytes, AddrGenType>(
+        addrgen,
+        fabric_connections,
+        packet_header,
+        fabric_mcast_hop_mask,
+        routing_direction,
+        payload_l1_address,
+        noc_payload_page,
+        size_bytes,
+        alignment,
+        offset);
+}
+
 }  // namespace ttnn::operations::ccl::common


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35603?issue=tenstorrent%7Ctt-metal%7C35571

### Problem description
Fabric users currently can send multicast packets to multiple devices using a "rectangular" multicast scheme. TUsers specify a `start_distance` and `range`, both in number of device hops. The multicast packet is then sent to all packets between `[src+start_distance, src+start_distance+range]`. For instance, a multicast packet sent from device 0 with `{start_distance: 2, range:2}` will be sent to devices 2 and 3:

<img width="681" height="131" alt="rectangular_mcast" src="https://github.com/user-attachments/assets/ed4d61a1-644d-43a4-87b8-61842f538569" />

However, certain models would benefit from a finer-grained multicast scheme. Specifically, a "sparse" multicast scheme was requested, where a user can control the specific devices where the multicast packet is written. An example use case would be for device 0 to send a multicast packet to devices 1 and 4, below:

<img width="681" height="81" alt="desired_mcast" src="https://github.com/user-attachments/assets/b93e40cd-5b5b-4074-ae22-863eaf88b015" />

### What's changed
- Enabled users to send Fabric 1D sparse multicast packets.
  - To do so, users specify a `hop mask` that indicates which hops (relative to the sender) they would like the packet written to. Hop mask is read from LSb to MSb. 
  - In the example above, device 0 wants to send to devices 1 and 4. As such, it will specify a hop mask of `0b01001`. 

<img width="681" height="171" alt="multicast_hop_mask" src="https://github.com/user-attachments/assets/68b7360f-cbb8-4558-a524-04c3a5a12ca4" />

- Added helper functions (such as `encode_1d_sparse_multicast` and `calculate_chip_sparse_multicast_routing_fields`) that convert this hop_mask into standard fabric multicast routing fields. 
  - The helper functions read the hop mask and convert each bit into a standard `FORWARD_ONLY (10)/WRITE_ONLY(01)/WRITE_AND_FORWARD(11)` encoding. 
  - Hops where data is written will be `WRITE_AND_FORWARD`, and hops that are skipped will be `FORWARD_ONLY`
  - The last hop to which data is written will be `WRITE_ONLY`, terminating the multicast packet.
  - In the example above, the hop mask of `0b01001` will be converted into `0b 00'01'10'10'11`. 

<img width="711" height="311" alt="multicast_routing-2" src="https://github.com/user-attachments/assets/db76aebe-af31-481c-ba6a-0b8cdd534c17" />

- Added APIs to `moe_utils.cpp` that allow models to specify fabric sparse multicast packets. 
- Added APIs to `linear/api.h` that allow kernels to send fabric sparse multicast NoC unicast write packets.
- Added unit tests to `test_basic_1d_fabric.cpp` that test sparse multicast packets. 

Caveats:
- Sparse multicast functions have been written to support all packet headers using a variable-length hop_mask; However, the protocol has only been tested with basic 1D LowLatency packet headers (`ExtensionWords=0`)
- APIs only specify `{sparse multicast, unicast write}` packets (don't support `atomic_inc`, `scatter_write`, etc). These other modes are untested with sparse multicast, but should probably still work. 
- `{sparse multicast, unicast write}` is the only combination that is tested in the unit tests. 

### Checklist
- [x] Get feedback on best way to insert ASSERTS into `moe_utils.cpp`
- [x] Get feedback on best way to integrate sparse multicast testing into fabric unit tests
- [x] Check if I'm allowed to write into `linear/api.h` and some other API files.
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast) https://github.com/tenstorrent/tt-metal/actions/runs/21535169997
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast) https://github.com/tenstorrent/tt-metal/actions/runs/21535173496
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast) (All passes except for tests that were disabled on main)
  - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/21535210908
  - Main: https://github.com/tenstorrent/tt-metal/actions/runs/21538563480
- [X] TT-fabric tests (fails like main)
  - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/21535199001
  - Main: https://github.com/tenstorrent/tt-metal/actions/runs/21538477180
- [x] Galaxy Quick https://github.com/tenstorrent/tt-metal/actions/runs/21535183179

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml)) (fails like main)
    - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/21535189109
    - Main: https://github.com/tenstorrent/tt-metal/actions/runs/21538487909

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml)) (fails like main)
  - My branch: https://github.com/tenstorrent/tt-metal/actions/runs/21535194513
  - Main: https://github.com/tenstorrent/tt-metal/actions/runs/21538549395

- [x] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jhaiTT/35603-fabric-sparse-linear-mcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jhaiTT/35603-fabric-sparse-linear-mcast)
  - [x] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml)) https://github.com/tenstorrent/tt-metal/actions/runs/21535177850