### PR TITLE
Add multiple link/core support in all_to_all_async_generic

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "all_to_all_async_generic.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include "ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.hpp"
 
 namespace ttnn::operations::experimental::ccl {
@@ -12,19 +14,24 @@ ttnn::Tensor ExecuteAllToAllAsyncGeneric::invoke(
     const std::optional<Tensor>& persistent_output_buffer,
     int32_t in_dim,
     int32_t out_dim,
-    uint32_t num_links,
+    std::optional<uint32_t> num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    ttnn::ccl::Topology topology,
+    std::optional<ttnn::ccl::Topology> topology,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     std::optional<uint32_t> cluster_axis) {
+    auto* mesh_device = input_tensor.device();
+    tt::tt_fabric::Topology topology_ = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
+    topology_ = ::ttnn::ccl::convert_2d_to_1d_topology(topology_);
+    uint32_t num_links_ = num_links.value_or(ttnn::operations::ccl::common::get_num_links(*mesh_device, cluster_axis));
+
     return ttnn::prim::all_to_all_async_generic(
         input_tensor,
         persistent_output_buffer,
         in_dim,
         out_dim,
-        num_links,
+        num_links_,
         memory_config,
-        topology,
+        topology_,
         subdevice_id,
         cluster_axis);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic.hpp
@@ -17,9 +17,9 @@ struct ExecuteAllToAllAsyncGeneric {
         const std::optional<Tensor>& persistent_output_buffer,
         int32_t in_dim,
         int32_t out_dim,
-        uint32_t num_links = 1,
+        std::optional<uint32_t> num_links = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-        ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
+        std::optional<ttnn::ccl::Topology> topology = std::nullopt,
         std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
         std::optional<uint32_t> cluster_axis = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/all_to_all_async_generic_nanobind.cpp
@@ -53,9 +53,9 @@ void bind_all_to_all_async_generic_op(nb::module_& mod, const ccl_operation_t& o
             nb::arg("out_dim"),
             nb::kw_only(),
             nb::arg("persistent_output_buffer") = nb::none(),
-            nb::arg("num_links") = 1,
+            nb::arg("num_links") = nb::none(),
             nb::arg("memory_config") = nb::none(),
-            nb::arg("topology") = ttnn::ccl::Topology::Linear,  // TODO_NANOBIND: nb_cast?
+            nb::arg("topology") = nb::none(),
             nb::arg("subdevice_id") = nb::none(),
             nb::arg("cluster_axis") = nb::none()});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -29,7 +29,6 @@ void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_to_all_async must be on device");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_to_all_async must be allocated in buffers on device");
-    TT_FATAL(operation_attributes.num_links == 1, "num_links must be 1, but is {}", operation_attributes.num_links);
 
     TT_FATAL(
         input_shape[operation_attributes.out_dim] % operation_attributes.num_devices == 0,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -98,8 +98,9 @@ AllToAllAsyncGenericProgram::create_at(
     std::vector<Tensor> output_tensors = {tensor_return_value};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, operation_attributes.topology);
 
-    const size_t num_senders_per_link = 1;
-    const auto* topology_type = operation_attributes.topology == ttnn::ccl::Topology::Ring ? "RING" : "LINEAR";
+    const bool is_ring = operation_attributes.topology == ttnn::ccl::Topology::Ring;
+    const size_t num_senders_per_link = is_ring ? 2 : 1;
+    const auto* topology_type = is_ring ? "RING" : "LINEAR";
 
     const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
         operation_attributes.num_links, num_senders_per_link, device, operation_attributes.sub_device_id);
@@ -129,11 +130,7 @@ AllToAllAsyncGenericProgram::create_at(
     CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
 
     const auto input_shape = get_tiled_shape(tensor_args.input_tensor);
-    uint32_t src_out_dims = 1;
     uint32_t src_in_dims = 1;
-    for (uint32_t i = 0; i < operation_attributes.out_dim; ++i) {
-        src_out_dims *= input_shape[i];
-    }
 
     for (uint32_t i = operation_attributes.out_dim + 1; i < input_shape.size(); ++i) {
         src_in_dims *= input_shape[i];
@@ -155,20 +152,30 @@ AllToAllAsyncGenericProgram::create_at(
         dst_in_dims *= output_shape[i];
     }
 
+    const uint32_t concat_num_half_tiles =
+        output_shape[operation_attributes.in_dim] * 2 / operation_attributes.num_devices;
+    const uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
+    const uint32_t num_blocks = dst_out_dims * dst_in_dims * concat_num_tiles;
+
+    const uint32_t num_blocks_devices = num_senders_per_link;
+    const uint32_t num_cores_per_blocks = operation_attributes.num_links;
+    const uint32_t devices_per_core = operation_attributes.num_devices / num_blocks_devices;
+    const uint32_t blocks_per_core = num_blocks / num_cores_per_blocks;
+
     auto sender_reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
-    sender_reader_kernel_config.defines.emplace("TOPOLOGY", topology_type);
     sender_reader_kernel_config.compile_args = {
         tt::CB::c_in0,                              // cb0_id
         page_size,                                  // tensor0_page_size
         device_index,                               // device_index
         operation_attributes.num_devices,           // num_devices
-        src_out_dims,                               // outer_dims_size
         input_shape[operation_attributes.out_dim],  // split_dim_size
         src_in_dims,                                // inner_dims_size
         input_shape[input_shape.size() - 1],        // last_dim_sizes
         number_pages_per_packet,                    // number_pages_per_packet
         reader_has_extra_half_tile,                 // has_reader_tail
         writer_has_extra_half_tile,                 // has_writer_tail
+        devices_per_core,                           // num_devices_per_core
+        blocks_per_core,                            // num_blocks_per_core
     };
 
     tt::tt_metal::TensorAccessorArgs(tensor_args.input_tensor.buffer())
@@ -187,16 +194,31 @@ AllToAllAsyncGenericProgram::create_at(
         tt::CB::c_in0,                              // cb0_id
         device_index,                               // device_index
         operation_attributes.num_devices,           // num_devices
-        dst_out_dims,                               // outer_dims_size
         output_shape[operation_attributes.in_dim],  // concat_dim_size
         dst_in_dims,                                // inner_dims_size
         number_pages_per_packet,                    // number_pages_per_packet
         writer_has_extra_half_tile,                 // has_writer_tail
         page_size,                                  // intermediate_page_size
-        reserved_packet_header_CB_index,
+        reserved_packet_header_CB_index,            // reserved_packet_header_cb_id
+        devices_per_core,                           // num_devices_per_core
+        blocks_per_core,                            // num_blocks_per_core
+        num_cores_per_blocks,                       // num_cores_per_blocks
     };
 
     tt::tt_metal::TensorAccessorArgs(tensor_return_value.buffer()).append_to(sender_writer_kernel_config.compile_args);
+    std::vector<int32_t> device_offsets;
+    if (is_ring) {
+        for (int d = operation_attributes.num_devices - 1; d >= 0; --d) {
+            int distance = (d + 1) / 2;
+            int device_offset = (d % 2 == 0) ? distance : -distance;
+            device_offsets.push_back(device_offset);
+        }
+    } else {
+        // Linear topology
+        for (uint32_t i = 0; i < operation_attributes.num_devices; ++i) {
+            device_offsets.push_back(i - device_index);
+        }
+    }
 
     auto sender_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -205,43 +227,81 @@ AllToAllAsyncGenericProgram::create_at(
         sender_worker_core_range,
         sender_writer_kernel_config);
 
-    std::vector<uint32_t> sender_reader_rt_args = {tensor_args.input_tensor.buffer()->address()};
-    tt::tt_metal::SetRuntimeArgs(program, sender_reader_kernel_id, sender_worker_core_range, sender_reader_rt_args);
+    CoreRange sender_box = sender_worker_core_range.bounding_box();
+    const uint32_t mcast_dest_noc_start_x = device->worker_core_from_logical_core(sender_box.start_coord).x;
+    const uint32_t mcast_dest_noc_end_x = device->worker_core_from_logical_core(sender_box.end_coord).x;
+    const uint32_t mcast_dest_noc_start_y = device->worker_core_from_logical_core(sender_box.start_coord).y;
+    const uint32_t mcast_dest_noc_end_y = device->worker_core_from_logical_core(sender_box.end_coord).y;
+    const uint32_t mcast_size = sender_box.size();
 
-    auto drain_sync_core = device->worker_core_from_logical_core({sender_worker_cores[0]});
-    std::vector<uint32_t> sender_writer_rt_args = {
-        tensor_return_value.buffer()->address(),
-        init_barrier_semaphore.address(),
-        final_barrier_semaphore.address(),
-        drain_sync_core.x,
-        drain_sync_core.y};
-    sender_writer_rt_args.push_back(forward_coord.has_value());
+    auto drain_sync_core = device->worker_core_from_logical_core(sender_worker_cores[0]);
 
-    if (forward_coord.has_value()) {
-        const auto sender_device_fabric_node_id = device->get_fabric_node_id(mesh_coordinate);
-        const auto forward_device_fabric_node_id = device->get_fabric_node_id(forward_coord.value());
-        tt::tt_fabric::append_fabric_connection_rt_args(
-            sender_device_fabric_node_id,
-            forward_device_fabric_node_id,
-            0,
-            program,
-            {sender_worker_cores[0]},
-            sender_writer_rt_args);
+    for (uint32_t core_id = 0; core_id < sender_worker_cores.size(); ++core_id) {
+        auto& core = sender_worker_cores[core_id];
+        std::vector<uint32_t> sender_reader_rt_args = {
+            tensor_args.input_tensor.buffer()->address(),
+            (core_id % num_blocks_devices) * devices_per_core,
+            (core_id / num_blocks_devices) * blocks_per_core,
+        };
+        for (auto d : device_offsets) {
+            if (num_senders_per_link == 1 || (core_id % num_blocks_devices == 0 && d >= 0) ||
+                (core_id % num_blocks_devices == 1 && d < 0)) {
+                sender_reader_rt_args.push_back(d);
+            }
+        }
+        tt::tt_metal::SetRuntimeArgs(program, sender_reader_kernel_id, {core}, sender_reader_rt_args);
+
+        std::vector<uint32_t> sender_writer_rt_args = {
+            tensor_return_value.buffer()->address(),
+            init_barrier_semaphore.address(),
+            final_barrier_semaphore.address(),
+            (core_id % num_blocks_devices) * devices_per_core,
+            (core_id / num_blocks_devices) * blocks_per_core,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            mcast_size,
+            drain_sync_core.x,
+            drain_sync_core.y};
+        for (auto d : device_offsets) {
+            if (num_senders_per_link == 1 || (core_id % num_blocks_devices == 0 && d >= 0) ||
+                (core_id % num_blocks_devices == 1 && d < 0)) {
+                sender_writer_rt_args.push_back(d);
+            }
+        }
+        bool with_forward =
+            (num_senders_per_link == 1 || (core_id % num_blocks_devices == 0)) && forward_coord.has_value();
+        bool with_backward =
+            (num_senders_per_link == 1 || (core_id % num_blocks_devices == 1)) && backward_coord.has_value();
+        sender_writer_rt_args.push_back(with_forward);
+
+        if (with_forward) {
+            const auto sender_device_fabric_node_id = device->get_fabric_node_id(mesh_coordinate);
+            const auto forward_device_fabric_node_id = device->get_fabric_node_id(forward_coord.value());
+            tt::tt_fabric::append_fabric_connection_rt_args(
+                sender_device_fabric_node_id,
+                forward_device_fabric_node_id,
+                core_id / num_senders_per_link,
+                program,
+                {core},
+                sender_writer_rt_args);
+        }
+
+        sender_writer_rt_args.push_back(with_backward);
+        if (with_backward) {
+            const auto sender_device_fabric_node_id = device->get_fabric_node_id(mesh_coordinate);
+            const auto backward_device_fabric_node_id = device->get_fabric_node_id(backward_coord.value());
+            tt::tt_fabric::append_fabric_connection_rt_args(
+                sender_device_fabric_node_id,
+                backward_device_fabric_node_id,
+                core_id / num_senders_per_link,
+                program,
+                {core},
+                sender_writer_rt_args);
+        }
+        tt::tt_metal::SetRuntimeArgs(program, sender_writer_kernel_id, {core}, sender_writer_rt_args);
     }
-
-    sender_writer_rt_args.push_back(backward_coord.has_value());
-    if (backward_coord.has_value()) {
-        const auto sender_device_fabric_node_id = device->get_fabric_node_id(mesh_coordinate);
-        const auto backward_device_fabric_node_id = device->get_fabric_node_id(backward_coord.value());
-        tt::tt_fabric::append_fabric_connection_rt_args(
-            sender_device_fabric_node_id,
-            backward_device_fabric_node_id,
-            0,
-            program,
-            {sender_worker_cores[0]},
-            sender_writer_rt_args);
-    }
-    tt::tt_metal::SetRuntimeArgs(program, sender_writer_kernel_id, sender_worker_core_range, sender_writer_rt_args);
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -15,13 +15,14 @@ constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
 constexpr uint32_t input_page_size = get_compile_time_arg_val(1);
 constexpr uint32_t current_device_id = get_compile_time_arg_val(2);
 constexpr uint32_t num_devices = get_compile_time_arg_val(3);
-constexpr uint32_t outer_dims_size = get_compile_time_arg_val(4);
-constexpr uint32_t split_dim_size = get_compile_time_arg_val(5);
-constexpr uint32_t inner_dims_size = get_compile_time_arg_val(6);
-constexpr uint32_t last_dim_size = get_compile_time_arg_val(7);
-constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(8);
-constexpr uint32_t has_reader_tail = get_compile_time_arg_val(9);
-constexpr uint32_t has_writer_tail = get_compile_time_arg_val(10);
+constexpr uint32_t split_dim_size = get_compile_time_arg_val(4);
+constexpr uint32_t inner_dims_size = get_compile_time_arg_val(5);
+constexpr uint32_t last_dim_size = get_compile_time_arg_val(6);
+constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(7);
+constexpr uint32_t has_reader_tail = get_compile_time_arg_val(8);
+constexpr uint32_t has_writer_tail = get_compile_time_arg_val(9);
+constexpr uint32_t num_devices_per_core = get_compile_time_arg_val(10);
+constexpr uint32_t num_blocks_per_core = get_compile_time_arg_val(11);
 
 template <typename AddrGenType>
 void read_data(
@@ -70,25 +71,20 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     size_t arg_idx = 0;
     address_t input_address = get_arg_val<address_t>(arg_idx++);
-    constexpr auto input_tensor_args = TensorAccessorArgs<11>();
+    address_t device_start_id = get_arg_val<address_t>(arg_idx++);
+    address_t block_start_id = get_arg_val<address_t>(arg_idx++);
+
+    constexpr auto input_tensor_args = TensorAccessorArgs<12>();
     auto input_addrgen = TensorAccessor(input_tensor_args, input_address, input_page_size);
     constexpr uint32_t split_num_half_tiles = split_dim_size * 2 / num_devices;
-#define LINEAR 1
-#define RING 2
+    constexpr uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
 
-#if TOPOLOGY == LINEAR
-    for (uint32_t device_id = 0; device_id < num_devices; ++device_id) {
-#elif TOPOLOGY == RING
-    for (int d = num_devices - 1; d >= 0; --d) {
-        int distance = (d + 1) / 2;
-        int val = (d % 2 == 0) ? distance : -distance;
-        uint32_t device_id = (current_device_id + val + num_devices) % num_devices;
-#else
-#error "Unsupported Topology Type"
-#endif
+    for (uint32_t did = 0; did < num_devices_per_core; ++did) {
+        int32_t device_offset = get_arg_val<int32_t>(arg_idx++);
+        int32_t distance = abs(device_offset);
+        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
+
         const uint32_t device_read_offset = (split_num_half_tiles * device_id) / 2;
-        const uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
-        uint64_t block_size = outer_dims_size * split_num_tiles * inner_dims_size;
 
         auto calculate_tile = [&](int b) {
             const uint32_t o = b / (split_num_tiles * inner_dims_size);
@@ -99,10 +95,11 @@ void kernel_main() {
             return std::tuple{s, i, tile_id};
         };
 
-        for (uint64_t block_idx = 0; block_idx < block_size; block_idx += number_pages_per_packet) {
-            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_size - block_idx));
+        uint64_t block_end_id = block_start_id + num_blocks_per_core;
+        for (uint64_t block_idx = block_start_id; block_idx < block_end_id; block_idx += number_pages_per_packet) {
+            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_end_id - block_idx));
 
-            cb_reserve_back(cb0_id, tiles_this_iteration);
+            cb_reserve_back(cb0_id, number_pages_per_packet);
             address_t l1_write_addr = get_write_ptr(cb0_id);
             for (uint32_t t = 0; t < tiles_this_iteration; ++t) {
                 auto [split_idx, inner_idx, tile_id] = calculate_tile(block_idx + t);
@@ -116,7 +113,7 @@ void kernel_main() {
             }
 
             noc_async_read_barrier();
-            cb_push_back(cb0_id, tiles_this_iteration);
+            cb_push_back(cb0_id, number_pages_per_packet);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -71,7 +71,6 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     size_t arg_idx = 0;
     address_t input_address = get_arg_val<address_t>(arg_idx++);
-    address_t device_start_id = get_arg_val<address_t>(arg_idx++);
     address_t block_start_id = get_arg_val<address_t>(arg_idx++);
 
     constexpr auto input_tensor_args = TensorAccessorArgs<12>();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -159,11 +159,12 @@ void kernel_main() {
     uint32_t device_start_id = get_arg_val<uint32_t>(arg_idx++);
     uint32_t block_start_id = get_arg_val<uint32_t>(arg_idx++);
 
+    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
+
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(arg_idx++);
 
-    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_size = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_y = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -17,13 +17,15 @@ using address_t = uint32_t;
 constexpr uint32_t cb0_id = get_compile_time_arg_val(0);
 constexpr uint32_t current_device_id = get_compile_time_arg_val(1);
 constexpr uint32_t num_devices = get_compile_time_arg_val(2);
-constexpr uint32_t outer_dims_size = get_compile_time_arg_val(3);
-constexpr uint32_t concat_dim_size = get_compile_time_arg_val(4);
-constexpr uint32_t inner_dims_size = get_compile_time_arg_val(5);
-constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(6);
-constexpr uint32_t has_half_tile = get_compile_time_arg_val(7);
-constexpr uint32_t output_page_size = get_compile_time_arg_val(8);
-constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(9);
+constexpr uint32_t concat_dim_size = get_compile_time_arg_val(3);
+constexpr uint32_t inner_dims_size = get_compile_time_arg_val(4);
+constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(5);
+constexpr uint32_t has_half_tile = get_compile_time_arg_val(6);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(7);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(8);
+constexpr uint32_t num_devices_per_core = get_compile_time_arg_val(9);
+constexpr uint32_t num_blocks_per_core = get_compile_time_arg_val(10);
+constexpr uint32_t num_cores_per_blocks = get_compile_time_arg_val(11);
 
 inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     FabricConnectionManager& fabric_connection, int device_offset) {
@@ -45,6 +47,7 @@ void write_data(
     int device_offset) {
     bool local = device_offset == 0;
     if (last) {
+        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
         if (local) {
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
             noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id, offset), payload_size_bytes);
@@ -91,6 +94,7 @@ void write_data(
     int device_offset) {
     bool local = device_offset == 0;
     if (last) {
+        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
         if (local) {
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
             noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id0, offset0), payload_size_bytes0);
@@ -151,10 +155,23 @@ void kernel_main() {
     address_t output_address = get_arg_val<address_t>(arg_idx++);
     uint32_t global_init_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t global_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    uint32_t device_start_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t block_start_id = get_arg_val<uint32_t>(arg_idx++);
+
+    const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(arg_idx++);
+
+    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_size = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_y = get_arg_val<uint32_t>(arg_idx++);
-    constexpr auto output_args = TensorAccessorArgs<10>();
+
+    constexpr auto output_args = TensorAccessorArgs<12>();
     auto output_addrgen = TensorAccessor(output_args, output_address, output_page_size);
+    size_t device_offsets_idx = arg_idx;
+    arg_idx += num_devices_per_core;
 
     // Build fabric connection
     auto fabric_connection =
@@ -176,12 +193,23 @@ void kernel_main() {
     cb_reserve_back(reserved_packet_header_cb_id, 1);
     auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
     cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_sema_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_sema_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_sema_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_sema_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_sema_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_sema_backward);
+
     fabric_connection.open_finish();
 
     constexpr bool has_pre_half_tile = has_half_tile && current_device_id % 2 == 1;
@@ -190,61 +218,67 @@ void kernel_main() {
     constexpr uint32_t concat_num_half_tiles = concat_dim_size * 2 / num_devices;
     constexpr uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
     constexpr uint32_t full_block_offset = (concat_num_half_tiles * current_device_id) / 2;
-
+    if (device_start_id == 0 && block_start_id == 0) {
 #define LINEAR 1
 #define RING 2
 #if TOPOLOGY == LINEAR
-    if (fabric_connection.has_forward_connection()) {
-        pkt_hdr_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
-        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr_forward->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - current_device_id - 1)});
-        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
-    }
+        if (fabric_connection.has_forward_connection()) {
+            pkt_hdr_sema_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+            fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+            pkt_hdr_sema_forward->to_chip_multicast(tt::tt_fabric::MulticastRoutingCommandHeader{
+                1, static_cast<uint8_t>(num_devices - current_device_id - 1)});
+            fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                packet_header_buffer_addr_sema_forward, sizeof(PACKET_HEADER_TYPE));
+        }
 
-    if (fabric_connection.has_backward_connection()) {
-        pkt_hdr_backward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
-        pkt_hdr_backward->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(current_device_id)});
-        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            packet_header_buffer_addr_backward, sizeof(PACKET_HEADER_TYPE));
-    }
-
-    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
-    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
-
-    for (uint32_t device_id = 0; device_id < num_devices; ++device_id) {
-        volatile PACKET_HEADER_TYPE* pkt_hdr;
-        int device_offset = device_id - current_device_id;
-        int distance = abs(device_offset);
-
+        if (fabric_connection.has_backward_connection()) {
+            pkt_hdr_sema_backward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+            pkt_hdr_sema_backward->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(current_device_id)});
+            fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+            fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+                packet_header_buffer_addr_sema_backward, sizeof(PACKET_HEADER_TYPE));
+        }
 #elif TOPOLOGY == RING
-    if (fabric_connection.has_forward_connection()) {
-        pkt_hdr_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
-        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr_forward->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - 1)});
-        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
-    }
-
-    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
-    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
-
-    for (int d = num_devices - 1; d >= 0; --d) {
-        volatile PACKET_HEADER_TYPE* pkt_hdr;
-        int distance = (d + 1) / 2;
-        int device_offset = (d % 2 == 0) ? distance : -distance;
-        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
-
+        if (fabric_connection.has_forward_connection()) {
+            pkt_hdr_forward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+            fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+            pkt_hdr_forward->to_chip_multicast(
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - 1)});
+            fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
+        }
 #else
 #error "Unsupported Topology Type"
 #endif
+        const uint64_t local_set_semaphore_noc_addr = get_noc_multicast_addr(
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            global_init_semaphore_addr);
+        uint32_t local_init_semaphore_addr_ptr = reinterpret_cast<uint32_t>(global_init_semaphore_addr_ptr);
+
+        if (mcast_size > 1) {
+            noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+            noc_semaphore_set_multicast_loopback_src(
+                local_init_semaphore_addr_ptr, local_set_semaphore_noc_addr, mcast_size, false);
+            noc_async_write_barrier();
+        }
+    }
+
+    noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
+    noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
+
+    for (uint32_t did = 0; did < num_devices_per_core; ++did) {
+        int32_t device_offset = get_arg_val<int32_t>(device_offsets_idx++);
+        int32_t distance = abs(device_offset);
+        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
+
+        volatile PACKET_HEADER_TYPE* pkt_hdr;
         if (device_offset > 0) {
             pkt_hdr = pkt_hdr_forward;
             pkt_hdr->to_chip_unicast(distance);
@@ -254,33 +288,32 @@ void kernel_main() {
             pkt_hdr->to_chip_unicast(distance);
         }
 
-        uint64_t block_size = outer_dims_size * concat_num_tiles * inner_dims_size;
         auto calculate_params = [&](int b) {
             const uint32_t o = b / (concat_num_tiles * inner_dims_size);
             const uint32_t c = (b / inner_dims_size) % concat_num_tiles;
             const uint32_t i = b % inner_dims_size;
             const uint32_t dest_tile_id =
                 o * inner_dims_size * concat_dim_size + (c + full_block_offset) * inner_dims_size + i;
-            bool last = (c == concat_num_tiles - 1) && o == outer_dims_size - 1 && i == inner_dims_size - 1;
             uint32_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
                                         ? output_page_size / 2
                                         : output_page_size;
             uint32_t offset = (has_pre_half_tile && c == 0) ? (current_device_id % 2) * output_page_size / 2 : 0;
-            return std::tuple{dest_tile_id, last, payload_size, offset};
+            return std::tuple{dest_tile_id, payload_size, offset};
         };
 
-        for (uint64_t b = 0; b < block_size; b += number_pages_per_packet) {
-            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_size - b));
+        uint64_t block_end_id = block_start_id + num_blocks_per_core;
+        for (uint64_t b = block_start_id; b < block_end_id; b += number_pages_per_packet) {
+            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_end_id - b));
 
-            cb_wait_front(cb0_id, tiles_this_iteration);
+            cb_wait_front(cb0_id, number_pages_per_packet);
             size_t l1_read_addr = get_read_ptr(cb0_id);
 
             if (tiles_this_iteration == 2) {
-                auto [dest_tile_id0, last0, payload_size0, offset0] = calculate_params(b);
-                auto [dest_tile_id1, last1, payload_size1, offset1] = calculate_params(b + 1);
-
+                auto [dest_tile_id0, payload_size0, offset0] = calculate_params(b);
+                auto [dest_tile_id1, payload_size1, offset1] = calculate_params(b + 1);
+                bool last = b == (block_end_id - 2);
                 write_data(
-                    last1,
+                    last,
                     dest_tile_id0,
                     dest_tile_id1,
                     output_addrgen,
@@ -294,8 +327,8 @@ void kernel_main() {
                     output_semaphore_noc_addr_in_pkt,
                     device_offset);
             } else {
-                auto [dest_tile_id, last, payload_size, offset] = calculate_params(b);
-
+                auto [dest_tile_id, payload_size, offset] = calculate_params(b);
+                bool last = b == (block_end_id - 1);
                 write_data(
                     last,
                     dest_tile_id,
@@ -309,13 +342,15 @@ void kernel_main() {
                     device_offset);
             }
 
-            cb_pop_front(cb0_id, tiles_this_iteration);
+            cb_pop_front(cb0_id, number_pages_per_packet);
         }
     }
 
     noc_async_write_barrier();
     fabric_connection.close();
 
-    noc_semaphore_wait(global_semaphore_addr_ptr, num_devices);
-    noc_semaphore_set(global_semaphore_addr_ptr, 0);
+    if (device_start_id == 0 && block_start_id == 0) {
+        noc_semaphore_wait(global_semaphore_addr_ptr, num_devices * num_cores_per_blocks);
+        noc_semaphore_set(global_semaphore_addr_ptr, 0);
+    }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Added multiple cores support, one core per link for linear topology and two cores for ring topology.
Also now list of device offsets is sent via runtime args to each core and can be in future modified on host side.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/all2all_opt)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/all2all_opt)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/all2all_opt)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/all2all_opt)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/all2all_opt)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/all2all_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/all2all_opt)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs