### PR TITLE
[tt-train] Update docs: use uv pip instead of pip after uv migration

### DIFF
--- a/tt-train/INSTALLING.md
+++ b/tt-train/INSTALLING.md
@@ -17,9 +17,10 @@ cd /path/to/tt-metal
 
 This script will:
 - Create a virtual environment in `python_env/`
-- Install the correct pip, setuptools, and wheel versions for your OS
 - Install development dependencies
 - Install tt-metal (ttnn) in editable mode
+
+> **Note:** The virtual environment is managed by [uv](https://github.com/astral-sh/uv) and does not include `pip`. You must use `uv pip` instead of `pip` for installing additional packages. See Step 2 below.
 
 Activate the environment:
 
@@ -88,18 +89,20 @@ source python_env/bin/activate
 
 ## Step 2: Install tt-train
 
-Once tt-metal is installed and your virtual environment is activated, install tt-train:
+Once tt-metal is installed and your virtual environment is activated, install tt-train using `uv pip`:
+
+> **Important:** tt-metal's virtual environment is created with `uv`, which does not include `pip` by default. You must use `uv pip` instead of `pip` for package installation. Using system `pip` will fail with errors like `canonicalize_name() got an unexpected keyword argument 'validate'`. See [issue #36208](https://github.com/tenstorrent/tt-metal/issues/36208) for details.
 
 **Regular installation:**
 
 ```bash
-pip install /path/to/tt-train/
+uv pip install /path/to/tt-train/
 ```
 
 **Editable installation (for development):**
 
 ```bash
-pip install -e /path/to/tt-train/
+uv pip install -e /path/to/tt-train/
 ```
 
 Use the editable installation (`-e`) if you plan to modify the tt-train source code and want changes to be reflected immediately without reinstalling.

--- a/tt-train/docs/INSTALLING_TTML.md
+++ b/tt-train/docs/INSTALLING_TTML.md
@@ -8,14 +8,16 @@ TT-Train provides the ttml module (`ttml`), written using nanobind, which provid
 
 ### 1. Install Python Package
 
+> **Important:** tt-metal uses `uv` for virtual environment management. You must use `uv pip` instead of `pip`. See [INSTALLING.md](../INSTALLING.md) for details.
+
 ```bash
-pip install .
+uv pip install .
 ```
 
 Or for editable/development install:
 
 ```bash
-pip install --no-build-isolation -e .
+uv pip install --no-build-isolation -e .
 ```
 
 ## Verification


### PR DESCRIPTION
### Description
After tt-metal's migration to uv (PR #35707), the virtual environment no longer includes pip. Users following the documentation encounter confusing errors when trying to install tt-train with `pip install`. This PR updates the documentation to use `uv pip` instead.

### Changes Made
- [ ] **New Feature:** N/A
- [ ] **Improvement:** N/A
- [x] **Bug Fix:** Update documentation to reflect correct installation procedure after uv migration
- [ ] **Refactor:** N/A

**Files changed:**
- `tt-train/INSTALLING.md` - Updated pip commands to uv pip, added notes about uv
- `tt-train/docs/INSTALLING_TTML.md` - Updated pip commands to uv pip

### Testing
- [x] Manual testing conducted
  - Verified `uv pip install -e .` works in tt-train directory
  - Verified `import ttml` works after installation

### Review Checklist
- [x] No breaking changes introduced
- [x] All tests pass successfully
- [x] Code complies with project style guidelines

### Additional Context
- Issue: https://github.com/tenstorrent/tt-metal/issues/36208
- Root cause: uv-created venvs don't include pip; system pip uses old packaging (21.3) which is incompatible with scikit_build_core
- Error users see: `canonicalize_name() got an unexpected keyword argument 'validate'`

Fixes #36208