### PR TITLE
[build-system] Add pip shim to warn users to use 'uv pip'

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -281,6 +281,19 @@ echo "  Python version: ${VENV_PYTHON_VERSION}"
 echo "Installing Python ${VENV_PYTHON_VERSION} via uv..."
 uv python install "${VENV_PYTHON_VERSION}"
 uv venv "$PYTHON_ENV_DIR" --python "${VENV_PYTHON_VERSION}"
+
+# Create pip shim to warn users to use 'uv pip' instead of 'pip'
+# uv-created venvs don't include pip, and system pip causes installation failures
+cat > "$PYTHON_ENV_DIR/bin/pip" << 'PIPSHIM'
+#!/bin/bash
+echo "ERROR: pip is not available in this virtual environment."
+echo ""
+echo "Please use 'uv pip' instead of 'pip'."
+exit 1
+PIPSHIM
+chmod +x "$PYTHON_ENV_DIR/bin/pip"
+ln -sf "$PYTHON_ENV_DIR/bin/pip" "$PYTHON_ENV_DIR/bin/pip3"
+
 source "$PYTHON_ENV_DIR/bin/activate"
 
 # Import functions for detecting OS (use absolute path from SCRIPT_DIR)


### PR DESCRIPTION
### Description
After migration to uv, the virtual environment does not include pip. When users run `pip install` it falls back to system pip, which fails with confusing errors like `canonicalize_name() got an unexpected keyword argument 'validate'`.

This PR adds a pip shim script that intercepts `pip` and `pip3` commands and shows a clear error message directing users to use `uv pip` instead.

### Changes Made
- [ ] **New Feature:** N/A
- [ ] **Improvement:** N/A
- [x] **Bug Fix:** Add pip/pip3 shim scripts to venv that show helpful error message
- [ ] **Refactor:** N/A

**Error message shown:**
```
ERROR: pip is not available in this virtual environment.

Please use 'uv pip' instead of 'pip'.
```

### Design Discussion: Shim vs Installing pip

**Why uv venvs don't include pip:**
`uv venv` creates lightweight venvs without pip by default. When users run `pip install`, the shell finds system pip (`/usr/bin/pip`), which uses system Python with an old `packaging` library (21.3), causing installation failures.

**Can pip and uv pip coexist?**
Yes. Both tools:
- Use PyPI (same package registry)
- Install to the same `site-packages/` directory
- Use standard Python packaging metadata (`.dist-info/`)
- Packages installed by one are visible to the other (`uv pip list` ≈ `pip list`)

**Alternative approach - install pip into venv:**
```bash
uv pip install pip
```
This would make both `pip` and `uv pip` work. However:
- The project has standardized on `uv pip`
- Installing pip adds ~10MB to each venv
- The shim provides a clear migration path for users with muscle memory

**Why the shim approach:**
- Zero additional dependencies
- Clear error message guides users to the correct command
- Consistent with project's `uv pip` standardization
- Catches the problem immediately rather than silently using system pip

### Testing
- [x] Manual testing conducted
  - Created venv with `create_venv.sh`
  - Verified `pip install numpy` shows error message and exits with code 1
  - Verified `pip3 install numpy` shows error message and exits with code 1
  - Verified `uv pip install` still works correctly

### CI Impact
The pip shim only exists inside venvs created by `create_venv.sh`. CI is not affected because:
- Container workflows already use `uv pip install`
- GitHub runner workflows use `actions/setup-python` (separate Python, not tt-metal venv)
- tt-train CI only runs C++ tests (ctest), no Python module installation

### Review Checklist
- [x] No breaking changes introduced
- [x] All tests pass successfully
- [x] Code complies with project style guidelines

### Additional Context
- Issue: https://github.com/tenstorrent/tt-metal/issues/36208
- Related PR: https://github.com/tenstorrent/tt-metal/pull/36295 (documentation update)

Fixes #36208