### PR TITLE
Migrate ttml metal ops to free function style

### DIFF
--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -40,8 +40,7 @@ constexpr auto cross_entropy_bw = ttnn::register_operation<
     "ttml::metal::cross_entropy_bw",
     ttml::metal::ops::cross_entropy_bw::CrossEntropyBackwardOperation>();
 
-constexpr auto softmax =
-    ttnn::register_operation<"ttml::metal::softmax", ttml::metal::ops::softmax::SoftmaxOperation>();
+// softmax is now a free function declared in ops/softmax/softmax.hpp
 
 constexpr auto profiler_no_op =
     ttnn::register_operation<"ttml::metal::profiler_no_op", ttml::metal::ops::profiler_no_op::ProfilerNoopOperation>();

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -17,33 +17,3 @@
 #include "ops/softmax/softmax.hpp"
 #include "ops/swiglu_fw/swiglu_fw.hpp"
 #include "optimizers/sgd_fused/sgd_fused.hpp"
-
-namespace ttml::metal {
-
-// rmsnorm_fw is now a free function declared in ops/rmsnorm_fw/rmsnorm_fw.hpp
-
-// rmsnorm_bw is now a free function declared in ops/rmsnorm_bw/rmsnorm_bw.hpp
-
-// layernorm_bw is now a free function declared in ops/layernorm_bw/layernorm_bw.hpp
-
-// layernorm_fw is now a free function declared in ops/layernorm_fw/layernorm_fw.hpp
-
-// cross_entropy_fw is now a free function declared in ops/cross_entropy_fw/cross_entropy_fw.hpp
-
-// cross_entropy_bw is now a free function declared in ops/cross_entropy_bw/cross_entropy_bw.hpp
-
-// softmax is now a free function declared in ops/softmax/softmax.hpp
-
-// profiler_no_op is now a free function declared in ops/profiler_no_op/profiler_no_op.hpp
-
-// silu_bw is now a free function declared in ops/silu_bw/silu_bw.hpp
-
-// sdpa_fw is now a free function declared in ops/sdpa_fw/sdpa_fw.hpp
-
-// sdpa_bw is now a free function declared in ops/sdpa_bw/sdpa_bw.hpp
-
-// swiglu_fw is now a free function declared in ops/swiglu_fw/swiglu_fw.hpp
-
-// sgd_fused is now a free function declared in optimizers/sgd_fused/sgd_fused.hpp
-
-}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -20,44 +20,30 @@
 
 namespace ttml::metal {
 
-constexpr auto rmsnorm_fw =
-    ttnn::register_operation<"ttml::metal::rmsnorm_fw", ttml::metal::ops::rmsnorm_fw::RMSNormForwardOperation>();
+// rmsnorm_fw is now a free function declared in ops/rmsnorm_fw/rmsnorm_fw.hpp
 
-constexpr auto rmsnorm_bw =
-    ttnn::register_operation<"ttml::metal::rmsnorm_bw", ttml::metal::ops::rmsnorm_bw::RMSNormBackwardOperation>();
+// rmsnorm_bw is now a free function declared in ops/rmsnorm_bw/rmsnorm_bw.hpp
 
-constexpr auto layernorm_bw =
-    ttnn::register_operation<"ttml::metal::layernorm_bw", ttml::metal::ops::layernorm_bw::LayerNormBackwardOperation>();
+// layernorm_bw is now a free function declared in ops/layernorm_bw/layernorm_bw.hpp
 
-constexpr auto layernorm_fw =
-    ttnn::register_operation<"ttml::metal::layernorm_fw", ttml::metal::ops::layernorm_fw::LayerNormForwardOperation>();
+// layernorm_fw is now a free function declared in ops/layernorm_fw/layernorm_fw.hpp
 
-constexpr auto cross_entropy_fw = ttnn::register_operation<
-    "ttml::metal::cross_entropy_fw",
-    ttml::metal::ops::cross_entropy_fw::CrossEntropyForwardOperation>();
+// cross_entropy_fw is now a free function declared in ops/cross_entropy_fw/cross_entropy_fw.hpp
 
-constexpr auto cross_entropy_bw = ttnn::register_operation<
-    "ttml::metal::cross_entropy_bw",
-    ttml::metal::ops::cross_entropy_bw::CrossEntropyBackwardOperation>();
+// cross_entropy_bw is now a free function declared in ops/cross_entropy_bw/cross_entropy_bw.hpp
 
 // softmax is now a free function declared in ops/softmax/softmax.hpp
 
-constexpr auto profiler_no_op =
-    ttnn::register_operation<"ttml::metal::profiler_no_op", ttml::metal::ops::profiler_no_op::ProfilerNoopOperation>();
+// profiler_no_op is now a free function declared in ops/profiler_no_op/profiler_no_op.hpp
 
-constexpr auto silu_bw =
-    ttnn::register_operation<"ttml::metal::silu_bw", ttml::metal::ops::silu_bw::SiLUBackwardOperation>();
+// silu_bw is now a free function declared in ops/silu_bw/silu_bw.hpp
 
-constexpr auto sdpa_fw =
-    ttnn::register_operation<"ttml::metal::sdpa_fw", ttml::metal::ops::sdpa_fw::SDPAForwardOperation>();
+// sdpa_fw is now a free function declared in ops/sdpa_fw/sdpa_fw.hpp
 
-constexpr auto sdpa_bw =
-    ttnn::register_operation<"ttml::metal::sdpa_bw", ttml::metal::ops::sdpa_bw::SDPABackwardOperation>();
+// sdpa_bw is now a free function declared in ops/sdpa_bw/sdpa_bw.hpp
 
-constexpr auto swiglu_fw =
-    ttnn::register_operation<"ttml::metal::swiglu_fw", ttml::metal::ops::swiglu_fw::SwiGLUForwardOperation>();
+// swiglu_fw is now a free function declared in ops/swiglu_fw/swiglu_fw.hpp
 
-constexpr auto sgd_fused =
-    ttnn::register_operation<"ttml::metal::sgd_fused", ttml::metal::optimizers::sgd_fused::SGDFusedOptimizer>();
+// sgd_fused is now a free function declared in optimizers/sgd_fused/sgd_fused.hpp
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/cross_entropy_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/cross_entropy_bw.cpp
@@ -6,10 +6,11 @@
 
 #include "device/cross_entropy_bw_device_operation.hpp"
 
-namespace ttml::metal::ops::cross_entropy_bw {
+namespace ttml::metal {
 
-ttnn::Tensor CrossEntropyBackwardOperation::invoke(
+ttnn::Tensor cross_entropy_bw(
     const ttnn::Tensor& input_tensor, const ttnn::Tensor& target_tensor, const ttnn::Tensor& grad, float scaler) {
     return ttnn::multiply(ttnn::prim::ttml_cross_entropy_bw(input_tensor, target_tensor, scaler), grad);
 }
-}  // namespace ttml::metal::ops::cross_entropy_bw
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/cross_entropy_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/cross_entropy_bw.hpp
@@ -8,13 +8,12 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::cross_entropy_bw {
+namespace ttml::metal {
 
-struct CrossEntropyBackwardOperation {
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input,   // logits : model output (N, 1, H, W)
-        const ttnn::Tensor& target,  // target : ground truth (N, H)
-        const ttnn::Tensor& grad,    // grad : support only  (1, 1, 1, 1)
-        float scaler);
-};
-}  // namespace ttml::metal::ops::cross_entropy_bw
+ttnn::Tensor cross_entropy_bw(
+    const ttnn::Tensor& input,   // logits : model output (N, 1, H, W)
+    const ttnn::Tensor& target,  // target : ground truth (N, H)
+    const ttnn::Tensor& grad,    // grad : support only  (1, 1, 1, 1)
+    float scaler);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/cross_entropy_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/cross_entropy_fw.cpp
@@ -6,10 +6,11 @@
 
 #include "device/cross_entropy_fw_device_operation.hpp"
 
-namespace ttml::metal::ops::cross_entropy_fw {
+namespace ttml::metal {
 
-ttnn::Tensor CrossEntropyForwardOperation::invoke(const ttnn::Tensor& input_tensor, const ttnn::Tensor& target_tensor) {
+ttnn::Tensor cross_entropy_fw(const ttnn::Tensor& input_tensor, const ttnn::Tensor& target_tensor) {
     auto result = ttnn::prim::ttml_cross_entropy_fw(input_tensor, target_tensor);
     return result;
 }
-}  // namespace ttml::metal::ops::cross_entropy_fw
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/cross_entropy_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/cross_entropy_fw.hpp
@@ -6,12 +6,11 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::cross_entropy_fw {
+namespace ttml::metal {
 
-struct CrossEntropyForwardOperation {
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input,  // logits : model output (N, 1, H, W)
-        const ttnn::Tensor& target  // target : ground truth (N, H)
-    );
-};
-}  // namespace ttml::metal::ops::cross_entropy_fw
+ttnn::Tensor cross_entropy_fw(
+    const ttnn::Tensor& input,  // logits : model output (N, 1, H, W)
+    const ttnn::Tensor& target  // target : ground truth (N, H)
+);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.cpp
@@ -8,9 +8,9 @@
 #include "core/compute_kernel_config.hpp"
 #include "device/layernorm_bw_device_operation.hpp"
 
-namespace ttml::metal::ops::layernorm_bw {
+namespace ttml::metal {
 
-std::vector<std::optional<ttnn::Tensor>> LayerNormBackwardOperation::invoke(
+std::vector<std::optional<ttnn::Tensor>> layernorm_bw(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& gamma_tensor,
     const ttnn::Tensor& mean_tensor,
@@ -43,4 +43,4 @@ std::vector<std::optional<ttnn::Tensor>> LayerNormBackwardOperation::invoke(
         reduction_with_reshape_to2D(result[2])};
 }
 
-}  // namespace ttml::metal::ops::layernorm_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.hpp
@@ -8,15 +8,13 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::layernorm_bw {
+namespace ttml::metal {
 
-struct LayerNormBackwardOperation {
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& input_tensor,     // [B, 1, S, C] - original input from forward
-        const ttnn::Tensor& gamma_tensor,     // [1, 1, 1, C] - scale parameter
-        const ttnn::Tensor& mean_tensor,      // [B, 1, S, 1] - mean from forward
-        const ttnn::Tensor& rstd_tensor,      // [B, 1, S, 1] - reciprocal std from forward
-        const ttnn::Tensor& dL_dout_tensor);  // [B, 1, S, C] - upstream gradient
-};
+std::vector<std::optional<ttnn::Tensor>> layernorm_bw(
+    const ttnn::Tensor& input_tensor,     // [B, 1, S, C] - original input from forward
+    const ttnn::Tensor& gamma_tensor,     // [1, 1, 1, C] - scale parameter
+    const ttnn::Tensor& mean_tensor,      // [B, 1, S, 1] - mean from forward
+    const ttnn::Tensor& rstd_tensor,      // [B, 1, S, 1] - reciprocal std from forward
+    const ttnn::Tensor& dL_dout_tensor);  // [B, 1, S, C] - upstream gradient
 
-}  // namespace ttml::metal::ops::layernorm_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.cpp
@@ -9,9 +9,9 @@
 #include "core/compute_kernel_config.hpp"
 #include "device/layernorm_fw_device_operation.hpp"
 
-namespace ttml::metal::ops::layernorm_fw {
+namespace ttml::metal {
 
-std::vector<std::optional<ttnn::Tensor>> LayerNormForwardOperation::invoke(
+std::vector<std::optional<ttnn::Tensor>> layernorm_fw(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& gamma_tensor,
     const ttnn::Tensor& beta_tensor,
@@ -21,4 +21,4 @@ std::vector<std::optional<ttnn::Tensor>> LayerNormForwardOperation::invoke(
     return ttnn::prim::ttml_layernorm_fw(input_tensor, gamma_tensor, beta_tensor, epsilon, return_mean_rstd);
 }
 
-}  // namespace ttml::metal::ops::layernorm_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/layernorm_fw.hpp
@@ -8,16 +8,14 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::layernorm_fw {
+namespace ttml::metal {
 
-struct LayerNormForwardOperation {
-    // Returns [output, mean, rstd] where mean and rstd are optional depending on return_mean_rstd
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& input_tensor,  // [B, 1, S, C] - input
-        const ttnn::Tensor& gamma_tensor,  // [1, 1, 1, C] - scale parameter
-        const ttnn::Tensor& beta_tensor,   // [1, 1, 1, C] - shift parameter
-        float epsilon = 1e-5F,             // epsilon for numerical stability
-        bool return_mean_rstd = false);    // whether to return mean and rstd
-};
+// Returns [output, mean, rstd] where mean and rstd are optional depending on return_mean_rstd
+std::vector<std::optional<ttnn::Tensor>> layernorm_fw(
+    const ttnn::Tensor& input_tensor,  // [B, 1, S, C] - input
+    const ttnn::Tensor& gamma_tensor,  // [1, 1, 1, C] - scale parameter
+    const ttnn::Tensor& beta_tensor,   // [1, 1, 1, C] - shift parameter
+    float epsilon = 1e-5F,             // epsilon for numerical stability
+    bool return_mean_rstd = false);    // whether to return mean and rstd
 
-}  // namespace ttml::metal::ops::layernorm_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/profiler_no_op.cpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/profiler_no_op.cpp
@@ -6,9 +6,10 @@
 
 #include "device/profiler_no_op_device_operation.hpp"
 
-namespace ttml::metal::ops::profiler_no_op {
+namespace ttml::metal {
 
-ttnn::Tensor ProfilerNoopOperation::invoke(const ttnn::Tensor& input_tensor, const std::string& identifier) {
+ttnn::Tensor profiler_no_op(const ttnn::Tensor& input_tensor, const std::string& identifier) {
     return ttnn::prim::ttml_profiler_no_op(input_tensor, identifier);
 }
-}  // namespace ttml::metal::ops::profiler_no_op
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/profiler_no_op.hpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/profiler_no_op.hpp
@@ -6,10 +6,8 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::profiler_no_op {
+namespace ttml::metal {
 
-struct ProfilerNoopOperation {
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const std::string& identifier);
-};
+ttnn::Tensor profiler_no_op(const ttnn::Tensor& input_tensor, const std::string& identifier);
 
-}  // namespace ttml::metal::ops::profiler_no_op
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
@@ -7,9 +7,9 @@
 #include "core/compute_kernel_config.hpp"
 #include "device/rmsnorm_bw_device_operation.hpp"
 
-namespace ttml::metal::ops::rmsnorm_bw {
+namespace ttml::metal {
 
-std::vector<std::optional<ttnn::Tensor>> RMSNormBackwardOperation::invoke(
+std::vector<std::optional<ttnn::Tensor>> rmsnorm_bw(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& gamma_tensor,
     const ttnn::Tensor& rms_tensor,
@@ -34,4 +34,4 @@ std::vector<std::optional<ttnn::Tensor>> RMSNormBackwardOperation::invoke(
     };
 }
 
-}  // namespace ttml::metal::ops::rmsnorm_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
@@ -8,14 +8,12 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::rmsnorm_bw {
+namespace ttml::metal {
 
-struct RMSNormBackwardOperation {
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& gamma_tensor,
-        const ttnn::Tensor& rms_tensor,  // intermediate from fw
-        const ttnn::Tensor& dL_dout_tensor);
-};
+std::vector<std::optional<ttnn::Tensor>> rmsnorm_bw(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& gamma_tensor,
+    const ttnn::Tensor& rms_tensor,  // intermediate from fw
+    const ttnn::Tensor& dL_dout_tensor);
 
-}  // namespace ttml::metal::ops::rmsnorm_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
@@ -6,9 +6,9 @@
 
 #include "device/rmsnorm_fw_device_operation.hpp"
 
-namespace ttml::metal::ops::rmsnorm_fw {
+namespace ttml::metal {
 
-std::vector<std::optional<ttnn::Tensor>> RMSNormForwardOperation::invoke(
+std::vector<std::optional<ttnn::Tensor>> rmsnorm_fw(
     const ttnn::Tensor& input_tensor, const ttnn::Tensor& gamma_tensor, bool return_intermediates, float epsilon) {
     auto result = ttnn::prim::ttml_rmsnorm_fw(input_tensor, gamma_tensor, return_intermediates, epsilon);
 
@@ -19,4 +19,4 @@ std::vector<std::optional<ttnn::Tensor>> RMSNormForwardOperation::invoke(
     return {result[0], result[1]};
 }
 
-}  // namespace ttml::metal::ops::rmsnorm_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
@@ -8,14 +8,12 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::rmsnorm_fw {
+namespace ttml::metal {
 
-struct RMSNormForwardOperation {
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& gamma_tensor,
-        bool return_intermediates = true,
-        float epsilon = 1e-6F);
-};
+std::vector<std::optional<ttnn::Tensor>> rmsnorm_fw(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& gamma_tensor,
+    bool return_intermediates = true,
+    float epsilon = 1e-6F);
 
-}  // namespace ttml::metal::ops::rmsnorm_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/sdpa_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/sdpa_bw.cpp
@@ -7,9 +7,9 @@
 #include "device/sdpa_bw_kv_device_operation.hpp"
 #include "device/sdpa_bw_q_device_operation.hpp"
 
-namespace ttml::metal::ops::sdpa_bw {
+namespace ttml::metal {
 
-std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> SDPABackwardOperation::invoke(
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> sdpa_bw(
     const ttnn::Tensor& grad_output,
     const ttnn::Tensor& attn_output,
     const ttnn::Tensor& query,
@@ -30,4 +30,4 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> SDPABackwardOperation::invo
     return {grad_Q, grad_K, grad_V};
 }
 
-}  // namespace ttml::metal::ops::sdpa_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/sdpa_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/sdpa_bw.hpp
@@ -6,20 +6,18 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::sdpa_bw {
+namespace ttml::metal {
 
-struct SDPABackwardOperation {
-    // Returns [grad_Q, grad_K, grad_V]
-    static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(
-        const ttnn::Tensor& grad_output,               // Gradient w.r.t. output
-        const ttnn::Tensor& attn_output,               // sdap forward output (needed for gradients)
-        const ttnn::Tensor& query,                     // input Q (needed for gradients)
-        const ttnn::Tensor& key,                       // input K (needed for gradients)
-        const ttnn::Tensor& value,                     // input V (needed for gradients)
-        const std::optional<ttnn::Tensor>& attn_mask,  // attention mask
-        const ttnn::Tensor& intermediates,             // From forward pass (attention weights, etc.)
-        const float dropout_probability = 0.0F,
-        const bool fp32_dest_acc_en = true);
-};
+// Returns [grad_Q, grad_K, grad_V]
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> sdpa_bw(
+    const ttnn::Tensor& grad_output,               // Gradient w.r.t. output
+    const ttnn::Tensor& attn_output,               // sdap forward output (needed for gradients)
+    const ttnn::Tensor& query,                     // input Q (needed for gradients)
+    const ttnn::Tensor& key,                       // input K (needed for gradients)
+    const ttnn::Tensor& value,                     // input V (needed for gradients)
+    const std::optional<ttnn::Tensor>& attn_mask,  // attention mask
+    const ttnn::Tensor& intermediates,             // From forward pass (attention weights, etc.)
+    const float dropout_probability = 0.0F,
+    const bool fp32_dest_acc_en = true);
 
-}  // namespace ttml::metal::ops::sdpa_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/sdpa_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/sdpa_fw.cpp
@@ -6,9 +6,9 @@
 
 #include "device/sdpa_fw_device_operation.hpp"
 
-namespace ttml::metal::ops::sdpa_fw {
+namespace ttml::metal {
 
-std::vector<std::optional<ttnn::Tensor>> SDPAForwardOperation::invoke(
+std::vector<std::optional<ttnn::Tensor>> sdpa_fw(
     const ttnn::Tensor& query,
     const ttnn::Tensor& key,
     const ttnn::Tensor& value,
@@ -24,6 +24,6 @@ std::vector<std::optional<ttnn::Tensor>> SDPAForwardOperation::invoke(
     }
 
     return {result[0], result[1]};  // maybe I need to return more than 2 tensors in the future
-};
+}
 
-}  // namespace ttml::metal::ops::sdpa_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/sdpa_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/sdpa_fw.hpp
@@ -7,17 +7,15 @@
 #include "metal/common/const_utils.hpp"
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::sdpa_fw {
+namespace ttml::metal {
 
-struct SDPAForwardOperation {
-    static std::vector<std::optional<ttnn::Tensor>> invoke(
-        const ttnn::Tensor& query,
-        const ttnn::Tensor& key,
-        const ttnn::Tensor& value,
-        AttentionMaskType mask_type = AttentionMaskType::Causal,
-        const std::optional<ttnn::Tensor>& mask = std::nullopt,  // only used when mask_type == Arbitrary
-        const float dropout_probability = 0.0F,
-        const bool return_intermediates = false);
-};
+std::vector<std::optional<ttnn::Tensor>> sdpa_fw(
+    const ttnn::Tensor& query,
+    const ttnn::Tensor& key,
+    const ttnn::Tensor& value,
+    AttentionMaskType mask_type = AttentionMaskType::Causal,
+    const std::optional<ttnn::Tensor>& mask = std::nullopt,  // only used when mask_type == Arbitrary
+    const float dropout_probability = 0.0F,
+    const bool return_intermediates = false);
 
-}  // namespace ttml::metal::ops::sdpa_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.cpp
@@ -7,13 +7,13 @@
 #include "core/compute_kernel_config.hpp"
 #include "device/silu_bw_device_operation.hpp"
 
-namespace ttml::metal::ops::silu_bw {
+namespace ttml::metal {
 
-ttnn::Tensor SiLUBackwardOperation::invoke(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor) {
+ttnn::Tensor silu_bw(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor) {
     return ttnn::prim::ttml_silu_bw(
         input_tensor,   // [B,1,S,C]
         dL_dout_tensor  //[B,1,S,C]
     );
 }
 
-}  // namespace ttml::metal::ops::silu_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/silu_bw.hpp
@@ -6,10 +6,8 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::silu_bw {
+namespace ttml::metal {
 
-struct SiLUBackwardOperation {
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor);
-};
+ttnn::Tensor silu_bw(const ttnn::Tensor& input_tensor, const ttnn::Tensor& dL_dout_tensor);
 
-}  // namespace ttml::metal::ops::silu_bw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/softmax/softmax.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/softmax.cpp
@@ -6,9 +6,10 @@
 
 #include "device/softmax_device_operation.hpp"
 
-namespace ttml::metal::ops::softmax {
+namespace ttml::metal {
 
-ttnn::Tensor SoftmaxOperation::invoke(const ttnn::Tensor& input_tensor, int32_t dim) {
+ttnn::Tensor softmax(const ttnn::Tensor& input_tensor, int32_t dim) {
     return ttnn::prim::ttml_softmax(input_tensor, dim);
 }
-}  // namespace ttml::metal::ops::softmax
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/softmax/softmax.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/softmax.hpp
@@ -6,9 +6,8 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::softmax {
+namespace ttml::metal {
 
-struct SoftmaxOperation {
-    static ttnn::Tensor invoke(const ttnn::Tensor& input, int32_t dim);
-};
-}  // namespace ttml::metal::ops::softmax
+ttnn::Tensor softmax(const ttnn::Tensor& input, int32_t dim);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -5,11 +5,10 @@
 #include "swiglu_fw.hpp"
 
 #include "device/swiglu_fw_device_operation.hpp"
-#include "metal/ops/swiglu_fw/swiglu_fw.hpp"
 
-namespace ttml::metal::ops::swiglu_fw {
+namespace ttml::metal {
 
-ttnn::Tensor SwiGLUForwardOperation::invoke(
+ttnn::Tensor swiglu_fw(
     const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
     return ttnn::prim::ttml_swiglu_fw(
         input_tensor,  // [B, 1, S, C]
@@ -19,4 +18,4 @@ ttnn::Tensor SwiGLUForwardOperation::invoke(
     );
 }
 
-}  // namespace ttml::metal::ops::swiglu_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -6,11 +6,9 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::ops::swiglu_fw {
+namespace ttml::metal {
 
-struct SwiGLUForwardOperation {
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3);
-};
+ttnn::Tensor swiglu_fw(
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3);
 
-}  // namespace ttml::metal::ops::swiglu_fw
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/sgd_fused.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/sgd_fused.cpp
@@ -6,9 +6,9 @@
 
 #include "device/sgd_fused_device_operation.hpp"
 
-namespace ttml::metal::optimizers::sgd_fused {
+namespace ttml::metal {
 
-ttnn::Tensor SGDFusedOptimizer::invoke(
+ttnn::Tensor sgd_fused(
     const ttnn::Tensor& param,
     const ttnn::Tensor& grad,
     const float lr,
@@ -19,4 +19,5 @@ ttnn::Tensor SGDFusedOptimizer::invoke(
     const std::optional<ttnn::Tensor>& momentum_buffer) {
     return ttnn::prim::ttml_sgd_fused(param, grad, lr, momentum, dampening, weight_decay, nesterov, momentum_buffer);
 }
-}  // namespace ttml::metal::optimizers::sgd_fused
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/sgd_fused.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/sgd_fused.hpp
@@ -6,17 +6,16 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
-namespace ttml::metal::optimizers::sgd_fused {
+namespace ttml::metal {
 
-struct SGDFusedOptimizer {
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& param_in,
-        const ttnn::Tensor& grad,
-        const float lr,
-        const float momentum,
-        const float dampening,
-        const float weight_decay,
-        const bool nesterov,
-        const std::optional<ttnn::Tensor>& momentum_buffer);
-};
-}  // namespace ttml::metal::optimizers::sgd_fused
+ttnn::Tensor sgd_fused(
+    const ttnn::Tensor& param_in,
+    const ttnn::Tensor& grad,
+    const float lr,
+    const float momentum,
+    const float dampening,
+    const float weight_decay,
+    const bool nesterov,
+    const std::optional<ttnn::Tensor>& momentum_buffer);
+
+}  // namespace ttml::metal

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -162,8 +162,7 @@ static void CompareKernelVsXArray(
         auto rstd_tensor = core::from_xtensor(rstd_data, &autograd::ctx().get_device());
         auto dy_tensor = core::from_xtensor(dy_4d, &autograd::ctx().get_device());
 
-        auto output_tensors = metal::ops::layernorm_bw::LayerNormBackwardOperation::invoke(
-            input_tensor, gamma_tensor, mean_tensor, rstd_tensor, dy_tensor);
+        auto output_tensors = metal::layernorm_bw(input_tensor, gamma_tensor, mean_tensor, rstd_tensor, dy_tensor);
 
         auto metal_dx_xtensor = core::to_xtensor(output_tensors[0].value());
         auto metal_dgamma_xtensor = core::to_xtensor(output_tensors[1].value());

--- a/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
@@ -105,8 +105,8 @@ static void CompareKernelVsXArray(
         auto beta_tensor = core::from_xtensor(beta_4d, &autograd::ctx().get_device());
 
         // Run metal kernel
-        auto output_tensors = metal::ops::layernorm_fw::LayerNormForwardOperation::invoke(
-            input_tensor, gamma_tensor, beta_tensor, 1e-6f, /* return_mean_rstd */ true);
+        auto output_tensors =
+            metal::layernorm_fw(input_tensor, gamma_tensor, beta_tensor, 1e-6f, /* return_mean_rstd */ true);
 
         auto metal_y_xtensor = core::to_xtensor(output_tensors[0].value());
         auto metal_mu_xtensor = core::to_xtensor(output_tensors[1].value());

--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -22,7 +22,7 @@ struct overload_t {
     Func func;
     std::tuple<Args...> args;
 
-    constexpr overload_t(Func f, const Args&... a) : func(f), args(std::make_tuple(a...)) {}
+    constexpr overload_t(Func f, Args... a) : func(f), args(std::make_tuple(a...)) {}
 };
 
 // Deduction guide

--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -22,7 +22,7 @@ struct overload_t {
     Func func;
     std::tuple<Args...> args;
 
-    constexpr overload_t(Func f, Args... a) : func(f), args(std::make_tuple(a...)) {}
+    constexpr overload_t(Func f, const Args&... a) : func(f), args(std::make_tuple(a...)) {}
 };
 
 // Deduction guide

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -106,7 +106,8 @@ std::vector<ttnn::Tensor> split(
         } else {
             input_tensor_4d = input_tensor;
         }
-        const auto outputs_4d = detail::split_last_dim_two_chunks_tiled(input_tensor_4d, memory_config);
+        const auto outputs_4d =
+            detail::split_last_dim_two_chunks_tiled(input_tensor_4d, memory_config);
         std::vector<ttnn::Tensor> outputs;
         outputs.reserve(detail::TWO_CHUNKS);
         for (const auto& t : outputs_4d) {

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
@@ -15,13 +15,13 @@ namespace ttnn {
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
     const ttnn::SmallVector<int64_t>& split_sizes,
-    int64_t dim = 0,
+    int64_t dim,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
     int64_t split_size,
-    int64_t dim = 0,
+    int64_t dim,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.hpp
@@ -15,13 +15,13 @@ namespace ttnn {
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
     const ttnn::SmallVector<int64_t>& split_sizes,
-    int64_t dim,
+    int64_t dim = 0,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 
 std::vector<ttnn::Tensor> split(
     const ttnn::Tensor& input_tensor,
     int64_t split_size,
-    int64_t dim,
+    int64_t dim = 0,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 
 }  // namespace ttnn


### PR DESCRIPTION
## Summary
- Convert all 13 ttml metal operations from struct+invoke pattern to plain C++ free functions
- Operations now live directly in `ttml::metal` namespace instead of nested `ttml::metal::ops::*` namespaces
- Removes `register_operation` boilerplate from operations.hpp

## Operations migrated
- rmsnorm_fw, rmsnorm_bw
- layernorm_fw, layernorm_bw
- cross_entropy_fw, cross_entropy_bw
- softmax, profiler_no_op, silu_bw
- sdpa_fw, sdpa_bw
- swiglu_fw, sgd_fused

## Test plan
- [x] Build passes with `./build_metal.sh -c --debug --build-all`
- [ ] Run ttml tests to verify functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)