### PR TITLE
#0: add lm heads and mlp/sharded expert ff1_3 and ff2 shapes to matmul deepseek test

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -64,8 +64,38 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             "tile_h": 32,
             "tile_w": 32,
         },
+        # mlp ff1 / ff3
+        {
+            "m": 32,
+            "k": 7168,
+            "n": 3584,  # 2304, don't have Galaxy 9x8 grid
+            "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
+            "in0_core_grid": (7, 8),
+            "out_core_grid": (7, 8),
+            "in0_dtype": ttnn.bfloat16,
+            "in1_dtype": ttnn.bfloat4_b,
+            "out_dtype": ttnn.bfloat16,
+            "expected_pcc": 0.99,
+            "tile_h": 32,
+            "tile_w": 32,
+        },
+        # mlp ff2
+        {
+            "m": 32,
+            "k": 3584,  # 2304, really need tiny tiles
+            "n": 7168,
+            "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
+            "in0_core_grid": (7, 8),
+            "out_core_grid": (7, 8),
+            "in0_dtype": ttnn.bfloat16,
+            "in1_dtype": ttnn.bfloat4_b,
+            "out_dtype": ttnn.bfloat16,
+            "expected_pcc": 0.99,
+            "tile_h": 32,
+            "tile_w": 32,
+        },
     ],
-    ids=["qkv_a", "wq_b", "wo"],
+    ids=["qkv_a", "wq_b", "wo", "ff1_ff3", "ff2"],
 )
 @pytest.mark.parametrize("num_iters", [1])
 def test_matmul_l1_dram_sharded(device, test_case, num_iters):

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -68,7 +68,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         {
             "m": 32,
             "k": 7168,
-            "n": 3584,  # 2304, don't have Galaxy 9x8 grid
+            "n": 3584,  # 2304, padded up
             "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
             "in0_core_grid": (7, 8),
             "out_core_grid": (7, 8),
@@ -82,7 +82,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         # mlp ff2
         {
             "m": 32,
-            "k": 3584,  # 2304, really need tiny tiles
+            "k": 3584,  # 2304, padded up
             "n": 7168,
             "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
             "in0_core_grid": (7, 8),
@@ -94,8 +94,53 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             "tile_h": 32,
             "tile_w": 32,
         },
+        # shared expert ff1 / ff3
+        {
+            "m": 32,
+            "k": 7168,
+            "n": 384,  # 256, padded up
+            "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
+            "in0_core_grid": (7, 8),
+            "out_core_grid": (3, 4),
+            "in0_dtype": ttnn.bfloat16,
+            "in1_dtype": ttnn.bfloat4_b,
+            "out_dtype": ttnn.bfloat16,
+            "expected_pcc": 0.99,
+            "tile_h": 32,
+            "tile_w": 32,
+        },
+        # shared expert ff2
+        {
+            "m": 32,
+            "k": 256,
+            "n": 7168,
+            "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
+            "in0_core_grid": (1, 8),
+            "out_core_grid": (7, 8),
+            "in0_dtype": ttnn.bfloat16,
+            "in1_dtype": ttnn.bfloat4_b,
+            "out_dtype": ttnn.bfloat16,
+            "expected_pcc": 0.99,
+            "tile_h": 32,
+            "tile_w": 32,
+        },
+        # lm heads
+        {
+            "m": 32,
+            "k": 7168,
+            "n": 16512,  # 16160 padded
+            "in0_shard_strategy": ttnn.ShardStrategy.WIDTH,
+            "in0_core_grid": (7, 8),
+            "out_core_grid": (8, 8),
+            "in0_dtype": ttnn.bfloat16,
+            "in1_dtype": ttnn.bfloat4_b,
+            "out_dtype": ttnn.bfloat16,
+            "expected_pcc": 0.99,
+            "tile_h": 32,
+            "tile_w": 32,
+        },
     ],
-    ids=["qkv_a", "wq_b", "wo", "ff1_ff3", "ff2"],
+    ids=["qkv_a", "wq_b", "wo", "mlp_ff1_ff3", "mlp_ff2", "shared_expert_ff1_ff3", "shared_expert_mlp_ff2", "lm_heads"],
 )
 @pytest.mark.parametrize("num_iters", [1])
 def test_matmul_l1_dram_sharded(device, test_case, num_iters):


### PR DESCRIPTION
### Ticket
Link to Github Issue N/A

### Problem description
Need to track perf of lm heads and mlp/sharded expert ff1_3 and ff2 shapes

### What's changed
- Added parameters to matmul deepseek test in nightly
- Tested locally that it passes

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-0_ff123)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_ff123)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_ff123)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_ff123)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_ff123)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_ff123)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_ff123)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs