### PR TITLE
Add 4x32/8x32 tiny tile support to DeepSeek matmul

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -17,7 +17,7 @@ using namespace ckernel;
 namespace custom_mm {
 // Finalization instruction count: set during init, used during math
 // m=1, m=4: 10 instructions (4 MVMUL + 4 MOV + 2 ELWADD)
-// m=8: 14 instructions (4 MVMUL + 8 MOV + 2 ELWADD)
+// m=8: 4 instructions (4 MVMUL only, no tail reduction)
 inline std::uint32_t finalization_len = 10;
 }  // namespace custom_mm
 
@@ -41,12 +41,21 @@ inline void custom_mm_configure_addrmod(
     }
         .set(ADDR_MOD_0);
 
-    addr_mod_t{
-        .srca = {.incr = 16, .clr = 0, .cr = 0},
-        .srcb = {.incr = 16, .clr = 0, .cr = 0},
-        .dest = {.incr = 16, .clr = 0, .cr = 0},
+    if (in0_tile_r_dim == 8) {
+        addr_mod_t{
+            .srca = {.incr = 16, .clr = 0, .cr = 0},
+            .srcb = {.incr = 16, .clr = 0, .cr = 0},
+            .dest = {.incr = 0, .clr = 1, .cr = 0},
+        }
+            .set(ADDR_MOD_1);
+    } else {
+        addr_mod_t{
+            .srca = {.incr = 16, .clr = 0, .cr = 0},
+            .srcb = {.incr = 16, .clr = 0, .cr = 0},
+            .dest = {.incr = 16, .clr = 0, .cr = 0},
+        }
+            .set(ADDR_MOD_1);
     }
-        .set(ADDR_MOD_1);
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 1, .cr = 0},
@@ -66,50 +75,54 @@ inline void custom_mm_configure_mop(
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
     const bool partial_face = false) {
     // Select MOV instruction count based on output tile height (in0_tile_r_dim)
-    // m=1: 4 MOVs (MOV_1_ROW), m=4: 4 MOVs (MOV_4_ROWS), m=8: 8 MOVs (2x MOV_4_ROWS)
-    // Replay buffer size: 8 MVMULs + MOVs + 2 ELWADDs
-    const std::uint32_t replay_buf_len = (in0_tile_r_dim == 8) ? 18 : 14;
-    // Finalization length: 4 MVMULs + MOVs + 2 ELWADDs (starting from offset 4)
-    custom_mm::finalization_len = (in0_tile_r_dim == 8) ? 14 : 10;
+    // m=1: 4 MOVs (MOV_1_ROW), m=4: 4 MOVs (MOV_4_ROWS), m=8: no tail reduction
+    // Replay buffer size: m=8: 8 MVMULs, m=1/4: 8 MVMULs + 4 MOVs + 2 ELWADDs = 14
+    const std::uint32_t replay_buf_len = (in0_tile_r_dim == 8) ? 8 : 14;
+    // Finalization length (starting from offset 4):
+    // m=8: 4 instructions (4 MVMULs), m=1/4: 10 instructions (4 MVMULs + 4 MOVs + 2 ELWADDs)
+    custom_mm::finalization_len = (in0_tile_r_dim == 8) ? 4 : 10;
 
     load_replay_buf(
         ckernel::math::replay_buf_offset,
         replay_buf_len,
         // Lambda function to load reply buffer
         [in0_tile_r_dim] {
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
-            TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);    // 16 (48)
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);  // 16 (48)
             if (in0_tile_r_dim == 8) {
-                // m=8: need 2x MOV_4_ROWS per face (8 MOV total)
-                TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 0);
-                TTI_MOVD2A(0, 4, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 4);
-                TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 16);
-                TTI_MOVD2A(0, 20, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 20);
-                TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 32);
-                TTI_MOVD2B(0, 4, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 36);
-                TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 48);
-                TTI_MOVD2B(0, 20, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 52);
-            } else if (in0_tile_r_dim == 4) {
-                // m=4: MOV_4_ROWS
-                TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 0);
-                TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 16);
-                TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 32);
-                TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 48);
+                // m=8: 8 MVMULs only, no tail reduction
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
+                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);    // 16 (48)
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
+                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);    // 16 (48)
             } else {
-                // m=1: MOV_1_ROW
-                TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 0);
-                TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 16);
-                TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 32);
-                TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 48);
+                // m=1/4: 8 MVMULs + MOVs + ELWADDs
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
+                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);    // 16 (48)
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);  // 16 (48)
+                if (in0_tile_r_dim == 4) {
+                    // m=4: MOV_4_ROWS
+                    TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 0);
+                    TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 16);
+                    TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 32);
+                    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 48);
+                } else {
+                    // m=1: MOV_1_ROW
+                    TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 0);
+                    TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 16);
+                    TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 32);
+                    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 48);
+                }
+                TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
+                TTI_ELWADD(3, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_3, 0);
             }
-            TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
-            TTI_ELWADD(3, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_3, 0);
         });
 }
 
@@ -142,19 +155,20 @@ inline void _llk_math_custom_mm_(
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
     if constexpr (partial_acc) {
-        // Partial K accumulation: run all kt_dim iterations with CLR_AB (instructions 0-3)
+        // Partial K accumulation: run all kt_dim iterations with first 4 MVMULs
         // MVMUL accumulates into dest, results persist for next K subblock
-        // NO finalization - skip instructions 4-13
+        // NO finalization - skip instructions 4+
         for (uint32_t i = 0; i < kt_dim; i++) {
             lltt::replay(ckernel::math::replay_buf_offset, 4);
         }
     } else {
         // Full accumulation with finalization
+        // First kt_dim-1 iterations: 4 MVMULs (instructions 0-3)
         for (uint32_t i = 0; i < kt_dim - 1; i++) {
             lltt::replay(ckernel::math::replay_buf_offset, 4);
         }
-        // Final K tile + finalization (MOVD2A/MOVD2B/ELWADD)
-        // Finalization length depends on tile height: 10 for m=1/4, 14 for m=8
+        // Final K tile + finalization (instructions 4 to 4+finalization_len)
+        // m=8: 4 MVMULs, m=1/4: 4 MVMULs + MOVs + ELWADDs
         lltt::replay(ckernel::math::replay_buf_offset + 4, custom_mm::finalization_len);
     }
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -75,7 +75,7 @@ inline void custom_mm_configure_mop(
     const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
     const bool partial_face = false) {
     // Select MOV instruction count based on output tile height (in0_tile_r_dim)
-    // m=1: 4 MOVs (MOV_1_ROW), m=4: 4 MOVs (MOV_4_ROWS), m=8: no tail reduction
+    // m=1/4: 4 MOVs (MOV_4_ROWS), m=8: no tail reduction
     // Replay buffer size: m=8: 8 MVMULs, m=1/4: 8 MVMULs + 4 MOVs + 2 ELWADDs = 14
     const std::uint32_t replay_buf_len = (in0_tile_r_dim == 8) ? 8 : 14;
     // Finalization length (starting from offset 4):
@@ -107,19 +107,11 @@ inline void custom_mm_configure_mop(
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0 (32)
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 0);  // 16 (48)
-                if (in0_tile_r_dim == 4) {
-                    // m=4: MOV_4_ROWS
-                    TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 0);
-                    TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 16);
-                    TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 32);
-                    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 48);
-                } else {
-                    // m=1: MOV_1_ROW
-                    TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 0);
-                    TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_1_ROW, 16);
-                    TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 32);
-                    TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 48);
-                }
+                // m=1/4: MOV_4_ROWS
+                TTI_MOVD2A(0, 0, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 0);
+                TTI_MOVD2A(0, 16, ADDR_MOD_3, p_movd2a::MOV_4_ROWS, 16);
+                TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 32);
+                TTI_MOVD2B(0, 16, ADDR_MOD_3, p_movd2b::MOV_4_ROWS, 48);
                 TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
                 TTI_ELWADD(3, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_3, 0);
             }

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
@@ -8,10 +8,10 @@
 #include "../../../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
 
 // Fused SiLU activation support (only when FUSE_SILU is defined)
-// For m=1 tiles, we use optimized SFPU with:
-// - VectorMode::R: processes only Face0+Face1 (top row), 2x faster
-// - ITERATIONS=2: processes 2 rows per face instead of 8, 4x faster
-// Total: ~8x faster than default silu_tile()
+// For tiny tiles (m <= 8), we use optimized SFPU with:
+// - VectorMode::R: processes only row faces, 2x faster
+// - ITERATIONS: minimum 2 required for SFPU, then scales (m<=4->2, m=8->4, m>=16->8)
+// Total: significant speedup vs default silu_tile()
 #ifdef FUSE_SILU
 #include "compute_kernel_api.h"  // for silu_tile_init() and llk_math_eltwise_unary_sfpu_silu
 #endif
@@ -51,6 +51,7 @@ void MAIN {
     constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
     constexpr uint32_t subblock_w = get_compile_time_arg_val(5);
     constexpr uint32_t num_subblocks_k = get_compile_time_arg_val(6);
+    constexpr uint32_t tile_r_dim = get_compile_time_arg_val(7);  // tile row dimension (m)
 
     constexpr uint32_t transpose = false;
     constexpr uint32_t num_subblocks_n = per_core_N / subblock_w;
@@ -89,11 +90,21 @@ void MAIN {
             cb_pop_front(cb_id_in1, subblock_k);
         }
 
-        // Apply fused SiLU activation - optimized for m=1 tiles
-        // VectorMode::R (2x) + ITERATIONS=2 (4x) = ~8x speedup
+        // Apply fused SiLU activation - optimized for tiny tiles
+        // VectorMode::R processes only row faces (2x speedup)
+        // ITERATIONS: minimum 2 for m<=4, then scale up (m=8->4, m=16->8)
 #ifdef FUSE_SILU
         for (uint32_t i = 0; i < subblock_w; i++) {
-            MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE, 2>(i, (int)VectorMode::R)));
+            // ITERATIONS must be compile-time constant for template
+            // Minimum ITERATIONS=2 required for SFPU to work correctly with VectorMode::R
+            if constexpr (tile_r_dim <= 4) {
+                MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE, 2>(i, (int)VectorMode::R)));
+            } else if constexpr (tile_r_dim == 8) {
+                MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE, 4>(i, (int)VectorMode::R)));
+            } else {
+                // For larger tiles (16, 32), use full iterations
+                MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE, 8>(i, (int)VectorMode::R)));
+            }
         }
 #endif
         tile_regs_commit();

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/op.py
@@ -290,6 +290,7 @@ class DRAMStreamingMatmul:
             per_core_N,
             subblock_w,
             num_subblocks_k,
+            in0_tile_shape[0],  # tile_r_dim (m) for SFPU SILU iterations
         ]
 
         # Runtime args (per-core: bank_id and vc)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -104,7 +104,7 @@ def shuffle_tensor_tiles(tensor, tile_size, num_banks):
 
 
 @pytest.mark.parametrize("k, n", [(7168, 2048), (2048, 7168)])
-@pytest.mark.parametrize("m", [4])
+@pytest.mark.parametrize("m", [1, 4, 8])
 @pytest.mark.parametrize("fused_activation", [None, "silu"])
 def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """Test simplified DRAM streaming matmul with optional fused activation.

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -104,7 +104,7 @@ def shuffle_tensor_tiles(tensor, tile_size, num_banks):
 
 
 @pytest.mark.parametrize("k, n", [(7168, 2048), (2048, 7168)])
-@pytest.mark.parametrize("m", [1])
+@pytest.mark.parametrize("m", [4])
 @pytest.mark.parametrize("fused_activation", [None, "silu"])
 def test_dram_streaming_matmul(device, k, n, m, fused_activation):
     """Test simplified DRAM streaming matmul with optional fused activation.


### PR DESCRIPTION
### Ticket
no ticket

### Problem description
Current custom_block_mm supports 1x32 only. Need to extend it to support more tile shapes for high batch Deepseek.

### What's changed
when load from D to A/B, copy 4 face rows instead of 1, for 4x32 tile. for 8x32 tile, copy 8 rows.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yugao/matmul-exp3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:yugao/matmul-exp3)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/matmul-exp3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/matmul-exp3)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/matmul-exp3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/matmul-exp3)
- [ ] New/Existing tests provide coverage for changes