### PR TITLE
Pool2D Support for Rank 2 and Rank 3 Tensors

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -823,7 +823,7 @@ def test_golden_maxpool2d_with_vovnet_params(device, padding):
     ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"
 
 
-# quick test to verify the results of max pool are the same for tesnors with the N or C dim squeezed
+# quick test to verify the results of max pool are the same for tensors with the N or C dim squeezed
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("rank", [4, 3, 2])
 def test_run_max_pool_low_rank(rank, device):

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -841,13 +841,10 @@ def test_run_max_pool_low_rank(rank, device):
 
     # Create input tensor based on rank
     if rank == 4:
-        test_shape = [1, 112, 112, 1]
         torch_test_input = torch_input_nhwc
     elif rank == 3:
-        test_shape = [112, 112, 1]
         torch_test_input = torch_input_nhwc.squeeze(0)  # Remove batch dim
     else:  # rank == 2
-        test_shape = [112, 112]
         torch_test_input = torch_input_nhwc.squeeze(0).squeeze(-1)  # Remove batch and channel dims
 
     # Convert to ttnn tensor

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -821,3 +821,47 @@ def test_golden_maxpool2d_with_vovnet_params(device, padding):
     assert torch.equal(
         golden_torch, torch_output
     ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",
+    (([1, 1, 112, 112],)),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    ((3, 3),),
+)
+@pytest.mark.parametrize(
+    "padding",
+    ((0, 0),),
+    ((1, 1),),
+)
+@pytest.mark.parametrize("stride", ((2, 2),))
+@pytest.mark.parametrize(
+    "dilation",
+    ((1, 1),),
+)
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_run_max_pool_low_rank(
+    input_shape,
+    kernel_size,
+    padding,
+    stride,
+    dilation,
+    device,
+    tensor_map,
+    in_dtype,
+):
+    run_max_pool2d(
+        input_shape,
+        kernel_size,
+        padding,
+        stride,
+        dilation,
+        device,
+        tensor_map,
+        ttnn.bfloat16,
+        ceil_mode=False,
+        config_tensor_in_dram=False,
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
@@ -823,45 +823,68 @@ def test_golden_maxpool2d_with_vovnet_params(device, padding):
     ), f"Golden function produces incorrect output. Expected shape: {torch_output.shape}, got: {golden_torch.shape}"
 
 
+# quick test to verify the results of max pool are the same for tesnors with the N or C dim squeezed
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
-@pytest.mark.parametrize(
-    "input_shape",
-    (([1, 1, 112, 112],)),
-)
-@pytest.mark.parametrize(
-    "kernel_size",
-    ((3, 3),),
-)
-@pytest.mark.parametrize(
-    "padding",
-    ((0, 0),),
-    ((1, 1),),
-)
-@pytest.mark.parametrize("stride", ((2, 2),))
-@pytest.mark.parametrize(
-    "dilation",
-    ((1, 1),),
-)
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_run_max_pool_low_rank(
-    input_shape,
-    kernel_size,
-    padding,
-    stride,
-    dilation,
-    device,
-    tensor_map,
-    in_dtype,
-):
-    run_max_pool2d(
-        input_shape,
-        kernel_size,
-        padding,
-        stride,
-        dilation,
-        device,
-        tensor_map,
-        ttnn.bfloat16,
-        ceil_mode=False,
-        config_tensor_in_dram=False,
+@pytest.mark.parametrize("rank", [4, 3, 2])
+def test_run_max_pool_low_rank(rank, device):
+    """Test max_pool2d with different tensor ranks: [1,112,112,1], [112,112,1], [112,112]"""
+    kernel_size = (3, 3)
+    stride = (2, 2)
+    padding = (0, 0)
+
+    # Create torch input in NCHW format [1, 1, 112, 112]
+    torch.manual_seed(0)
+    torch_input_nchw = torch.randn(1, 1, 112, 112, dtype=torch.bfloat16)
+
+    # Permute to NHWC [1, 112, 112, 1]
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1)
+
+    # Create input tensor based on rank
+    if rank == 4:
+        test_shape = [1, 112, 112, 1]
+        torch_test_input = torch_input_nhwc
+    elif rank == 3:
+        test_shape = [112, 112, 1]
+        torch_test_input = torch_input_nhwc.squeeze(0)  # Remove batch dim
+    else:  # rank == 2
+        test_shape = [112, 112]
+        torch_test_input = torch_input_nhwc.squeeze(0).squeeze(-1)  # Remove batch and channel dims
+
+    # Convert to ttnn tensor
+    ttnn_input = ttnn.from_torch(
+        torch_test_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
     )
+
+    # Run ttnn max_pool2d
+    ttnn_output = ttnn.max_pool2d(
+        input_tensor=ttnn_input,
+        batch_size=1,
+        input_h=112,
+        input_w=112,
+        channels=1,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=(1, 1),
+    )
+
+    # Run torch reference
+    torch_output_nchw = torch.nn.functional.max_pool2d(
+        torch_input_nchw,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+    )
+    torch_output_nhwc = torch_output_nchw.permute(0, 2, 3, 1)
+
+    # Convert ttnn output to torch and compare
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    # ttnn output is always 4D [1, H, W, 1], reshape for comparison
+    out_h, out_w = torch_output_nchw.shape[2], torch_output_nchw.shape[3]
+    ttnn_output_torch = ttnn_output_torch.reshape(1, out_h, out_w, 1)
+
+    assert torch.equal(ttnn_output_torch, torch_output_nhwc)

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -55,7 +55,7 @@ Tensor global_avg_pool2d(
         input_4d = ttnn::reshape(input, reshaped_logical, reshaped_padded);
         in_shape = input_4d.padded_shape();
     } else if (rank != 4) {
-        TT_THROW("Input tensor must be rank 2, 3, or 4");
+        TT_THROW("Input tensor must be rank 2, 3, or 4, got rank {}", rank);
     }
 
     auto output = input_4d;

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/experimental/reshape/view.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 namespace tt::tt_metal {
 
@@ -26,9 +27,39 @@ Tensor pool_2d(
 Tensor global_avg_pool2d(
     const Tensor& input, const MemoryConfig& memory_config, const std::optional<DataType>& output_dtype) {
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor needs to be on device");
-    auto output = input;
 
+    // Handle different tensor ranks: 2D [H,W], 3D [H,W,C], or 4D [N,H,W,C]
     auto in_shape = input.padded_shape();
+    auto logical_shape = input.logical_shape();
+    uint32_t rank = in_shape.rank();
+
+    Tensor input_4d = input;
+
+    // Reshape to 4D if needed
+    if (rank == 3) {
+        // Rank 3: [H, W, C] -> [1, H, W, C]
+        log_debug(
+            tt::LogOp,
+            "GlobalAvgPool2D: Rank-3 input tensor detected, assuming [H, W, C] format and reshaping to [1, H, W, C]");
+        ttnn::Shape reshaped_logical({1, logical_shape[0], logical_shape[1], logical_shape[2]});
+        ttnn::Shape reshaped_padded({1, in_shape[0], in_shape[1], in_shape[2]});
+        input_4d = ttnn::reshape(input, reshaped_logical, reshaped_padded);
+        in_shape = input_4d.padded_shape();
+    } else if (rank == 2) {
+        // Rank 2: [H, W] -> [1, H, W, 1]
+        log_debug(
+            tt::LogOp,
+            "GlobalAvgPool2D: Rank-2 input tensor detected, assuming [H, W] format and reshaping to [1, H, W, 1]");
+        ttnn::Shape reshaped_logical({1, logical_shape[0], logical_shape[1], 1});
+        ttnn::Shape reshaped_padded({1, in_shape[0], in_shape[1], 1});
+        input_4d = ttnn::reshape(input, reshaped_logical, reshaped_padded);
+        in_shape = input_4d.padded_shape();
+    } else if (rank != 4) {
+        TT_THROW("Input tensor must be rank 2, 3, or 4");
+    }
+
+    auto output = input_4d;
+
     ttnn::Shape output_shape({in_shape[0], 1, in_shape[1] * in_shape[2], in_shape[3]});
     output = ttnn::experimental::view(output, output_shape);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/14722

### Problem description
Currently Pool2D requires input tensors to be rank 4.  In some cases if the N or C dimensions are 1 a tensor may be represented as rank 2 or 3.  If one of these low rank tensors was passed to max pool it would crash.

### What's changed
Pool2D has been updated to detect Rank 2 or 3 tensors and reshape then as necessary assuming dims of either HWC or HW.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21260254218
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
http://github.com/tenstorrent/tt-metal/actions/runs/21260258239/job/61220707580
only failing 1 test which is now skipped for BH on main
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21260270654
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21260276509
unrelated failures same as main
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/21260281826
Only failing 1 test also failing on main