### PR TITLE
[skip ci] Update time_budget.yaml

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -64,8 +64,8 @@ metal_infra:
     wh_galaxy: 0
     bh_galaxy: 0
 
-
-# Current time budgets are sums of timeouts of existing tests.
+# Current time budgets are based on sums of existing tests.
+# No official decision has been made yet for division of budgets per team.
 ttnn:
   unit:
     wh_llmbox: 50
@@ -94,7 +94,7 @@ models:
   e2e:
     wh_llmbox: 35
   unit:
-    wh_llmbox: 257
+    wh_llmbox: 277
   integration:
     wh_llmbox: 422
   perf:


### PR DESCRIPTION
Fix time budget issue due to lowering models unit t3k budget conflicting with a test being added.

Force merging because T3k unit test pipelines will keep failing otherwise.

Reference
https://tenstorrent.slack.com/archives/C08SJ7MGESY/p1769107117052839