### PR TITLE
Fix disable_mock_mode() to fully reset mock device state

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -87,4 +87,20 @@ TEST_F(MockDeviceAPIFixture, ConfigureMockModeFromHwDetectsArchitecture) {
     ASSERT_TRUE(desc.has_value());
 }
 
+TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
+    experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+    EXPECT_TRUE(experimental::get_mock_cluster_desc().has_value());
+
+    experimental::disable_mock_mode();
+    EXPECT_FALSE(experimental::is_mock_mode_registered());
+    EXPECT_FALSE(experimental::get_mock_cluster_desc().has_value());
+
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 2);
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+    auto desc = experimental::get_mock_cluster_desc();
+    ASSERT_TRUE(desc.has_value());
+    EXPECT_EQ(*desc, "wormhole_N300.yaml");
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -4,9 +4,12 @@
 
 #include <gtest/gtest.h>
 #include <tt-metalium/experimental/mock_device.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <umd/device/types/arch.hpp>
 
+#include "impl/context/metal_context.hpp"
 #include "llrt/get_platform_architecture.hpp"
+#include "llrt/tt_cluster.hpp"
 
 namespace tt::tt_metal {
 
@@ -88,6 +91,7 @@ TEST_F(MockDeviceAPIFixture, ConfigureMockModeFromHwDetectsArchitecture) {
 }
 
 TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
+    // Test API state transitions: configure, disable, reconfigure
     experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
     EXPECT_TRUE(experimental::is_mock_mode_registered());
     EXPECT_TRUE(experimental::get_mock_cluster_desc().has_value());
@@ -101,6 +105,36 @@ TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
     auto desc = experimental::get_mock_cluster_desc();
     ASSERT_TRUE(desc.has_value());
     EXPECT_EQ(*desc, "wormhole_N300.yaml");
+}
+
+TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardwareWithDeviceCreation) {
+    // Comprehensive test: verify disable_mock_mode() properly reinitializes MetalContext
+    // and cleans up device-specific data structures when switching from mock to real hardware
+    experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
+    EXPECT_TRUE(experimental::is_mock_mode_registered());
+
+    // Create and close a device to populate device-specific maps
+    {
+        auto device = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+        device->close();
+        device.reset();
+    }
+
+    // Disable mock mode - should reinitialize MetalContext for real hardware
+    // This clears device-specific maps (dram_bank_offset_map_, l1_bank_offset_map_, etc.)
+    // and reinitializes base objects (cluster_, hal_) with real hardware
+    experimental::disable_mock_mode();
+    EXPECT_FALSE(experimental::is_mock_mode_registered());
+    EXPECT_EQ(MetalContext::instance().get_cluster().get_target_device_type(), tt::TargetDevice::Silicon);
+
+    // Create real hardware device - verifies full reinitialization worked correctly
+    // including cleanup and reinitialization of device-specific data structures
+    {
+        auto real_device = distributed::MeshDevice::create(distributed::MeshDeviceConfig(distributed::MeshShape{1, 1}));
+        EXPECT_EQ(MetalContext::instance().get_cluster().get_target_device_type(), tt::TargetDevice::Silicon);
+        real_device->close();
+        real_device.reset();
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -92,6 +92,9 @@ public:
         bool minimal = false);
     void teardown();
 
+    // Switch from mock mode to real hardware (requires all devices to be closed)
+    void reinitialize_for_real_hardware();
+
     // Control plane accessors
     void initialize_control_plane();
     tt::tt_fabric::ControlPlane& get_control_plane();
@@ -152,6 +155,7 @@ private:
     void initialize_control_plane_impl();  // Private implementation without mutex
     void teardown_fabric_config();
     void teardown_base_objects();
+    void initialize_base_objects();
 
     void reset_cores(ChipId device_id);
     void assert_cores(ChipId device_id);

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -70,6 +70,7 @@ public:
     std::unique_ptr<ProfilerStateManager>& profiler_state_manager() { return profiler_state_manager_; }
     std::unique_ptr<DataCollector>& data_collector() { return data_collector_; }
     std::unique_ptr<DeviceManager>& device_manager() { return device_manager_; }
+    bool is_device_manager_initialized() const { return device_manager_ != nullptr; }
 
     std::unique_ptr<NOCDebugState>& noc_debug_state() { return noc_debug_state_; }
 
@@ -210,6 +211,9 @@ private:
     // Mutex to protect timeout detection for thread-safe access
     std::mutex dispatch_timeout_detection_mutex_;
     bool dispatch_timeout_detection_processed_ = false;
+
+    // Mutex to protect reinitialization operations (switching between mock and real hardware)
+    std::mutex reinitialization_mutex_;
 
     // Written to device as part of FW init, device-specific
     std::unordered_map<ChipId, std::vector<int32_t>> dram_bank_offset_map_;

--- a/tt_metal/impl/device/mock_device.cpp
+++ b/tt_metal/impl/device/mock_device.cpp
@@ -8,10 +8,10 @@
 #include <tt_stl/assert.hpp>
 #include <unordered_map>
 #include "llrt/get_platform_architecture.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal::experimental {
 
-// Internal configuration struct
 struct MockDeviceConfig {
     tt::ARCH arch;
     uint32_t num_chips;
@@ -33,8 +33,13 @@ void configure_mock_mode_from_hw() {
 }
 
 void disable_mock_mode() {
+    if (!g_registered_mock_config.has_value()) {
+        return;
+    }
+
     g_registered_mock_config = std::nullopt;
-    log_info(tt::LogMetal, "Mock mode disabled");
+    tt::tt_metal::MetalContext::instance().reinitialize_for_real_hardware();
+    log_info(tt::LogMetal, "Mock mode disabled and switched to real hardware");
 }
 
 bool is_mock_mode_registered() {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -654,6 +654,13 @@ public:
             runtime_target_device_ = tt::TargetDevice::Mock;
         }
     }
+    void clear_mock_cluster_desc() {
+        mock_cluster_desc_path.clear();
+        // Only reset to Silicon if simulator is not enabled
+        if (simulator_path.empty()) {
+            runtime_target_device_ = tt::TargetDevice::Silicon;
+        }
+    }
 
     // Target device accessor
     TargetDevice get_target_device() const { return runtime_target_device_; }


### PR DESCRIPTION
Fix disable_mock_mode() to fully reset mock device state
Fixes issue #14000

Issue:
disable_mock_mode() cleared the config flag but not mock_cluster_desc_path in rtoptions_, so subsequent devices still used mock mode.

Solution:
- Added MetalContext::reinitialize_for_real_hardware() to reinitialize cluster/hal with real hardware
- Added RunTimeOptions::clear_mock_cluster_desc() to clear mock state
- Updated disable_mock_mode() to call reinitialization

Impact:
Enables switching from mock device to real hardware within the same process.
