### PR TITLE
[GPT-OSS] reduce default prefill chunk size experts

### DIFF
--- a/models/demos/gpt_oss/tt/experts_throughput/__init__.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/__init__.py
@@ -183,7 +183,7 @@ class ThroughputExperts:
         topk_expert_indices: ttnn.Tensor,
         topk_expert_weights: ttnn.Tensor,
         is_decode: bool = True,
-        chunk_size: int = 2048,
+        chunk_size: int = 1024,
     ) -> ttnn.Tensor:
         """
         Forward pass - automatically dispatches to decode or prefill.
@@ -250,7 +250,7 @@ class ThroughputExperts:
         hidden_states: ttnn.Tensor,
         topk_expert_indices: ttnn.Tensor,
         topk_expert_weights: ttnn.Tensor,
-        chunk_size: int = 2048,
+        chunk_size: int = 1024,
     ) -> ttnn.Tensor:
         """
         Prefill forward pass.

--- a/models/demos/gpt_oss/tt/experts_throughput/weights.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/weights.py
@@ -139,19 +139,6 @@ def load_throughput_expert_weights(
         1, num_experts, 1, hidden_size
     )
 
-    # Transpose for matmul: [1, num_experts, out_features, in_features] -> [1, num_experts, in_features, out_features]
-    # w1 = w1.transpose(-1, -2)
-    # w2 = w2.transpose(-1, -2)
-    # w3 = w3.transpose(-1, -2)
-
-    # Reshape bias for proper broadcasting with sparse_matmul output
-    # sparse_matmul output shape: [1, num_sparse_blocks, 1, num_local_experts, local_batch, dim]
-    # We need bias shape: [1, 1, 1, num_local_experts, 1, dim] after sharding
-    # So before sharding: [1, 1, 1, num_experts, 1, dim]
-    w1_bias = w1_bias.reshape(1, 1, 1, num_experts, 1, intermediate_size)
-    w3_bias = w3_bias.reshape(1, 1, 1, num_experts, 1, intermediate_size)
-    w2_bias = w2_bias.reshape(1, 1, 1, num_experts, 1, hidden_size)
-
     # Load and shard weights
     w1_tt = _shard_experts_by_device(
         w1,

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -108,7 +108,7 @@ class ModelArgs:
             self.tokenizer = AutoTokenizer.from_pretrained(self.weights_path, trust_remote_code=True)
             self.processor = None  # GPT-OSS doesn't use vision processor
 
-        self.capped_warmup_seq_len = 2048
+        self.capped_warmup_seq_len = self.max_prefill_chunk_size
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 
     def get_warmup_prefill_supported_seq_lens(self):


### PR DESCRIPTION
### Ticket
#29619 

### Problem description
GPT-OSS-120b runs out of DRAM in prefill for sequences > 1k.

### What's changed
Reduce the prefill chunk size to increase the supported prefill length to 128k

#### Model tests

- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=handrews/fix-gpt-oss-seq-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:handrews/fix-gpt-oss-seq-len)
- [ ] [![(Galaxy) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=handrews/fix-gpt-oss-seq-len)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml?query=branch:handrews/fix-gpt-oss-seq-len)
