### PR TITLE
Add support of choosing position_ids in tests

### DIFF
--- a/models/demos/deepseek_v3/tests/pytest_utils.py
+++ b/models/demos/deepseek_v3/tests/pytest_utils.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+def expand_test_cases_with_position_ids_ranges(base_cases):
+    """
+    Expand test cases where position_ids ranges are expanded into individual test cases.
+
+    Args:
+        base_cases: List of tuples (mode, seq_len, batch_size_per_row, decode_position_ids)
+            where decode_position_ids can be:
+            - None: random position_ids
+            - int: single position_id
+            - tuple(start, end): range from start to end (inclusive), step=1
+            - tuple(start, end, step): range from start to end (inclusive) with given step
+
+    Returns:
+        List of expanded test cases with individual position_ids
+
+    Examples:
+        >>> base_cases = [
+        ...     ("decode", 1, 32, None),  # Random position_ids
+        ...     ("decode", 1, 32, 1024),  # Single position_id
+        ...     ("decode", 1, 32, (4096, 4100, 2)),  # Range with step=2: 4096, 4098, 4100
+        ... ]
+        >>> expand_test_cases_with_position_ids_ranges(base_cases)
+        [
+            ("decode", 1, 32, None),
+            ("decode", 1, 32, 1024),
+            ("decode", 1, 32, 4096),
+            ("decode", 1, 32, 4098),
+            ("decode", 1, 32, 4100),
+        ]
+    """
+
+    def _process_tuple(mode, seq_len, batch_size_per_row, decode_position_ids):
+        expanded_cases = []
+        if isinstance(decode_position_ids, tuple):
+            if len(decode_position_ids) == 2:
+                # Expand range into individual position_ids with step=1
+                start, end = decode_position_ids
+                step = 1
+            elif len(decode_position_ids) == 3:
+                # Expand range into individual position_ids with given step
+                start, end, step = decode_position_ids
+                if step <= 0:
+                    raise ValueError(f"step must be > 0, got {step}")
+            else:
+                raise ValueError(
+                    f"Invalid range format: {decode_position_ids}. Expected (start, end) or (start, end, step)"
+                )
+
+            for pos_id in range(start, end + 1, step):
+                expanded_cases.append((mode, seq_len, batch_size_per_row, pos_id))
+        else:
+            expanded_cases.append((mode, seq_len, batch_size_per_row, decode_position_ids))
+
+        return expanded_cases
+
+    expanded_cases = []
+    for sample in base_cases:
+        values = getattr(sample, "values", None)
+        is_pytest_param = values is not None and hasattr(sample, "marks") and hasattr(sample, "id")
+        if is_pytest_param:
+            mode, seq_len, batch_size_per_row, decode_position_ids = values
+        else:
+            mode, seq_len, batch_size_per_row, decode_position_ids = sample
+
+        cur_cases = _process_tuple(mode, seq_len, batch_size_per_row, decode_position_ids)
+        if is_pytest_param:
+            cur_cases = [pytest.param(*case, marks=sample.marks, id=sample.id) for case in cur_cases]
+        expanded_cases.extend(cur_cases)
+
+    return expanded_cases
+
+
+def build_expanded_test_ids(expanded_cases):
+    """
+    Build pytest ids for expanded test cases.
+
+    This is intended to be used with the output of
+    `expand_test_cases_with_position_ids_ranges`, so the IDs align with the
+    expanded (mode, seq_len, batch_size_per_row, decode_position_ids) tuples.
+    For prefill cases, `decode_position_ids` is not applicable and is omitted
+    from the generated ID.
+
+    Examples:
+        >>> expanded_cases = [
+        ...     ("decode", 1, 32, None),
+        ...     ("decode", 1, 32, 1024),
+        ...     ("prefill", 128, 1, None),
+        ... ]
+        >>> build_expanded_test_ids(expanded_cases)
+        [
+            "mode_decode_seq_1_batch_32_pos_random",
+            "mode_decode_seq_1_batch_32_pos_1024",
+            "mode_prefill_seq_128_batch_1",
+        ]
+    """
+    expanded_ids = []
+    for val in expanded_cases:
+        if not isinstance(val, tuple) and getattr(val, "values", None) is None:
+            expanded_ids.append(str(val))
+            continue
+
+        values = getattr(val, "values", None)
+        if values is not None:
+            mode, seq_len, batch_size_per_row, decode_pos = values
+        else:
+            mode, seq_len, batch_size_per_row, decode_pos = val
+        if mode == "decode":
+            pos_str = decode_pos if decode_pos is not None else "random"
+            expanded_ids.append(f"mode_{mode}_seq_{seq_len}_batch_{batch_size_per_row}_pos_{pos_str}")
+        else:
+            expanded_ids.append(f"mode_{mode}_seq_{seq_len}_batch_{batch_size_per_row}")
+    return expanded_ids

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -12,6 +12,10 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.conftest import PREFILL_SEQ_LENS
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3DecoderLayer
+from models.demos.deepseek_v3.tests.pytest_utils import (
+    build_expanded_test_ids,
+    expand_test_cases_with_position_ids_ranges,
+)
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_1d import DecoderBlock1D
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_1d_base import DecoderBlock1DBase
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
@@ -44,6 +48,7 @@ def generate_reference_io(
     batch_size: int,
     mode: str,
     state_dict: dict[str, torch.Tensor],
+    decode_position_id: int | None = None,
 ):
     reference_model = DeepseekV3DecoderLayer(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
     if module_path is not None:
@@ -62,7 +67,18 @@ def generate_reference_io(
     if mode == "prefill":
         position_ids_or_seq_lens = torch.tensor([seq_len])
     else:
-        position_ids = position_ids_or_seq_lens = torch.randint(0, hf_config.max_seq_len - 1, (batch_size,))
+        if decode_position_id is None:
+            position_ids = position_ids_or_seq_lens = torch.randint(
+                0, hf_config.max_seq_len - 1, (batch_size,), dtype=torch.long
+            )
+        else:
+            if not isinstance(decode_position_id, int):
+                raise ValueError(f"decode_position_id must be int or None, got {type(decode_position_id)}")
+            if not (0 <= decode_position_id < hf_config.max_seq_len):
+                raise ValueError(
+                    f"decode_position_id must be in [0, {hf_config.max_seq_len - 1}], got {decode_position_id}"
+                )
+            position_ids = position_ids_or_seq_lens = torch.ones(batch_size, dtype=torch.long) * decode_position_id
     reference_output, input_cache, output_cache = run_reference_with_attention(
         reference_model, torch_input, position_ids_or_seq_lens, layer_idx, hf_config, mode, False
     )
@@ -88,6 +104,7 @@ def run_test_forward_pass_decoder1d(
     ccl,
     force_recalculate_weight_config,
     state_dict,
+    decode_position_ids: int | None = None,
 ):
     # Check params
     if mode == "prefill":
@@ -104,6 +121,7 @@ def run_test_forward_pass_decoder1d(
         batch_size,
         mode,
         state_dict,
+        decode_position_ids,
     )
 
     # Set up page config
@@ -198,6 +216,7 @@ def run_test_forward_pass_decoder2d(
     ccl,
     force_recalculate_weight_config,
     state_dict,
+    decode_position_ids: int | None = None,
 ):
     # Check params
     if mode == "prefill":
@@ -216,6 +235,7 @@ def run_test_forward_pass_decoder2d(
         batch_size,
         mode,
         state_dict,
+        decode_position_ids,
     )
 
     # Set up page config
@@ -292,6 +312,29 @@ def run_test_forward_pass_decoder2d(
     assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.9899)
 
 
+# Base test cases - ranges will be expanded into individual test cases
+# see documentation for expand_test_cases_with_position_ids_ranges for more details
+BASE_TEST_CASES = [
+    # mode, seq_len, batch_size_per_row, decode_position_ids
+    ("decode", 1, USERS_PER_ROW, None),
+] + [
+    ("prefill", seq_len, 1, None)
+    if seq_len == 128
+    else pytest.param(
+        "prefill",
+        seq_len,
+        1,
+        None,
+        marks=pytest.mark.skip(
+            f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+        ),
+    )
+    for seq_len in PREFILL_SEQ_LENS
+]
+EXPANDED_TEST_CASES = expand_test_cases_with_position_ids_ranges(BASE_TEST_CASES)
+EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
+
+
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -353,23 +396,9 @@ def run_test_forward_pass_decoder2d(
     ],
 )
 @pytest.mark.parametrize(
-    "mode, seq_len, batch_size_per_row",
-    [
-        ("decode", 1, 32),
-    ]
-    + [
-        ("prefill", seq_len, 1)
-        if seq_len == 128
-        else pytest.param(
-            "prefill",
-            seq_len,
-            1,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
-            ),
-        )
-        for seq_len in PREFILL_SEQ_LENS
-    ],
+    "mode, seq_len, batch_size_per_row, decode_position_ids",
+    EXPANDED_TEST_CASES,
+    ids=EXPANDED_TEST_IDS,
 )
 def test_forward_pass(
     DecoderBlockClass: type[DecoderBlock1DBase],
@@ -378,6 +407,7 @@ def test_forward_pass(
     mode,
     seq_len,
     batch_size_per_row,
+    decode_position_ids,
     hf_config_short,
     cache_path,
     mesh_device,
@@ -388,6 +418,9 @@ def test_forward_pass(
     set_deterministic_env,
     state_dict,
 ):
+    if mode != "decode":
+        decode_position_ids = None
+
     test_closure(
         DecoderBlockClass,
         module_path,
@@ -402,6 +435,7 @@ def test_forward_pass(
         ccl,
         force_recalculate_weight_config,
         state_dict,
+        decode_position_ids,
     )
 
 

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 import torch
-from _pytest.mark.structures import ParameterSet
 from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
@@ -14,6 +13,10 @@ import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.conftest import PREFILL_SEQ_LENS
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
+from models.demos.deepseek_v3.tests.pytest_utils import (
+    build_expanded_test_ids,
+    expand_test_cases_with_position_ids_ranges,
+)
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
@@ -32,102 +35,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
 
 PCC_REQUIRED = 0.99
 PCC_REQUIRED_KVPE = 0.999
-
-
-def expand_test_cases_with_position_ids_ranges(base_cases):
-    """
-    Expand test cases where position_ids ranges are expanded into individual test cases.
-
-    Args:
-        base_cases: List of tuples (mode, seq_len, batch_size_per_row, decode_position_ids)
-            where decode_position_ids can be:
-            - None: random position_ids
-            - int: single position_id
-            - tuple(start, end): range from start to end (inclusive), step=1
-            - tuple(start, end, step): range from start to end (inclusive) with given step
-
-    Returns:
-        List of expanded test cases with individual position_ids
-
-    Examples:
-        >>> base_cases = [
-        ...     ("decode", 1, 32, None),  # Random position_ids
-        ...     ("decode", 1, 32, 1024),  # Single position_id: 1024
-        ...     ("decode", 1, 32, (4096, 4100, 2)),  # Range with step=2: 4096, 4098, 4100
-        ... ]
-        >>> expand_test_cases_with_position_ids_ranges(base_cases)
-        [
-            ("decode", 1, 32, None),
-            ("decode", 1, 32, 1024),
-            ("decode", 1, 32, 4096),
-            ("decode", 1, 32, 4098),
-            ("decode", 1, 32, 4100),
-        ]
-    """
-
-    def _process_tuple(mode, seq_len, batch_size_per_row, decode_position_ids):
-        expanded_cases = []
-        if isinstance(decode_position_ids, tuple):
-            if len(decode_position_ids) == 2:
-                # Expand range into individual position_ids with step=1
-                start, end = decode_position_ids
-                step = 1
-            elif len(decode_position_ids) == 3:
-                # Expand range into individual position_ids with given step
-                start, end, step = decode_position_ids
-                if step <= 0:
-                    raise ValueError(f"step must be > 0, got {step}")
-            else:
-                raise ValueError(
-                    f"Invalid range format: {decode_position_ids}. Expected (start, end) or (start, end, step)"
-                )
-
-            # Expand range with step
-            for pos_id in range(start, end + 1, step):
-                expanded_cases.append((mode, seq_len, batch_size_per_row, pos_id))
-        else:
-            # Keep as is (None or int)
-            expanded_cases.append((mode, seq_len, batch_size_per_row, decode_position_ids))
-
-        return expanded_cases
-
-    expanded_cases = []
-    for sample in base_cases:
-        is_pytest_param = isinstance(sample, ParameterSet)
-        if is_pytest_param:
-            mode, seq_len, batch_size_per_row, decode_position_ids = sample.values
-        else:
-            mode, seq_len, batch_size_per_row, decode_position_ids = sample
-
-        cur_cases = _process_tuple(mode, seq_len, batch_size_per_row, decode_position_ids)
-
-        if is_pytest_param:
-            cur_cases = [pytest.param(*values, marks=sample.marks, id=sample.id) for values in cur_cases]
-        expanded_cases.extend(cur_cases)
-
-    return expanded_cases
-
-
-def build_expanded_test_ids(expanded_cases):
-    """Build pytest ids for expanded test cases."""
-    expanded_ids = []
-    for val in expanded_cases:
-        if not isinstance(val, tuple):
-            expanded_ids.append(str(val))
-            continue
-
-        if isinstance(val, ParameterSet):
-            mode, seq_len, batch_size_per_row, decode_pos = val.values
-        else:
-            mode, seq_len, batch_size_per_row, decode_pos = val
-
-        if mode == "decode":
-            pos_str = decode_pos if decode_pos is not None else "random"
-            expanded_ids.append(f"mode_{mode}_seq_{seq_len}_batch_{batch_size_per_row}_pos_{pos_str}")
-        else:
-            # Prefill ignores decode_position_ids, so omit it from the ID
-            expanded_ids.append(f"mode_{mode}_seq_{seq_len}_batch_{batch_size_per_row}")
-    return expanded_ids
 
 
 def get_cache_on_host(tt_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice) -> torch.Tensor:

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -10,6 +10,10 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.conftest import PREFILL_SEQ_LENS
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3ForCausalLM
+from models.demos.deepseek_v3.tests.pytest_utils import (
+    build_expanded_test_ids,
+    expand_test_cases_with_position_ids_ranges,
+)
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
@@ -35,6 +39,7 @@ def generate_reference_io(
     hf_config: PretrainedConfig,
     model_path: str,
     state_dict: dict[str, torch.Tensor],
+    decode_position_id: int | None = None,
 ):
     """Generate reference input and output for the given mode using either real or random weights."""
     # This needs to be disabled as deterministic way to quantize weights is not supported
@@ -69,10 +74,18 @@ def generate_reference_io(
     if mode == "prefill":
         position_ids_or_seq_lens = torch.tensor([seq_len])
     else:
-        # position_ids = torch.randint(0, hf_config.max_seq_len - 1, (batch_size,))
-        position_ids = position_ids_or_seq_lens = torch.zeros(
-            (batch_size,), dtype=torch.long
-        )  # TODO: investigate the PCC issue with real weights
+        if decode_position_id is None:
+            position_ids = position_ids_or_seq_lens = torch.randint(
+                0, hf_config.max_seq_len - 1, (batch_size,), dtype=torch.long
+            )
+        else:
+            if not isinstance(decode_position_id, int):
+                raise ValueError(f"decode_position_id must be int or None, got {type(decode_position_id)}")
+            if not (0 <= decode_position_id < hf_config.max_seq_len):
+                raise ValueError(
+                    f"decode_position_id must be in [0, {hf_config.max_seq_len - 1}], got {decode_position_id}"
+                )
+            position_ids = position_ids_or_seq_lens = torch.ones(batch_size, dtype=torch.long) * decode_position_id
 
     logger.info(
         f"Running reference model with torch_input shape: {torch_input.shape} and position_ids shape: {position_ids_or_seq_lens.shape}"
@@ -102,6 +115,7 @@ def run_test_forward_pass_dpmodel(
     ccl,
     force_recalculate_weight_config,
     state_dict,
+    decode_position_ids: int | None = None,
 ):
     # Check params
     if mode == "prefill":
@@ -114,7 +128,7 @@ def run_test_forward_pass_dpmodel(
     # Get reference IO
     logger.info("Setting up reference IO")
     state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
-        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path, state_dict
+        use_real_weights, mode, seq_len, batch_size, hf_config_short, model_path, state_dict, decode_position_ids
     )
 
     # Set up page config
@@ -187,6 +201,30 @@ def run_test_forward_pass_dpmodel(
     assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.97)
 
 
+# Base test cases - ranges will be expanded into individual test cases
+# see documentation for expand_test_cases_with_position_ids_ranges for more details
+BASE_TEST_CASES = [
+    # mode, seq_len, batch_size_per_row, decode_position_ids
+    # ("decode", 1, USERS_PER_ROW, None), # TODO: test gives low PCC for random position_ids and non-zero position_ids cases. Need to investigate why.
+    ("decode", 1, USERS_PER_ROW, 0),
+] + [
+    ("prefill", seq_len, 1, None)
+    if seq_len == 128
+    else pytest.param(
+        "prefill",
+        seq_len,
+        1,
+        None,
+        marks=pytest.mark.skip(
+            f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+        ),
+    )
+    for seq_len in PREFILL_SEQ_LENS
+]
+EXPANDED_TEST_CASES = expand_test_cases_with_position_ids_ranges(BASE_TEST_CASES)
+EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
+
+
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -199,29 +237,16 @@ def run_test_forward_pass_dpmodel(
     [True],  # Test only with real weights for now
 )
 @pytest.mark.parametrize(
-    "mode, seq_len, batch_size_per_row",
-    [
-        ("decode", 1, 32),
-    ]
-    + [
-        ("prefill", seq_len, 1)
-        if seq_len == 128
-        else pytest.param(
-            "prefill",
-            seq_len,
-            1,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
-            ),
-        )
-        for seq_len in PREFILL_SEQ_LENS
-    ],
+    "mode, seq_len, batch_size_per_row, decode_position_ids",
+    EXPANDED_TEST_CASES,
+    ids=EXPANDED_TEST_IDS,
 )
 def test_forward_pass(
     use_real_weights,
     mode,
     seq_len,
     batch_size_per_row,
+    decode_position_ids,
     hf_config_short,
     cache_path,
     mesh_device,
@@ -233,6 +258,10 @@ def test_forward_pass(
 ):
     # Set less layers and shorter max length for the sake of testing
     hf_config_short.num_hidden_layers = 8
+
+    # Only use decode_position_ids for decode mode
+    if mode != "decode":
+        decode_position_ids = None
 
     run_test_forward_pass_dpmodel(
         use_real_weights,
@@ -246,6 +275,7 @@ def test_forward_pass(
         ccl,
         force_recalculate_weight_config,
         state_dict,
+        decode_position_ids,
     )
 
 


### PR DESCRIPTION
### Ticket
None

### What's changed
positions ids are created randomly for decode path. This change adds
support for selecting a specific position id for all the users. It also
allows to pass range of positions IDs to generate multiple tests for
decode path of test_model.py and test_decoder_block.py
This is needed to test these module for more concretely for various decode
size/positions.

Also little refactoring of test_mla.py
