### PR TITLE
Update PCC threshold for tt_transformers attention test

### DIFF
--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -61,7 +61,7 @@ def test_attention_inference(
     ensure_gc,
 ):
     dtype = ttnn.bfloat8_b
-    pcc = 0.99
+    pcc = 0.985
 
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len, cache_hf=True)
     model_args.n_layers = 1  # For the unit test, just run a single layer


### PR DESCRIPTION
### Problem description
This [PR](https://github.com/tenstorrent/tt-metal/pull/35618) caused one of the `t3000-unit-tests/t3k_llama3.2-90b_tests` to fail due to a below threshold PCC (`0.9860343790264618` vs `0.990677545460982` on `main` vs threshold of `0.99`) e.g. [this pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/21227431254/job/61078594508). It wasn't caught because the test was failing on `main` for other reasons. Triage [report](https://github.com/tenstorrent/tt-metal/actions/runs/21259781518).

The new exponential functions have ULP < 1 everywhere (except one point at large inputs -- see plot in the original PR). For other results in the test output the RTOL got better so I believe the threshold reduction is justified.

### What's changed
Decrease the PCC threshold to 0.985.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sosborne/update-pcc-threshold)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sosborne/update-pcc-threshold)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sosborne/update-pcc-threshold)


#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sosborne/update-pcc-threshold)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sosborne/update-pcc-threshold)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sosborne/update-pcc-threshold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sosborne/update-pcc-threshold)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)