### PR TITLE
Adding tailscale0 to tcp exclude list in mpirun scripts

### DIFF
--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -179,7 +179,7 @@ default() {
     fi
 
     # Build the command for each rank group
-    local base_mpirun_args="--tag-output --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_exclude docker0,lo"
+    local base_mpirun_args="--tag-output --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_exclude docker0,lo,tailscale0"
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then

--- a/tools/scaleout/exabox/recover_4x32.sh
+++ b/tools/scaleout/exabox/recover_4x32.sh
@@ -20,9 +20,9 @@ echo "Using hosts: $HOSTS"
 echo ""
 
 echo "Running tt-smi -glx_reset..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
 sleep 5
 
 echo ""
 echo "Running cluster validation..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/4xBH_4x32_intrapod/fsd.textproto --send-traffic --num-iterations 5
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/4xBH_4x32_intrapod/fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/recover_8x16.sh
+++ b/tools/scaleout/exabox/recover_8x16.sh
@@ -20,9 +20,9 @@ echo "Using hosts: $HOSTS"
 echo ""
 
 echo "Running tt-smi -glx_reset..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
 sleep 5
 
 echo ""
 echo "Running cluster validation..."
-mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto --send-traffic --num-iterations 5
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 --tag-output ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto --send-traffic --num-iterations 5

--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -37,7 +37,7 @@ for i in {1..50}; do
         echo ""
 
         echo "Running tt-smi -glx_reset..."
-        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
 
         echo ""
         echo "Running cluster validation..."

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -37,7 +37,7 @@ for i in {1..50}; do
         echo ""
 
         echo "Running tt-smi -glx_reset..."
-        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo tt-smi -glx_reset
+        mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
         sleep 5
 
         echo ""


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:akirby/exclude-tailscale0)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akirby/exclude-tailscale0)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akirby/exclude-tailscale0)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akirby/exclude-tailscale0)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akirby/exclude-tailscale0)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akirby/exclude-tailscale0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akirby/exclude-tailscale0)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs