### PR TITLE
#31107 Support binary_ng scalar value direct sharded to L1 for perfor…

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -665,19 +665,12 @@ inline auto is_uneven(const TensorSpec& t) {
 }
 
 bool is_native_L1_sharding(const TensorSpec& a, const std::optional<TensorSpec>& b, const MemoryConfig& c) {
-    // scalar value treated as interleaved
-    if (!b.has_value()) {
+    if (!c.is_sharded()) {
         return false;
     }
 
-    // does not work for width and block sharding, pcc error,
-    // maybe support later to improve performance
-    // if (!b.has_value() && a.memory_config().is_sharded()) {
-    //     return !is_uneven(a);
-    // }
-
-    if (!c.is_sharded()) {
-        return false;
+    if (!b.has_value() && a.memory_config().is_sharded()) {
+        return !is_uneven(a);
     }
 
     // a and b identical shape, no broadcast on any dimension

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -51,13 +51,41 @@ void kernel_main() {
     uint32_t start_tw = offset_c % Wt;
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
-    // Use simple linear tile reading for treating sharded as interleaved
-    for (uint32_t i = 0; i < dst_num_tiles; ++i) {
-        cb_reserve_back(cb_id_src, onetile);
-        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-        noc_async_read_page(start_tile_id + i, src, l1_write_addr_src);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_src, onetile);
+    // this is the INPUT tile offset
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+                            cb_reserve_back(cb_id_src, onetile);
+                            uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                            noc_async_read_page(tile_offset + tw, src, l1_write_addr_src);
+                            noc_async_read_barrier();
+                            cb_push_back(cb_id_src, onetile);
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                    }
+                    tile_offset += next_c_shift;
+                }
+                tile_offset += next_n_shift;
+            }
+            tile_offset += next_d_shift;
+        }
+        tile_offset += next_nd_shift;
     }
 #endif
 }


### PR DESCRIPTION
…mance

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31107)

### Problem description
Current implementation only use tensor accessor for both even and uneven shard.

### What's changed
Same kernel supports both direct L1 sharding for even shard, and tensor accessor for uneven shard. Direct L1 sharding is high performance.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dchen/31107-scalar_sharding)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/31107-scalar_sharding)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/31107-scalar_sharding)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/31107-scalar_sharding)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/31107-scalar_sharding)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/31107-scalar_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/31107-scalar_sharding)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs