### PR TITLE
Fixing the opcode names in perf logs

### DIFF
--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -21,7 +21,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
-
+#include <iostream>
 using json = nlohmann::json;
 
 namespace tt::tt_metal::op_profiler {
@@ -412,6 +412,10 @@ inline json get_base_json(
 
     auto as_string = [](std::string_view v) -> std::string { return {v.data(), v.size()}; };
     std::string opName = as_string(tt::stl::get_type_name<device_operation_t>());
+    if constexpr (requires { device_operation_t::get_type_name(operation_attributes); }) {
+        opName = device_operation_t::get_type_name(operation_attributes);
+    }
+
     std::replace(opName.begin(), opName.end(), ',', ';');
     j["op_code"] = opName;
 

--- a/ttnn/api/tools/profiler/op_profiler.hpp
+++ b/ttnn/api/tools/profiler/op_profiler.hpp
@@ -21,7 +21,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
-#include <iostream>
+
 using json = nlohmann::json;
 
 namespace tt::tt_metal::op_profiler {


### PR DESCRIPTION
### Ticket
N/A
### Problem description
Some code in `op_profiler.hpp` was removed in commit 197bbceafc81f60076143a46643726679375922c that caused opcodes to be logged using their template type name verbatim (e.g., `Conv2dDeviceOperation` started showing up as `MeshDeviceOperationAdapter<ttnn::prim::Conv2dDeviceOperation`).
### What's changed
This PR adds those lines back to fix the opcode names showing up in the perf reports.

### Checklist
- [x] [All-post commits](https://github.com/tenstorrent/tt-metal/actions/runs/21268452113)
- [x] [Blackhole post commit](https://github.com/tenstorrent/tt-metal/actions/runs/21268475061) compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/21263094566/job/61204281746).
- [x] New/Existing tests provide coverage for changes