### PR TITLE
[TTT] fix model prefill api

### DIFF
--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -195,7 +195,14 @@ class Transformer(LightweightModule):
         return tt_tokens, tt_page_table, tt_chunk_page_table
 
     def prepare_inputs_prefill(
-        self, tokens, start_pos=0, page_table=None, chunk_page_table=None, trace_enabled=False, last_token_idx=None
+        self,
+        tokens,
+        start_pos=0,
+        page_table=None,
+        chunk_page_table=None,
+        trace_enabled=False,
+        last_token_idx=None,
+        global_user_id=None,
     ):
         """
         Inputs are torch tensors or python types. This function returns ttnn


### PR DESCRIPTION
### Problem description
#34733 broke the TTT model API

### What's changed
Add the required prefill global user id as an unused arg

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix-ttt-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix-ttt-prefill)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=fix-ttt-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:fix-ttt-prefill)
- [ ] [![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=fix-ttt-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch:fix-ttt-prefill) 
- [ ] [![vLLM nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml/badge.svg?branch=fix-ttt-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml?query=branch:fix-ttt-prefill) Qwen2.5 VL failing due to existing issue