### PR TITLE
[skip ci] Bumped expected decode time falcon7b_common

### DIFF
--- a/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
@@ -87,9 +87,9 @@ def test_device_perf_wh_bare_metal(
         ("prefill", 1, 128, 0, "BFLOAT16-DRAM", 2115),
         ("prefill", 1, 1024, 0, "BFLOAT16-DRAM", 3120),
         ("prefill", 1, 2048, 0, "BFLOAT16-DRAM", 2870),
-        ("decode", 32, 1, 128, "BFLOAT16-L1_SHARDED", 629),
+        ("decode", 32, 1, 128, "BFLOAT16-L1_SHARDED", 647),
         ("decode", 32, 1, 1024, "BFLOAT16-L1_SHARDED", 572),
-        ("decode", 32, 1, 2047, "BFLOAT16-L1_SHARDED", 533),
+        ("decode", 32, 1, 2047, "BFLOAT16-L1_SHARDED", 548),
     ),
 )
 def test_device_perf(llm_mode, batch, seq_len, kv_cache_len, model_config_str, samples):


### PR DESCRIPTION
### Problem description
Falcon7b is failing due to being above expected threshold of samples/s
(faster than expected)
https://github.com/tenstorrent/tt-metal/actions/runs/21277862753/job/61241439895

### What's changed
- bumped expected device perf for decode 128 and 2047 seq lengths

### Checklist
- [X] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) - CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/21281302469)