### PR TITLE
Fixing invalid shape error Device Perf and Frequent models CI:

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -324,9 +324,13 @@ void device_module(nb::module_& m_device) {
 
     m_device.def(
         "pad_to_tile_shape",
-        [](const std::array<uint32_t, 4>& unpadded_shape) -> std::vector<uint32_t> {
+        [](const std::array<uint32_t, 4>& unpadded_shape) -> nb::list {
             auto result = ttnn::operations::data_movement::pad_to_tile_shape(ttnn::Shape(unpadded_shape));
-            return std::vector<uint32_t>(result.cbegin(), result.cend());
+            nb::list py_list;
+            for (auto val : result) {
+                py_list.append(val);
+            }
+            return py_list;
         },
         nb::arg("unpadded_shape"),
         R"doc(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

Frequent Model Tests Pipeline fails on swin_s due to "Invalid Shape Error" after calling `pad_to_tile_shape`: https://github.com/tenstorrent/tt-metal/actions/runs/21236924141/job/61121091271

Commit 9ba5d5c3e ("Enable MeshWorkload in ttnn.generic op") add `NB_MAKE_OPAQUE(std::vector<uint32_t>);`.

The `NB_MAKE_OPAQUE(std::vector<uint32_t>)` macro tells nanobind to treat `std::vector<uint32_t>` as an opaque type globally across all translation units. This disables the standard type caster from `<nanobind/stl/vector.h>` that would normally convert `std::vector<uint32_t>` to/from Python lists.
Instead, all `std::vector<uint32_t>` returns now become ttnn._ttnn.program_descriptor.VectorUInt32 objects, which is not compatible with functions expecting a Python list or tuple.

The pad_to_tile_shape function in device.cpp returns `std::vector<uint32_t>`, and `create_sharded_memory_config_` expects a list, tuple, or `ttnn.Shape` - not a `VectorUInt32`.

This led to errors upon the introduction of `minimal_matmul_split` ( #35907 ). 

### What's changed

device.cpp has been modified to explicitly return a Python `nb::list` instead of relying on the (now disabled) automatic type caster:
This ensures pad_to_tile_shape always returns a proper Python list, regardless of the NB_MAKE_OPAQUE declaration.


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures) (time out on eltwise -> seem unrelated to these changes)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures) + [Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/21342808658)(https://github.com/tenstorrent/tt-metal/actions/runs/21342808658) (swin_s test case works)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/debug-minmal-matmul-ci-failures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/debug-minmal-matmul-ci-failures)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs