### PR TITLE
[GPT-OSS] fix prefill b1 and reduce demo times

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -235,8 +235,7 @@ def prepare_gpt_oss_generator_args(
             True,  # warmup_prefill
         ),
         (
-            # "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
-            "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",  # input_prompts
+            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             1,  # data_parallel
             128,  # batch_size
             1,  # repeat_batches

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -187,7 +187,7 @@ def prepare_gpt_oss_generator_args(
 )
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, users_row_sharded, long_context_mode",
+    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, users_row_sharded, long_context_mode, warmup_prefill",
     [
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -202,6 +202,7 @@ def prepare_gpt_oss_generator_args(
             False,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
+            True,  # warmup_prefill
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",  # input_prompts
@@ -216,6 +217,7 @@ def prepare_gpt_oss_generator_args(
             False,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
+            True,  # warmup_prefill
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -230,9 +232,11 @@ def prepare_gpt_oss_generator_args(
             False,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
+            True,  # warmup_prefill
         ),
         (
-            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            # "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",  # input_prompts
             1,  # data_parallel
             128,  # batch_size
             1,  # repeat_batches
@@ -244,6 +248,7 @@ def prepare_gpt_oss_generator_args(
             False,  # enable_prefill_trace
             True,  # users_row_sharded
             False,  # long_context_mode
+            False,  # warmup_prefill
         ),
         # Long-context mode: 1 user per row with 128k tokens, batch=128 for decode throughput
         (
@@ -259,6 +264,7 @@ def prepare_gpt_oss_generator_args(
             False,  # enable_prefill_trace
             True,  # users_row_sharded
             True,  # long_context_mode - single user per row gets all page blocks
+            False,  # warmup_prefill
         ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
@@ -341,6 +347,7 @@ def test_gpt_oss_demo(
     enable_prefill_trace,
     users_row_sharded,
     long_context_mode,
+    warmup_prefill,
     is_ci_env,
     state_dict,
 ):
@@ -570,17 +577,18 @@ def test_gpt_oss_demo(
             logger.info(f"First generated token (user 0): '{tokenizer.decode(prefilled_token[0])}'")
         else:
             # Standard batch prefill (matching tt_transformers)
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            logits = generator.prefill_forward_text(
-                input_tokens_prefill_pt,
-                page_table=page_table,
-                kv_cache=tt_kv_cache,
-                prompt_lens=decoding_pos,
-                enable_trace=enable_prefill_trace,
-            )
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+            if warmup_prefill:
+                logger.info("Starting prefill warmup...")
+                profiler.start(f"compile_prefill", iteration=batch_idx)
+                logits = generator.prefill_forward_text(
+                    input_tokens_prefill_pt,
+                    page_table=page_table,
+                    kv_cache=tt_kv_cache,
+                    prompt_lens=decoding_pos,
+                    enable_trace=enable_prefill_trace,
+                )
+                profiler.end(f"compile_prefill", iteration=batch_idx)
+                logger.info("Finished prefill warmup")
 
             logger.info(f"Starting prefill...")
             profiler.start(f"inference_prefill", iteration=batch_idx)
@@ -590,6 +598,7 @@ def test_gpt_oss_demo(
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
                 enable_trace=enable_prefill_trace,
+                warmup_prefill=False,  # we can warmup prefill ourselves above if we want to
             )
             prefilled_token = torch.argmax(logits, dim=-1)
             profiler.end(f"inference_prefill", iteration=batch_idx)
@@ -700,7 +709,7 @@ def test_gpt_oss_demo(
     profiler.end("run")
 
     # Calculate performance metrics for the first batch only
-    compile_prefill_time = profiler.get_duration("compile_prefill")
+    compile_prefill_time = profiler.get_duration("compile_prefill") if warmup_prefill else None
     compile_decode_time = profiler.get_duration("compile_decode")
 
     total_inference_prefill_time = profiler.get_duration("inference_prefill")
@@ -731,14 +740,16 @@ def test_gpt_oss_demo(
         "decode_t/s/u": decode_tok_s_user,  # tokens/s/u
         "decode_t/s": decode_tok_s,  # tokens/s
         # Optional measurements
-        "Total compile time": compile_prefill_time + compile_decode_time,
+        "Total compile time": compile_prefill_time + compile_decode_time if warmup_prefill else compile_decode_time,
         "Full demo runtime": profiler.get_duration("run"),
     }
 
     # Performance logging (like tt-transformers)
     logger.info("")
     logger.info(f"=== Performance metrics ===")
-    logger.info(f"Prefill compile time: {round(compile_prefill_time, 2)}s")
+    logger.info(
+        f"Prefill compile time: {round(compile_prefill_time, 2)}s" if warmup_prefill else "Prefill compile time: N/A"
+    )
     logger.info(f"Decode compile time: {round(compile_decode_time, 2)}s")
     logger.info("")
     logger.info(f"Average Time to First Token (TTFT): {round(avg_time_to_first_token * 1000, 2)}ms")

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -50,10 +50,9 @@ def _process_prefill_chunk(
     program_config: ProgramConfig,
     ep,
     tp,
-    batch_size,
-    seq_len,
 ):
     """Process a single chunk of the sequence in prefill mode."""
+    _, batch_size, seq_len, hidden_size = hidden_states.shape
     activation_dtype = ttnn.bfloat8_b
     TILE_SIZE = 32
 
@@ -231,9 +230,6 @@ def prefill_forward(
     # Reshard for sequence parallelism if needed
     if sp > 1:
         hidden_states, routing_weights = _reshard_for_sequence_parallel(hidden_states, routing_weights, mesh_device)
-        local_seq_len = hidden_states.shape[seq_dim]
-    else:
-        local_seq_len = seq_len_global
 
     # Chunk processing for very long sequences
     chunk_size = program_config.sequence_chunk_size
@@ -258,8 +254,6 @@ def prefill_forward(
             program_config,
             ep,
             tp,
-            batch_size,
-            local_seq_len,
         )
         next_states_list.append(next_states)
         hidden_chunk.deallocate(True)

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -108,7 +108,7 @@ class ModelArgs:
             self.tokenizer = AutoTokenizer.from_pretrained(self.weights_path, trust_remote_code=True)
             self.processor = None  # GPT-OSS doesn't use vision processor
 
-        self.capped_warmup_seq_len = self.max_prefill_chunk_size
+        self.capped_warmup_seq_len = 2048
         self.trace_prefill_supported_seq_lens = self.get_trace_prefill_supported_seq_lens()
 
     def get_warmup_prefill_supported_seq_lens(self):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -273,6 +273,7 @@ class Generator:
         model_id_warmup=None,
         start_pos: list[int] = None,  # Cached prefixes lengths
         return_hidden_states=False,
+        warmup_prefill=True,
         **kwargs,
     ):
         self.mode = "prefill"
@@ -283,7 +284,8 @@ class Generator:
             enable_trace = False
 
         # we need this here becuase of tt-metal tests
-        self.warmup_model_prefill(kv_cache, enable_trace)
+        if warmup_prefill:
+            self.warmup_model_prefill(kv_cache, enable_trace)
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size


### PR DESCRIPTION
GPT-OSS batch=1 prefill > 16k was failing due to mismatch sequence length in chunked prefill (e.g https://github.com/tenstorrent/tt-metal/actions/runs/21284620940/job/61263166939#step:16:484)

Tests were also timing out due to excessive prefill warm ups so made this an optional in the TTT generator.

### Checklist
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=handrews/fix-gpt-oss-b1-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:handrews/fix-gpt-oss-b1-prefill)
- [ ] [![vLLM nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml/badge.svg?branch=handrews/fix-gpt-oss-b1-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml?query=branch:handrews/fix-gpt-oss-b1-prefill)
- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=handrews/fix-gpt-oss-b1-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:handrews/fix-gpt-oss-b1-prefill)