### PR TITLE
#36320: fix large tensor softmax missing program cache info

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
@@ -26,3 +26,9 @@ def test_ttnn_softmax_sdxl_attention(device, shape):
     tt_output = ttnn.softmax(tt_input, dim=-1, numeric_stable=True)
     tt_output_torch = ttnn.to_torch(tt_output)
     assert_with_pcc(torch_output, tt_output_torch, pcc=0.999)
+
+    # test program cache
+    torch_output2 = F.softmax(torch_output, dim=-1, dtype=torch.bfloat16)
+    tt_output2 = ttnn.softmax(tt_output, dim=-1, numeric_stable=True)
+    tt_output_torch2 = ttnn.to_torch(tt_output2)
+    assert_with_pcc(torch_output2, tt_output_torch2, pcc=0.999)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -369,11 +369,12 @@ SoftmaxProgramFactoryAttentionOptimized::cached_program_t SoftmaxProgramFactoryA
         curr_row += num_tile_rows_per_core;
     }
 
-    return {std::move(program), {reader_kernels_id, writer_kernels_id, softmax_kernels_id, grid_size,
-                                 fp32_dest_acc_en,  scalar_tile_size,  in0_tile_size,      im_tile_size,
-                                 out0_tile_size,    mask_tile_size,    cb_in0_id,          cb_out0_id,
-                                 cb_intermed1_id,   cb_in2_id,         cb_intermed0_id,    cb_intermed3_id,
-                                 cb_in3_id,         cb_in4_id,         cb_intermed2_id,    cb_intermed4_id}};
+    return {
+        std::move(program),
+        {reader_kernels_id, writer_kernels_id, softmax_kernels_id, grid_size,       fp32_dest_acc_en, scalar_tile_size,
+         in0_tile_size,     im_tile_size,      out0_tile_size,     mask_tile_size,  cb_in0_id,        cb_out0_id,
+         cb_intermed1_id,   cb_in2_id,         cb_intermed0_id,    cb_intermed3_id, cb_in3_id,        cb_in4_id,
+         cb_intermed2_id,   cb_intermed4_id,   use_large_kernel,   cb_length}};
 }
 
 void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
@@ -405,25 +406,41 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
     uint32_t block_size = cached_program.shared_variables.fp32_dest_acc_en ? tt::tt_metal::find_max_divisor(Wt, 4)
                                                                            : tt::tt_metal::find_max_divisor(Wt, 8);
 
+    bool use_large_kernel = cached_program.shared_variables.use_large_kernel;
+    uint32_t cb_length = cached_program.shared_variables.cb_length;
+
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
-    uint32_t in0_t = attributes.numeric_stable ? tt::div_up(Wt, block_size) * block_size : block_size * 2;
-    uint32_t out0_t = block_size * 2;
+    uint32_t in0_t, out0_t, im0_t, im3_t, im4_t;
     uint32_t im1_t = 1;  // 1/sum(exp(x))
     uint32_t in2_t = 1;  // scaler for reduce coming from reader
     uint32_t in3_t = 1;  // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
+    uint32_t im2_t = 1;
+
+    if (use_large_kernel) {
+        // Use fixed sizes matching create() for large kernel
+        in0_t = 80;
+        out0_t = block_size * 2;
+        im0_t = 80;
+        im3_t = 80;
+        im4_t = 80;
+    } else {
+        // Standard calculation for regular kernel
+        in0_t = attributes.numeric_stable ? tt::div_up(Wt, block_size) * block_size : block_size * 2;
+        out0_t = block_size * 2;
+        im4_t = tt::div_up(Wt, block_size) * block_size;
+
+        // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing
+        im0_t = block_size * tt::div_up(Wt, block_size);
+        TT_FATAL(im0_t == Wt, "Intermediate buffer size (im0_t={}) must match width (Wt={})", im0_t, Wt);
+
+        // used for buffering scale-mask
+        // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
+        im3_t = block_size * (tt::div_up(Wt, block_size) + 1);
+        TT_FATAL(im3_t == Wt + block_size, "im3_t {} == Wt {}+ block_size {}", im3_t, Wt, block_size);
+    }
+
     uint32_t in4_t =
         tt::div_up(Wt, block_size) * block_size;  // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
-    uint32_t im2_t = 1;
-    uint32_t im4_t = tt::div_up(Wt, block_size) * block_size;
-
-    // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing
-    uint32_t im0_t = block_size * tt::div_up(Wt, block_size);
-    TT_FATAL(im0_t == Wt, "Intermediate buffer size (im0_t={}) must match width (Wt={})", im0_t, Wt);
-
-    // used for buffering scale-mask
-    // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
-    uint32_t im3_t = block_size * (tt::div_up(Wt, block_size) + 1);
-    TT_FATAL(im3_t == Wt + block_size, "im3_t {} == Wt {}+ block_size {}", im3_t, Wt, block_size);
 
     TT_FATAL(Wt % block_size == 0, "Wt {} must be divisible by block size {}", Wt, block_size);
     TT_FATAL((block_size != -1), "Wt {} must be divisible by one of the numbers in the range from 8 to 1.", Wt);
@@ -554,7 +571,7 @@ void SoftmaxProgramFactoryAttentionOptimized::override_runtime_arguments(
         softmax_kernel_args[3] = block_size;
         softmax_kernel_args[4] = curr_ht;
         softmax_kernel_args[5] = mask_padded_data;
-        softmax_kernel_args[6] = cached_program.shared_variables.fp32_dest_acc_en ? 1 : 0;
+        softmax_kernel_args[6] = cb_length;
 
         writer_kernel_args[0] = dst_buffer_address;
         writer_kernel_args[1] = num_tile_rows_per_core * Wt;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.hpp
@@ -25,6 +25,8 @@ struct SoftmaxProgramFactoryAttentionOptimized {
         uint32_t scalar_tile_size{}, in0_tile_size{}, im_tile_size{}, out0_tile_size{}, mask_tile_size{};
         tt::tt_metal::CBHandle cb_in0_id{}, cb_out0_id{}, cb_intermed1_id{}, cb_in2_id{}, cb_intermed0_id{};
         std::optional<tt::tt_metal::CBHandle> cb_intermed3_id, cb_in3_id, cb_in4_id, cb_intermed2_id, cb_intermed4_id;
+        bool use_large_kernel{};
+        uint32_t cb_length{};
     };
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
     static cached_program_t create(const SoftmaxParams&, const SoftmaxInputs&, Tensor&);


### PR DESCRIPTION
### Ticket
Link to Github Issue #36320

### Problem description
Info related to large tensor softmax was missing from the shared variables cache and override runtime args function

### What's changed
- Add missing info
- Test locally that this worked:
Original code result:
```
FAILED tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py::test_ttnn_softmax_sdxl_attention[shape=[2, 10, 512, 8192]] - RuntimeError: TT_THROW @ /localdev/bbradel/tt-metal/tt_metal/impl/program/program.cpp:908: tt::exception
info:
Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 1723520 B which is beyond max L1 size of 1499136 B
```
Updated code result:
```
PASSED tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py::test_ttnn_softmax_sdxl_attention[shape=[2, 10, 512, 8192]]
```

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-36320_softmax_pc)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-36320_softmax_pc)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-36320_softmax_pc)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-36320_softmax_pc)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-36320_softmax_pc)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-36320_softmax_pc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-36320_softmax_pc)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs