### PR TITLE
Improve err message if mesh shape is bad

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -375,6 +375,9 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
     const DispatchCoreConfig& dispatch_core_config,
     tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
     size_t worker_l1_size) {
+    TT_FATAL(
+        !device_ids.empty(), "Cannot create unit meshes with empty device_ids. At least one device ID is required.");
+
     // Validate all devices are on compute meshes (not switches) before creating any resources
     const auto& mesh_graph = MetalContext::instance().get_control_plane().get_mesh_graph();
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -63,7 +63,14 @@ MeshDeviceViewImpl::MeshDeviceViewImpl(
     const MeshShape& shape,
     const std::vector<MaybeRemote<IDevice*>>& devices,
     const std::vector<tt::tt_fabric::FabricNodeId>& fabric_node_ids) :
-    devices_(shape, devices), fabric_node_ids_(shape, fabric_node_ids), mesh_id_(fabric_node_ids.front().mesh_id) {
+    devices_(shape, devices), fabric_node_ids_(shape, fabric_node_ids), mesh_id_([&fabric_node_ids, &shape]() {
+        TT_FATAL(
+            !fabric_node_ids.empty(),
+            "Cannot create MeshDeviceView with empty fabric_node_ids. "
+            "MeshShape {} must have at least one device (mesh_size > 0).",
+            shape);
+        return fabric_node_ids.front().mesh_id;
+    }()) {
     if (devices_.shape().dims() == 2) {
         shape_2d_ = Shape2D(devices_.shape()[0], devices_.shape()[1]);
     }

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -142,6 +142,22 @@ SystemMesh::MappedDevices SystemMesh::Impl::get_mapped_devices(
     const MeshShape& system_shape = coordinate_translator_.global_shape();
     const MeshShape requested_shape = shape.value_or(system_shape);
     mapped_devices.mesh_shape = requested_shape;
+
+    // Validate requested mesh shape has valid size
+    const size_t requested_size = requested_shape.mesh_size();
+    const size_t system_size = system_shape.mesh_size();
+    TT_FATAL(
+        requested_size > 0,
+        "Requested mesh shape {} has zero devices (mesh_size=0). MeshShape must have at least one device.",
+        requested_shape);
+    TT_FATAL(
+        requested_size <= system_size,
+        "Requested mesh shape {} requires {} devices, but only {} devices are available in the system mesh {}.",
+        requested_shape,
+        requested_size,
+        system_size,
+        system_shape);
+
     const size_t system_dimensions = system_shape.dims();
 
     const MeshCoordinate system_offset = [&offset, system_dimensions]() {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36330)

### Problem description
We don't check properly for empty or too big mesh shape when opening device, which causes segfault without any useful error message.

### What's changed
Add a few TT_FATALs to catch this in all ways to open device / subdevice. 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=philei/improve-error-wrong-mesh-device-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:philei/improve-error-wrong-mesh-device-shape)