### PR TITLE
Fix move kernel compilation

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -254,7 +254,6 @@ def test_move_sharded_to_interleaved_rejected(device):
 
 def test_move_interleaved_to_sharded(device):
     """Test move from interleaved to sharded layout."""
-    from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
 
     torch.manual_seed(42)
     shape = [1, 1, 128, 64]

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -223,3 +223,69 @@ def test_move_sharded_custom_grid(device):
         device,
         dtype,
     )
+
+
+def test_move_sharded_to_interleaved_rejected(device):
+    """Verify move rejects sharded-to-interleaved conversion (output must be sharded)."""
+    torch.manual_seed(42)
+    shape = [1, 1, 128, 64]
+    core_count = 4
+
+    # Create sharded input tensor
+    shard_grid = get_shard_grid_from_num_cores(core_count, device)
+    shard_shape = [shape[2] // core_count, shape[3]]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+
+    input_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=shard_spec,
+    )
+
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        input_torch, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=input_mem_config
+    )
+
+    # Attempt to move to interleaved layout should fail
+    with pytest.raises(RuntimeError, match="Expected output tensor memory config to be sharded"):
+        ttnn.move(input_tensor, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+
+def test_move_interleaved_to_sharded(device):
+    """Test move from interleaved to sharded layout."""
+    from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
+
+    torch.manual_seed(42)
+    shape = [1, 1, 128, 64]
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+    core_count = min(4, compute_grid_size.x * compute_grid_size.y)
+
+    # Create interleaved input tensor
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        input_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    # Move to sharded layout
+    shard_grid = get_shard_grid_from_num_cores(core_count, device)
+    shard_shape = [shape[2] // core_count, shape[3]]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+
+    output_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=shard_spec,
+    )
+
+    output_tensor = ttnn.move(input_tensor, memory_config=output_mem_config)
+
+    # Verify result
+    output_torch = output_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+
+    assert torch.equal(output_torch, input_torch)

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
     cb_reserve_back(cb_id, num_pages);
     uint32_t l1_write_addr = get_write_ptr(cb_id);
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
-        uint64_t src_noc_addr = get_noc_addr(i, src_addrgen);
+        uint64_t src_noc_addr = src_addrgen.get_noc_addr(i);
         noc_async_read(src_noc_addr, l1_write_addr, page_size);
         noc_async_read_barrier();
         l1_write_addr += aligned_page_size;
@@ -83,7 +83,7 @@ void kernel_main() {
     cb_wait_front(cb_id, num_pages);
     uint32_t l1_read_addr = get_read_ptr(cb_id);
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
-        uint64_t dst_noc_addr = get_noc_addr(i, dst_addrgen);
+        uint64_t dst_noc_addr = dst_addrgen.get_noc_addr(i);
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         noc_async_write_barrier();
         l1_read_addr += aligned_page_size;


### PR DESCRIPTION
### Ticket
None

### Problem description
There is a kernel, which doesn't compile. Seems there is no test either, otherwise compilation failure would have beed discovered.

### What's changed
Fix compilation error. Add two tests.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vlad/fix-move-kernel-compilation)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/fix-move-kernel-compilation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-move-kernel-compilation)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-move-kernel-compilation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-move-kernel-compilation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/fix-move-kernel-compilation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-move-kernel-compilation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs