### PR TITLE
[skip ci] Enable bugprone-exception-escape in clang-tidy-light

### DIFF
--- a/.clang-tidy-light
+++ b/.clang-tidy-light
@@ -1,3 +1,4 @@
+bugprone-exception-escape
 cppcoreguidelines-pro-type-cstyle-cast
 cppcoreguidelines-special-member-functions
 readability-math-missing-parentheses


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `bugprone-exception-escape` clang-tidy check is not currently enabled in our lightweight clang-tidy configuration. This check catches functions that may allow exceptions to escape when they shouldn't (e.g., destructors, move constructors, `noexcept` functions), which can lead to undefined behavior and crashes.

### What's changed
Added `bugprone-exception-escape` to `.clang-tidy-light` to enable this check during CI builds. This will help identify and prevent potential exception-related bugs.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-ctl-bugprone-exception-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-ctl-bugprone-exception-escape)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-ctl-bugprone-exception-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-ctl-bugprone-exception-escape)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-ctl-bugprone-exception-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-ctl-bugprone-exception-escape)
- [x] New/Existing tests provide coverage for changes