### PR TITLE
Fix build failure on systems where linker doesn't support --gdb-index

### DIFF
--- a/cmake/linking.cmake
+++ b/cmake/linking.cmake
@@ -203,7 +203,19 @@ endif()
 #===============================================================================
 # LINKER MISC CONFIGURATION
 #===============================================================================
-add_link_options($<$<CONFIG:Debug,RelWithDebInfo>:-Wl,--gdb-index>)
+# Check if linker supports --gdb-index for faster debugging
+check_linker_flag(
+    CXX
+    "-Wl,--gdb-index"
+    LINKER_SUPPORTS_GDB_INDEX
+)
+
+if(LINKER_SUPPORTS_GDB_INDEX)
+    message(STATUS "Linker supports --gdb-index, enabling for Debug builds")
+    add_link_options($<$<CONFIG:Debug,RelWithDebInfo>:-Wl,--gdb-index>)
+else()
+    message(STATUS "Linker does not support --gdb-index, skipping")
+endif()
 
 #===============================================================================
 # LTO (LINK TIME OPTIMIZATION) CONFIGURATION


### PR DESCRIPTION
### Problem Description

The `--gdb-index` linker flag was being unconditionally added for Debug and RelWithDebInfo builds in `cmake/linking.cmake`. This causes build failures on systems where the linker doesn't support this option (e.g., GNU ld version 2.38).

Error encountered:
```
/usr/bin/ld: unrecognized option '--gdb-index'
clang++-20: error: linker command failed with exit code 1
```

### Solution

This PR adds a check using CMake's `check_linker_flag()` to detect linker support for `--gdb-index` before adding the flag. This follows the same pattern already used in the file for other optional linker features like `--compress-debug-sections`.

### What's Changed

- Added `check_linker_flag()` call to test for `--gdb-index` support
- Conditionally add the flag only when supported
- Added informative status messages for both supported and unsupported cases

### Testing

- ✅ Build succeeds on systems with linkers that don't support `--gdb-index` (GNU ld 2.38)
- ✅ Build still uses `--gdb-index` on systems with compatible linkers
- ✅ All pre-commit hooks pass

### Impact

This change improves build portability across different systems and linker versions while maintaining the debugging optimization where available.