### PR TITLE
Make device close resilient to kernel hangs and timeouts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1259,7 +1259,14 @@ def reset_tensix(tt_open_devices=None):
         logger.info(f"Running reset for pci devices: {tt_open_devices_str}")
         smi_reset_result = run_process_and_get_result(f"tt-smi -r {tt_open_devices_str}")
 
-    logger.info(f"tt-smi reset status: {smi_reset_result.returncode}")
+    if smi_reset_result.returncode != 0:
+        logger.warning(
+            f"tt-smi reset failed with status {smi_reset_result.returncode}. "
+            "The device may be in an inconsistent state. This can happen if device handles "
+            "are still open (e.g., UMD connection held by the process). Subsequent tests may fail."
+        )
+    else:
+        logger.info("tt-smi reset completed successfully")
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -168,13 +168,12 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
             }
         }
 
-        if (num_outstanding_reads_ != 0) {
+        if (auto reads = num_outstanding_reads_.exchange(0); reads != 0) {
             log_warning(
                 LogMetal,
                 "FDMeshCommandQueue destructor: {} outstanding reads remaining. "
                 "This may indicate a device hang or timeout occurred.",
-                num_outstanding_reads_.load());
-            num_outstanding_reads_.store(0);
+                reads);
         }
     }
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -134,7 +134,7 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
     bool is_mock =
         tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
-    if (in_use_ && !thread_exception_state_.load()) {
+    if (in_use_ && !thread_exception_state_.load(std::memory_order_acquire)) {
         // If the FDMeshCommandQueue is being used, have it clear worker state
         // before going out of scope. This is a blocking operation - it waits
         // for all queued up work to complete.

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -134,9 +134,7 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
     bool is_mock =
         tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
-    bool skip_clear = thread_exception_state_.load();
-
-    if (in_use_ && !skip_clear) {
+    if (in_use_ && !thread_exception_state_.load()) {
         // If the FDMeshCommandQueue is being used, have it clear worker state
         // before going out of scope. This is a blocking operation - it waits
         // for all queued up work to complete.

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -134,7 +134,17 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
     bool is_mock =
         tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
-    if (in_use_) {
+    // Signal reader thread to exit early - this allows cleanup to proceed even if device is hung.
+    // Must be done before any blocking operations to prevent deadlocks.
+    {
+        std::lock_guard lock(reader_thread_cv_mutex_);
+        exit_condition_ = true;
+        reader_thread_cv_.notify_one();
+    }
+
+    // If there was an exception in the reader thread, skip the blocking clear operation
+    // as the device is likely in an unrecoverable state.
+    if (in_use_ && !thread_exception_state_.load()) {
         // If the FDMeshCommandQueue is being used, have it clear worker state
         // before going out of scope. This is a blocking operation - it waits
         // for all queued up work to complete.
@@ -144,23 +154,38 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
         this->clear_expected_num_workers_completed();
     }
 
+    // Log warnings instead of aborting - destructors should never throw or abort.
+    // These conditions indicate a problem but the process should be allowed to continue
+    // so that subsequent tests can run and the device can be properly reset.
     if (!is_mock) {
-        TT_FATAL(completion_queue_reads_.empty(), "The completion reader queue must be empty when closing devices.");
-
-        for (const auto& queue : read_descriptors_) {
-            TT_FATAL(queue.second->empty(), "No buffer read requests should be outstanding when closing devices.");
+        if (!completion_queue_reads_.empty()) {
+            log_warning(
+                LogMetal,
+                "FDMeshCommandQueue destructor: completion reader queue is not empty. "
+                "This may indicate a device hang or timeout occurred.");
+            completion_queue_reads_.clear();
         }
 
-        TT_FATAL(
-            num_outstanding_reads_ == 0,
-            "Mismatch between num_outstanding reads and number of entries in completion reader queue.");
+        for (const auto& queue : read_descriptors_) {
+            if (!queue.second->empty()) {
+                log_warning(
+                    LogMetal,
+                    "FDMeshCommandQueue destructor: buffer read requests still outstanding for device {}. "
+                    "This may indicate a device hang or timeout occurred.",
+                    queue.first);
+            }
+        }
+
+        if (num_outstanding_reads_ != 0) {
+            log_warning(
+                LogMetal,
+                "FDMeshCommandQueue destructor: {} outstanding reads remaining. "
+                "This may indicate a device hang or timeout occurred.",
+                num_outstanding_reads_.load());
+            num_outstanding_reads_.store(0);
+        }
     }
 
-    {
-        std::lock_guard lock(reader_thread_cv_mutex_);
-        reader_thread_cv_.notify_one();
-        exit_condition_ = true;
-    }
     completion_queue_reader_thread_.join();
 }
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -134,14 +134,7 @@ FDMeshCommandQueue::~FDMeshCommandQueue() {
     bool is_mock =
         tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
-    // If there was an exception in the reader thread, the device is likely in an unrecoverable
-    // state. Signal exit early and skip the blocking clear operation.
     bool skip_clear = thread_exception_state_.load();
-    if (skip_clear) {
-        std::lock_guard lock(reader_thread_cv_mutex_);
-        exit_condition_ = true;
-        reader_thread_cv_.notify_one();
-    }
 
     if (in_use_ && !skip_clear) {
         // If the FDMeshCommandQueue is being used, have it clear worker state

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -930,7 +930,7 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         }
 
         auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev_id);
-        // Wrap in try-catch so that device close continues even if dispatch cores timeout.
+        // Wrap in try-catch so that device close continues even if dispatch cores fail or timeout.
         // This allows the device handles to be properly released, enabling subsequent
         // device opens and tt-smi resets to succeed.
         try {
@@ -938,7 +938,7 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         } catch (const std::exception& e) {
             log_warning(
                 LogMetal,
-                "Device {}: Timeout waiting for dispatch cores to finish during device close. "
+                "Device {}: Exception waiting for dispatch cores to finish during device close. "
                 "Continuing with device cleanup. Error: {}",
                 dev_id,
                 e.what());

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -930,7 +930,19 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         }
 
         auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev_id);
-        tt::llrt::internal_::wait_until_cores_done(dev_id, dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
+        // Wrap in try-catch so that device close continues even if dispatch cores timeout.
+        // This allows the device handles to be properly released, enabling subsequent
+        // device opens and tt-smi resets to succeed.
+        try {
+            tt::llrt::internal_::wait_until_cores_done(dev_id, dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
+        } catch (const std::exception& e) {
+            log_warning(
+                LogMetal,
+                "Device {}: Timeout waiting for dispatch cores to finish during device close. "
+                "Continuing with device cleanup. Error: {}",
+                dev_id,
+                e.what());
+        }
     }
 
     // Process registered termination signals from topology

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -46,7 +46,14 @@ def close_device(device: "ttnn.device.Device"):
         Closing device 0
 
     """
-    synchronize_device(device)
+    # Try to synchronize first, but don't let failures prevent device close.
+    # If synchronize fails (e.g., due to device timeout/hang), we still need
+    # to close the device to release handles and allow subsequent operations.
+    try:
+        synchronize_device(device)
+    except Exception as e:
+        logger.warning(f"close_device: synchronize_device failed with: {e}. Continuing with device close.")
+
     ttnn._ttnn.device.close_device(device)
 
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -51,8 +51,8 @@ def close_device(device: "ttnn.device.Device"):
     # to close the device to release handles and allow subsequent operations.
     try:
         synchronize_device(device)
-    except Exception as e:
-        logger.warning(f"close_device: synchronize_device failed with: {e}. Continuing with device close.")
+    except Exception:
+        logger.exception("close_device: synchronize_device failed. Continuing with device close.")
 
     ttnn._ttnn.device.close_device(device)
 


### PR DESCRIPTION
## Ticket
https://github.com/tenstorrent/tt-metal/issues/36387

## Problem

When a kernel hangs (e.g., due to a bug or timeout), the test process would abort with `Fatal Python error: Aborted` instead of failing cleanly. This prevents:
- Subsequent tests from running
- The device from being properly reset
- The process from exiting gracefully

## Root Cause

Several destructors and cleanup functions were using `TT_FATAL` assertions or letting exceptions propagate, which caused aborts during cleanup when devices were in a hung state.

## Solution

Made device cleanup resilient to timeouts and hangs:

### 1. FDMeshCommandQueue destructor (`fd_mesh_command_queue.cpp`)
- Signal reader thread to exit early before any blocking operations
- Replace `TT_FATAL` assertions with `log_warning` calls
- Skip blocking clear if exception state is set
- Clear queues gracefully on timeout to prevent further issues

### 2. ScopedDevices destructor (`mesh_device.cpp`)
- Wrap `close_devices` in try-catch to prevent exceptions from propagating out of destructor
- Log warnings when device close fails due to timeout

### 3. DeviceManager::close_devices (`device_manager.cpp`)
- Wrap `wait_until_cores_done` in try-catch for dispatch cores
- Log warning and continue cleanup if cores timeout

### 4. Python close_device (`device.py`)
- Wrap `synchronize_device` in try-catch
- Continue with device close even if synchronize fails

### 5. conftest.py
- Add warning when tt-smi reset fails
- Explain possible causes and impact

## Result

When a kernel hangs:
- ✅ Tests fail with `RuntimeError` instead of `Fatal Python error: Aborted`
- ✅ Subsequent tests can attempt to run
- ✅ The process exits cleanly
- ✅ Warnings are logged to help diagnose issues

---------------

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/21306221136)
- [x] [BHPC](https://github.com/tenstorrent/tt-metal/actions/runs/21323108571)