### PR TITLE
Add Llama demo tests back to WH 6u upstream container

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -310,9 +310,8 @@ test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
-# test_suite_wh_6u_llama_demo_tests was removed because of
-# https://github.com/tenstorrent/tt-metal/issues/34990
 hw_topology_test_suites["wh_6u"]="
+test_suite_wh_6u_llama_demo_tests
 test_suite_wh_6u_metal_torus_xy_health_check_tests
 test_suite_wh_6u_model_unit_tests
 test_suite_wh_6u_metal_unit_tests

--- a/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tests/test_llama_model.py
@@ -367,7 +367,8 @@ def test_llama_model_inference(
                 if run_ref_pt:
                     pt_decode_input = embd(encoded_prompts_tensor[:, i]).view(batch, seqlen, -1)
             else:
-                tt_out_tok_device0 = ttnn.get_device_tensors(tt_out_tok)[0]
+                # tt_out_tok is a tuple of (tt_out_tok, tt_log_probs)
+                tt_out_tok_device0 = ttnn.get_device_tensors(tt_out_tok[0])[0]
                 tt_out_tok_cpu = tt_out_tok_device0.cpu(blocking=True, cq_id=0)
                 tt_out_tok = ttnn.to_torch(
                     tt_out_tok_cpu,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34990#issuecomment-3791068722

### Problem description
Llama demo is passing now so we add back to 6u upstream container

### What's changed
mentioned above

### Checklist
- [x] [Upstream tests](https://github.com/tenstorrent/tt-metal/actions/runs/21303697972) wh-6u test image passing