### PR TITLE
Deepseek blitz TP/SP broadcast

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_broadcast_batch1.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_broadcast_batch1.py
@@ -11,6 +11,13 @@ from models.common.utility_functions import skip_for_wormhole_b0, skip_for_n_or_
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
 
 
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
 def run_with_trace(
     mesh_device,
     sender_coord,
@@ -20,6 +27,8 @@ def run_with_trace(
     output_mem_config,
     num_iter=20,
     subdevice_id=None,
+    cluster_axis=None,
+    secondary_cluster_axis=None,
 ):
     # Compile Run
     logger.info("Compiling model")
@@ -30,6 +39,8 @@ def run_with_trace(
         memory_config=output_mem_config,
         topology=broadcast_topology,
         subdevice_id=subdevice_id,
+        cluster_axis=cluster_axis,
+        secondary_cluster_axis=secondary_cluster_axis,
     )
     ttnn.synchronize_device(mesh_device)
 
@@ -44,6 +55,8 @@ def run_with_trace(
             memory_config=output_mem_config,
             topology=broadcast_topology,
             subdevice_id=subdevice_id,
+            cluster_axis=cluster_axis,
+            secondary_cluster_axis=secondary_cluster_axis,
         )
     ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
     ttnn.synchronize_device(mesh_device)
@@ -79,6 +92,7 @@ def run_broadcast_impl(
     tensor_mem_layout=None,
     cluster_axis=None,
     mesh_mapper_config=None,
+    secondary_cluster_axis=None,
 ):
     if mesh_mapper_config is None:
         # Mesh shape is (num_devices, 1), so we shard along dimension 0 (batch) across the first mesh dimension
@@ -197,6 +211,8 @@ def run_broadcast_impl(
             output_mem_config,
             num_iter=num_iters,
             subdevice_id=worker_sub_device_id,
+            cluster_axis=cluster_axis,
+            secondary_cluster_axis=secondary_cluster_axis,
         )
         tt_out_tensor_list.append(tt_out_tensor)
     else:
@@ -208,6 +224,8 @@ def run_broadcast_impl(
                 memory_config=output_mem_config,
                 topology=broadcast_topology,
                 subdevice_id=worker_sub_device_id,
+                cluster_axis=cluster_axis,
+                secondary_cluster_axis=secondary_cluster_axis,
             )
             tt_out_tensor_list.append(tt_out_tensors)
 
@@ -255,8 +273,8 @@ def run_broadcast_impl(
             4,
             1,
             1,
-            [1, 1536],
-            (1, 1536),
+            [1, 7168],
+            (1, 7168),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
             None,
             None,
@@ -275,7 +293,13 @@ def run_broadcast_impl(
 @pytest.mark.parametrize(
     "device_params",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 217872}),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": create_fabric_router_config(15232),
+                "trace_region_size": 573440,
+            }
+        ),
     ],
     indirect=["device_params"],
     ids=["fabric_1d_linear_trace"],
@@ -298,6 +322,7 @@ def test_broadcast_batch1(
 ):
     validate_test(num_devices, ttnn.Topology.Linear, bh_2d_mesh_device.shape, 0)
     mesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    print("mesh device shape: ", mesh_device.shape)
     sender_coord_tuple = (sender_idx, 0)
     sender_coord = ttnn.MeshCoordinate(sender_coord_tuple)
 
@@ -321,3 +346,182 @@ def test_broadcast_batch1(
         output_shard_grid=output_shard_grid,
         tensor_mem_layout=tensor_mem_layout,
     )
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@skip_for_n_or_less_dev(7)  # Need 8 devices for 4x2 mesh
+@pytest.mark.parametrize(
+    "mesh_rows, mesh_cols, num_links, sender_row, sender_col, output_shape, input_shard_shape, input_shard_grid, tensor_mem_layout",
+    [
+        (
+            4,
+            2,
+            1,
+            1,
+            0,
+            [1, 7168],
+            (1, 7168),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [20])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": create_fabric_router_config(15232),
+                "trace_region_size": 573440,
+            }
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_2d_dual_axis_trace"],
+)
+def test_broadcast_batch1_dual_axis(
+    bh_2d_mesh_device,
+    mesh_rows,
+    mesh_cols,
+    sender_row,
+    sender_col,
+    output_shape,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    tensor_mem_layout,
+):
+    """
+    Test dual-axis broadcast on a 2D mesh.
+    Sender at (sender_row, sender_col) broadcasts:
+    1. First across secondary_cluster_axis (axis 1) to the device at same row, different column
+    2. Then both sender and secondary sender broadcast along cluster_axis (axis 0) to all devices in their columns
+    """
+    num_devices = mesh_rows * mesh_cols
+    print("num_devices: ", num_devices)
+    print("bh_2d_mesh_device.shape: ", bh_2d_mesh_device.shape)
+    print("ttnn.MeshShape(mesh_rows, mesh_cols):", ttnn.MeshShape((mesh_rows, mesh_cols)))
+    # validate_test(num_devices, ttnn.Topology.Linear, bh_2d_mesh_device.shape, 0)
+    mesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    print(f"mesh device shape: {mesh_device.shape}")
+
+    sender_coord_tuple = (sender_row, sender_col)
+    sender_coord = ttnn.MeshCoordinate(sender_coord_tuple)
+
+    # For 2D mesh, use a mesh mapper that shards along row (axis 0) and replicates along column (axis 1)
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], mesh_device.shape)
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # Set up sharded memory config
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec)
+    output_mem_config = input_mem_config
+
+    input_tensor_mesh_list = []
+    sender_tensor_list = []
+
+    for i in range(num_iters):
+        # Create sender tensor
+        sender_tensor = torch.rand(output_shape, dtype=torch.bfloat16)
+        sender_tensor_list.append(sender_tensor)
+
+        device_tensors = []
+        for row in range(mesh_rows):
+            if row == sender_row:
+                device_tensors.append(sender_tensor)
+            else:
+                device_tensors.append(torch.zeros_like(sender_tensor))
+
+        # Concatenate along dim 0 (batch) - this gives [mesh_rows, 7168]
+        mesh_tensor_torch = torch.cat(device_tensors, dim=0)
+        input_tensor_mesh = ttnn.from_torch(
+            mesh_tensor_torch,
+            device=mesh_device,
+            layout=layout,
+            tile=ttnn.Tile((1, 32)),
+            dtype=input_dtype,
+            memory_config=input_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                mesh_mapper_config,
+            ),
+        )
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    for i in range(num_iters):
+        print("Running dual-axis broadcast iteration ", i)
+        tt_out_tensors = ttnn.experimental.deepseek_minimal_broadcast(
+            input_tensor_mesh_list[i],
+            sender_coord=sender_coord,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=ttnn.Topology.Linear,
+            subdevice_id=worker_sub_device_id,
+            cluster_axis=0,
+            secondary_cluster_axis=1,
+        )
+        tt_out_tensor_list.append(tt_out_tensors)
+
+    logger.info("Waiting for op")
+    ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+    logger.info("Done op")
+
+    # Compare tensors - all devices should have the sender's data
+    # With PlacementShard(0) along rows and PlacementReplicate() along cols,
+    # we have mesh_rows shards, each replicated across mesh_cols columns
+    for iter_idx in range(len(tt_out_tensor_list)):
+        output_tensor_torch = ttnn.to_torch(
+            tt_out_tensor_list[iter_idx],
+            mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
+        )
+        sender_tensor = sender_tensor_list[iter_idx]
+        slice_size = output_shape[0]  # Batch dimension
+        # Check each row's shard (mesh_rows shards total)
+        for row_idx in range(mesh_rows):
+            start = row_idx * slice_size
+            end = start + slice_size
+            received = output_tensor_torch[start:end, :]
+            assert (
+                received.shape == sender_tensor.shape
+            ), f"Shape mismatch at row {row_idx}: received {received.shape}, expected {sender_tensor.shape}"
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(received, sender_tensor)
+            else:
+                eq, output = comp_pcc(received, sender_tensor)
+            if not eq:
+                logger.error(f"output mismatch for row {row_idx}")
+                assert eq, f"Row {row_idx} FAILED: {output}"
+
+    assert (
+        mesh_device.num_program_cache_entries() == 1 or mesh_device.num_program_cache_entries() == num_iters
+    ), f"Device has {mesh_device.num_program_cache_entries()} program cache entries"
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_deepseek_minimal_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_deepseek_minimal_all_reduce.py
@@ -31,6 +31,7 @@ def run_with_trace(
     num_iter=20,
     num_warmup_iter=15,
     subdevice_id=None,
+    persistent_output_tensor=None,
 ):
     """Run the all-reduce operation with trace capture for performance testing."""
     profiler = BenchmarkProfiler()
@@ -41,6 +42,7 @@ def run_with_trace(
         input_tensor_mesh,
         cluster_axis=cluster_axis,
         intermediate_tensor=intermediate_tensor,
+        persistent_output_tensor=persistent_output_tensor,
         num_links=num_links,
         topology=topology,
     )
@@ -54,6 +56,7 @@ def run_with_trace(
             input_tensor_mesh,
             cluster_axis=cluster_axis,
             intermediate_tensor=intermediate_tensor,
+            persistent_output_tensor=persistent_output_tensor,
             num_links=num_links,
             topology=topology,
         )
@@ -68,6 +71,7 @@ def run_with_trace(
             input_tensor_mesh,
             cluster_axis=cluster_axis,
             intermediate_tensor=intermediate_tensor,
+            persistent_output_tensor=persistent_output_tensor,
             num_links=num_links,
             topology=topology,
         )
@@ -108,6 +112,7 @@ def run_with_trace_residual(
     num_iter=20,
     num_warmup_iter=15,
     subdevice_id=None,
+    persistent_output_tensor=None,
 ):
     """Run the all-reduce operation with fused residual add and trace capture for performance testing."""
     profiler = BenchmarkProfiler()
@@ -119,6 +124,7 @@ def run_with_trace_residual(
         cluster_axis=cluster_axis,
         intermediate_tensor=intermediate_tensor,
         residual_tensor=residual_tensor_mesh,
+        persistent_output_tensor=persistent_output_tensor,
         num_links=num_links,
         topology=topology,
     )
@@ -133,6 +139,7 @@ def run_with_trace_residual(
             cluster_axis=cluster_axis,
             intermediate_tensor=intermediate_tensor,
             residual_tensor=residual_tensor_mesh,
+            persistent_output_tensor=persistent_output_tensor,
             num_links=num_links,
             topology=topology,
         )
@@ -148,6 +155,7 @@ def run_with_trace_residual(
             cluster_axis=cluster_axis,
             intermediate_tensor=intermediate_tensor,
             residual_tensor=residual_tensor_mesh,
+            persistent_output_tensor=persistent_output_tensor,
             num_links=num_links,
             topology=topology,
         )
@@ -198,6 +206,7 @@ def run_deepseek_minimal_all_reduce_impl(
     intermediate_shape=None,
     intermediate_tile_shape=(32, 32),
     intermediate_shard_shape=None,
+    use_persistent_buffers=True,
 ):
     if mesh_mapper_config is None:
         # Mesh shape is (num_devices, 1), so we shard along dimension 0 (batch) across the first mesh dimension
@@ -280,7 +289,6 @@ def run_deepseek_minimal_all_reduce_impl(
                 mesh_mapper_config,
             ),
         )
-        input_tensor_mesh_list.append(input_tensor_mesh)
 
         # Create intermediate tensor with standard 32x32 tiles
         # Use provided intermediate_shape or derive from output_shape
@@ -313,26 +321,51 @@ def run_deepseek_minimal_all_reduce_impl(
         )
         intermediate_tensor_list.append(intermediate_tensor)
 
+        # Create persistent output tensor with same shape and memory config as input
+        # Must concatenate num_devices copies to match the mesh mapper config (PlacementShard(0))
+        if use_persistent_buffers:
+            output_tensor_per_device = torch.zeros(output_shape, dtype=torch.bfloat16)
+            output_tensor_torch = torch.cat([output_tensor_per_device] * num_devices, dim=0)
+            persistent_output_tensor = ttnn.from_torch(
+                output_tensor_torch,
+                device=mesh_device,
+                layout=layout,
+                tile=ttnn.Tile(input_tile_shape),
+                dtype=input_dtype,
+                memory_config=input_mem_config,
+                mesh_mapper=ttnn.create_mesh_mapper(
+                    mesh_device,
+                    mesh_mapper_config,
+                ),
+            )
+        else:
+            persistent_output_tensor = None
+        input_tensor_mesh_list.append((input_tensor_mesh, persistent_output_tensor))
+
     tt_out_tensor_list = []
     if trace_mode:
+        input_tensor, persistent_output = input_tensor_mesh_list[0]
         tt_out_tensor = run_with_trace(
             mesh_device,
-            input_tensor_mesh_list[0],
+            input_tensor,
             intermediate_tensor_list[0],
             cluster_axis,
             num_links,
             topology,
             num_iter=num_iters,
             subdevice_id=worker_sub_device_id,
+            persistent_output_tensor=persistent_output,
         )
         tt_out_tensor_list.append(tt_out_tensor)
     else:
         for i in range(num_iters):
             logger.info(f"Running iteration {i}")
+            input_tensor, persistent_output = input_tensor_mesh_list[i]
             tt_out_tensor = ttnn.experimental.deepseek_minimal_all_reduce(
-                input_tensor_mesh_list[i],
+                input_tensor,
                 cluster_axis=cluster_axis,
                 intermediate_tensor=intermediate_tensor_list[i],
+                persistent_output_tensor=persistent_output,
                 num_links=num_links,
                 topology=topology,
             )
@@ -402,6 +435,7 @@ def run_deepseek_minimal_all_reduce_impl(
 )
 @pytest.mark.parametrize("num_iters", [20])
 @pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("use_persistent_buffers", [True, False], ids=["persistent_buffers", "no_persistent_buffers"])
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -432,6 +466,7 @@ def test_deepseek_minimal_all_reduce_trace(
     intermediate_shape,
     intermediate_tile_shape,
     intermediate_shard_shape,
+    use_persistent_buffers,
 ):
     """Trace-enabled version of the all-reduce test for performance testing."""
     # Validate we have the right mesh configuration
@@ -460,6 +495,7 @@ def test_deepseek_minimal_all_reduce_trace(
         intermediate_shape=intermediate_shape,
         intermediate_tile_shape=intermediate_tile_shape,
         intermediate_shard_shape=intermediate_shard_shape,
+        use_persistent_buffers=use_persistent_buffers,
     )
 
 
@@ -484,6 +520,7 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
     intermediate_shape=None,
     intermediate_tile_shape=(32, 32),
     intermediate_shard_shape=None,
+    use_persistent_buffers=True,
 ):
     """Test implementation with fused residual add."""
     if mesh_mapper_config is None:
@@ -587,6 +624,21 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
             mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_mapper_config),
         )
 
+        if use_persistent_buffers:
+            output_tensor_per_device = torch.zeros(output_shape, dtype=torch.bfloat16)
+            output_tensor_torch = torch.cat([output_tensor_per_device] * num_devices, dim=0)
+            persistent_output_tensor = ttnn.from_torch(
+                output_tensor_torch,
+                device=mesh_device,
+                layout=layout,
+                tile=ttnn.Tile(input_tile_shape),
+                dtype=input_dtype,
+                memory_config=input_mem_config,
+                mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_mapper_config),
+            )
+        else:
+            persistent_output_tensor = None
+
         if trace_mode and i == 0:
             # For trace mode, run with trace on first iteration only
             tt_out_tensor = run_with_trace_residual(
@@ -599,6 +651,7 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
                 topology,
                 num_iter=num_iters,
                 subdevice_id=worker_sub_device_id,
+                persistent_output_tensor=persistent_output_tensor,
             )
         elif not trace_mode:
             logger.info(f"Running iteration {i} with residual add")
@@ -607,6 +660,7 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
                 cluster_axis=cluster_axis,
                 intermediate_tensor=intermediate_tensor,
                 residual_tensor=residual_tensor_mesh,
+                persistent_output_tensor=persistent_output_tensor,
                 num_links=num_links,
                 topology=topology,
             )
@@ -670,6 +724,7 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("num_iters", [20])
 @pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("use_persistent_buffers", [True, False], ids=["persistent_buffers", "no_persistent_buffers"])
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -700,6 +755,7 @@ def test_deepseek_minimal_all_reduce_with_residual_trace(
     intermediate_shape,
     intermediate_tile_shape,
     intermediate_shard_shape,
+    use_persistent_buffers,
 ):
     """Trace-enabled test for all-reduce with fused residual add."""
     validate_test(num_devices, topology, bh_2d_mesh_device.shape, cluster_axis)
@@ -726,4 +782,5 @@ def test_deepseek_minimal_all_reduce_with_residual_trace(
         intermediate_shape=intermediate_shape,
         intermediate_tile_shape=intermediate_tile_shape,
         intermediate_shard_shape=intermediate_shard_shape,
+        use_persistent_buffers=use_persistent_buffers,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_deepseek_minimal_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_deepseek_minimal_all_reduce.py
@@ -729,13 +729,13 @@ def run_deepseek_minimal_all_reduce_with_residual_impl(
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
             "fabric_router_config": create_fabric_router_config(15232),
             "trace_region_size": 573440,
         },
     ],
     indirect=["device_params"],
-    ids=["fabric_1d_trace"],
+    ids=["fabric_2d_trace"],
 )
 def test_deepseek_minimal_all_reduce_with_residual_trace(
     bh_2d_mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce.cpp
@@ -16,9 +16,16 @@ ttnn::Tensor ExecuteDeepseekMinimalAllReduce::invoke(
     const ttnn::ccl::Topology topology,
     std::optional<uint32_t> cluster_axis,
     const std::optional<ttnn::Tensor>& intermediate_tensor,
-    const std::optional<ttnn::Tensor>& residual_tensor) {
+    const std::optional<ttnn::Tensor>& residual_tensor,
+    const std::optional<ttnn::Tensor>& persistent_output_tensor) {
     return ttnn::prim::deepseek_minimal_all_reduce(
-        input_tensor, num_links, topology, cluster_axis, intermediate_tensor, residual_tensor);
+        input_tensor,
+        num_links,
+        topology,
+        cluster_axis,
+        intermediate_tensor,
+        residual_tensor,
+        persistent_output_tensor);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce.hpp
@@ -18,7 +18,8 @@ struct ExecuteDeepseekMinimalAllReduce {
         ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
         std::optional<uint32_t> cluster_axis = std::nullopt,
         const std::optional<ttnn::Tensor>& intermediate_tensor = std::nullopt,
-        const std::optional<ttnn::Tensor>& residual_tensor = std::nullopt);
+        const std::optional<ttnn::Tensor>& residual_tensor = std::nullopt,
+        const std::optional<ttnn::Tensor>& persistent_output_tensor = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/deepseek_minimal_all_reduce_nanobind.cpp
@@ -31,15 +31,24 @@ void bind_deepseek_minimal_all_reduce_op(nb::module_ mod, const ccl_operation_t&
                std::optional<uint32_t> cluster_axis,
                const std::optional<ttnn::Tensor>& intermediate_tensor,
                const std::optional<ttnn::Tensor>& residual_tensor,
+               const std::optional<ttnn::Tensor>& persistent_output_tensor,
                const uint32_t num_links,
                const tt::tt_fabric::Topology topology) -> ttnn::Tensor {
-                return self(input_tensor, num_links, topology, cluster_axis, intermediate_tensor, residual_tensor);
+                return self(
+                    input_tensor,
+                    num_links,
+                    topology,
+                    cluster_axis,
+                    intermediate_tensor,
+                    residual_tensor,
+                    persistent_output_tensor);
             },
             nb::arg("input_tensor"),
             nb::kw_only(),
             nb::arg("cluster_axis") = nb::none(),
             nb::arg("intermediate_tensor") = nb::none(),
             nb::arg("residual_tensor") = nb::none(),
+            nb::arg("persistent_output_tensor") = nb::none(),
             nb::arg("num_links") = 2,
             nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear)});
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation.cpp
@@ -83,6 +83,9 @@ TensorSpec DeepseekMinimalAllReduceDeviceOperation::compute_output_specs(
 
 Tensor DeepseekMinimalAllReduceDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.persistent_output_tensor.has_value()) {
+        return tensor_args.persistent_output_tensor.value();
+    }
     return create_device_tensor(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
@@ -115,7 +118,8 @@ ttnn::operations::experimental::ccl::deepseek_minimal_all_reduce::DeepseekMinima
         tt::tt_fabric::Topology topology,
         std::optional<uint32_t> cluster_axis,
         const std::optional<ttnn::Tensor>& intermediate_tensor,
-        const std::optional<ttnn::Tensor>& residual_tensor) {
+        const std::optional<ttnn::Tensor>& residual_tensor,
+        const std::optional<ttnn::Tensor>& persistent_output_tensor) {
     using OperationType =
         ttnn::operations::experimental::ccl::deepseek_minimal_all_reduce::DeepseekMinimalAllReduceDeviceOperation;
 
@@ -136,7 +140,10 @@ ttnn::operations::experimental::ccl::deepseek_minimal_all_reduce::DeepseekMinima
     auto operation_attributes = OperationType::operation_attributes_t{
         .num_links = num_links, .ring_size = num_devices, .topology = topology, .cluster_axis = cluster_axis};
     auto tensor_args = OperationType::tensor_args_t{
-        .input_tensor = input_tensor, .intermediate_tensor = intermediate_tensor, .residual_tensor = residual_tensor};
+        .input_tensor = input_tensor,
+        .intermediate_tensor = intermediate_tensor,
+        .residual_tensor = residual_tensor,
+        .persistent_output_tensor = persistent_output_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation.hpp
@@ -50,6 +50,7 @@ ttnn::operations::experimental::ccl::deepseek_minimal_all_reduce::DeepseekMinima
         tt::tt_fabric::Topology topology,
         std::optional<uint32_t> cluster_axis,
         const std::optional<ttnn::Tensor>& intermediate_tensor,
-        const std::optional<ttnn::Tensor>& residual_tensor = std::nullopt);
+        const std::optional<ttnn::Tensor>& residual_tensor = std::nullopt,
+        const std::optional<ttnn::Tensor>& persistent_output_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/deepseek_minimal_all_reduce_device_operation_types.hpp
@@ -21,6 +21,7 @@ struct tensor_args_t {
     Tensor input_tensor;
     std::optional<Tensor> intermediate_tensor;
     std::optional<Tensor> residual_tensor;  // Optional residual input for fused residual add
+    std::optional<Tensor> persistent_output_tensor;  // Optional persistent output buffer
 };
 
 }  // namespace ttnn::operations::experimental::ccl::deepseek_minimal_all_reduce

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/receiver_reader.cpp
@@ -50,7 +50,9 @@ void kernel_main() {
 
     if constexpr (!using_persistent_buffer) {
         auto* sem_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(sem_header_addr);
-        fabric_set_unicast_route<false>((tt::tt_fabric::LowLatencyPacketHeader*)sem_header_ptr, sender_num_hops);
+        fabric_set_unicast_route(fabric_connection, sem_header_ptr, 0);
+        sem_header_ptr->to_chip_unicast(sender_num_hops);
+
         sem_header_ptr->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sender_sem_noc_addr, 1});
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/receiver_reader.cpp
@@ -30,6 +30,7 @@ void kernel_main() {
     constexpr uint32_t num_standard_tiles = get_compile_time_arg_val(6);
     constexpr uint32_t cb_residual = get_compile_time_arg_val(7);  // CB for residual tensor (optional)
     constexpr uint32_t has_residual = get_compile_time_arg_val(8);
+    constexpr bool using_persistent_buffer = get_compile_time_arg_val(9);
 
     constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
     constexpr uint8_t sender_num_hops = 1;
@@ -47,13 +48,16 @@ void kernel_main() {
 
     const uint64_t sender_sem_noc_addr = get_noc_addr(remote_sender_noc_x, remote_sender_noc_y, sender_semaphore_addr);
 
-    auto* sem_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(sem_header_addr);
-    fabric_set_unicast_route<false>((tt::tt_fabric::LowLatencyPacketHeader*)sem_header_ptr, sender_num_hops);
-    sem_header_ptr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sender_sem_noc_addr, 1});
+    if constexpr (!using_persistent_buffer) {
+        auto* sem_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(sem_header_addr);
+        fabric_set_unicast_route<false>((tt::tt_fabric::LowLatencyPacketHeader*)sem_header_ptr, sender_num_hops);
+        sem_header_ptr->to_noc_unicast_atomic_inc(
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sender_sem_noc_addr, 1});
 
-    auto& connection = fabric_connection.get(0).sender;
-    connection.wait_for_empty_write_slot();
-    connection.send_payload_flush_blocking_from_address((uint32_t)sem_header_ptr, packet_header_size_bytes);
+        auto& connection = fabric_connection.get(0).sender;
+        connection.wait_for_empty_write_slot();
+        connection.send_payload_flush_blocking_from_address((uint32_t)sem_header_ptr, packet_header_size_bytes);
+    }
 
     // Push local and residual tiles to compute immediately (they're ready)
     // This allows compute to start (local + residual) while waiting for remote data

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_all_reduce/device/kernels/sender_writer.cpp
@@ -48,7 +48,8 @@ void kernel_main() {
     cb_push_back(packet_header_cb_id, 1);
 
     auto* packet_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
-    fabric_set_unicast_route<false>((tt::tt_fabric::LowLatencyPacketHeader*)packet_header_ptr, dst_num_hops);
+    fabric_set_unicast_route(fabric_connection, packet_header_ptr, 0);
+    packet_header_ptr->to_chip_unicast(dst_num_hops);
 
     //  wait for receiver to signal it is ready
     if constexpr (!using_persistent_buffer) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.cpp
@@ -18,7 +18,8 @@ ttnn::Tensor ExecuteDeepseekMinimalBroadcast::invoke(
     const ttnn::ccl::Topology topology,
     std::optional<uint32_t> cluster_axis,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-    std::optional<uint32_t> secondary_cluster_axis) {
+    std::optional<uint32_t> secondary_cluster_axis,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer) {
     return ttnn::prim::deepseek_minimal_broadcast(
         input_tensor,
         sender_coord,
@@ -27,7 +28,8 @@ ttnn::Tensor ExecuteDeepseekMinimalBroadcast::invoke(
         topology,
         cluster_axis,
         subdevice_id,
-        secondary_cluster_axis);
+        secondary_cluster_axis,
+        persistent_output_buffer);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.cpp
@@ -17,9 +17,17 @@ ttnn::Tensor ExecuteDeepseekMinimalBroadcast::invoke(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const ttnn::ccl::Topology topology,
     std::optional<uint32_t> cluster_axis,
-    std::optional<tt::tt_metal::SubDeviceId> subdevice_id) {
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    std::optional<uint32_t> secondary_cluster_axis) {
     return ttnn::prim::deepseek_minimal_broadcast(
-        input_tensor, sender_coord, num_links, memory_config, topology, cluster_axis, subdevice_id);
+        input_tensor,
+        sender_coord,
+        num_links,
+        memory_config,
+        topology,
+        cluster_axis,
+        subdevice_id,
+        secondary_cluster_axis);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.hpp
@@ -19,7 +19,8 @@ struct ExecuteDeepseekMinimalBroadcast {
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
         ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
         std::optional<uint32_t> cluster_axis = std::nullopt,
-        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt);
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        std::optional<uint32_t> secondary_cluster_axis = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast.hpp
@@ -20,7 +20,8 @@ struct ExecuteDeepseekMinimalBroadcast {
         ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear,
         std::optional<uint32_t> cluster_axis = std::nullopt,
         std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
-        std::optional<uint32_t> secondary_cluster_axis = std::nullopt);
+        std::optional<uint32_t> secondary_cluster_axis = std::nullopt,
+        const std::optional<ttnn::Tensor>& persistent_output_buffer = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast_nanobind.cpp
@@ -33,8 +33,17 @@ void bind_deepseek_minimal_broadcast_op(nb::module_ mod, const ccl_operation_t& 
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const uint32_t num_links,
-               const tt::tt_fabric::Topology topology) -> ttnn::Tensor {
-                return self(input_tensor, sender_coord, num_links, memory_config, topology, cluster_axis, subdevice_id);
+               const tt::tt_fabric::Topology topology,
+               std::optional<uint32_t> secondary_cluster_axis) -> ttnn::Tensor {
+                return self(
+                    input_tensor,
+                    sender_coord,
+                    num_links,
+                    memory_config,
+                    topology,
+                    cluster_axis,
+                    subdevice_id,
+                    secondary_cluster_axis);
             },
             nb::arg("input_tensor"),
             nb::arg("sender_coord"),
@@ -43,7 +52,8 @@ void bind_deepseek_minimal_broadcast_op(nb::module_ mod, const ccl_operation_t& 
             nb::arg("subdevice_id") = nb::none(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("num_links") = 1,
-            nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear)});
+            nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
+            nb::arg("secondary_cluster_axis") = nb::none()});
 }
 
 }  // namespace
@@ -54,6 +64,8 @@ void bind_deepseek_minimal_broadcast(nb::module_& mod) {
         ttnn::experimental::deepseek_minimal_broadcast,
         R"doc(
         Performs a broadcast operation from a sender device to all other mesh devices across a cluster axis.
+        Supports dual-axis broadcast where the sender first sends to a secondary sender across a secondary axis,
+        then both senders broadcast along the primary cluster axis in parallel.
 
         Args:
             input_tensor (ttnn.Tensor)
@@ -67,11 +79,12 @@ void bind_deepseek_minimal_broadcast(nb::module_& mod) {
             num_links (int, optional): Number of links to use for the all-broadcast operation. Defaults to `1`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+            secondary_cluster_axis (int, optional): For dual-axis broadcast, the secondary axis to first send data across before broadcasting along the primary axis. Defaults to `None`.
 
         Returns:
             ttnn.Tensor of the output on the mesh device.
 
-        Example:
+        Example (single-axis):
             >>> sender_tensor = torch.randn([1, 1, 32, 256], dtype=torch.bfloat16)
             >>> num_devices = 4
             >>> device_tensors = []
@@ -94,6 +107,16 @@ void bind_deepseek_minimal_broadcast(nb::module_& mod) {
                             memory_config=mem_config,
                             mesh_mapper=ttnn.create_mesh_mapper(mesh_device,mesh_mapper_config))
             >>> output = ttnn.experimental.broadcast(ttnn_tensor, sender_coord)
+
+        Example (dual-axis for 4x2 mesh):
+            >>> # Sender at (1,0) first sends to (1,1) across axis 1, then both broadcast along axis 0
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(4, 2))
+            >>> sender_coord = MeshCoordinate((1, 0))
+            >>> output = ttnn.experimental.deepseek_minimal_broadcast(
+                    ttnn_tensor,
+                    sender_coord,
+                    cluster_axis=0,
+                    secondary_cluster_axis=1)
 
         )doc");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/deepseek_minimal_broadcast_nanobind.cpp
@@ -34,7 +34,8 @@ void bind_deepseek_minimal_broadcast_op(nb::module_ mod, const ccl_operation_t& 
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const uint32_t num_links,
                const tt::tt_fabric::Topology topology,
-               std::optional<uint32_t> secondary_cluster_axis) -> ttnn::Tensor {
+               std::optional<uint32_t> secondary_cluster_axis,
+               const std::optional<ttnn::Tensor>& persistent_output_buffer) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     sender_coord,
@@ -43,7 +44,8 @@ void bind_deepseek_minimal_broadcast_op(nb::module_ mod, const ccl_operation_t& 
                     topology,
                     cluster_axis,
                     subdevice_id,
-                    secondary_cluster_axis);
+                    secondary_cluster_axis,
+                    persistent_output_buffer);
             },
             nb::arg("input_tensor"),
             nb::arg("sender_coord"),
@@ -53,7 +55,8 @@ void bind_deepseek_minimal_broadcast_op(nb::module_ mod, const ccl_operation_t& 
             nb::arg("memory_config") = nb::none(),
             nb::arg("num_links") = 1,
             nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
-            nb::arg("secondary_cluster_axis") = nb::none()});
+            nb::arg("secondary_cluster_axis") = nb::none(),
+            nb::arg("persistent_output_buffer") = nb::none()});
 }
 
 }  // namespace
@@ -80,6 +83,7 @@ void bind_deepseek_minimal_broadcast(nb::module_& mod) {
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
             secondary_cluster_axis (int, optional): For dual-axis broadcast, the secondary axis to first send data across before broadcasting along the primary axis. Defaults to `None`.
+            persistent_output_buffer (ttnn.Tensor, optional): Pre-allocated output buffer for persistent operation. When provided, barrier synchronization is skipped. Defaults to `None`.
 
         Returns:
             ttnn.Tensor of the output on the mesh device.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.cpp
@@ -65,12 +65,12 @@ void DeepseekMinimalBroadcastDeviceOperation::validate_on_program_cache_miss(
         "Input tensor must be in tile size (1,32). Got tile size: ({}, {})",
         tile_height,
         tile_width);
-    // input shape should be (1,1536)
+    // input shape should be (1,7168)
     // To do add shape (1,7168) once fabric supports larger packets
     const auto& input_shape = input_tensor.logical_shape();
     TT_FATAL(
-        input_shape[0] == 1 && input_shape[1] == 1536,
-        "Input tensor shape must be (1,1536). Got shape: ({}, {})",
+        input_shape[0] == 1 && input_shape[1] == 7168,
+        "Input tensor shape must be (1,7168). Got shape: ({}, {})",
         input_shape[0],
         input_shape[1]);
 }
@@ -109,6 +109,7 @@ tt::stl::hash::hash_t DeepseekMinimalBroadcastDeviceOperation::compute_program_h
         operation_attributes.output_mem_config,
         operation_attributes.topology,
         operation_attributes.cluster_axis,
+        operation_attributes.secondary_cluster_axis,
         subdevice_core_range_set,
         tensor_args,
         program_factory.index());
@@ -125,7 +126,8 @@ Tensor deepseek_minimal_broadcast(
     const std::optional<MemoryConfig>& memory_config,
     tt::tt_fabric::Topology topology,
     std::optional<uint32_t> cluster_axis,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<uint32_t> secondary_cluster_axis) {
     using OperationType = ttnn::experimental::prim::DeepseekMinimalBroadcastDeviceOperation;
 
     const auto& tensor_topology = input_tensor.tensor_topology();
@@ -158,6 +160,7 @@ Tensor deepseek_minimal_broadcast(
         .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
         .topology = ccl_topology,
         .cluster_axis = cluster_axis,
+        .secondary_cluster_axis = secondary_cluster_axis,
         .sub_device_id = sub_device_id};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
@@ -49,6 +49,7 @@ Tensor deepseek_minimal_broadcast(
     const std::optional<MemoryConfig>& memory_config,
     tt::tt_fabric::Topology topology,
     std::optional<uint32_t> cluster_axis,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    std::optional<uint32_t> secondary_cluster_axis = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation.hpp
@@ -50,6 +50,7 @@ Tensor deepseek_minimal_broadcast(
     tt::tt_fabric::Topology topology,
     std::optional<uint32_t> cluster_axis,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
-    std::optional<uint32_t> secondary_cluster_axis = std::nullopt);
+    std::optional<uint32_t> secondary_cluster_axis = std::nullopt,
+    const std::optional<Tensor>& persistent_output_buffer = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
@@ -17,6 +17,7 @@ struct DeepseekMinimalBroadcastParams {
     MemoryConfig output_mem_config;
     tt::tt_fabric::Topology topology{};
     std::optional<uint32_t> cluster_axis;
+    std::optional<uint32_t> secondary_cluster_axis;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_device_operation_types.hpp
@@ -19,10 +19,12 @@ struct DeepseekMinimalBroadcastParams {
     std::optional<uint32_t> cluster_axis;
     std::optional<uint32_t> secondary_cluster_axis;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+    bool using_persistent_buffers = false;
 };
 
 struct DeepseekMinimalBroadcastInputs {
     Tensor input_tensor;
+    std::optional<Tensor> persistent_output_buffer;
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.cpp
@@ -272,6 +272,9 @@ DeepseekMinimalBroadcastProgramFactory::cached_program_t DeepseekMinimalBroadcas
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
 
+    // Add using_persistent_buffers flag
+    writer_compile_args.push_back(operation_attributes.using_persistent_buffers ? 1 : 0);
+
     auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
@@ -14,6 +14,7 @@ struct DeepseekMinimalBroadcastProgramFactory {
         tt::tt_metal::GlobalSemaphore semaphore;
         tt::tt_metal::GlobalSemaphore barrier_semaphore;
         uint32_t ring_index = 0;
+        bool is_secondary_sender = false;
     };
 
     using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/deepseek_minimal_broadcast_program_factory.hpp
@@ -13,6 +13,7 @@ struct DeepseekMinimalBroadcastProgramFactory {
         tt::tt_metal::KernelHandle worker_sender_writer_kernel_id{};
         tt::tt_metal::GlobalSemaphore semaphore;
         tt::tt_metal::GlobalSemaphore barrier_semaphore;
+        tt::tt_metal::GlobalSemaphore secondary_sync_semaphore;
         uint32_t ring_index = 0;
         bool is_secondary_sender = false;
     };
@@ -40,7 +41,8 @@ private:
         const DeepseekMinimalBroadcastInputs& tensor_args,
         Tensor& output_tensor,
         const tt::tt_metal::GlobalSemaphore& semaphore,
-        const tt::tt_metal::GlobalSemaphore& barrier_semaphore);
+        const tt::tt_metal::GlobalSemaphore& barrier_semaphore,
+        const tt::tt_metal::GlobalSemaphore& secondary_sync_semaphore);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_reader_batch1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_reader_batch1.cpp
@@ -20,6 +20,9 @@ constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
 constexpr bool is_sender = get_compile_time_arg_val(3);
 constexpr uint32_t core_noc_x = get_compile_time_arg_val(4);
 constexpr uint32_t core_noc_y = get_compile_time_arg_val(5);
+// Dual-axis broadcast args
+constexpr bool is_secondary_sender = get_compile_time_arg_val(6);
+constexpr bool is_active_broadcaster = get_compile_time_arg_val(7);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -29,12 +32,28 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
+    DPRINT << "start of broadcast_tile_reader_batch1" << ENDL();
+    DPRINT << "CT args:\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << ENDL();
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << ENDL();
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << ENDL();
+    DPRINT << "is_sender: " << (uint32_t)is_sender << ENDL();
+    DPRINT << "core noc x: " << (uint32_t)core_noc_x << ENDL();
+    DPRINT << "core noc y: " << (uint32_t)core_noc_y << ENDL();
+    DPRINT << "is_secondary_sender: " << (uint32_t)is_secondary_sender << ENDL();
+    DPRINT << "is_active_broadcaster: " << (uint32_t)is_active_broadcaster << ENDL();
     if (is_sender) {
         size_t arg_idx = 0;
         // Load the input tensor spec
         uint32_t tensor_address0 = get_arg_val<uint32_t>(arg_idx++);
         uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
         uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
+
+        DPRINT << "RT args\n";
+        DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << ENDL();
+        DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << ENDL();
+        DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << ENDL();
+
         uint32_t num_pages_to_read = std::min(tile_id_end - tile_id_start, packet_size_in_pages);
         cb_reserve_back(cb0_id, packet_size_in_pages);
         const uint32_t l1_write_addr = get_write_ptr(cb0_id);
@@ -44,4 +63,5 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb0_id, packet_size_in_pages);
     }
+    DPRINT << "end of broadcast_tile_reader_batch1" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_reader_batch1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_reader_batch1.cpp
@@ -32,27 +32,12 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
-    DPRINT << "start of broadcast_tile_reader_batch1" << ENDL();
-    DPRINT << "CT args:\n";
-    DPRINT << "cb0_id: " << (uint32_t)cb0_id << ENDL();
-    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << ENDL();
-    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << ENDL();
-    DPRINT << "is_sender: " << (uint32_t)is_sender << ENDL();
-    DPRINT << "core noc x: " << (uint32_t)core_noc_x << ENDL();
-    DPRINT << "core noc y: " << (uint32_t)core_noc_y << ENDL();
-    DPRINT << "is_secondary_sender: " << (uint32_t)is_secondary_sender << ENDL();
-    DPRINT << "is_active_broadcaster: " << (uint32_t)is_active_broadcaster << ENDL();
     if (is_sender) {
         size_t arg_idx = 0;
         // Load the input tensor spec
         uint32_t tensor_address0 = get_arg_val<uint32_t>(arg_idx++);
         uint32_t tile_id_start = get_arg_val<uint32_t>(arg_idx++);
         uint32_t tile_id_end = get_arg_val<uint32_t>(arg_idx++);
-
-        DPRINT << "RT args\n";
-        DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << ENDL();
-        DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << ENDL();
-        DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << ENDL();
 
         uint32_t num_pages_to_read = std::min(tile_id_end - tile_id_start, packet_size_in_pages);
         cb_reserve_back(cb0_id, packet_size_in_pages);
@@ -63,5 +48,4 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb0_id, packet_size_in_pages);
     }
-    DPRINT << "end of broadcast_tile_reader_batch1" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_writer_batch1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_writer_batch1.cpp
@@ -31,10 +31,25 @@ constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(4);
 constexpr bool is_sender = get_compile_time_arg_val(5);
 constexpr uint32_t core_noc_x = get_compile_time_arg_val(6);
 constexpr uint32_t core_noc_y = get_compile_time_arg_val(7);
-constexpr uint32_t start_distance_in_hops_forward = get_compile_time_arg_val(8);
-constexpr uint32_t range_hops_forward = get_compile_time_arg_val(9);
-constexpr uint32_t start_distance_in_hops_backward = get_compile_time_arg_val(10);
-constexpr uint32_t range_hops_backward = get_compile_time_arg_val(11);
+// Dual-axis broadcast args
+constexpr bool is_secondary_sender = get_compile_time_arg_val(8);
+constexpr bool is_active_broadcaster = get_compile_time_arg_val(9);
+constexpr bool has_secondary_axis = get_compile_time_arg_val(10);
+// Data mcast targets (0 for non-broadcasters)
+constexpr uint32_t mcast_num_targets_forward = get_compile_time_arg_val(11);
+constexpr uint32_t mcast_num_targets_backward = get_compile_time_arg_val(12);
+// Primary axis mcast hop args (for barrier, all devices need these)
+constexpr uint32_t start_distance_in_hops_forward = get_compile_time_arg_val(13);
+constexpr uint32_t range_hops_forward = get_compile_time_arg_val(14);
+constexpr uint32_t start_distance_in_hops_backward = get_compile_time_arg_val(15);
+constexpr uint32_t range_hops_backward = get_compile_time_arg_val(16);
+// Secondary axis args (for sender to secondary sender transfer)
+constexpr bool has_secondary_target = get_compile_time_arg_val(17);
+constexpr uint32_t num_secondary_targets = get_compile_time_arg_val(18);
+
+// Number of primary axis connections (forward + backward)
+constexpr uint32_t num_primary_connections =
+    (start_distance_in_hops_forward > 0 ? 1 : 0) + (start_distance_in_hops_backward > 0 ? 1 : 0);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -44,6 +59,28 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
+    DPRINT << "start of broadcast_tile_writer_batch1" << ENDL();
+    DPRINT << "CT args:\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << ENDL();
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << ENDL();
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << ENDL();
+    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << ENDL();
+    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << ENDL();
+    DPRINT << "is_sender: " << (uint32_t)is_sender << ENDL();
+    DPRINT << "core noc x: " << (uint32_t)core_noc_x << ENDL();
+    DPRINT << "core noc y: " << (uint32_t)core_noc_y << ENDL();
+    DPRINT << "is_secondary_sender: " << (uint32_t)is_secondary_sender << ENDL();
+    DPRINT << "is_active_broadcaster: " << (uint32_t)is_active_broadcaster << ENDL();
+    DPRINT << "has_secondary_axis: " << (uint32_t)has_secondary_axis << ENDL();
+    DPRINT << "mcast_num_targets_forward: " << (uint32_t)mcast_num_targets_forward << ENDL();
+    DPRINT << "mcast_num_targets_backward: " << (uint32_t)mcast_num_targets_backward << ENDL();
+    DPRINT << "start_distance_in_hops_forward: " << (uint32_t)start_distance_in_hops_forward << ENDL();
+    DPRINT << "range_hops_forward: " << (uint32_t)range_hops_forward << ENDL();
+    DPRINT << "start_distance_in_hops_backward: " << (uint32_t)start_distance_in_hops_backward << ENDL();
+    DPRINT << "range_hops_backward: " << (uint32_t)range_hops_backward << ENDL();
+    DPRINT << "has_secondary_target: " << (uint32_t)has_secondary_target << ENDL();
+    DPRINT << "num_secondary_targets: " << (uint32_t)num_secondary_targets << ENDL();
+    DPRINT << "num primary connections: " << (uint32_t)num_primary_connections << ENDL();
 
     size_t arg_idx = 0;
     // Load the input tensor spec
@@ -59,14 +96,36 @@ void kernel_main() {
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t ring_index = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_connections = get_arg_val<uint32_t>(arg_idx++);
     size_t arg_for_fab = arg_idx;
 
-    auto sem_route_id = PacketHeaderPool::allocate_header_n(num_connections);
-    auto fused_route_id = PacketHeaderPool::allocate_header_n(num_connections);
+    DPRINT << "RT args\n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << ENDL();
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << ENDL();
+    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << ENDL();
+    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << ENDL();
+    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << ENDL();
+    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << ENDL();
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << ENDL();
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << ENDL();
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << ENDL();
+    DPRINT << "barrier_sem: " << (uint32_t)barrier_sem << ENDL();
+    DPRINT << "barrier_sem_noc0_x: " << (uint32_t)barrier_sem_noc0_x << ENDL();
+    DPRINT << "barrier_sem_noc0_y: " << (uint32_t)barrier_sem_noc0_y << ENDL();
+    DPRINT << "ring_index: " << (uint32_t)ring_index << ENDL();
+    DPRINT << "num_connections: " << (uint32_t)num_connections << ENDL();
+
+    auto sem_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
+    auto fused_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
+    // Allocate separate route for secondary axis unicast (if applicable)
+    auto secondary_route_id = has_secondary_target ? PacketHeaderPool::allocate_header_n(1) : 0;
     tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
 
+    DPRINT << "before open connections, num_connections=" << num_connections
+           << ", num_primary=" << num_primary_connections << "\n";
     open_connections(fabric_connection, num_connections, arg_for_fab);
+    DPRINT << "after open connections\n";
 
     uint8_t starts[] = {
         static_cast<uint8_t>(start_distance_in_hops_forward), static_cast<uint8_t>(start_distance_in_hops_backward)};
@@ -96,9 +155,12 @@ void kernel_main() {
         fabric_connection,
         sem_route_id,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
+    DPRINT << "waiting for barrier sync\n";
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
-    // 1. mcast via fabric to remote tensor addresses
+
+    DPRINT << "after barrier sync\n";
+
     if (is_sender) {
         uint32_t num_pages_to_read = std::min(tile_id_end - tile_id_start, packet_size_in_pages);
         cb_wait_front(cb0_id, packet_size_in_pages);
@@ -107,9 +169,30 @@ void kernel_main() {
         dst_noc_addr += tile_id_start * tensor0_page_size;
         noc_async_write(l1_read_addr, dst_noc_addr, tensor0_page_size * num_pages_to_read);
 
-        // 2. Fused: mcast payload + increment output ready semaphore
         uint64_t out_ready_sem_noc_addr_in_pkt =
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+
+        // For dual-axis mode: first unicast to secondary sender, then mcast along primary axis
+        if constexpr (has_secondary_target) {
+            DPRINT << "Sending to secondary sender first\n";
+            auto& secondary_slot = fabric_connection.get(num_primary_connections);
+            volatile PACKET_HEADER_TYPE* secondary_header = PacketHeaderPool::header_table[secondary_route_id].first;
+
+            // Set up unicast route for 2D fabric
+            fabric_set_unicast_route(fabric_connection, secondary_header, num_primary_connections);
+
+            // Send data + semaphore increment to secondary sender
+            fabric_unicast_noc_fused_unicast_with_atomic_inc(
+                &secondary_slot.sender,
+                secondary_header,
+                l1_read_addr,
+                tensor0_page_size * num_pages_to_read,
+                tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
+                    dst_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
+                1);  // 1 hop to secondary sender
+
+            DPRINT << "Sent to secondary sender, now mcast along primary axis\n";
+        }
 
         fabric_multicast_noc_fused_unicast_with_atomic_inc_with_state<
             UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
@@ -142,14 +225,57 @@ void kernel_main() {
         close_connections(fabric_connection);
 
         noc_async_write_barrier();
-    } else {
+    } else if constexpr (is_secondary_sender) {
+        DPRINT << "Secondary sender: waiting for data from primary sender\n";
+        // Secondary sender: wait for data from primary sender, then broadcast along primary axis
+        // First wait for data to arrive from primary sender
         if (wait_output_semaphore) {
             volatile tt_l1_ptr uint32_t* sem_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
             noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
         }
+        DPRINT << "Secondary sender: received data, resetting semaphore\n";
 
-        // 4. global semaphore reset
+        // Reset semaphore after receiving data
+        if (reset_global_semaphore) {
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
+        }
+
+        // broadcast the received data along the primary axis
+        uint32_t num_pages_to_read = std::min(tile_id_end - tile_id_start, packet_size_in_pages);
+        uint64_t src_noc_addr = get_noc_addr(core_noc_x, core_noc_y, tensor_address0, 0);
+        src_noc_addr += tile_id_start * tensor0_page_size;
+
+        // Mcast the data along primary axis
+        uint64_t out_ready_sem_noc_addr_in_pkt =
+            safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+
+        DPRINT << "Secondary sender: broadcasting along primary axis\n";
+        fabric_multicast_noc_fused_unicast_with_atomic_inc_with_state<
+            UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
+            UnicastFusedAtomicIncUpdateMask::PayloadSize>(
+            fabric_connection,
+            fused_route_id,
+            static_cast<size_t>(tensor_address0 + tile_id_start * tensor0_page_size),
+            tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{src_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
+            tensor0_page_size * num_pages_to_read);
+        noc_async_writes_flushed();
+
+        close_connections(fabric_connection);
+
+        noc_async_write_barrier();
+        DPRINT << "Secondary sender: done\n";
+    } else {
+        DPRINT << "Receiver: waiting for data\n";
+        // Receiver: wait for data from broadcaster
+        if (wait_output_semaphore) {
+            volatile tt_l1_ptr uint32_t* sem_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
+            noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
+        }
+        DPRINT << "Receiver: received data\n";
+
+        // Reset global semaphore
         if (reset_global_semaphore) {
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
         }
@@ -157,5 +283,7 @@ void kernel_main() {
         close_connections(fabric_connection);
 
         noc_async_write_barrier();
+        DPRINT << "Receiver: done\n";
     }
+    DPRINT << "end of broadcast_tile_writer_batch1" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_writer_batch1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_minimal_broadcast/device/kernels/broadcast_tile_writer_batch1.cpp
@@ -31,25 +31,20 @@ constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(4);
 constexpr bool is_sender = get_compile_time_arg_val(5);
 constexpr uint32_t core_noc_x = get_compile_time_arg_val(6);
 constexpr uint32_t core_noc_y = get_compile_time_arg_val(7);
-// Dual-axis broadcast args
 constexpr bool is_secondary_sender = get_compile_time_arg_val(8);
-constexpr bool is_active_broadcaster = get_compile_time_arg_val(9);
-constexpr bool has_secondary_axis = get_compile_time_arg_val(10);
-// Data mcast targets (0 for non-broadcasters)
-constexpr uint32_t mcast_num_targets_forward = get_compile_time_arg_val(11);
-constexpr uint32_t mcast_num_targets_backward = get_compile_time_arg_val(12);
-// Primary axis mcast hop args (for barrier, all devices need these)
-constexpr uint32_t start_distance_in_hops_forward = get_compile_time_arg_val(13);
-constexpr uint32_t range_hops_forward = get_compile_time_arg_val(14);
-constexpr uint32_t start_distance_in_hops_backward = get_compile_time_arg_val(15);
-constexpr uint32_t range_hops_backward = get_compile_time_arg_val(16);
-// Secondary axis args (for sender to secondary sender transfer)
-constexpr bool has_secondary_target = get_compile_time_arg_val(17);
-constexpr uint32_t num_secondary_targets = get_compile_time_arg_val(18);
+constexpr bool has_secondary_target = get_compile_time_arg_val(9);
+constexpr bool has_reverse_secondary_connection = get_compile_time_arg_val(10);
+constexpr uint32_t start_distance_in_hops_forward = get_compile_time_arg_val(11);
+constexpr uint32_t range_hops_forward = get_compile_time_arg_val(12);
+constexpr uint32_t start_distance_in_hops_backward = get_compile_time_arg_val(13);
+constexpr uint32_t range_hops_backward = get_compile_time_arg_val(14);
 
 // Number of primary axis connections (forward + backward)
 constexpr uint32_t num_primary_connections =
     (start_distance_in_hops_forward > 0 ? 1 : 0) + (start_distance_in_hops_backward > 0 ? 1 : 0);
+
+// Index of the secondary axis connection
+constexpr uint32_t secondary_connection_idx = num_primary_connections;
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -59,28 +54,6 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
-    DPRINT << "start of broadcast_tile_writer_batch1" << ENDL();
-    DPRINT << "CT args:\n";
-    DPRINT << "cb0_id: " << (uint32_t)cb0_id << ENDL();
-    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << ENDL();
-    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << ENDL();
-    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << ENDL();
-    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << ENDL();
-    DPRINT << "is_sender: " << (uint32_t)is_sender << ENDL();
-    DPRINT << "core noc x: " << (uint32_t)core_noc_x << ENDL();
-    DPRINT << "core noc y: " << (uint32_t)core_noc_y << ENDL();
-    DPRINT << "is_secondary_sender: " << (uint32_t)is_secondary_sender << ENDL();
-    DPRINT << "is_active_broadcaster: " << (uint32_t)is_active_broadcaster << ENDL();
-    DPRINT << "has_secondary_axis: " << (uint32_t)has_secondary_axis << ENDL();
-    DPRINT << "mcast_num_targets_forward: " << (uint32_t)mcast_num_targets_forward << ENDL();
-    DPRINT << "mcast_num_targets_backward: " << (uint32_t)mcast_num_targets_backward << ENDL();
-    DPRINT << "start_distance_in_hops_forward: " << (uint32_t)start_distance_in_hops_forward << ENDL();
-    DPRINT << "range_hops_forward: " << (uint32_t)range_hops_forward << ENDL();
-    DPRINT << "start_distance_in_hops_backward: " << (uint32_t)start_distance_in_hops_backward << ENDL();
-    DPRINT << "range_hops_backward: " << (uint32_t)range_hops_backward << ENDL();
-    DPRINT << "has_secondary_target: " << (uint32_t)has_secondary_target << ENDL();
-    DPRINT << "num_secondary_targets: " << (uint32_t)num_secondary_targets << ENDL();
-    DPRINT << "num primary connections: " << (uint32_t)num_primary_connections << ENDL();
 
     size_t arg_idx = 0;
     // Load the input tensor spec
@@ -100,32 +73,15 @@ void kernel_main() {
     const uint32_t num_connections = get_arg_val<uint32_t>(arg_idx++);
     size_t arg_for_fab = arg_idx;
 
-    DPRINT << "RT args\n";
-    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << ENDL();
-    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << ENDL();
-    DPRINT << "tile_id_start: " << (uint32_t)tile_id_start << ENDL();
-    DPRINT << "tile_id_end: " << (uint32_t)tile_id_end << ENDL();
-    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << ENDL();
-    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << ENDL();
-    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << ENDL();
-    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << ENDL();
-    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << ENDL();
-    DPRINT << "barrier_sem: " << (uint32_t)barrier_sem << ENDL();
-    DPRINT << "barrier_sem_noc0_x: " << (uint32_t)barrier_sem_noc0_x << ENDL();
-    DPRINT << "barrier_sem_noc0_y: " << (uint32_t)barrier_sem_noc0_y << ENDL();
-    DPRINT << "ring_index: " << (uint32_t)ring_index << ENDL();
-    DPRINT << "num_connections: " << (uint32_t)num_connections << ENDL();
-
     auto sem_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
     auto fused_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
     // Allocate separate route for secondary axis unicast (if applicable)
     auto secondary_route_id = has_secondary_target ? PacketHeaderPool::allocate_header_n(1) : 0;
+    // Allocate route for reverse secondary connection (secondary sender -> primary sender)
+    auto reverse_secondary_route_id = has_reverse_secondary_connection ? PacketHeaderPool::allocate_header_n(1) : 0;
     tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
 
-    DPRINT << "before open connections, num_connections=" << num_connections
-           << ", num_primary=" << num_primary_connections << "\n";
     open_connections(fabric_connection, num_connections, arg_for_fab);
-    DPRINT << "after open connections\n";
 
     uint8_t starts[] = {
         static_cast<uint8_t>(start_distance_in_hops_forward), static_cast<uint8_t>(start_distance_in_hops_backward)};
@@ -144,22 +100,49 @@ void kernel_main() {
     uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
 
     uint64_t barrier_sem_noc_addr_in_pkt = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
-    fabric_multicast_noc_unicast_atomic_inc_set_state<
-        UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
-        fabric_connection,
-        sem_route_id,
-        starts,
-        ranges,
-        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
-    fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
-        fabric_connection,
-        sem_route_id,
-        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
-    DPRINT << "waiting for barrier sync\n";
-    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
-    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
-    DPRINT << "after barrier sync\n";
+    // Secondary axis barrier between primary sender and secondary sender
+    // Both devices send an atomic inc to each other and wait
+    if constexpr (has_secondary_target || has_reverse_secondary_connection) {
+        auto& secondary_slot = fabric_connection.get(secondary_connection_idx);
+        auto route_id = has_secondary_target ? secondary_route_id : reverse_secondary_route_id;
+        volatile PACKET_HEADER_TYPE* sec_sync_header = PacketHeaderPool::header_table[route_id].first;
+        fabric_set_unicast_route(fabric_connection, sec_sync_header, secondary_connection_idx);
+
+        uint64_t out_ready_sem_noc_addr_in_pkt =
+            safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+
+        // Send atomic inc to the other device
+        fabric_unicast_noc_unicast_atomic_inc(
+            &secondary_slot.sender,
+            sec_sync_header,
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 1},
+            1);
+
+        // Wait for the other device's atomic inc
+        volatile tt_l1_ptr uint32_t* sync_sem_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
+        noc_semaphore_wait_min(sync_sem_ptr, 1);
+        noc_semaphore_set(sync_sem_ptr, 0);
+    }
+
+    if (!is_sender) {
+        // Now do the column-wise barrier (primary axis sync)
+        // do it for the sender later to overlap with data sending
+        fabric_multicast_noc_unicast_atomic_inc_set_state<
+            UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+            fabric_connection,
+            sem_route_id,
+            starts,
+            ranges,
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
+        fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+            fabric_connection,
+            sem_route_id,
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
+    }
 
     if (is_sender) {
         uint32_t num_pages_to_read = std::min(tile_id_end - tile_id_start, packet_size_in_pages);
@@ -167,19 +150,17 @@ void kernel_main() {
         size_t l1_read_addr = get_read_ptr(cb0_id);
         uint64_t dst_noc_addr = get_noc_addr(core_noc_x, core_noc_y, tensor_address0, 0);
         dst_noc_addr += tile_id_start * tensor0_page_size;
-        noc_async_write(l1_read_addr, dst_noc_addr, tensor0_page_size * num_pages_to_read);
 
         uint64_t out_ready_sem_noc_addr_in_pkt =
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
 
         // For dual-axis mode: first unicast to secondary sender, then mcast along primary axis
         if constexpr (has_secondary_target) {
-            DPRINT << "Sending to secondary sender first\n";
-            auto& secondary_slot = fabric_connection.get(num_primary_connections);
+            auto& secondary_slot = fabric_connection.get(secondary_connection_idx);
             volatile PACKET_HEADER_TYPE* secondary_header = PacketHeaderPool::header_table[secondary_route_id].first;
 
             // Set up unicast route for 2D fabric
-            fabric_set_unicast_route(fabric_connection, secondary_header, num_primary_connections);
+            fabric_set_unicast_route(fabric_connection, secondary_header, secondary_connection_idx);
 
             // Send data + semaphore increment to secondary sender
             fabric_unicast_noc_fused_unicast_with_atomic_inc(
@@ -190,9 +171,22 @@ void kernel_main() {
                 tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
                     dst_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
                 1);  // 1 hop to secondary sender
-
-            DPRINT << "Sent to secondary sender, now mcast along primary axis\n";
         }
+
+        // Now do the column-wise barrier (primary axis sync)
+        fabric_multicast_noc_unicast_atomic_inc_set_state<
+            UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+            fabric_connection,
+            sem_route_id,
+            starts,
+            ranges,
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
+        fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+            fabric_connection,
+            sem_route_id,
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
         fabric_multicast_noc_fused_unicast_with_atomic_inc_with_state<
             UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
@@ -202,6 +196,8 @@ void kernel_main() {
             l1_read_addr,
             tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{dst_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
             tensor0_page_size * num_pages_to_read);
+
+        noc_async_write(l1_read_addr, dst_noc_addr, tensor0_page_size * num_pages_to_read);
         noc_async_writes_flushed();
         cb_pop_front(cb0_id, packet_size_in_pages);
 
@@ -226,7 +222,6 @@ void kernel_main() {
 
         noc_async_write_barrier();
     } else if constexpr (is_secondary_sender) {
-        DPRINT << "Secondary sender: waiting for data from primary sender\n";
         // Secondary sender: wait for data from primary sender, then broadcast along primary axis
         // First wait for data to arrive from primary sender
         if (wait_output_semaphore) {
@@ -234,7 +229,6 @@ void kernel_main() {
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
             noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
         }
-        DPRINT << "Secondary sender: received data, resetting semaphore\n";
 
         // Reset semaphore after receiving data
         if (reset_global_semaphore) {
@@ -250,7 +244,6 @@ void kernel_main() {
         uint64_t out_ready_sem_noc_addr_in_pkt =
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
 
-        DPRINT << "Secondary sender: broadcasting along primary axis\n";
         fabric_multicast_noc_fused_unicast_with_atomic_inc_with_state<
             UnicastFusedAtomicIncUpdateMask::WriteDstAddr | UnicastFusedAtomicIncUpdateMask::SemaphoreAddr |
             UnicastFusedAtomicIncUpdateMask::PayloadSize>(
@@ -264,16 +257,13 @@ void kernel_main() {
         close_connections(fabric_connection);
 
         noc_async_write_barrier();
-        DPRINT << "Secondary sender: done\n";
     } else {
-        DPRINT << "Receiver: waiting for data\n";
         // Receiver: wait for data from broadcaster
         if (wait_output_semaphore) {
             volatile tt_l1_ptr uint32_t* sem_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
             noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
         }
-        DPRINT << "Receiver: received data\n";
 
         // Reset global semaphore
         if (reset_global_semaphore) {
@@ -283,7 +273,5 @@ void kernel_main() {
         close_connections(fabric_connection);
 
         noc_async_write_barrier();
-        DPRINT << "Receiver: done\n";
     }
-    DPRINT << "end of broadcast_tile_writer_batch1" << ENDL();
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/35547

### Problem description
Provide context for the problem.

### What's changed
This PR adds support to minimal broadcast op to broadcast the data across all 8 devices on a 4x2 mesh. 
- The sender device first sends its data to the neighbour device on cluster axis 1 (TP)
- Then both devices mcast the data to the devices across their column (SP)
- The op has 3 hops in total and takes 4 us when using persistent buffers

This op is needed at the beginning of the decode batch 1

The PR also adds the persistent buffer support for tp_all_reduce op which drops its latency to 3.6 us

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nardo/broadcast_all)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/broadcast_all)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/broadcast_all)
- [ ] [![Blackhole Nightly Test](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml?query=branch:nardo/broadcast_all)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/broadcast_all)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/broadcast_all)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nardo/broadcast_all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/broadcast_all)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs