### PR TITLE
Deepseek V3 Flash MLA decode optimizations 

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode.py
@@ -34,6 +34,12 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
     ],
 )
 @pytest.mark.parametrize(
+    "q_mem_config",
+    [
+        None,  # default memory config (no replication)
+    ],
+)
+@pytest.mark.parametrize(
     "use_paged_attention",
     [
         # False,
@@ -64,6 +70,7 @@ def test_flash_mla_decode(
     d_rope,
     q_num_cores,
     q_dtype,
+    q_mem_config,
     dtype,
     use_paged_attention,
     block_size,
@@ -81,6 +88,7 @@ def test_flash_mla_decode(
         d_rope,
         q_num_cores,
         q_dtype,
+        q_mem_config,
         dtype,
         use_paged_attention,
         block_size,

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
@@ -10,73 +10,34 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
 )
 
 
-# When Q is pre-sharded and replicated across cores for MLA parallelization:
-# - Original Q shape: (1, batch, num_heads, head_dim) e.g. (1, 4, 128, 576)
-# - Each core gets a shard of (32, head_dim) = one tile row of heads
-# - Q is replicated so each reducer group has its Q locally available
-#
-# To use this feature, set in SDPAProgramConfig:
-#   q_locally_available=True
-#   max_cores_per_head_batch=<cores per reducer group>
-#
-# The program factory will deduce:
-#   - batch size from K/V tensor shape
-#   - num_groups = total_shards / max_cores_per_head_batch
-#   - q_heads_parallel_factor = num_groups / batch
-#   - num_q_heads = q_heads_parallel_factor * shard_height
-
-
 def create_replicated_q_shard_spec(device, batch, nh, d, num_cores_per_head=4):
-    """
-    Creates a memory config where Q is replicated within each reducer group.
-
-    The core list follows the SDPA program factory's interleaved pattern:
-    - Output cores (reducers) are at logical indices 0..num_output_cores-1
-    - Worker cores start at index num_output_cores
-    - For each virtual batch: [output_core, worker1, worker2, worker3]
-
-    When this config is used, the program config should have:
-        q_locally_available=True
-        max_cores_per_head_batch=num_cores_per_head
-    """
-    q_heads_parallel_factor = (nh + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE  # ceil(nh / 32)
+    q_heads_parallel_factor = (nh + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
     num_virtual_batches = batch * q_heads_parallel_factor
-    num_output_cores = num_virtual_batches
-
-    # Total cores needed = num_virtual_batches * num_cores_per_head
     total_cores = num_virtual_batches * num_cores_per_head
 
-    # Shard shape: each core gets (32, D) = (TILE_HEIGHT, head_dim)
-    shard_height = ttnn.TILE_SIZE  # 32
+    shard_height = ttnn.TILE_SIZE
     shard_width = d
 
-    # Use device's actual grid size
     grid_x = device.compute_with_storage_grid_size().x
     grid_y = device.compute_with_storage_grid_size().y
-
-    print(f"grid_x: {grid_x}, grid_y: {grid_y}, total_cores_needed: {total_cores}")
 
     if total_cores > grid_x * grid_y:
         raise ValueError(f"Not enough cores: need {total_cores}, have {grid_x * grid_y}")
 
-    # Build core list in the exact SDPA order (matching program factory)
     tile_h = 4
     tile_w = 4
-
     num_tiles_y = grid_y // tile_h
     num_tiles_x = grid_x // tile_w
 
     core_list = []
-    for tile_x in range(num_tiles_x):  # quadrant cols
-        for tile_y in range(num_tiles_y):  # quadrant rows
-            for local_y in range(tile_h):  # row inside quadrant
-                for local_x in range(tile_w):  # col inside quadrant
+    for tile_x in range(num_tiles_x):
+        for tile_y in range(num_tiles_y):
+            for local_y in range(tile_h):
+                for local_x in range(tile_w):
                     x = tile_x * tile_w + local_x
                     y = tile_y * tile_h + local_y
                     core_list.append((x, y))
-    print(f"core_list: {core_list[:total_cores]}")
 
-    # Create core range set from the list (only use cores we need)
     core_range_set = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in core_list[:total_cores]]
     )
@@ -88,87 +49,19 @@ def create_replicated_q_shard_spec(device, batch, nh, d, num_cores_per_head=4):
     )
 
 
-@pytest.mark.parametrize(
-    "batch",
-    [
-        # 1,  # Single batch
-        # 2,  # Multiple batches # Removing to reduce CI load
-        4,  # Multiple batches # Removing to reduce CI load
-        # 8,  # Even larger batch size
-    ],
-)
-@pytest.mark.parametrize(
-    "seq_len",
-    [
-        1 * 1024,  # Long sequence length
-    ],
-)
-@pytest.mark.parametrize(
-    "nh",
-    [
-        # 16,
-        # 32,
-        128,
-    ],
-)
-@pytest.mark.parametrize(
-    "nkv",
-    [
-        1,
-        # 8, # Removing to reduce CI load
-        # 16,
-    ],
-)
-@pytest.mark.parametrize(
-    "kv_lora_rank",
-    [
-        # 64,
-        512,
-    ],
-)
-@pytest.mark.parametrize(
-    "d_rope",
-    [
-        # 0,
-        # 32,
-        64,
-        # 128,
-    ],
-)
-@pytest.mark.parametrize(
-    "q_num_cores",
-    [
-        # 0,  # No sharding
-        # 8,  # Shard across 8 cores
-        64,  # Shard across all cores
-    ],
-)
-@pytest.mark.parametrize(
-    "q_dtype, dtype",
-    [
-        (ttnn.bfloat16, ttnn.bfloat8_b),
-    ],
-)
-@pytest.mark.parametrize(
-    "q_custom_shard",
-    [
-        True,
-    ],
-)
-@pytest.mark.parametrize(
-    "use_paged_attention",
-    [
-        # False,
-        True,
-    ],
-)
-@pytest.mark.parametrize(
-    "block_size",
-    [
-        32,
-        # 128,
-    ],
-)
+@pytest.mark.parametrize("batch", [4])
+@pytest.mark.parametrize("seq_len", [1 * 1024])
+@pytest.mark.parametrize("nh", [128])
+@pytest.mark.parametrize("nkv", [1])
+@pytest.mark.parametrize("kv_lora_rank", [512])
+@pytest.mark.parametrize("d_rope", [64])
+@pytest.mark.parametrize("q_num_cores", [64])
+@pytest.mark.parametrize("q_dtype, dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)])
+@pytest.mark.parametrize("q_custom_shard", [True])
+@pytest.mark.parametrize("reuse_k", [True])
+@pytest.mark.parametrize("use_paged_attention", [True])
+@pytest.mark.parametrize("block_size", [32])
+@pytest.mark.parametrize("max_cores_per_head_batch", [4])
 def test_flash_mla_decode_stress(
     device,
     batch,
@@ -183,13 +76,13 @@ def test_flash_mla_decode_stress(
     dtype,
     use_paged_attention,
     block_size,
+    reuse_k,
+    max_cores_per_head_batch,
     function_level_defaults,
     reset_seeds,
 ):
-    # If GQA (nkv > 1), then only batch shard
-    # If nkv == 1, then batch * nh shard, unless q_num_cores is 0 (ie, in DRAM)
     num_sharding_cores = batch if nkv > 1 else max(batch, q_num_cores)
-    if nh * (kv_lora_rank + d_rope) * nkv / num_sharding_cores >= 8 * 1024:  # found experimentally
+    if nh * (kv_lora_rank + d_rope) * nkv / num_sharding_cores >= 8 * 1024:
         pytest.skip(
             f"Skipping test with large values, due to memory constraints. Got {nh=}, {kv_lora_rank=}, {nkv=}, {batch=}, {q_num_cores=}, {d_rope=}"
         )
@@ -221,7 +114,8 @@ def test_flash_mla_decode_stress(
         dtype,
         use_paged_attention,
         block_size,
-        True,
+        reuse_k,
+        max_cores_per_head_batch,
     )
 
     ttnn.ReadDeviceProfiler(device)

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
@@ -10,12 +10,91 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
 )
 
 
+# When Q is pre-sharded and replicated across cores for MLA parallelization:
+# - Original Q shape: (1, batch, num_heads, head_dim) e.g. (1, 4, 128, 576)
+# - Each core gets a shard of (32, head_dim) = one tile row of heads
+# - Q is replicated so each reducer group has its Q locally available
+#
+# To use this feature, set in SDPAProgramConfig:
+#   q_locally_available=True
+#   max_cores_per_head_batch=<cores per reducer group>
+#
+# The program factory will deduce:
+#   - batch size from K/V tensor shape
+#   - num_groups = total_shards / max_cores_per_head_batch
+#   - q_heads_parallel_factor = num_groups / batch
+#   - num_q_heads = q_heads_parallel_factor * shard_height
+
+
+def create_replicated_q_shard_spec(device, batch, nh, d, num_cores_per_head=4):
+    """
+    Creates a memory config where Q is replicated within each reducer group.
+
+    The core list follows the SDPA program factory's interleaved pattern:
+    - Output cores (reducers) are at logical indices 0..num_output_cores-1
+    - Worker cores start at index num_output_cores
+    - For each virtual batch: [output_core, worker1, worker2, worker3]
+
+    When this config is used, the program config should have:
+        q_locally_available=True
+        max_cores_per_head_batch=num_cores_per_head
+    """
+    q_heads_parallel_factor = (nh + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE  # ceil(nh / 32)
+    num_virtual_batches = batch * q_heads_parallel_factor
+    num_output_cores = num_virtual_batches
+
+    # Total cores needed = num_virtual_batches * num_cores_per_head
+    total_cores = num_virtual_batches * num_cores_per_head
+
+    # Shard shape: each core gets (32, D) = (TILE_HEIGHT, head_dim)
+    shard_height = ttnn.TILE_SIZE  # 32
+    shard_width = d
+
+    # Use device's actual grid size
+    grid_x = device.compute_with_storage_grid_size().x
+    grid_y = device.compute_with_storage_grid_size().y
+
+    print(f"grid_x: {grid_x}, grid_y: {grid_y}, total_cores_needed: {total_cores}")
+
+    if total_cores > grid_x * grid_y:
+        raise ValueError(f"Not enough cores: need {total_cores}, have {grid_x * grid_y}")
+
+    # Build core list in the exact SDPA order (matching program factory)
+    tile_h = 4
+    tile_w = 4
+
+    num_tiles_y = grid_y // tile_h
+    num_tiles_x = grid_x // tile_w
+
+    core_list = []
+    for tile_x in range(num_tiles_x):  # quadrant cols
+        for tile_y in range(num_tiles_y):  # quadrant rows
+            for local_y in range(tile_h):  # row inside quadrant
+                for local_x in range(tile_w):  # col inside quadrant
+                    x = tile_x * tile_w + local_x
+                    y = tile_y * tile_h + local_y
+                    core_list.append((x, y))
+    print(f"core_list: {core_list[:total_cores]}")
+
+    # Create core range set from the list (only use cores we need)
+    core_range_set = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for x, y in core_list[:total_cores]]
+    )
+    return ttnn.create_sharded_memory_config(
+        shape=(shard_height, shard_width),
+        core_grid=core_range_set,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
 @pytest.mark.parametrize(
     "batch",
     [
-        1,  # Single batch
+        # 1,  # Single batch
         # 2,  # Multiple batches # Removing to reduce CI load
-        8,  # Even larger batch size
+        4,  # Multiple batches # Removing to reduce CI load
+        # 8,  # Even larger batch size
     ],
 )
 @pytest.mark.parametrize(
@@ -27,8 +106,8 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
 @pytest.mark.parametrize(
     "nh",
     [
-        16,
-        32,
+        # 16,
+        # 32,
         128,
     ],
 )
@@ -37,29 +116,30 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
     [
         1,
         # 8, # Removing to reduce CI load
-        16,
+        # 16,
     ],
 )
 @pytest.mark.parametrize(
     "kv_lora_rank",
     [
-        64,
+        # 64,
         512,
     ],
 )
 @pytest.mark.parametrize(
     "d_rope",
     [
-        0,
-        32,
-        128,
+        # 0,
+        # 32,
+        64,
+        # 128,
     ],
 )
 @pytest.mark.parametrize(
     "q_num_cores",
     [
-        0,  # No sharding
-        8,  # Shard across 8 cores
+        # 0,  # No sharding
+        # 8,  # Shard across 8 cores
         64,  # Shard across all cores
     ],
 )
@@ -70,9 +150,15 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
     ],
 )
 @pytest.mark.parametrize(
+    "q_custom_shard",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
     "use_paged_attention",
     [
-        False,
+        # False,
         True,
     ],
 )
@@ -80,7 +166,7 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
     "block_size",
     [
         32,
-        128,
+        # 128,
     ],
 )
 def test_flash_mla_decode_stress(
@@ -93,6 +179,7 @@ def test_flash_mla_decode_stress(
     d_rope,
     q_num_cores,
     q_dtype,
+    q_custom_shard,
     dtype,
     use_paged_attention,
     block_size,
@@ -116,6 +203,10 @@ def test_flash_mla_decode_stress(
             f"Skipping test with nkv {nkv} not divisible by effective_num_cores {effective_num_cores} / batch {batch}."
         )
 
+    q_mem_config = (
+        create_replicated_q_shard_spec(device, batch, nh, kv_lora_rank + d_rope, 4) if q_custom_shard else None
+    )
+
     run_flash_mla_decode_impl(
         device,
         batch,
@@ -126,7 +217,11 @@ def test_flash_mla_decode_stress(
         d_rope,
         q_num_cores,
         q_dtype,
+        q_mem_config,
         dtype,
         use_paged_attention,
         block_size,
+        True,
     )
+
+    ttnn.ReadDeviceProfiler(device)

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
@@ -57,7 +57,7 @@ def create_replicated_q_shard_spec(device, batch, nh, d, num_cores_per_head=4):
 @pytest.mark.parametrize("d_rope", [64])
 @pytest.mark.parametrize("q_num_cores", [64])
 @pytest.mark.parametrize("q_dtype, dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)])
-@pytest.mark.parametrize("q_custom_shard", [False])
+@pytest.mark.parametrize("q_custom_shard", [True, False])
 @pytest.mark.parametrize("reuse_k", [True])
 @pytest.mark.parametrize("use_paged_attention", [True])
 @pytest.mark.parametrize("block_size", [32])

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from models.common.utility_functions import is_wormhole_b0
 import ttnn
 from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import (
     run_flash_mla_decode_impl,
@@ -57,7 +57,7 @@ def create_replicated_q_shard_spec(device, batch, nh, d, num_cores_per_head=4):
 @pytest.mark.parametrize("d_rope", [64])
 @pytest.mark.parametrize("q_num_cores", [64])
 @pytest.mark.parametrize("q_dtype, dtype", [(ttnn.bfloat16, ttnn.bfloat8_b)])
-@pytest.mark.parametrize("q_custom_shard", [True])
+@pytest.mark.parametrize("q_custom_shard", [False])
 @pytest.mark.parametrize("reuse_k", [True])
 @pytest.mark.parametrize("use_paged_attention", [True])
 @pytest.mark.parametrize("block_size", [32])
@@ -97,7 +97,9 @@ def test_flash_mla_decode_stress(
         )
 
     q_mem_config = (
-        create_replicated_q_shard_spec(device, batch, nh, kv_lora_rank + d_rope, 4) if q_custom_shard else None
+        create_replicated_q_shard_spec(device, batch, nh, kv_lora_rank + d_rope, 4)
+        if q_custom_shard and is_wormhole_b0()
+        else None
     )
 
     run_flash_mla_decode_impl(

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -2,12 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import math
 import torch
-import numpy as np
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
-    comp_allclose,
     comp_pcc,
 )
 from models.common.utility_functions import nearest_y
@@ -22,7 +19,7 @@ from models.tt_transformers.tt.common import (
 
 
 def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_len, scale, is_causal=True):
-    b, nh, _, _ = Q.shape  # b, nh, 1, d
+    b, nh, _, _ = Q.shape
     _, nkv, _, _ = K.shape
 
     attn_mask = None
@@ -34,19 +31,15 @@ def scaled_dot_product_attention_reference(Q, K, V, start_indices, padded_layer_
     else:
         assert False, "Non-causal attention is not supported in this function."
 
-    Q_slice = Q[:, :nh, :, :]  # b, nh, 1, d
-    K_slice = K[:, :nkv, :padded_layer_len, :]  # b, nkv, S, d
-    K_slice = torch.cat(
-        [K_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
-    )  # b, nh, d, S
-    V_slice = V[:, :, :padded_layer_len, :]  # b, nkv, S, d
-    V_slice = torch.cat(
-        [V_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
-    )  # b, nh, d, S
-    attn_mask_slice = attn_mask[:, :nh, :, :]  # b, nh, 1, S
+    Q_slice = Q[:, :nh, :, :]
+    K_slice = K[:, :nkv, :padded_layer_len, :]
+    K_slice = torch.cat([K_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    V_slice = V[:, :, :padded_layer_len, :]
+    V_slice = torch.cat([V_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    attn_mask_slice = attn_mask[:, :nh, :, :]
     out = torch.nn.functional.scaled_dot_product_attention(
         Q_slice, K_slice, V_slice, attn_mask_slice, scale=scale, is_causal=False
-    )  # b, nh, 1, d
+    )
 
     return out
 
@@ -56,14 +49,11 @@ def scaled_dot_product_attention_reference_prefill(Q, K, V, scale, is_causal=Tru
     Full-sequence causal SDPA reference.
     Q: (B, nh, S, d_qk), K/V: (B, nkv, S, d)
     """
-
-    b, nh, S, d_qk = Q.shape
-    _, nkv, _, d_v = V.shape
-    # Expand KV to match Q heads
+    _, nh, _, _ = Q.shape
+    _, nkv, _, _ = V.shape
     head_rep = nh // nkv
-    K_exp = K.repeat_interleave(head_rep, dim=1)  # (B, nh, S, d_qk)
-    V_exp = V.repeat_interleave(head_rep, dim=1)  # (B, nh, S, d_v)
-    # Use PyTorch's builtin causal attention
+    K_exp = K.repeat_interleave(head_rep, dim=1)
+    V_exp = V.repeat_interleave(head_rep, dim=1)
     return torch.nn.functional.scaled_dot_product_attention(
         Q, K_exp, V_exp, attn_mask=None, scale=scale, is_causal=is_causal
     )
@@ -104,7 +94,6 @@ def to_paged_cache(
         paged_cache: The converted paged cache tensor.
     """
     batch_size, nh, seq_len, dim = cache.shape
-
     block_size, max_num_blocks = config.block_size, config.max_num_blocks
     assert (
         max_num_blocks % batch_size == 0
@@ -113,23 +102,9 @@ def to_paged_cache(
         max_num_blocks // batch_size
     ), f"Sequence length {seq_len} must equal effective paged seq_len {block_size * (max_num_blocks // batch_size)}."
 
-    paged_cache = cache.reshape(batch_size, nh, -1, block_size, dim)  # (B, H, num_blocks // B, block_size, D)
-    paged_cache = paged_cache.transpose(1, 2)  # (B, num_blocks // B, H, block_size, D)
-    paged_cache = paged_cache.reshape(max_num_blocks, nh, block_size, dim)  # (num_blocks, H, block_size, D)
-
-    """
-    Get the reverse mapping to reorder the paged cache,
-    so that paged cache + mapping = original cache
-    and paged_cache = original_cache + inverse mapping
-
-    For example:
-        cache = [0, 1, 2, 3]
-        mapping = [1, 3, 0, 2]
-        inverse_mapping (argsort) = [2, 0, 3, 1]
-    Then,
-        paged_cache = cache[inverse_mapping] = [2, 0, 3, 1]
-        paged_cache[mapping] = cache = [0, 1, 2, 3]
-    """
+    paged_cache = cache.reshape(batch_size, nh, -1, block_size, dim)
+    paged_cache = paged_cache.transpose(1, 2)
+    paged_cache = paged_cache.reshape(max_num_blocks, nh, block_size, dim)
 
     inverse_mapping = torch.argsort(mapping.view(-1))
     paged_cache = paged_cache[inverse_mapping]
@@ -151,7 +126,7 @@ def from_paged_cache(
     Returns:
         cache: The converted cache tensor.
     """
-    max_num_blocks, nh, block_size, dim = paged_cache.shape  # (max_num_blocks, H, block_size, D)
+    max_num_blocks, nh, block_size, dim = paged_cache.shape
     assert (
         block_size == config.block_size
     ), f"block_size {block_size} must match the paged attention config block size {config.block_size}."
@@ -161,12 +136,10 @@ def from_paged_cache(
 
     batch, num_blocks_per_batch = mapping.shape
 
-    # Use the mapping to get the original order, paged_cache + mapping = original cache
     cache = paged_cache[mapping.view(-1)]
-
-    cache = cache.reshape(batch, num_blocks_per_batch, nh, block_size, dim)  # (B, num_blocks // B, H, block_size, D)
-    cache = cache.transpose(1, 2)  # (B, H, num_blocks // B, block_size, D)
-    cache = cache.reshape(batch, nh, -1, dim)  # (B, H, seq_len, D)
+    cache = cache.reshape(batch, num_blocks_per_batch, nh, block_size, dim)
+    cache = cache.transpose(1, 2)
+    cache = cache.reshape(batch, nh, -1, dim)
 
     return cache
 
@@ -178,8 +151,6 @@ def nearest_n(x, n):
 def nearest_pow_2(x):
     if x < 1:
         raise ValueError("x must be >= 1")
-    import math
-
     power = math.ceil(math.log2(x))
     return 1 << power
 
@@ -199,6 +170,7 @@ def run_flash_mla_decode_impl(
     use_paged_attention=False,
     block_size=ttnn.TILE_SIZE,
     reuse_k=False,
+    max_cores_per_head_batch=16,
 ):
     # Can't run too many iters, or run out of L1
     num_iters = 3
@@ -215,7 +187,6 @@ def run_flash_mla_decode_impl(
     logger.debug(f"Query Data Type: {q_dtype}")
     logger.debug(f"Key-Value Data Type: {dtype}")
 
-    # Paged attention configuration
     paged_attention_cfg = None
     if use_paged_attention:
         assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
@@ -229,24 +200,19 @@ def run_flash_mla_decode_impl(
     ######################
     ### Torch Setup
     ######################
-    q = torch.randn(batch, nh, 1, kv_lora_rank + d_rope).float()  # (B, H, S (1 for decode), D)
-    k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()  # (B, H, S, D)
-    v = k[..., :kv_lora_rank]  # (B, H, S, D)
+    q = torch.randn(batch, nh, 1, kv_lora_rank + d_rope).float()
+    k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()
+    v = k[..., :kv_lora_rank]
 
-    # In this configuration, q is replicated across all cores within each head group
-    # num_cores_per_head_for_config is used to tell the program factory about the replication factor
-    num_cores_per_head_for_config = 1  # Default: no replication
     if q_mem_config is not None:
-        # Replicate Q for each core in the reducer group
         num_cores_per_head = 4
-        num_cores_per_head_for_config = num_cores_per_head  # Pass replication factor to program config
-        q_heads_parallel_factor = 4
-        num_virtual_batches = batch * q_heads_parallel_factor  # 16 virtual batches
-        heads_per_vbatch = nh // q_heads_parallel_factor  # 32 heads per virtual batch
-        q_permuted = q.permute(2, 0, 1, 3)  # (S, B, H, D) = (1, 4, 128, 576)
-        q_reshaped = q_permuted.reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)  # (1, 4, 4, 32, 576)
-        q_replicated = q_reshaped.repeat_interleave(num_cores_per_head, dim=2)  # (1, 4, 16, 32, 576)
-        q_for_tt = q_replicated.reshape(1, 1, -1, q_replicated.shape[-1])  # (1, 1, 2048, 576)
+        q_heads_parallel_factor = math.ceil(nh / ttnn.TILE_SIZE)
+        num_virtual_batches = batch * q_heads_parallel_factor
+        heads_per_vbatch = nh // q_heads_parallel_factor
+        q_permuted = q.permute(2, 0, 1, 3)
+        q_reshaped = q_permuted.reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)
+        q_replicated = q_reshaped.repeat_interleave(num_cores_per_head, dim=2)
+        q_for_tt = q_replicated.reshape(1, 1, -1, q_replicated.shape[-1])
     else:
         q_for_tt = q.permute(2, 0, 1, 3)  # Original path: (1, 4, 128, 576)
 
@@ -260,28 +226,12 @@ def run_flash_mla_decode_impl(
     tt_page_table = None
     if paged_attention_cfg:
         page_table = page_table_setup(batch, paged_attention_cfg)
-        tt_k_torch = to_paged_cache(
-            k,
-            page_table,
-            paged_attention_cfg,
-        )
-        tt_k_torch_og = from_paged_cache(
-            tt_k_torch,
-            page_table,
-            paged_attention_cfg,
-        )
+        tt_k_torch = to_paged_cache(k, page_table, paged_attention_cfg)
+        tt_k_torch_og = from_paged_cache(tt_k_torch, page_table, paged_attention_cfg)
         assert torch.all(tt_k_torch_og == k), "Paged cache conversion for K failed."
 
-        tt_v_torch = to_paged_cache(
-            v,
-            page_table,
-            paged_attention_cfg,
-        )
-        tt_v_torch_og = from_paged_cache(
-            tt_v_torch,
-            page_table,
-            paged_attention_cfg,
-        )
+        tt_v_torch = to_paged_cache(v, page_table, paged_attention_cfg)
+        tt_v_torch_og = from_paged_cache(tt_v_torch, page_table, paged_attention_cfg)
         assert torch.all(tt_v_torch_og == v), "Paged cache conversion for V failed."
 
         tt_page_table = ttnn.from_torch(
@@ -291,26 +241,24 @@ def run_flash_mla_decode_impl(
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
-    q_chunk_size = 0  # Not used in decode
+    q_chunk_size = 0
     k_chunk_size = 32
 
     scale = (kv_lora_rank + d_rope) ** -0.5
 
-    max_start_idx = seq_len - 1
-    # [0, 170, 341, 512]
+    max_start_idx = seq_len // 2
     start_indices = [max_start_idx] * batch
     padded_layer_len = nearest_y(max_start_idx + 1, k_chunk_size)
 
-    # Check if Q is pre-sharded/replicated (custom q_mem_config provided)
     q_locally_available = q_mem_config is not None and q_mem_config != ttnn.DRAM_MEMORY_CONFIG
 
     sdpa_program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
-        k_chunk_size=k_chunk_size,
+        k_chunk_size=0,
         exp_approx_mode=False,
-        max_cores_per_head_batch=4,  # Cores per reducer group
-        q_locally_available=q_locally_available,  # Program factory deduces B and num_q_heads from K/V and shard config
+        max_cores_per_head_batch=max_cores_per_head_batch,
+        q_locally_available=q_locally_available,
     )
 
     compute_kernel_config = ttnn.WormholeComputeKernelConfig(
@@ -320,8 +268,7 @@ def run_flash_mla_decode_impl(
         packer_l1_acc=False,
     )
 
-    # Set up input tensors
-    if q_num_cores < 1:  # DRAM
+    if q_num_cores < 1:
         q_mem_config = ttnn.DRAM_MEMORY_CONFIG
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
     else:
@@ -332,13 +279,11 @@ def run_flash_mla_decode_impl(
             )
 
         if nkv == 1:
-            # Batch + nh shard if nkv == 1
-            q_num_cores = min(batch * nh, q_num_cores)  # Limit q_num_cores to batch size
+            q_num_cores = min(batch * nh, q_num_cores)
         else:
-            # Only batch shard if nkv > 1
-            q_num_cores = min(batch, q_num_cores)  # Limit q_num_cores to batch size
+            q_num_cores = min(batch, q_num_cores)
 
-        block_height = 32  # nearest_y(np.prod(q_for_tt.shape[:-1]) // q_num_cores, ttnn.TILE_SIZE)
+        block_height = ttnn.TILE_SIZE
 
         q_core_grid = ttnn.num_cores_to_corerangeset(
             q_num_cores, device.compute_with_storage_grid_size(), row_wise=True
@@ -357,15 +302,13 @@ def run_flash_mla_decode_impl(
                 use_height_and_width_as_shard_shape=True,
             )
         else:
-            # Custom q_mem_config provided (Q is replicated for local reads)
             out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
-    # GQA only supports DRAM memory config for output
     if nkv > 1:
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     tt_q = ttnn.from_torch(
-        q_for_tt,  # (S, B, H, D)
+        q_for_tt,
         device=device,
         dtype=q_dtype,
         layout=ttnn.TILE_LAYOUT,
@@ -466,7 +409,7 @@ def run_flash_mla_decode_impl(
         pcc_threshold = 0.98
 
     for i, (tt_out, out_t) in enumerate(zip(tt_outs, outs)):
-        tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)  # (S, B, H, D) -> (B, H, S, D)
+        tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)
         for b in range(batch):
             for h in range(nh):
                 out_pass, out_pcc = comp_pcc(tt_out_torch[b, h, :, :], out_t[b, h, :, :], pcc_threshold)
@@ -494,7 +437,6 @@ def run_flash_mla_prefill_impl(
     use_paged_attention=False,
     block_size=ttnn.TILE_SIZE,
 ):
-    # Log the test parameters
     logger.debug(f"Running FlashMLA Prefill with parameters: ")
     logger.debug(f"Batch: {batch}")
     logger.debug(f"Sequence Length: {seq_len}")
@@ -505,7 +447,6 @@ def run_flash_mla_prefill_impl(
     logger.debug(f"Query Data Type: {q_dtype}")
     logger.debug(f"Key-Value Data Type: {dtype}")
 
-    # Paged attention configuration
     paged_attention_cfg = None
     if use_paged_attention:
         assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
@@ -516,31 +457,16 @@ def run_flash_mla_prefill_impl(
             max_num_blocks=max_num_blocks,
         )
 
-    ######################
-    ### Torch Setup
-    ######################
-    q = torch.randn(batch, nh, seq_len, kv_lora_rank + d_rope).float()  # (B, H, S (1 for decode), D)
-    k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()  # (B, H, S, D)
-    v = k[..., :kv_lora_rank]  # (B, H, S, D)
-    ######################
-    ### TT Setup
-    #######################
+    q = torch.randn(batch, nh, seq_len, kv_lora_rank + d_rope).float()
+    k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()
+    v = k[..., :kv_lora_rank]
 
-    # Page-related setup
     tt_k_torch = k
     tt_page_table = None
     if paged_attention_cfg:
         page_table = page_table_setup(batch, paged_attention_cfg)
-        tt_k_torch = to_paged_cache(
-            k,
-            page_table,
-            paged_attention_cfg,
-        )
-        tt_k_torch_og = from_paged_cache(
-            tt_k_torch,
-            page_table,
-            paged_attention_cfg,
-        )
+        tt_k_torch = to_paged_cache(k, page_table, paged_attention_cfg)
+        tt_k_torch_og = from_paged_cache(tt_k_torch, page_table, paged_attention_cfg)
         assert torch.all(tt_k_torch_og == k), "Paged cache conversion for K failed."
 
         tt_page_table = ttnn.from_torch(
@@ -571,23 +497,20 @@ def run_flash_mla_prefill_impl(
     )
 
     tt_q = ttnn.from_torch(
-        q,  # (B, H, S, D)
+        q,
         device=device,
         dtype=q_dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_k = ttnn.from_torch(
-        tt_k_torch,  # (B, H, S, D)
+        tt_k_torch,
         device=device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    ##########################
-    ### FlashMLA Prefill
-    ##########################
     if tt_page_table:
         tt_out = ttnn.transformer.chunked_flash_mla_prefill(
             tt_q,
@@ -612,13 +535,9 @@ def run_flash_mla_prefill_impl(
             attn_mask=None,
             is_causal=True,
         )
-    tt_back = ttnn.to_torch(tt_out)  # now (B, H_padded, S_padded, D)
-    # slice out the padded heads and sequence length; no permute needed
-    tt_out_torch = tt_back[:, :nh, :seq_len, :]  # (B, nh, S, D)
+    tt_back = ttnn.to_torch(tt_out)
+    tt_out_torch = tt_back[:, :nh, :seq_len, :]
 
-    ########################
-    ### Validation
-    ########################
     out_t = scaled_dot_product_attention_reference_prefill(
         q,
         k,

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -4,6 +4,7 @@
 
 import math
 import torch
+import numpy as np
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -105,7 +106,19 @@ def to_paged_cache(
     paged_cache = cache.reshape(batch_size, nh, -1, block_size, dim)
     paged_cache = paged_cache.transpose(1, 2)
     paged_cache = paged_cache.reshape(max_num_blocks, nh, block_size, dim)
+    """
+    Get the reverse mapping to reorder the paged cache,
+    so that paged cache + mapping = original cache
+    and paged_cache = original_cache + inverse mapping
 
+    For example:
+        cache = [0, 1, 2, 3]
+        mapping = [1, 3, 0, 2]
+        inverse_mapping (argsort) = [2, 0, 3, 1]
+    Then,
+        paged_cache = cache[inverse_mapping] = [2, 0, 3, 1]
+        paged_cache[mapping] = cache = [0, 1, 2, 3]
+    """
     inverse_mapping = torch.argsort(mapping.view(-1))
     paged_cache = paged_cache[inverse_mapping]
 
@@ -140,7 +153,6 @@ def from_paged_cache(
     cache = cache.reshape(batch, num_blocks_per_batch, nh, block_size, dim)
     cache = cache.transpose(1, 2)
     cache = cache.reshape(batch, nh, -1, dim)
-
     return cache
 
 
@@ -187,6 +199,7 @@ def run_flash_mla_decode_impl(
     logger.debug(f"Query Data Type: {q_dtype}")
     logger.debug(f"Key-Value Data Type: {dtype}")
 
+    # Paged attention configuration
     paged_attention_cfg = None
     if use_paged_attention:
         assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
@@ -204,6 +217,8 @@ def run_flash_mla_decode_impl(
     k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()
     v = k[..., :kv_lora_rank]
 
+    # When Q memory config is provided, it is expected that Q is sharded such that
+    # each worker core has its own local Q shard
     if q_mem_config is not None:
         num_cores_per_head = 4
         q_heads_parallel_factor = math.ceil(nh / ttnn.TILE_SIZE)
@@ -242,12 +257,12 @@ def run_flash_mla_decode_impl(
         )
 
     q_chunk_size = 0
-    k_chunk_size = 32
+    k_chunk_size = 128
 
     scale = (kv_lora_rank + d_rope) ** -0.5
 
     max_start_idx = seq_len // 2
-    start_indices = [max_start_idx] * batch
+    start_indices = np.linspace(0, max_start_idx, batch, dtype=np.int32).tolist() if batch > 1 else [max_start_idx]
     padded_layer_len = nearest_y(max_start_idx + 1, k_chunk_size)
 
     q_locally_available = q_mem_config is not None and q_mem_config != ttnn.DRAM_MEMORY_CONFIG
@@ -268,6 +283,7 @@ def run_flash_mla_decode_impl(
         packer_l1_acc=False,
     )
 
+    # Set up input tensors
     if q_num_cores < 1:
         q_mem_config = ttnn.DRAM_MEMORY_CONFIG
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
@@ -283,7 +299,7 @@ def run_flash_mla_decode_impl(
         else:
             q_num_cores = min(batch, q_num_cores)
 
-        block_height = ttnn.TILE_SIZE
+        block_height = nearest_y(np.prod(q.shape[:-1]) // q_num_cores, ttnn.TILE_SIZE)
 
         q_core_grid = ttnn.num_cores_to_corerangeset(
             q_num_cores, device.compute_with_storage_grid_size(), row_wise=True
@@ -304,6 +320,7 @@ def run_flash_mla_decode_impl(
         else:
             out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
+    # GQA only supports DRAM memory config for output
     if nkv > 1:
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
@@ -437,6 +454,7 @@ def run_flash_mla_prefill_impl(
     use_paged_attention=False,
     block_size=ttnn.TILE_SIZE,
 ):
+    # Log the test parameters
     logger.debug(f"Running FlashMLA Prefill with parameters: ")
     logger.debug(f"Batch: {batch}")
     logger.debug(f"Sequence Length: {seq_len}")
@@ -447,6 +465,7 @@ def run_flash_mla_prefill_impl(
     logger.debug(f"Query Data Type: {q_dtype}")
     logger.debug(f"Key-Value Data Type: {dtype}")
 
+    # Paged attention configuration
     paged_attention_cfg = None
     if use_paged_attention:
         assert seq_len % block_size == 0, f"Sequence length must be a multiple of {block_size=} for paged attention."
@@ -457,10 +476,18 @@ def run_flash_mla_prefill_impl(
             max_num_blocks=max_num_blocks,
         )
 
+    ######################
+    ### Torch Setup
+    ######################
     q = torch.randn(batch, nh, seq_len, kv_lora_rank + d_rope).float()
     k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()
     v = k[..., :kv_lora_rank]
 
+    ######################
+    ### TT Setup
+    #######################
+
+    # Page-related setup
     tt_k_torch = k
     tt_page_table = None
     if paged_attention_cfg:
@@ -511,6 +538,9 @@ def run_flash_mla_prefill_impl(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    ##########################
+    ### FlashMLA Prefill
+    ##########################
     if tt_page_table:
         tt_out = ttnn.transformer.chunked_flash_mla_prefill(
             tt_q,
@@ -538,6 +568,9 @@ def run_flash_mla_prefill_impl(
     tt_back = ttnn.to_torch(tt_out)
     tt_out_torch = tt_back[:, :nh, :seq_len, :]
 
+    ########################
+    ### Validation
+    ########################
     out_t = scaled_dot_product_attention_reference_prefill(
         q,
         k,

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -194,6 +194,7 @@ def run_flash_mla_decode_impl(
     d_rope,
     q_num_cores,
     q_dtype,
+    q_mem_config,
     dtype,
     use_paged_attention=False,
     block_size=ttnn.TILE_SIZE,
@@ -231,6 +232,23 @@ def run_flash_mla_decode_impl(
     q = torch.randn(batch, nh, 1, kv_lora_rank + d_rope).float()  # (B, H, S (1 for decode), D)
     k = torch.randn(batch, nkv, seq_len, kv_lora_rank + d_rope).float()  # (B, H, S, D)
     v = k[..., :kv_lora_rank]  # (B, H, S, D)
+
+    # In this configuration, q is replicated across all cores within each head group
+    # num_cores_per_head_for_config is used to tell the program factory about the replication factor
+    num_cores_per_head_for_config = 1  # Default: no replication
+    if q_mem_config is not None:
+        # Replicate Q for each core in the reducer group
+        num_cores_per_head = 4
+        num_cores_per_head_for_config = num_cores_per_head  # Pass replication factor to program config
+        q_heads_parallel_factor = 4
+        num_virtual_batches = batch * q_heads_parallel_factor  # 16 virtual batches
+        heads_per_vbatch = nh // q_heads_parallel_factor  # 32 heads per virtual batch
+        q_permuted = q.permute(2, 0, 1, 3)  # (S, B, H, D) = (1, 4, 128, 576)
+        q_reshaped = q_permuted.reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)  # (1, 4, 4, 32, 576)
+        q_replicated = q_reshaped.repeat_interleave(num_cores_per_head, dim=2)  # (1, 4, 16, 32, 576)
+        q_for_tt = q_replicated.reshape(1, 1, -1, q_replicated.shape[-1])  # (1, 1, 2048, 576)
+    else:
+        q_for_tt = q.permute(2, 0, 1, 3)  # Original path: (1, 4, 128, 576)
 
     ######################
     ### TT Setup
@@ -274,20 +292,25 @@ def run_flash_mla_decode_impl(
         )
 
     q_chunk_size = 0  # Not used in decode
-    k_chunk_size = 128
+    k_chunk_size = 32
 
     scale = (kv_lora_rank + d_rope) ** -0.5
 
-    max_start_idx = seq_len // 2
-    start_indices = np.linspace(0, max_start_idx, batch, dtype=np.int32).tolist() if batch > 1 else [max_start_idx]
-
+    max_start_idx = seq_len - 1
+    # [0, 170, 341, 512]
+    start_indices = [max_start_idx] * batch
     padded_layer_len = nearest_y(max_start_idx + 1, k_chunk_size)
+
+    # Check if Q is pre-sharded/replicated (custom q_mem_config provided)
+    q_locally_available = q_mem_config is not None and q_mem_config != ttnn.DRAM_MEMORY_CONFIG
 
     sdpa_program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=False,
+        max_cores_per_head_batch=4,  # Cores per reducer group
+        q_locally_available=q_locally_available,  # Program factory deduces B and num_q_heads from K/V and shard config
     )
 
     compute_kernel_config = ttnn.WormholeComputeKernelConfig(
@@ -315,36 +338,40 @@ def run_flash_mla_decode_impl(
             # Only batch shard if nkv > 1
             q_num_cores = min(batch, q_num_cores)  # Limit q_num_cores to batch size
 
-        block_height = nearest_y(np.prod(q.shape[:-1]) // q_num_cores, ttnn.TILE_SIZE)
+        block_height = 32  # nearest_y(np.prod(q_for_tt.shape[:-1]) // q_num_cores, ttnn.TILE_SIZE)
 
         q_core_grid = ttnn.num_cores_to_corerangeset(
             q_num_cores, device.compute_with_storage_grid_size(), row_wise=True
         )
-
-        q_mem_config = ttnn.create_sharded_memory_config(
-            shape=(block_height, q.shape[-1]),
-            core_grid=q_core_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            use_height_and_width_as_shard_shape=True,
-        )
-        out_mem_config = ttnn.create_sharded_memory_config(
-            shape=(block_height, v.shape[-1]),
-            core_grid=q_core_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            use_height_and_width_as_shard_shape=True,
-        )
+        if q_mem_config is None:
+            q_mem_config = ttnn.create_sharded_memory_config(
+                shape=(block_height, q.shape[-1]),
+                core_grid=q_core_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                use_height_and_width_as_shard_shape=True,
+            )
+            out_mem_config = ttnn.create_sharded_memory_config(
+                shape=(block_height, v.shape[-1]),
+                core_grid=q_core_grid,
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                use_height_and_width_as_shard_shape=True,
+            )
+        else:
+            # Custom q_mem_config provided (Q is replicated for local reads)
+            out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     # GQA only supports DRAM memory config for output
     if nkv > 1:
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     tt_q = ttnn.from_torch(
-        q.permute(2, 0, 1, 3),  # (B, H, S, D) -> (S, B, H, D)
+        q_for_tt,  # (S, B, H, D)
         device=device,
         dtype=q_dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=q_mem_config,
     )
+
     tt_k = ttnn.from_torch(
         tt_k_torch,
         device=device,
@@ -440,9 +467,10 @@ def run_flash_mla_decode_impl(
 
     for i, (tt_out, out_t) in enumerate(zip(tt_outs, outs)):
         tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)  # (S, B, H, D) -> (B, H, S, D)
-
-        out_pass, out_pcc = comp_pcc(tt_out_torch, out_t, pcc_threshold)
-        logger.debug(f"Output PCC: {out_pcc}")
+        for b in range(batch):
+            for h in range(nh):
+                out_pass, out_pcc = comp_pcc(tt_out_torch[b, h, :, :], out_t[b, h, :, :], pcc_threshold)
+                logger.debug(f"Output PCC for batch {b}, head {h}: {out_pcc}")
 
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -52,6 +52,7 @@ def scaled_dot_product_attention_reference_prefill(Q, K, V, scale, is_causal=Tru
     """
     _, nh, _, _ = Q.shape
     _, nkv, _, _ = V.shape
+    # Expand KV to match Q heads
     head_rep = nh // nkv
     K_exp = K.repeat_interleave(head_rep, dim=1)
     V_exp = V.repeat_interleave(head_rep, dim=1)
@@ -149,6 +150,7 @@ def from_paged_cache(
 
     batch, num_blocks_per_batch = mapping.shape
 
+    # Use the mapping to get the original order, paged_cache + mapping = original cache
     cache = paged_cache[mapping.view(-1)]
     cache = cache.reshape(batch, num_blocks_per_batch, nh, block_size, dim)
     cache = cache.transpose(1, 2)
@@ -232,7 +234,7 @@ def run_flash_mla_decode_impl(
             .reshape(1, 1, -1, q.shape[-1])
         )
     else:
-        q_for_tt = q.permute(2, 0, 1, 3)  # Original path: (1, 4, 128, 576)
+        q_for_tt = q.permute(2, 0, 1, 3)
 
     ######################
     ### TT Setup

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -268,15 +268,12 @@ def run_flash_mla_decode_impl(
     start_indices = np.linspace(0, max_start_idx, batch, dtype=np.int32).tolist() if batch > 1 else [max_start_idx]
     padded_layer_len = nearest_y(max_start_idx + 1, k_chunk_size)
 
-    q_locally_available = q_mem_config is not None and q_mem_config != ttnn.DRAM_MEMORY_CONFIG
-
     sdpa_program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
         exp_approx_mode=False,
         max_cores_per_head_batch=max_cores_per_head_batch,
-        q_locally_available=q_locally_available,
     )
 
     compute_kernel_config = ttnn.WormholeComputeKernelConfig(

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -222,7 +222,6 @@ def run_flash_mla_decode_impl(
     if q_mem_config is not None:
         num_cores_per_head = 4
         q_heads_parallel_factor = math.ceil(nh / ttnn.TILE_SIZE)
-        num_virtual_batches = batch * q_heads_parallel_factor
         heads_per_vbatch = nh // q_heads_parallel_factor
         q_permuted = q.permute(2, 0, 1, 3)
         q_reshaped = q_permuted.reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)
@@ -270,7 +269,7 @@ def run_flash_mla_decode_impl(
     sdpa_program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
-        k_chunk_size=0,
+        k_chunk_size=k_chunk_size,
         exp_approx_mode=False,
         max_cores_per_head_batch=max_cores_per_head_batch,
         q_locally_available=q_locally_available,

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -430,10 +430,8 @@ def run_flash_mla_decode_impl(
 
     for i, (tt_out, out_t) in enumerate(zip(tt_outs, outs)):
         tt_out_torch = ttnn.to_torch(tt_out)[..., :nh, :].permute(1, 2, 0, 3)
-        for b in range(batch):
-            for h in range(nh):
-                out_pass, out_pcc = comp_pcc(tt_out_torch[b, h, :, :], out_t[b, h, :, :], pcc_threshold)
-                logger.debug(f"Output PCC for batch {b}, head {h}: {out_pcc}")
+        out_pass, out_pcc = comp_pcc(tt_out_torch, out_t, pcc_threshold)
+        logger.debug(f"Output PCC: {out_pcc}")
 
     assert out_pass, f"Output mismatch: PCC {out_pcc} < 0.99"
 

--- a/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/mla_test_utils.py
@@ -220,13 +220,17 @@ def run_flash_mla_decode_impl(
     # When Q memory config is provided, it is expected that Q is sharded such that
     # each worker core has its own local Q shard
     if q_mem_config is not None:
-        num_cores_per_head = 4
         q_heads_parallel_factor = math.ceil(nh / ttnn.TILE_SIZE)
+        assert (
+            q_heads_parallel_factor > 1
+        ), f"Custom Q memory config requires q_heads_parallel_factor > 1, got {q_heads_parallel_factor}."
         heads_per_vbatch = nh // q_heads_parallel_factor
-        q_permuted = q.permute(2, 0, 1, 3)
-        q_reshaped = q_permuted.reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)
-        q_replicated = q_reshaped.repeat_interleave(num_cores_per_head, dim=2)
-        q_for_tt = q_replicated.reshape(1, 1, -1, q_replicated.shape[-1])
+        q_for_tt = (
+            q.permute(2, 0, 1, 3)
+            .reshape(1, batch, q_heads_parallel_factor, heads_per_vbatch, -1)
+            .repeat_interleave(max_cores_per_head_batch, dim=2)
+            .reshape(1, 1, -1, q.shape[-1])
+        )
     else:
         q_for_tt = q.permute(2, 0, 1, 3)  # Original path: (1, 4, 128, 576)
 

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
@@ -31,7 +31,7 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_d
 @pytest.mark.parametrize(
     "block_size",
     [
-        32,
+        64,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
@@ -9,11 +9,11 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_d
 
 
 @pytest.mark.parametrize(
-    "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores",
+    "batch, seq_len, nh, nkv, kv_lora_rank, d_rope, q_num_cores, q_mem_config",
     # batch, seq_len, num heads q, num heads kv, kv lora rank, dim rope, number of cores to shard q on
     [
-        (4, 1024, 128, 1, 512, 64, 64),  # DeepSeek V3 TG full DP
-        (2, 1024, 8, 1, 128, 64, 0),  # small config, DRAM Q
+        (4, 1024, 128, 1, 512, 64, 64, None),  # DeepSeek V3 TG full DP
+        (2, 1024, 8, 1, 128, 64, 0, None),  # small config, DRAM Q
     ],
 )
 @pytest.mark.parametrize(
@@ -50,6 +50,7 @@ def test_flash_mla_decode(
     d_rope,
     q_num_cores,
     q_dtype,
+    q_mem_config,
     dtype,
     use_paged_attention,
     block_size,
@@ -67,9 +68,10 @@ def test_flash_mla_decode(
         d_rope,
         q_num_cores,
         q_dtype,
-        None,
+        q_mem_config,
         dtype,
         use_paged_attention,
         block_size,
         reuse_k,
+        max_cores_per_head_batch=4,
     )

--- a/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_mla_decode.py
@@ -31,7 +31,7 @@ from tests.ttnn.unit_tests.operations.sdpa.mla_test_utils import run_flash_mla_d
 @pytest.mark.parametrize(
     "block_size",
     [
-        64,
+        32,
     ],
 )
 @pytest.mark.parametrize(
@@ -67,6 +67,7 @@ def test_flash_mla_decode(
         d_rope,
         q_num_cores,
         q_dtype,
+        None,
         dtype,
         use_paged_attention,
         block_size,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -16,6 +16,7 @@ struct SDPAProgramConfig {
     std::size_t k_chunk_size;
     std::optional<bool> exp_approx_mode;
     uint32_t max_cores_per_head_batch = 16;
+    bool q_locally_available = false;
 };
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -16,7 +16,6 @@ struct SDPAProgramConfig {
     std::size_t k_chunk_size;
     std::optional<bool> exp_approx_mode;
     uint32_t max_cores_per_head_batch = 16;
-    bool q_locally_available = false;
 };
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -239,7 +239,6 @@ void kernel_main() {
     const uint32_t out_in0_block_w_dynamic = Sk_chunk_t_dynamic;
     const uint32_t out_num_blocks_dynamic = 1;
     const uint32_t qk_chunk_tiles_dynamic = Sq_chunk_t * Sk_chunk_t_dynamic;
-    const uint32_t k_chunk_tiles_dynamic = Sk_chunk_t_dynamic * DHt;
 #else
     constexpr uint32_t qk_subblock_h_dynamic = qk_subblock_h;
     constexpr uint32_t qk_subblock_w_dynamic = qk_subblock_w;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -64,7 +64,6 @@ void kernel_main() {
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(29);
     constexpr uint32_t num_tree_reduction_rounds = get_compile_time_arg_val(30);
     constexpr uint32_t original_block_size = get_compile_time_arg_val(31);
-    constexpr bool reuse_k = get_compile_time_arg_val(32) == 1;
     constexpr bool has_block_padding = original_block_size > 0 && original_block_size < 32;
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -64,6 +64,7 @@ void kernel_main() {
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(29);
     constexpr uint32_t num_tree_reduction_rounds = get_compile_time_arg_val(30);
     constexpr uint32_t original_block_size = get_compile_time_arg_val(31);
+    constexpr bool reuse_k = get_compile_time_arg_val(32) == 1;
     constexpr bool has_block_padding = original_block_size > 0 && original_block_size < 32;
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
@@ -146,7 +147,6 @@ void kernel_main() {
         } else {
             // Read cur_pos from CB using mailbox-based synchronization (issue #27979)
             constexpr uint32_t cb_index_id = tt::CBIndex::c_8;
-
             cb_wait_front(cb_index_id, 1);
             cur_pos = read_tile_value(cb_index_id, 0, cur_batch / q_heads_parallel_factor);
             cb_pop_front(cb_index_id, 1);
@@ -239,6 +239,7 @@ void kernel_main() {
     const uint32_t out_in0_block_w_dynamic = Sk_chunk_t_dynamic;
     const uint32_t out_num_blocks_dynamic = 1;
     const uint32_t qk_chunk_tiles_dynamic = Sq_chunk_t * Sk_chunk_t_dynamic;
+    const uint32_t k_chunk_tiles_dynamic = Sk_chunk_t_dynamic * DHt;
 #else
     constexpr uint32_t qk_subblock_h_dynamic = qk_subblock_h;
     constexpr uint32_t qk_subblock_w_dynamic = qk_subblock_w;
@@ -412,7 +413,6 @@ void kernel_main() {
                  */
                 reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, Sq_chunk_t, vector_mode>(
                     cb_cur_max, cb_prev_max, Sk_chunk_t_dynamic, k_chunk > k_chunk_start);
-
                 /* QK -= cb_cur_max */
                 /* QK = exp(QK)*/
                 reconfig_data_format(cb_qk_im, cb_cur_max);
@@ -661,7 +661,6 @@ void kernel_main() {
             //   - cb_out_accumulate_im: O
             //   - cb_prev_sum: L
             //   - cb_prev_max: M
-
             // Move O to output CB
             move_block<true>(cb_out_accumulate_im, cb_out_o, out_chunk_tiles);
             // Move M to output CB

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -677,7 +677,6 @@ uint64_t read_k(
 
 template <
     uint32_t cb_v_in,
-    uint32_t DHt,
     uint32_t vDHt,
     uint32_t num_kv_heads,
     uint32_t block_size_t,
@@ -685,7 +684,6 @@ template <
     uint32_t barrier_threshold,
     bool is_page_table_sharded,
     bool reuse_k,
-    bool use_mcast,
     typename VReaderType>
 void read_v(
     uint32_t v_chunk_tiles,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -161,7 +161,6 @@ void fill_tile_partial_sliding_window(uint32_t cb_id, uint32_t tile_id, uint32_t
         }
     }
 }
-
 /******************************************************************************
  *                   Attention Mask Functions                                 *
  ******************************************************************************/
@@ -392,51 +391,6 @@ void generate_block_padding_mask(uint32_t Sk_chunk_t, uint32_t block_size) {
 /******************************************************************************
  *                   Writer Kernel Specific Functions                         *
  ******************************************************************************/
-
-template <
-    uint32_t out_chunk_tiles,
-    uint32_t cb_out,
-    uint32_t cb_out_m,
-    uint32_t cb_out_l,
-    uint32_t cb_intermed_out,
-    uint32_t PNHt>
-void worker_compute(
-    uint64_t in0_sender_semaphore_noc_addr,
-    uint32_t worker_id,
-    uint32_t reduce_core_noc_x,
-    uint32_t reduce_core_noc_y) {
-    uint32_t out_tile_id = 0;
-
-    // Wait for compute to deliver output chunk
-    cb_wait_front(cb_out, out_chunk_tiles);
-    cb_wait_front(cb_out_m, PNHt);
-    cb_wait_front(cb_out_l, PNHt);
-
-    // Write output chunk to reducer
-    constexpr uint32_t tile_bytes = get_tile_size(cb_out);
-    uint32_t worker_offset = worker_id * (out_chunk_tiles + 2 * PNHt) * tile_bytes;
-    constexpr uint32_t o_write_size = out_chunk_tiles * tile_bytes;
-    constexpr uint32_t ml_write_size = PNHt * tile_bytes;
-    uint64_t output_write_addr =
-        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, get_write_ptr(cb_intermed_out)) + worker_offset;
-
-    // send the max logits first then the logits sum then the partial output to the reducer
-    noc_async_write(get_read_ptr(cb_out_m), output_write_addr, ml_write_size);
-    output_write_addr += ml_write_size;
-    noc_async_write(get_read_ptr(cb_out_l), output_write_addr, ml_write_size);
-    output_write_addr += ml_write_size;
-    noc_async_write(get_read_ptr(cb_out), output_write_addr, o_write_size);
-
-    // increment semaphore
-    noc_async_write_barrier();
-    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-
-    // pop front
-    cb_pop_front(cb_out, out_chunk_tiles);
-    cb_pop_front(cb_out_m, PNHt);
-    cb_pop_front(cb_out_l, PNHt);
-}
-
 template <uint32_t cb_out, uint32_t out_chunk_tiles, uint32_t barrier_threshold, typename WriterType>
 uint32_t write_tiles_to_memory(uint32_t& out_tile_id, const WriterType& out_writer, uint32_t& barrier_count) {
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
@@ -514,6 +468,105 @@ uint32_t write_partial_tiles_to_memory(
  *                   Reader Kernel Specific Functions                         *
  ******************************************************************************/
 template <
+    uint32_t cb_q_in,
+    uint32_t cb_q_rm,
+    uint32_t q_tile_bytes,
+    uint32_t q_chunk_tiles,
+    bool is_q_sharded,
+    bool tilize_q,
+    bool use_half_tile,
+    uint32_t barrier_threshold,
+    typename QArgsType>
+void read_q(
+    bool q_locally_available,
+    bool is_output_core,
+    uint32_t q_addr,
+    uint32_t output_core_noc_x,
+    uint32_t output_core_noc_y,
+    uint32_t q_chunk_size_bytes,
+    const QArgsType& q_args,
+    uint32_t q_page_size_bytes,
+    uint32_t q_batch_offset) {
+    // If Q is locally available (pre-sharded to all cores), just reserve and push
+    if (q_locally_available) {
+        if constexpr (tilize_q) {
+            cb_reserve_back(cb_q_rm, q_chunk_tiles);
+            cb_push_back(cb_q_rm, q_chunk_tiles);
+        } else {
+            cb_reserve_back(cb_q_in, q_chunk_tiles);
+            cb_push_back(cb_q_in, q_chunk_tiles);
+        }
+        return;
+    }
+
+    if constexpr (is_q_sharded) {
+        // Q is sharded - read from output core's L1
+        uint64_t q_read_addr =
+            is_output_core ? get_noc_addr(q_addr) : get_noc_addr(output_core_noc_x, output_core_noc_y, q_addr);
+
+        uint32_t q_write_ptr;
+        if constexpr (tilize_q) {
+            cb_reserve_back(cb_q_rm, q_chunk_tiles);
+            q_write_ptr = get_write_ptr(cb_q_rm);
+        } else {
+            cb_reserve_back(cb_q_in, q_chunk_tiles);
+            q_write_ptr = get_write_ptr(cb_q_in);
+        }
+
+        if constexpr (use_half_tile && !tilize_q) {
+            // Q is stored as 32x32 tiles but we want 16x32 half tiles
+            for (uint32_t tile = 0; tile < q_chunk_tiles; tile++) {
+                noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
+                q_read_addr += 2 * q_tile_bytes;  // Skip bottom half of each tile
+                q_write_ptr += q_tile_bytes;
+            }
+        } else {
+            noc_async_read(q_read_addr, q_write_ptr, q_chunk_size_bytes);
+        }
+        noc_async_read_barrier();
+
+        if constexpr (tilize_q) {
+            cb_push_back(cb_q_rm, q_chunk_tiles);
+        } else {
+            cb_push_back(cb_q_in, q_chunk_tiles);
+        }
+    } else {
+        // Q is not sharded - read tiles from DRAM
+        const auto q_reader = TensorAccessor(q_args, q_addr, q_page_size_bytes);
+        uint32_t q_tile_id = q_batch_offset;
+
+        cb_reserve_back(cb_q_in, q_chunk_tiles);
+        uint32_t q_write_ptr = get_write_ptr(cb_q_in);
+        uint32_t barrier_count = 0;
+
+        for (uint32_t tile = 0; tile < q_chunk_tiles; ++tile) {
+            uint64_t q_read_addr = q_reader.get_noc_addr(q_tile_id);
+            noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
+            q_tile_id += 1;
+            q_write_ptr += q_tile_bytes;
+
+            if (++barrier_count == barrier_threshold) {
+                noc_async_read_barrier();
+                barrier_count = 0;
+            }
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_q_in, q_chunk_tiles);
+    }
+}
+
+// Multicast parameters for K streaming (vertical multicast along y, same x)
+struct KMcastParams {
+    bool do_mcast;                               // true = sender, false = receiver
+    uint32_t mcast_x;                            // x coordinate for multicast (fixed for vertical)
+    uint32_t mcast_y0;                           // y start for multicast range
+    uint32_t mcast_y1;                           // y end for multicast range
+    uint32_t num_dests;                          // number of multicast destinations
+    uint32_t mcast_sem_addr;                     // semaphore address for synchronization
+    volatile tt_l1_ptr uint32_t* mcast_sem_ptr;  // semaphore pointer
+};
+
+template <
     uint32_t cb_k_in,
     uint32_t DHt,
     uint32_t num_kv_heads,
@@ -521,6 +574,7 @@ template <
     uint32_t k_tile_bytes,
     uint32_t barrier_threshold,
     bool is_page_table_sharded,
+    bool use_mcast,
     typename KReaderType>
 uint64_t read_k(
     uint32_t k_chunk_tiles,
@@ -530,38 +584,110 @@ uint64_t read_k(
     const KReaderType& k_reader,
     volatile tt_l1_ptr uint16_t* page_table_ptr_u16,
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32,
-    uint32_t& barrier_count) {
+    uint32_t& barrier_count,
+    const KMcastParams& mcast_params = {}) {
+    // Size of one row of K (one column of K^T) = DHt tiles
+    constexpr uint32_t row_tile_bytes = DHt * k_tile_bytes;
+
     cb_reserve_back(cb_k_in, k_chunk_tiles);
     uint32_t k_write_ptr = get_write_ptr(cb_k_in);
     uint64_t k_base_read_ptr = get_noc_addr(k_write_ptr);
     barrier_count = 0;
-    for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
-        uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
-        uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
-        uint32_t physical_k_tile_id =
-            (is_page_table_sharded)
-                ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
-                      virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
-                      virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
-        for (uint32_t col = 0; col < DHt; ++col) {
-            noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
-            physical_k_tile_id += 1;                               // Go to next tile in row
-            k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;  // Go to next column in CB
 
-            if (++barrier_count == barrier_threshold) {
+    if constexpr (use_mcast) {
+        if (mcast_params.do_mcast) {
+            for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
+                uint32_t row_write_ptr = k_write_ptr + row * row_tile_bytes;
+                uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
+                uint32_t physical_k_tile_id =
+                    (is_page_table_sharded)
+                        ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
+                              virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
+                        : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
+                              virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
+                // Read one row of K, write contiguously (DHt tiles)
+                for (uint32_t col = 0; col < DHt; ++col) {
+                    noc_async_read_tile(physical_k_tile_id, k_reader, row_write_ptr);
+                    physical_k_tile_id += 1;        // Go to next tile in K row
+                    row_write_ptr += k_tile_bytes;  // Contiguous write (next tile in buffer)
+
+                    if (++barrier_count == barrier_threshold) {
+                        noc_async_read_barrier();
+                        barrier_count = 0;
+                    }
+                }
                 noc_async_read_barrier();
-                barrier_count = 0;
+                // Multicast just this row (DHt tiles) to other cores (vertical multicast)
+                uint32_t row_start_ptr = k_write_ptr + row * row_tile_bytes;
+                uint64_t dst_mcast_addr = get_noc_multicast_addr(
+                    mcast_params.mcast_x,   // x (same column)
+                    mcast_params.mcast_y0,  // y_start
+                    mcast_params.mcast_x,   // x (same column)
+                    mcast_params.mcast_y1,  // y_end
+                    row_start_ptr);
+
+                noc_async_write_multicast(
+                    row_start_ptr,
+                    dst_mcast_addr,
+                    row_tile_bytes,  // Only this row (DHt tiles)
+                    mcast_params.num_dests,
+                    /*linked=*/false);
+
+                // Ensure data multicast is complete
+                noc_async_write_barrier();
+                // Signal "tiles ready" via semaphore multicast
+                constexpr uint32_t VALID = 1;
+                noc_semaphore_set(mcast_params.mcast_sem_ptr, VALID);
+
+                uint64_t sem_mcast_addr = get_noc_multicast_addr(
+                    mcast_params.mcast_x,
+                    mcast_params.mcast_y0,
+                    mcast_params.mcast_x,
+                    mcast_params.mcast_y1,
+                    mcast_params.mcast_sem_addr);
+                noc_semaphore_set_multicast(mcast_params.mcast_sem_addr, sem_mcast_addr, mcast_params.num_dests, false);
+                // Push DHt tiles (one K^T column) - allows compute to start immediately
+                cb_push_back(cb_k_in, DHt);
+                noc_async_write_barrier();
+            }
+        } else {
+            for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
+                noc_semaphore_wait(mcast_params.mcast_sem_ptr, 1);
+                noc_semaphore_set(mcast_params.mcast_sem_ptr, 0);
+                cb_push_back(cb_k_in, DHt);
             }
         }
+    } else {
+        // Non-multicast path: original transposed read
+        for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
+            uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
+            uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
+            uint32_t physical_k_tile_id =
+                (is_page_table_sharded)
+                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
+                          virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
+                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
+                          virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
+            for (uint32_t col = 0; col < DHt; ++col) {
+                noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                physical_k_tile_id += 1;                               // Go to next tile in row
+                k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;  // Go to next column in CB
+
+                if (++barrier_count == barrier_threshold) {
+                    noc_async_read_barrier();
+                    barrier_count = 0;
+                }
+            }
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_k_in, k_chunk_tiles);
     }
-    noc_async_read_barrier();
-    cb_push_back(cb_k_in, k_chunk_tiles);
     return k_base_read_ptr;
 }
 
 template <
     uint32_t cb_v_in,
+    uint32_t DHt,
     uint32_t vDHt,
     uint32_t num_kv_heads,
     uint32_t block_size_t,
@@ -569,6 +695,7 @@ template <
     uint32_t barrier_threshold,
     bool is_page_table_sharded,
     bool reuse_k,
+    bool use_mcast,
     typename VReaderType>
 void read_v(
     uint32_t v_chunk_tiles,
@@ -583,7 +710,6 @@ void read_v(
     uint32_t k_tile_bytes = 0) {
     cb_reserve_back(cb_v_in, v_chunk_tiles);
     uint32_t v_write_ptr = get_write_ptr(cb_v_in);
-
     if constexpr (reuse_k) {
         // Read V chunk (transpose of K), from K's L1 buffer
         uint64_t k_read_ptr = k_base_read_ptr;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -586,7 +586,6 @@ uint64_t read_k(
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32,
     uint32_t& barrier_count,
     const KMcastParams& mcast_params = {}) {
-    // Size of one row of K (one column of K^T) = DHt tiles
     constexpr uint32_t row_tile_bytes = DHt * k_tile_bytes;
 
     cb_reserve_back(cb_k_in, k_chunk_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -586,8 +586,6 @@ uint64_t read_k(
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32,
     uint32_t& barrier_count,
     const KMcastParams& mcast_params = {}) {
-    constexpr uint32_t row_tile_bytes = DHt * k_tile_bytes;
-
     cb_reserve_back(cb_k_in, k_chunk_tiles);
     uint32_t k_write_ptr = get_write_ptr(cb_k_in);
     uint64_t k_base_read_ptr = get_noc_addr(k_write_ptr);
@@ -596,7 +594,7 @@ uint64_t read_k(
     if constexpr (use_mcast) {
         if (mcast_params.do_mcast) {
             for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
-                uint32_t row_write_ptr = k_write_ptr + row * row_tile_bytes;
+                uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
                 uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
                 uint32_t physical_k_tile_id =
                     (is_page_table_sharded)
@@ -604,57 +602,49 @@ uint64_t read_k(
                               virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
                         : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
                               virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
-                // Read one row of K, write contiguously (DHt tiles)
                 for (uint32_t col = 0; col < DHt; ++col) {
-                    noc_async_read_tile(physical_k_tile_id, k_reader, row_write_ptr);
-                    physical_k_tile_id += 1;        // Go to next tile in K row
-                    row_write_ptr += k_tile_bytes;  // Contiguous write (next tile in buffer)
-
+                    noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                    physical_k_tile_id += 1;
+                    k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;
                     if (++barrier_count == barrier_threshold) {
                         noc_async_read_barrier();
                         barrier_count = 0;
                     }
                 }
-                noc_async_read_barrier();
-                // Multicast just this row (DHt tiles) to other cores (vertical multicast)
-                uint32_t row_start_ptr = k_write_ptr + row * row_tile_bytes;
-                uint64_t dst_mcast_addr = get_noc_multicast_addr(
-                    mcast_params.mcast_x,   // x (same column)
-                    mcast_params.mcast_y0,  // y_start
-                    mcast_params.mcast_x,   // x (same column)
-                    mcast_params.mcast_y1,  // y_end
-                    row_start_ptr);
-
-                noc_async_write_multicast(
-                    row_start_ptr,
-                    dst_mcast_addr,
-                    row_tile_bytes,  // Only this row (DHt tiles)
-                    mcast_params.num_dests,
-                    /*linked=*/false);
-
-                // Ensure data multicast is complete
-                noc_async_write_barrier();
-                // Signal "tiles ready" via semaphore multicast
-                constexpr uint32_t VALID = 1;
-                noc_semaphore_set(mcast_params.mcast_sem_ptr, VALID);
-
-                uint64_t sem_mcast_addr = get_noc_multicast_addr(
-                    mcast_params.mcast_x,
-                    mcast_params.mcast_y0,
-                    mcast_params.mcast_x,
-                    mcast_params.mcast_y1,
-                    mcast_params.mcast_sem_addr);
-                noc_semaphore_set_multicast(mcast_params.mcast_sem_addr, sem_mcast_addr, mcast_params.num_dests, false);
-                // Push DHt tiles (one K^T column) - allows compute to start immediately
-                cb_push_back(cb_k_in, DHt);
-                noc_async_write_barrier();
             }
+            noc_async_read_barrier();
+            // Multicast the full K^T chunk to all receiver cores at once
+            uint64_t dst_mcast_addr = get_noc_multicast_addr(
+                mcast_params.mcast_x,   // x (same column)
+                mcast_params.mcast_y0,  // y_start
+                mcast_params.mcast_x,   // x (same column)
+                mcast_params.mcast_y1,  // y_end
+                k_write_ptr);
+            noc_async_write_multicast(
+                k_write_ptr,
+                dst_mcast_addr,
+                k_chunk_tiles * k_tile_bytes,
+                mcast_params.num_dests,
+                /*linked=*/false);
+            // Ensure data multicast is complete before signaling
+            noc_async_write_barrier();
+            // Signal all receivers that the full K^T chunk is ready
+            constexpr uint32_t VALID = 1;
+            noc_semaphore_set(mcast_params.mcast_sem_ptr, VALID);
+            uint64_t sem_mcast_addr = get_noc_multicast_addr(
+                mcast_params.mcast_x,
+                mcast_params.mcast_y0,
+                mcast_params.mcast_x,
+                mcast_params.mcast_y1,
+                mcast_params.mcast_sem_addr);
+            noc_semaphore_set_multicast(mcast_params.mcast_sem_addr, sem_mcast_addr, mcast_params.num_dests, false);
+            cb_push_back(cb_k_in, k_chunk_tiles);
+            noc_async_write_barrier();
         } else {
-            for (uint32_t row = 0; row < Sk_chunk_t_dynamic; ++row) {
-                noc_semaphore_wait(mcast_params.mcast_sem_ptr, 1);
-                noc_semaphore_set(mcast_params.mcast_sem_ptr, 0);
-                cb_push_back(cb_k_in, DHt);
-            }
+            // Wait for single signal that the full K^T chunk is ready
+            noc_semaphore_wait(mcast_params.mcast_sem_ptr, 1);
+            noc_semaphore_set(mcast_params.mcast_sem_ptr, 0);
+            cb_push_back(cb_k_in, k_chunk_tiles);
         }
     } else {
         // Non-multicast path: original transposed read

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -644,6 +644,7 @@ uint64_t read_k(
             // Wait for single signal that the full K^T chunk is ready
             noc_semaphore_wait(mcast_params.mcast_sem_ptr, 1);
             noc_semaphore_set(mcast_params.mcast_sem_ptr, 0);
+            noc_async_atomic_barrier();
             cb_push_back(cb_k_in, k_chunk_tiles);
         }
     } else {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -48,10 +48,13 @@ void kernel_main() {
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(30);
     constexpr uint32_t original_block_size = get_compile_time_arg_val(31);
     constexpr bool has_block_padding = is_paged_attention && original_block_size > 0 && original_block_size < 32;
+    constexpr uint32_t k_mcast_semaphore_id = get_compile_time_arg_val(32);
+    constexpr bool q_locally_available = get_compile_time_arg_val(33) == 1;
+    constexpr bool use_k_mcast = get_compile_time_arg_val(34) == 1;
 
-    constexpr auto k_args = TensorAccessorArgs<32>();
-    constexpr auto q_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
-    constexpr auto v_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto q_args = TensorAccessorArgs<35>();
+    constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
     constexpr auto pos_args = TensorAccessorArgs<mask_args.next_compile_time_args_offset()>();
     constexpr auto page_table_args = TensorAccessorArgs<pos_args.next_compile_time_args_offset()>();
@@ -73,6 +76,11 @@ void kernel_main() {
     const uint32_t core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t core_num_in_output = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t cur_pos_arg = get_arg_val<uint32_t>(arg_idx++);
+    const bool do_k_mcast = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_y0 = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t mcast_y1 = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_dests = get_arg_val<uint32_t>(arg_idx++);
 
     // idle core
     if (q_addr == 0) {
@@ -90,10 +98,8 @@ void kernel_main() {
             constexpr uint32_t cb_index_id = tt::CBIndex::c_8;
             cb_reserve_back(cb_index_id, 1);
             uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
-
             if constexpr (!is_cur_pos_tensor_sharded) {
                 const auto addrg = TensorAccessor(pos_args, pos_addr, index_stick_size_B);
-
                 // index_tensor has one page to read
                 uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
                 noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
@@ -103,7 +109,6 @@ void kernel_main() {
             volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
             cur_pos = index_ptr[cur_batch / q_heads_parallel_factor];
         }
-
         if (cur_pos == UINT32_MAX) {
             // cur_pos of -1 indicates that the user should be skipped
             return;
@@ -160,67 +165,28 @@ void kernel_main() {
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
     constexpr uint32_t mask_tile_bytes = get_tile_size(cb_mask_in);
     constexpr uint32_t attention_sink_tile_bytes = get_tile_size(cb_attention_sink);
-
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_cores>();
     uint32_t barrier_count = 0;
 
     // Read Q entirely - always read into cb_q_in
     // When tilize_q is true, compute will tilize back to cb_q_in
     // When tilize_q is false, Q is already tilized
-    uint32_t q_batch_offset = cur_batch * q_chunk_tiles;
+    uint32_t k_mcast_sem_addr = get_semaphore(k_mcast_semaphore_id);
+    volatile tt_l1_ptr uint32_t* k_mcast_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(k_mcast_sem_addr);
+    const uint32_t q_batch_offset = cur_batch * q_chunk_tiles;
 
-    if constexpr (is_q_sharded) {
-        uint64_t q_read_addr;
-        uint32_t q_write_ptr;
-        if (is_output_core) {
-            q_read_addr = get_noc_addr(q_addr);
-        } else {
-            q_read_addr = get_noc_addr(output_core_noc_x, output_core_noc_y, q_addr);
-        }
-        if constexpr (tilize_q) {
-            cb_reserve_back(cb_q_rm, q_chunk_tiles);
-            q_write_ptr = get_write_ptr(cb_q_rm);
-        } else {
-            cb_reserve_back(cb_q_in, q_chunk_tiles);
-            q_write_ptr = get_write_ptr(cb_q_in);
-        }
-        if constexpr (use_half_tile and not tilize_q) {
-            // q_addr represents 32x32 tiles; read them as 16x32 tiles
-            // TODO: Properly setup q input as tiny tiles and remove special handling for tiny tiles
-            for (uint8_t tile = 0; tile < q_chunk_tiles; tile++) {
-                noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
-                q_read_addr += 2 * q_tile_bytes;
-                q_write_ptr += q_tile_bytes;
-            }
-        } else {
-            noc_async_read(q_read_addr, q_write_ptr, q_chunk_size_bytes);
-        }
-        noc_async_read_barrier();
-        if constexpr (tilize_q) {
-            cb_push_back(cb_q_rm, q_chunk_tiles);
-        } else {
-            cb_push_back(cb_q_in, q_chunk_tiles);
-        }
-    } else {
-        const auto q_reader = TensorAccessor(q_args, q_addr, q_page_size_bytes);
-        uint32_t q_tile_id = q_batch_offset;
-        cb_reserve_back(cb_q_in, q_chunk_tiles);
-        uint32_t q_write_ptr = get_write_ptr(cb_q_in);
-        for (uint32_t tile = 0; tile < q_chunk_tiles; ++tile) {
-            uint64_t q_read_addr = q_reader.get_noc_addr(q_tile_id);
-            noc_async_read(q_read_addr, q_write_ptr, q_tile_bytes);
-            q_tile_id += 1;
-            q_write_ptr += q_tile_bytes;
-            if (++barrier_count == barrier_threshold) {
-                noc_async_read_barrier();
-                barrier_count = 0;
-            }
-        }
-        noc_async_read_barrier();
-        cb_push_back(cb_q_in, q_chunk_tiles);
-    }
+    // Read Q
+    read_q<cb_q_in, cb_q_rm, q_tile_bytes, q_chunk_tiles, is_q_sharded, tilize_q, use_half_tile, barrier_threshold>(
+        q_locally_available,
+        is_output_core,
+        q_addr,
+        output_core_noc_x,
+        output_core_noc_y,
+        q_chunk_size_bytes,
+        q_args,
+        q_page_size_bytes,
+        q_batch_offset);
 
-    // Read the rest
     const auto k_reader = TensorAccessor(k_args, k_addr, k_tile_bytes);
 
     const auto v_reader = TensorAccessor(v_args, v_addr, v_tile_bytes);
@@ -243,17 +209,15 @@ void kernel_main() {
         cb_push_back(cb_attention_sink, PNHt);
     }
 
+    // Read page table
     volatile tt_l1_ptr uint32_t* page_table_ptr;
     uint32_t page_table_cb_wr_ptr = 0;
-    // Typed pointers for page table entries in L1
     volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
     volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
     if constexpr (is_paged_attention) {
         constexpr uint32_t cb_id_page_table = tt::CBIndex::c_9;
         uint32_t num_pages_to_read = is_page_table_sharded ? B : 1;
-
         cb_reserve_back(cb_id_page_table, num_pages_to_read);
-
         // Read page table from DRAM
         if constexpr (!is_page_table_sharded) {
             page_table_ptr = read_page_table_for_batch(
@@ -268,7 +232,6 @@ void kernel_main() {
                 get_write_ptr(cb_id_page_table) + (cur_batch / q_heads_parallel_factor) * page_table_page_size;
             page_table_ptr_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_table_cb_wr_ptr);
         }
-
         cb_push_back(cb_id_page_table, num_pages_to_read);
     }
 
@@ -278,59 +241,67 @@ void kernel_main() {
         const uint32_t mask_batch_offset = ((cur_batch / q_heads_parallel_factor) % Bkv) * PNHt * St;
         const uint32_t mask_chunk_offset = k_chunk_start * Sk_chunk_t_dynamic;
         uint32_t mask_start_tile_id = mask_batch_offset + mask_chunk_offset;
+        // Setup multicast parameters for K streaming (vertical multicast)
+        KMcastParams k_mcast_params = {
+            .do_mcast = do_k_mcast,
+            .mcast_x = mcast_x,
+            .mcast_y0 = mcast_y0,
+            .mcast_y1 = mcast_y1,
+            .num_dests = num_dests,
+            .mcast_sem_addr = k_mcast_sem_addr,
+            .mcast_sem_ptr = k_mcast_sem_ptr};
+
         if constexpr (is_paged_attention) {
             for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
                 const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t_dynamic;
                 uint64_t k_base_read_ptr;
-                {
-                    // Read K chunk in row-major order (to simplify page mapping). Write tiles to CB in transposed
-                    // order.
-                    k_base_read_ptr = read_k<
-                        cb_k_in,
-                        DHt,
-                        num_kv_heads,
-                        block_size_t,
-                        k_tile_bytes,
-                        barrier_threshold,
-                        is_page_table_sharded>(
-                        k_chunk_tiles,
-                        cur_head,
-                        Sk_chunk_t_dynamic,
-                        k_chunk_start_row_num,
-                        k_reader,
-                        page_table_ptr_u16,
-                        page_table_ptr_u32,
-                        barrier_count);
-                }
+
+                // Read K chunk - supports both multicast and non-multicast paths
+                k_base_read_ptr = read_k<
+                    cb_k_in,
+                    DHt,
+                    num_kv_heads,
+                    block_size_t,
+                    k_tile_bytes,
+                    barrier_threshold,
+                    is_page_table_sharded,
+                    use_k_mcast>(
+                    k_chunk_tiles,
+                    cur_head,
+                    Sk_chunk_t_dynamic,
+                    k_chunk_start_row_num,
+                    k_reader,
+                    page_table_ptr_u16,
+                    page_table_ptr_u32,
+                    barrier_count,
+                    k_mcast_params);
 
                 if constexpr (use_attention_mask) {
                     mask_start_tile_id = read_mask_chunk<cb_mask_in, mask_tile_bytes, barrier_threshold, PNHt>(
                         PSt, Sk_chunk_t_dynamic, mask_chunk_tiles, mask_start_tile_id, mask_reader);
                 }
-
-                {
-                    // Read V chunk - either from DRAM or from K's L1 buffer (transpose) when reuse_k is true
-                    read_v<
-                        cb_v_in,
-                        vDHt,
-                        num_kv_heads,
-                        block_size_t,
-                        v_tile_bytes,
-                        barrier_threshold,
-                        is_page_table_sharded,
-                        reuse_k>(
-                        v_chunk_tiles,
-                        cur_head,
-                        Sk_chunk_t_dynamic,
-                        k_chunk_start_row_num,
-                        v_reader,
-                        page_table_ptr_u16,
-                        page_table_ptr_u32,
-                        barrier_count,
-                        k_base_read_ptr,
-                        k_tile_bytes);
-                }
-
+                // Read V chunk - either from DRAM or from K's L1 buffer (transpose) when reuse_k is true
+                read_v<
+                    cb_v_in,
+                    DHt,
+                    vDHt,
+                    num_kv_heads,
+                    block_size_t,
+                    v_tile_bytes,
+                    barrier_threshold,
+                    is_page_table_sharded,
+                    reuse_k,
+                    use_k_mcast>(
+                    v_chunk_tiles,
+                    cur_head,
+                    Sk_chunk_t_dynamic,
+                    k_chunk_start_row_num,
+                    v_reader,
+                    page_table_ptr_u16,
+                    page_table_ptr_u32,
+                    barrier_count,
+                    k_base_read_ptr,
+                    k_tile_bytes);
             }
         } else {
             // Offset for current batch

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -283,15 +283,13 @@ void kernel_main() {
                 // Read V chunk - either from DRAM or from K's L1 buffer (transpose) when reuse_k is true
                 read_v<
                     cb_v_in,
-                    DHt,
                     vDHt,
                     num_kv_heads,
                     block_size_t,
                     v_tile_bytes,
                     barrier_threshold,
                     is_page_table_sharded,
-                    reuse_k,
-                    use_k_mcast>(
+                    reuse_k>(
                     v_chunk_tiles,
                     cur_head,
                     Sk_chunk_t_dynamic,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -6,7 +6,6 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #include "api/debug/assert.h"
-
 #include "ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp"
 #include "dataflow_common.hpp"
 
@@ -257,7 +256,6 @@ void kernel_main() {
 
             for (uint32_t round = 0; round < num_active_rounds; ++round) {
                 uint32_t child_id = active_children_per_round[round];
-
                 if (child_id != UINT32_MAX) {
                     // Wait for this specific child to send its results
                     // Poll until round-specific nibble is >= 1

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -151,7 +151,9 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
         // Paged attention verification
         TT_FATAL(
             !operation_attributes.share_cache.value_or(false), "Share cache feature not supported for paged attention");
-        const auto B = q_shape[1];
+        TT_FATAL(tensor_args.page_table_tensor.has_value(), "Must have page_table tensor for paged attention");
+        const auto& page_table_tensor = tensor_args.page_table_tensor.value();
+        const auto B = page_table_tensor.padded_shape()[0];
 
         if (operation_attributes.is_causal) {
             // Check cur pos tensor for causal mode
@@ -176,9 +178,6 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
                     B);
             }
         }
-
-        TT_FATAL(tensor_args.page_table_tensor.has_value(), "Must have page_table tensor for paged attention");
-        const auto& page_table_tensor = tensor_args.page_table_tensor.value();
 
         if (page_table_tensor.is_sharded()) {
             TT_FATAL(
@@ -351,11 +350,46 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
 TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.q;
+    const auto q_shape = input.padded_shape();
+    const auto q_shape_unpadded = input.logical_shape();
+
+    const bool q_locally_available =
+        operation_attributes.program_config.has_value() && operation_attributes.program_config->q_locally_available;
+
+    uint32_t B;
+    if (operation_attributes.paged_attention && tensor_args.page_table_tensor.has_value()) {
+        const auto& page_table = tensor_args.page_table_tensor.value();
+        if (page_table.is_sharded()) {
+            uint32_t num_cores = page_table.memory_config().shard_spec()->grid.num_cores();
+            B = page_table.padded_shape()[0] / num_cores;
+        } else {
+            B = page_table.padded_shape()[0];
+        }
+    } else {
+        // Non-paged: K tensor has shape [B, num_kv_heads, S, D] or similar
+        B = tensor_args.k.padded_shape()[0];
+    }
+    uint32_t num_q_heads;
+    if (q_locally_available && input.is_sharded()) {
+        const uint32_t q_shard_height = input.memory_config().shard_spec()->shape[0];
+        const uint32_t max_cores = operation_attributes.program_config->max_cores_per_head_batch;
+        const uint32_t num_q_shards = input.memory_config().shard_spec()->grid.num_cores();
+        const uint32_t num_groups = num_q_shards / max_cores;
+        const uint32_t q_heads_parallel_factor = num_groups / B;
+        num_q_heads = q_heads_parallel_factor * q_shard_height;
+    } else {
+        num_q_heads = q_shape_unpadded[2];
+    }
+
     Layout output_layout = Layout::TILE;
     ttnn::Shape output_shape = input.logical_shape();
     if (input.layout() == Layout::ROW_MAJOR) {
-        output_shape[2] = round_up_to_tile(output_shape[2], tt::constants::TILE_HEIGHT);
+        output_shape[2] = tt::round_up(num_q_heads, tt::constants::TILE_HEIGHT);
         output_layout = Layout::ROW_MAJOR;
+    } else {
+        output_shape[1] = B;
+        output_shape[2] = tt::round_up(num_q_heads, tt::constants::TILE_HEIGHT);
+        output_layout = Layout::TILE;
     }
     bool use_mla = operation_attributes.use_mla.value_or(false);
     if (use_mla) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -374,10 +374,10 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     }
     uint32_t num_q_heads;
     // Q heads parallelization
-    TT_FATAL(
-        q_locally_available && input.is_sharded(),
-        "In order for Q tensor to be locally available to all worker cores, it must be sharded");
-    if (q_locally_available && input.is_sharded()) {
+    if (q_locally_available) {
+        TT_FATAL(
+            q_locally_available && input.is_sharded(),
+            "In order for Q tensor to be locally available to all worker cores, it must be sharded");
         const uint32_t q_shard_height = input.memory_config().shard_spec()->shape[0];
         const uint32_t max_cores = operation_attributes.program_config->max_cores_per_head_batch;
         const uint32_t num_q_shards = input.memory_config().shard_spec()->grid.num_cores();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -153,7 +153,7 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
             !operation_attributes.share_cache.value_or(false), "Share cache feature not supported for paged attention");
         TT_FATAL(tensor_args.page_table_tensor.has_value(), "Must have page_table tensor for paged attention");
         const auto& page_table_tensor = tensor_args.page_table_tensor.value();
-        const auto B = page_table_tensor.padded_shape()[0];
+        const auto B = page_table_tensor.is_sharded() ? q_shape[1] : page_table_tensor.padded_shape()[0];
 
         if (operation_attributes.is_causal) {
             // Check cur pos tensor for causal mode

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -352,8 +352,7 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     const auto& input = tensor_args.q;
     const auto q_shape = input.padded_shape();
     const auto q_shape_unpadded = input.logical_shape();
-    const bool q_locally_available =
-        operation_attributes.program_config.has_value() && operation_attributes.program_config->q_locally_available;
+    const bool use_mla = operation_attributes.use_mla.value_or(false);
     uint32_t B;
     if (operation_attributes.paged_attention && tensor_args.page_table_tensor.has_value()) {
         const auto& page_table = tensor_args.page_table_tensor.value();
@@ -369,23 +368,22 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
             B = page_table.padded_shape()[0];
         }
     } else {
-        // Non-paged: K tensor has shape [B, num_kv_heads, S, D] or similar
         B = tensor_args.k.padded_shape()[0];
     }
-    uint32_t num_q_heads;
-    // Q heads parallelization
-    if (q_locally_available) {
-        TT_FATAL(
-            q_locally_available && input.is_sharded(),
-            "In order for Q tensor to be locally available to all worker cores, it must be sharded");
+    bool q_locally_available = false;
+    uint32_t num_q_heads = q_shape_unpadded[2];
+
+    if (input.is_sharded() && use_mla && operation_attributes.program_config.has_value()) {
         const uint32_t q_shard_height = input.memory_config().shard_spec()->shape[0];
         const uint32_t max_cores = operation_attributes.program_config->max_cores_per_head_batch;
         const uint32_t num_q_shards = input.memory_config().shard_spec()->grid.num_cores();
         const uint32_t num_groups = num_q_shards / max_cores;
         const uint32_t q_heads_parallel_factor = num_groups / B;
-        num_q_heads = q_heads_parallel_factor * q_shard_height;
-    } else {
-        num_q_heads = q_shape_unpadded[2];
+
+        q_locally_available = (q_shape[2] == B * q_shard_height * q_heads_parallel_factor * max_cores);
+        if (q_locally_available) {
+            num_q_heads = q_heads_parallel_factor * q_shard_height;
+        }
     }
 
     Layout output_layout = Layout::TILE;
@@ -398,7 +396,6 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
         output_shape[2] = tt::round_up(num_q_heads, tt::constants::TILE_HEIGHT);
         output_layout = Layout::TILE;
     }
-    bool use_mla = operation_attributes.use_mla.value_or(false);
     if (use_mla) {
         output_shape[3] = operation_attributes.head_dim_v.value();
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -352,16 +352,19 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
     const auto& input = tensor_args.q;
     const auto q_shape = input.padded_shape();
     const auto q_shape_unpadded = input.logical_shape();
-
     const bool q_locally_available =
         operation_attributes.program_config.has_value() && operation_attributes.program_config->q_locally_available;
-
     uint32_t B;
     if (operation_attributes.paged_attention && tensor_args.page_table_tensor.has_value()) {
         const auto& page_table = tensor_args.page_table_tensor.value();
         if (page_table.is_sharded()) {
             uint32_t num_cores = page_table.memory_config().shard_spec()->grid.num_cores();
-            B = page_table.padded_shape()[0] / num_cores;
+            const uint32_t total_batch = page_table.padded_shape()[0];
+            TT_FATAL(
+                total_batch % num_cores == 0,
+                "Paged attention with sharded page table expects batch dimension batch size to be divisible by number "
+                "of cores");
+            B = total_batch / num_cores;
         } else {
             B = page_table.padded_shape()[0];
         }
@@ -370,6 +373,10 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
         B = tensor_args.k.padded_shape()[0];
     }
     uint32_t num_q_heads;
+    // Q heads parallelization
+    TT_FATAL(
+        q_locally_available && input.is_sharded(),
+        "In order for Q tensor to be locally available to all worker cores, it must be sharded");
     if (q_locally_available && input.is_sharded()) {
         const uint32_t q_shard_height = input.memory_config().shard_spec()->shape[0];
         const uint32_t max_cores = operation_attributes.program_config->max_cores_per_head_batch;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -552,7 +552,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     const uint32_t q_chunk_size_bytes =
         q_tiles * (tilize_q ? num_q_heads * TILE_WIDTH * input_tensor_q.element_size() : q_tile_size);
     const uint32_t reuse_k = (tensor_args.v.has_value() ? 0 : 1) | (q_heads_parallel_factor > 1 ? 1 : 0);
-
     // ========== Compile Time Arguments ==========
     std::vector<uint32_t> reader_compile_time_args_common = {
         B,
@@ -589,7 +588,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         original_block_size,
         k_mcast_semaphore_id,
         (uint32_t)q_locally_available,
-        (uint32_t)(q_heads_parallel_factor > 1),  // use_k_mcast
+        (uint32_t)use_col_major_group_indexing,  // use_k_mcast
     };
     tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
@@ -1034,8 +1033,8 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         bool do_output = (worker_id_for_output == UINT32_MAX);
         bool do_k_mcast = false;
         uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
-        if (q_heads_parallel_factor > 1) {
-            do_k_mcast = (core.y == 0 || core.y == 4);
+        if (use_col_major_group_indexing) {
+            do_k_mcast = (core.y % q_heads_parallel_factor == 0);
             num_dests = q_heads_parallel_factor - 1;
             if (do_k_mcast && num_dests > 0) {
                 auto phys_start = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -61,8 +61,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     const bool use_cur_pos_tensor = cur_pos_tensor.has_value();
     const bool use_attention_mask = attn_mask.has_value();
     const bool use_attention_sink = attention_sink.has_value();
-    const bool q_locally_available = program_config.has_value() && program_config->q_locally_available;
-
     // ========== Tensor Shapes ==========
     auto q_shape = input_tensor_q.padded_shape();
     q_shape[2] = tt::round_up(q_shape[2], tt::constants::TILE_HEIGHT);
@@ -87,6 +85,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
 
     // Handle paged attention sequence length
     if (is_paged_attention) {
+        B = page_table_tensor.value().padded_shape()[0];
         uint32_t block_size = k_shape[2];
         original_block_size = input_tensor_k.logical_shape()[2];
         page_block_size_t = block_size / TILE_HEIGHT;
@@ -95,23 +94,24 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     }
 
     // ========== Q Sharding & MLA Parallelization ==========
+    // Q is "locally available" when sharded for MLA with data replicated across all worker cores.
+    //   Replicated layout:   Q shape = (1, 1, B * num_q_heads * num_cores_per_head, D) — batch folded into dim 2.
+    //   Non-replicated layout: Q shape = (1, B, num_q_heads, D) — batch in dim 1.
+    bool q_locally_available = false;
     if (is_q_sharded && use_mla) {
         const uint32_t q_shard_height = input_tensor_q.memory_config().shard_spec()->shape[0];
         const uint32_t max_cores = program_config.has_value() ? program_config->max_cores_per_head_batch : 16;
+        const uint32_t num_q_shards = input_tensor_q.memory_config().shard_spec()->grid.num_cores();
+        const uint32_t num_groups = num_q_shards / max_cores;
+        q_heads_parallel_factor = num_groups / B;
+        q_locally_available = (q_shape[2] == B * q_shard_height * q_heads_parallel_factor * max_cores);
         if (q_locally_available) {
-            // Deduce batch from page_table (paged) or K tensor (non-paged)
-            B = is_paged_attention ? page_table_tensor.value().padded_shape()[0] : k_shape[0];
-            // Deduce Q heads from shard config: num_groups = shards / cores_per_group
-            const uint32_t num_q_shards = input_tensor_q.memory_config().shard_spec()->grid.num_cores();
-            const uint32_t num_groups = num_q_shards / max_cores;
-            q_heads_parallel_factor = num_groups / B;
             num_q_heads = q_heads_parallel_factor * q_shard_height;
             PNH = num_q_heads;
-            B *= q_heads_parallel_factor;
         } else {
             q_heads_parallel_factor = std::max(1u, (num_q_heads + q_shard_height - 1) / q_shard_height);
-            B *= q_heads_parallel_factor;
         }
+        B *= q_heads_parallel_factor;
         TT_FATAL(
             q_heads_parallel_factor == 1 || num_kv_heads == 1,
             "Q head parallelization (factor={}) requires num_kv_heads=1, got {}",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -216,6 +216,29 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // column-major group indexing is used to keep batch groups spatially close for efficient K multicast along columns.
     const bool use_col_major_group_indexing =
         (q_heads_parallel_factor > 1) && (grid_size.y >= num_cores_per_head) && !on_subcoregrid && q_locally_available;
+    uint32_t num_group_rows = 0;
+    uint32_t num_group_cols = 0;
+    uint32_t num_groups_total = 0;
+    if (use_col_major_group_indexing) {
+        num_groups_total = num_active_cores / num_cores_per_head;
+        num_group_rows = grid_size.x / num_cores_per_head;
+        num_group_cols = num_groups_total / num_group_rows;
+        TT_FATAL(
+            num_group_cols % q_heads_parallel_factor == 0,
+            "num_group_cols must be divisible by q_heads_parallel_factor");
+        TT_FATAL(
+            num_heads_per_core == 1, "Column major allocation of core groups is only supported for num kv heads = 1");
+        TT_FATAL(
+            num_active_cores % num_cores_per_head == 0,
+            "num_active_cores must be divisible by num_cores_per_head for even distribution.");
+        TT_FATAL(grid_size.x % num_cores_per_head == 0, "grid_size.x must be divisible by num_cores_per_head");
+        TT_FATAL(
+            num_groups_total == B,
+            "num_groups_total must be equal to B (for q heads parallel factor > 1, B is number of virtual batches)");
+        TT_FATAL(
+            num_group_cols * num_group_rows == num_groups_total,
+            "num_group_cols * num_group_rows must be equal to num_groups_total");
+    }
 
     // ========== Core Group Assignment ==========
     // Core layout depends on sharding and indexing mode:
@@ -262,11 +285,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // ========== Physical Core Coordinate Maps ==========
     // Col-major group index for reducer/output cores
     // Guard: if num_cores_per_head > grid_size.x, groups don't fit in a row, so clamp to 1
-    const uint32_t num_groups_per_row = std::max(1u, (uint32_t)(grid_size.x / num_cores_per_head));
-    const uint32_t num_group_rows = (num_output_cores + num_groups_per_row - 1) / num_groups_per_row;
     auto get_col_major_group_idx = [&](uint32_t row_major_idx) -> uint32_t {
-        uint32_t group_row = row_major_idx / num_groups_per_row;
-        uint32_t group_col = row_major_idx % num_groups_per_row;
+        uint32_t group_row = row_major_idx / num_group_rows;
+        uint32_t group_col = row_major_idx % num_group_rows;
         return (group_col * num_group_rows) + group_row;
     };
 
@@ -319,7 +340,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         "Column-major group indexing: enabled={}, cores_per_head={}, groups_per_row={}",
         use_col_major_group_indexing,
         num_cores_per_head,
-        num_groups_per_row);
+        num_group_rows);
 
     // ========== Compute Configuration ==========
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
@@ -527,7 +548,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     create_cb(CBIndex::c_16, out_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
     create_cb(CBIndex::c_17, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
     create_cb(CBIndex::c_18, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
-    create_cb(CBIndex::c_19, intermed_output_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    if (intermed_output_tiles > 0) {
+        create_cb(CBIndex::c_19, intermed_output_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    }
     auto cb_out_final_id = create_cb(
         CBIndex::c_20,
         out_tiles * out_tile_size,
@@ -677,7 +700,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         sliding_window_size,
         num_tree_reduction_rounds,
         original_block_size,
-        reuse_k,  // reuse_k: if V not provided or q_heads_parallel_factor > 1
     };
 
     // ========== Compute Defines ==========
@@ -744,9 +766,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         uint32_t cur_batch = 0, cur_head = 0, core_num_in_reduce = 0, core_num_in_output = 0;
         if (use_col_major_group_indexing) {
             uint32_t group_idx = i / num_cores_per_head;          // row-major group index
-            uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
-            uint32_t group_col = group_idx % num_groups_per_row;  // which column of groups
-            cur_batch = group_col * grid_size.y + group_row;      // column-major: batches go down columns first
+            uint32_t group_row = group_idx / num_group_rows;      // which row of groups (0 to grid_size.y-1)
+            uint32_t group_col = group_idx % num_group_rows;      // which column of groups
+            cur_batch = group_col * num_group_cols + group_row;   // column-major: batches go down columns first
             cur_head = 0;                                         // single KV head when using this indexing
             core_num_in_reduce =
                 i % num_cores_per_head;               // position within the reduction group (0 to num_cores_per_head-1)
@@ -905,7 +927,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             std::vector<uint32_t> reader_rt_args(20, 0);
 
             // Writer runtime args - need to match the size with tree reduction params
-            // Base args (9) + tree params (6) + children_per_round (MAX_TREE_REDUCTION_ROUNDS) + group coords
+            // Base args (10) + tree params (6) + children_per_round (MAX_TREE_REDUCTION_ROUNDS) + group coords
             // (2*num_cores_per_head)
             // + reducer coords + output coords
             std::vector<uint32_t> writer_rt_args(10 + 6 + MAX_TREE_REDUCTION_ROUNDS + (2 * num_cores_per_head), 0);
@@ -947,7 +969,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
          .is_causal = is_causal,
          .use_mla = use_mla,
          .use_col_major_group_indexing = use_col_major_group_indexing,
-         .grid_size = grid_size}};
+         .grid_size = grid_size,
+         .num_group_rows = num_group_rows,
+         .num_group_cols = num_group_cols}};
 }
 
 void SdpaDecodeProgramFactory::override_runtime_arguments(
@@ -980,6 +1004,7 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     const bool is_causal = shared_variables.is_causal;
     const bool use_col_major_group_indexing = shared_variables.use_col_major_group_indexing;
     const auto& grid_size = shared_variables.grid_size;
+    const uint32_t num_group_cols = shared_variables.num_group_cols;
 
     auto* q_buffer = tensor_args.q.buffer();
     auto* k_buffer = tensor_args.k.buffer();
@@ -1024,7 +1049,7 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
             uint32_t group_idx = i / num_cores_per_head;          // row-major group index
             uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
             uint32_t group_col = group_idx % num_groups_per_row;  // which column of groups
-            cur_batch = group_col * grid_size.y + group_row;      // column-major: batches go down columns first
+            cur_batch = group_col * num_group_cols + group_row;   // column-major: batches go down columns first
             cur_head = 0;                                         // single KV head when using this indexing
             core_num_in_reduce = i % num_cores_per_head;          // position within the reduction group
             core_num_in_output = core_num_in_reduce;              // same as reduce for single head

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -83,6 +83,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     uint32_t page_block_size_t = 0;
     uint32_t q_heads_parallel_factor = 1;
     uint32_t original_block_size = 0;
+    bool has_block_padding = false;
 
     // Handle paged attention sequence length
     if (is_paged_attention) {
@@ -90,7 +91,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         original_block_size = input_tensor_k.logical_shape()[2];
         page_block_size_t = block_size / TILE_HEIGHT;
         S = page_table_tensor.value().padded_shape()[-1] * S;
+        has_block_padding = original_block_size < TILE_HEIGHT;
     }
+
     // ========== Q Sharding & MLA Parallelization ==========
     if (is_q_sharded && use_mla) {
         const uint32_t q_shard_height = input_tensor_q.memory_config().shard_spec()->shape[0];
@@ -234,7 +237,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             (i < num_active_cores ? core_group : core_group_idle).push_back(core);
         }
     } else if ((is_q_sharded || is_output_sharded) && !use_col_major_group_indexing) {
-        // Q/output sharded without spatial indexing: reorder cores so reducers are at batch boundaries
+        // Q/output sharded without row major group assignment: reorder cores so reducers are at batch boundaries
         // This ensures i % num_cores_per_batch == 0 identifies output/reducer cores
         uint32_t reducer_idx = 0, worker_idx = num_output_cores;
         for (uint32_t i = 0; i < num_cores_available; ++i) {
@@ -250,7 +253,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         }
     } else {
         // Q in DRAM, no sharding: simple linear assignment
-        // or Q sharded out sharded but uses spatial indexing
         for (uint32_t i = 0; i < num_cores_available; ++i) {
             CoreCoord core = {i % grid_size.x, i / grid_size.x};
             (i < num_active_cores ? core_group : core_group_idle).push_back(core);
@@ -502,6 +504,10 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     create_cb(CBIndex::c_12, scale_tiles * scalar_tile_size, scalar_df, scalar_tile_size, &scalar_tile);
     if (sliding_window_size > 0) {
         create_cb(CBIndex::c_13, qk_tiles * mask_tile_size, mask_df, mask_tile_size, &mask_tile);
+    }
+    // Block padding mask (when block_size < TILE_HEIGHT, masks zero-padded rows in each K tile)
+    if (has_block_padding) {
+        create_cb(CBIndex::c_14, qk_tiles * mask_tile_size, mask_df, mask_tile_size, &mask_tile);
     }
 
     // Intermediate CBs

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -265,7 +265,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     auto get_col_major_group_idx = [&](uint32_t row_major_idx) -> uint32_t {
         uint32_t group_row = row_major_idx / num_groups_per_row;
         uint32_t group_col = row_major_idx % num_groups_per_row;
-        return group_col * num_group_rows + group_row;
+        return (group_col * num_group_rows) + group_row;
     };
 
     // Reducer cores (one per KV head group)
@@ -552,7 +552,8 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // If q is tilized and want to use tiny tiles, this is ignored since we need to skip bottom half of tiles
     const uint32_t q_chunk_size_bytes =
         q_tiles * (tilize_q ? num_q_heads * TILE_WIDTH * input_tensor_q.element_size() : q_tile_size);
-    const uint32_t reuse_k = (tensor_args.v.has_value() ? 0 : 1) | (q_heads_parallel_factor > 1 ? 1 : 0);
+    const uint32_t reuse_k = (tensor_args.v.has_value() ? 0 : 1);
+
     // ========== Compile Time Arguments ==========
     std::vector<uint32_t> reader_compile_time_args_common = {
         B,
@@ -901,7 +902,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             // Base args (9) + tree params (6) + children_per_round (MAX_TREE_REDUCTION_ROUNDS) + group coords
             // (2*num_cores_per_head)
             // + reducer coords + output coords
-            std::vector<uint32_t> writer_rt_args(9 + 6 + MAX_TREE_REDUCTION_ROUNDS + 2 * num_cores_per_head, 0);
+            std::vector<uint32_t> writer_rt_args(10 + 6 + MAX_TREE_REDUCTION_ROUNDS + (2 * num_cores_per_head), 0);
 
             // Compute runtime args - 65 indicates idle core
             // Base args (7) + tree params (5) + children_per_round (MAX_TREE_REDUCTION_ROUNDS)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -259,7 +259,8 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
 
     // ========== Physical Core Coordinate Maps ==========
     // Col-major group index for reducer/output cores
-    const uint32_t num_groups_per_row = grid_size.x / num_cores_per_head;  // groups that fit in one row
+    // Guard: if num_cores_per_head > grid_size.x, groups don't fit in a row, so clamp to 1
+    const uint32_t num_groups_per_row = std::max(1u, (uint32_t)(grid_size.x / num_cores_per_head));
     const uint32_t num_group_rows = (num_output_cores + num_groups_per_row - 1) / num_groups_per_row;
     auto get_col_major_group_idx = [&](uint32_t row_major_idx) -> uint32_t {
         uint32_t group_row = row_major_idx / num_groups_per_row;
@@ -731,7 +732,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     // ========== Runtime Arguments ==========
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t cur_batch, cur_head, core_num_in_reduce, core_num_in_output;
+        bool do_k_mcast = false;
+        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
+        uint32_t cur_batch = 0, cur_head = 0, core_num_in_reduce = 0, core_num_in_output = 0;
         if (use_col_major_group_indexing) {
             uint32_t group_idx = i / num_cores_per_head;          // row-major group index
             uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
@@ -741,6 +744,15 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             core_num_in_reduce =
                 i % num_cores_per_head;               // position within the reduction group (0 to num_cores_per_head-1)
             core_num_in_output = core_num_in_reduce;  // same as reduce for single head
+            do_k_mcast = (core.y % q_heads_parallel_factor == 0);
+            num_dests = q_heads_parallel_factor - 1;
+            if (do_k_mcast && num_dests > 0) {
+                auto phys_start = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
+                auto phys_end = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
+                mcast_x = phys_start.x;
+                mcast_y0 = phys_start.y;
+                mcast_y1 = phys_end.y;
+            }
         } else {
             cur_head = (i % num_cores_per_batch) / num_cores_per_head;
             cur_batch = i / num_cores_per_batch;
@@ -751,19 +763,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         uint32_t worker_id_for_output = (core_num_in_output == 0) ? UINT32_MAX : core_num_in_output - 1;
         bool do_reduce = (worker_id_for_reduce == UINT32_MAX);
         bool do_output = (worker_id_for_output == UINT32_MAX);
-        bool do_k_mcast = false;
-        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
-        if (q_heads_parallel_factor > 1) {
-            do_k_mcast = (core.y == 0 || core.y == 4);
-            num_dests = q_heads_parallel_factor - 1;
-            if (do_k_mcast && num_dests > 0) {
-                auto phys_start = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
-                auto phys_end = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
-                mcast_x = phys_start.x;
-                mcast_y0 = phys_start.y;
-                mcast_y1 = phys_end.y;
-            }
-        }
         uint32_t cur_pos =
             (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
 
@@ -1009,10 +1008,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     // Set rt args
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t cur_batch, cur_head, core_num_in_reduce, core_num_in_output;
+        bool do_k_mcast = false;
+        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
+        uint32_t cur_batch = 0, cur_head = 0, core_num_in_reduce = 0, core_num_in_output = 0;
 
         if (use_col_major_group_indexing) {
-            uint32_t num_groups_per_row = grid_size.x / num_cores_per_head;
+            uint32_t num_groups_per_row = std::max(1u, (uint32_t)(grid_size.x / num_cores_per_head));
             uint32_t group_idx = i / num_cores_per_head;          // row-major group index
             uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
             uint32_t group_col = group_idx % num_groups_per_row;  // which column of groups
@@ -1020,6 +1021,15 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
             cur_head = 0;                                         // single KV head when using this indexing
             core_num_in_reduce = i % num_cores_per_head;          // position within the reduction group
             core_num_in_output = core_num_in_reduce;              // same as reduce for single head
+            do_k_mcast = (core.y % q_heads_parallel_factor == 0);
+            num_dests = q_heads_parallel_factor - 1;
+            if (do_k_mcast && num_dests > 0) {
+                auto phys_start = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
+                auto phys_end = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
+                mcast_x = phys_start.x;
+                mcast_y0 = phys_start.y;
+                mcast_y1 = phys_end.y;
+            }
         } else {
             cur_head = (i % num_cores_per_batch) / num_cores_per_head;
             cur_batch = i / num_cores_per_batch;
@@ -1031,19 +1041,7 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         uint32_t worker_id_for_output = (core_num_in_output == 0) ? UINT32_MAX : core_num_in_output - 1;
         bool do_reduce = (worker_id_for_reduce == UINT32_MAX);
         bool do_output = (worker_id_for_output == UINT32_MAX);
-        bool do_k_mcast = false;
-        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
-        if (use_col_major_group_indexing) {
-            do_k_mcast = (core.y % q_heads_parallel_factor == 0);
-            num_dests = q_heads_parallel_factor - 1;
-            if (do_k_mcast && num_dests > 0) {
-                auto phys_start = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
-                auto phys_end = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
-                mcast_x = phys_start.x;
-                mcast_y0 = phys_start.y;
-                mcast_y1 = phys_end.y;
-            }
-        }
+
         uint32_t cur_pos =
             (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
         uint32_t reduction_group_base_idx;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -82,11 +82,14 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     uint32_t num_q_heads = q_shape_unpadded[2];
     uint32_t page_block_size_t = 0;
     uint32_t q_heads_parallel_factor = 1;
+    uint32_t original_block_size = 0;
 
     // Handle paged attention sequence length
     if (is_paged_attention) {
-        page_block_size_t = k_shape[2] / TILE_HEIGHT;
-        S = page_table_tensor.value().padded_shape()[-1] * k_shape[2];
+        uint32_t block_size = k_shape[2];
+        original_block_size = input_tensor_k.logical_shape()[2];
+        page_block_size_t = block_size / TILE_HEIGHT;
+        S = page_table_tensor.value().padded_shape()[-1] * S;
     }
     // ========== Q Sharding & MLA Parallelization ==========
     if (is_q_sharded && use_mla) {
@@ -596,7 +599,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         .append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(page_table_tensor ? page_table_tensor->buffer() : nullptr)
         .append_to(reader_compile_time_args_common);
-
     if (use_attention_sink) {
         tt_metal::TensorAccessorArgs(*attention_sink->buffer()).append_to(reader_compile_time_args_common);
     } else {
@@ -668,7 +670,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         sliding_window_size,
         num_tree_reduction_rounds,
         original_block_size,
-        (uint32_t)use_mla,  // reuse_k: if MLA, V = K
+        reuse_k,  // reuse_k: if V not provided or q_heads_parallel_factor > 1
     };
 
     // ========== Compute Defines ==========
@@ -678,7 +680,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     compute_defines["LOG2_DHT_GRANULARITY"] = std::to_string(log2_dht_granularity);
 
     if (Sk_chunk_t > 0) {
-        // Static chunk size: set granularities for softmax loops
         auto add_granularity = [&](const char* name, uint32_t value) {
             uint32_t log2_val = std::log2(value);
             TT_FATAL(value == (1u << log2_val), "{} ({}) must be power of 2", name, value);
@@ -1009,8 +1010,8 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     // Set rt args
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        // Core role identification - must match create() exactly
         uint32_t cur_batch, cur_head, core_num_in_reduce, core_num_in_output;
+
         if (use_col_major_group_indexing) {
             uint32_t num_groups_per_row = grid_size.x / num_cores_per_head;
             uint32_t group_idx = i / num_cores_per_head;          // row-major group index
@@ -1021,14 +1022,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
             core_num_in_reduce = i % num_cores_per_head;          // position within the reduction group
             core_num_in_output = core_num_in_reduce;              // same as reduce for single head
         } else {
-            // Must match create() exactly
             cur_head = (i % num_cores_per_batch) / num_cores_per_head;
             cur_batch = i / num_cores_per_batch;
             core_num_in_reduce = i % num_cores_per_head;
             core_num_in_output = i % num_cores_per_batch;
         }
 
-        // Must match create() exactly
         uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? UINT32_MAX : core_num_in_reduce - 1;
         uint32_t worker_id_for_output = (core_num_in_output == 0) ? UINT32_MAX : core_num_in_output - 1;
         bool do_reduce = (worker_id_for_reduce == UINT32_MAX);
@@ -1049,6 +1048,8 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         uint32_t cur_pos =
             (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
         uint32_t reduction_group_base_idx;
+
+        TreeReductionParams tree_params = get_tree_reduction_params(core_num_in_reduce, num_cores_per_head);
         if (use_col_major_group_indexing) {
             // For column-major indexing: the group starts at (i / num_cores_per_head) * num_cores_per_head
             reduction_group_base_idx = (i / num_cores_per_head) * num_cores_per_head;
@@ -1095,12 +1096,16 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         writer_args[arg_idx++] = core_num_in_reduce;
         writer_args[arg_idx++] = core_num_in_output;
         writer_args[arg_idx++] = cur_pos;
-        arg_idx++;  // is_tree_root
-        arg_idx++;  // parent_core_in_group
-        arg_idx++;  // send_at_round
-        arg_idx++;  // num_children
-        arg_idx++;  // my_active_rounds
+        writer_args[arg_idx++] = tree_params.is_root ? 1u : 0u;
+        writer_args[arg_idx++] = tree_params.parent_core_in_group;
+        writer_args[arg_idx++] = tree_params.send_at_round;
+        writer_args[arg_idx++] = tree_params.num_children;
+        writer_args[arg_idx++] = tree_params.my_active_rounds;
         writer_args[arg_idx++] = reduction_group_base_idx;
+        // Add children_per_round array (MAX_TREE_REDUCTION_ROUNDS elements)
+        for (unsigned int children : tree_params.children_per_round) {
+            writer_args[arg_idx++] = children;
+        }
 
         // compute runtime args
         arg_idx = 0;
@@ -1111,6 +1116,16 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         compute_args[arg_idx++] = core_num_in_reduce;
         compute_args[arg_idx++] = core_num_in_output;
         compute_args[arg_idx++] = cur_pos;
+        // Tree reduction parameters for compute
+        compute_args[arg_idx++] = tree_params.is_root ? 1u : 0u;
+        compute_args[arg_idx++] = tree_params.parent_core_in_group;
+        compute_args[arg_idx++] = tree_params.send_at_round;
+        compute_args[arg_idx++] = tree_params.num_children;
+        compute_args[arg_idx++] = tree_params.my_active_rounds;
+        // Add children_per_round array for compute
+        for (unsigned int children : tree_params.children_per_round) {
+            compute_args[arg_idx++] = children;
+        }
     }
     if (q_locally_available) {
         UpdateDynamicCircularBufferAddress(program, cb_q_in_id, *q_buffer);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -85,7 +85,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
 
     // Handle paged attention sequence length
     if (is_paged_attention) {
-        B = page_table_tensor.value().padded_shape()[0];
+        B = page_table_tensor->is_sharded() ? page_table_tensor->padded_shape()[0] /
+                                                  page_table_tensor->memory_config().shard_spec()->grid.num_cores()
+                                            : page_table_tensor->padded_shape()[0];
         uint32_t block_size = k_shape[2];
         original_block_size = input_tensor_k.logical_shape()[2];
         page_block_size_t = block_size / TILE_HEIGHT;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -23,760 +23,534 @@ namespace ttnn::prim {
 
 SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     const SdpaDecodeParams& operation_attributes, const SdpaDecodeInputs& tensor_args, Tensor& tensor_return_value) {
+    // ========== Input Tensors ==========
     const auto& input_tensor_q = tensor_args.q;
     const auto& input_tensor_k = tensor_args.k;
-    bool use_mla = operation_attributes.use_mla.value_or(false);
-    if (!use_mla) {
-        TT_FATAL(tensor_args.v.has_value(), "V tensor must be provided when MLA is disabled.");
-    }
-    const auto& input_tensor_v = tensor_args.v.has_value() ? tensor_args.v.value() : input_tensor_k;
-
     const auto& cur_pos_tensor = tensor_args.cur_pos_tensor;
     const auto& page_table_tensor = tensor_args.page_table_tensor;
     const auto& attn_mask = tensor_args.attn_mask;
     const auto& attention_sink = tensor_args.attention_sink;
-
     const auto& output_tensor = tensor_return_value;
 
-    auto scale = operation_attributes.scale;
-    if (not scale.has_value()) {
-        scale = 1.0f / std::sqrt(static_cast<float>(input_tensor_q.padded_shape()[-1]));
-    }
-    auto sliding_window_size = operation_attributes.sliding_window_size;
-    if (not sliding_window_size.has_value()) {
-        sliding_window_size = 0;
-    }
-    const auto is_causal = operation_attributes.is_causal;
+    // ========== Operation Attributes ==========
+    const bool use_mla = operation_attributes.use_mla.value_or(false);
+    const bool is_causal = operation_attributes.is_causal;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
     const auto& program_config = operation_attributes.program_config;
-    const auto& k_chunk_size = operation_attributes.k_chunk_size;
-    std::optional<bool> share_cache = operation_attributes.share_cache;
-    const auto& head_dim_v = operation_attributes.head_dim_v.value_or(0);
+    const uint32_t k_chunk_size = operation_attributes.k_chunk_size;
+    const uint32_t head_dim_v = operation_attributes.head_dim_v.value_or(0);
     const auto& cur_pos_ids = operation_attributes.cur_pos;
+    const float scale =
+        operation_attributes.scale.value_or(1.0f / std::sqrt(static_cast<float>(input_tensor_q.padded_shape()[-1])));
+    const uint32_t sliding_window_size = operation_attributes.sliding_window_size.value_or(0);
+    bool share_cache = operation_attributes.share_cache.value_or(false);
 
-    /*
-    Q: 1 x B x PNH x DH
-    K: B x NKV x S x DH
-    V: B x NKV x S x DH
-    */
+    // V tensor: use K if MLA (V is subset of K), otherwise require explicit V
+    TT_FATAL(use_mla || tensor_args.v.has_value(), "V tensor must be provided when MLA is disabled.");
+    const auto& input_tensor_v = tensor_args.v.value_or(input_tensor_k);
 
-    /*
-    Initially during compile time, we compile the kernel based on the longest sequence length in the batch.
-    During runtime, we may override the number of chunks being processed based on the actual sequence length of the
-    current batch.
-    */
+    // ========== Device & Program ==========
+    IDevice* device = input_tensor_q.device();
+    Program program = CreateProgram();
 
+    // ========== Feature Flags ==========
     const bool is_paged_attention = page_table_tensor.has_value();
-
-    auto q_shape = input_tensor_q.padded_shape();
+    const bool is_q_sharded = input_tensor_q.is_sharded();
+    const bool is_output_sharded = output_tensor.is_sharded();
     const bool tilize_q = input_tensor_q.layout() == Layout::ROW_MAJOR;
-    q_shape[2] = tt::round_up(q_shape[2], tt::constants::TILE_HEIGHT);  // round up for row major Q tensor.
+    const bool use_cur_pos_tensor = cur_pos_tensor.has_value();
+    const bool use_attention_mask = attn_mask.has_value();
+    const bool use_attention_sink = attention_sink.has_value();
+    const bool q_locally_available = program_config.has_value() && program_config->q_locally_available;
+
+    // ========== Tensor Shapes ==========
+    auto q_shape = input_tensor_q.padded_shape();
+    q_shape[2] = tt::round_up(q_shape[2], tt::constants::TILE_HEIGHT);
     const auto& q_shape_unpadded = input_tensor_q.logical_shape();
     const auto& k_shape = input_tensor_k.padded_shape();
     const auto& v_shape = input_tensor_v.padded_shape();
 
-    // Use k_shape for S and DH since Q might be different for decode
-    uint32_t B = q_shape[1], PNH = q_shape[2], S = k_shape[2], DH = k_shape[3];
-
-    // If MLA is enabled, vDH is overridden by head_dim_v. Otherwise, vDH is same as DH.
+    // ========== Core Dimensions ==========
+    // B = batch size, PNH = padded num Q heads, S = sequence length, DH = head dim
+    uint32_t B = q_shape[1];
+    uint32_t PNH = q_shape[2];
+    uint32_t S = k_shape[2];
+    uint32_t DH = k_shape[3];
     uint32_t vDH = use_mla ? head_dim_v : v_shape[3];
-
+    uint32_t Bkv = k_shape[0];
     uint32_t num_kv_heads = k_shape[1];
     uint32_t num_q_heads = q_shape_unpadded[2];
     uint32_t page_block_size_t = 0;
-
-    bool is_q_sharded = input_tensor_q.is_sharded();
-    bool is_output_sharded = output_tensor.is_sharded();
-
-    // balance the number of cores to use based on batch
     uint32_t q_heads_parallel_factor = 1;
-    if (is_q_sharded && use_mla) {
-        uint32_t q_shard_height = input_tensor_q.memory_config().shard_spec()->shape[0];
-        q_heads_parallel_factor = std::max((uint32_t)1, (num_q_heads + q_shard_height - 1) / q_shard_height);
 
-        if (q_heads_parallel_factor > 1) {
-            TT_FATAL(
-                num_kv_heads == 1,
-                "If parallelizing over Q num heads (with parallelization factor q_heads_parallel_factor: {}), then "
-                "num_kv_heads must be 1, but got num_kv_heads: {}",
-                q_heads_parallel_factor,
-                num_kv_heads);
-        }
-
-        B *= q_heads_parallel_factor;  // adjust batch size to account for Q sharding
-    }
-
-    // original_block_size: the unpadded block size in elements (e.g., 16 for block_size=16).
-    // When block_size < TILE_HEIGHT, tiles have zero-padded rows that must be masked.
-    uint32_t original_block_size = 0;
+    // Handle paged attention sequence length
     if (is_paged_attention) {
-        uint32_t block_size = k_shape[2];
-        original_block_size = input_tensor_k.logical_shape()[2];
-        page_block_size_t = block_size / TILE_HEIGHT;
-        // get real S using the page_table_tensor
-        S = page_table_tensor.value().padded_shape()[-1] * S;
+        page_block_size_t = k_shape[2] / TILE_HEIGHT;
+        S = page_table_tensor.value().padded_shape()[-1] * k_shape[2];
     }
-    const bool has_block_padding = is_paged_attention && original_block_size < TILE_HEIGHT;
-    uint32_t Bkv = k_shape[0];
-    uint32_t St = S / TILE_HEIGHT;
-    uint32_t DHt = DH / TILE_WIDTH;
-    uint32_t vDHt = vDH / TILE_WIDTH;
-    uint32_t PNHt = PNH / q_heads_parallel_factor / TILE_HEIGHT;
-
-    const uint32_t Sk_chunk_t = k_chunk_size / TILE_HEIGHT;
-
-    if (!share_cache.has_value()) {
-        // default share_cache to false
-        share_cache = false;
+    // ========== Q Sharding & MLA Parallelization ==========
+    if (is_q_sharded && use_mla) {
+        const uint32_t q_shard_height = input_tensor_q.memory_config().shard_spec()->shape[0];
+        const uint32_t max_cores = program_config.has_value() ? program_config->max_cores_per_head_batch : 16;
+        if (q_locally_available) {
+            // Deduce batch from page_table (paged) or K tensor (non-paged)
+            B = is_paged_attention ? page_table_tensor.value().padded_shape()[0] : k_shape[0];
+            // Deduce Q heads from shard config: num_groups = shards / cores_per_group
+            const uint32_t num_q_shards = input_tensor_q.memory_config().shard_spec()->grid.num_cores();
+            const uint32_t num_groups = num_q_shards / max_cores;
+            q_heads_parallel_factor = num_groups / B;
+            num_q_heads = q_heads_parallel_factor * q_shard_height;
+            PNH = num_q_heads;
+            B *= q_heads_parallel_factor;
+        } else {
+            q_heads_parallel_factor = std::max(1u, (num_q_heads + q_shard_height - 1) / q_shard_height);
+            B *= q_heads_parallel_factor;
+        }
+        TT_FATAL(
+            q_heads_parallel_factor == 1 || num_kv_heads == 1,
+            "Q head parallelization (factor={}) requires num_kv_heads=1, got {}",
+            q_heads_parallel_factor,
+            num_kv_heads);
     }
-    if (share_cache.value()) {
+    if (share_cache) {
         TT_FATAL(B % Bkv == 0, "Batch dim in Q must be divisible by batch dim in KV if sharing cache");
     }
 
-    // log_debug all of the above
-    log_debug(tt::LogOp, "B: {}", B);
-    log_debug(tt::LogOp, "PNH: {}", PNH);
-    log_debug(tt::LogOp, "S: {}", S);
-    log_debug(tt::LogOp, "DH: {}", DH);
-    log_debug(tt::LogOp, "num_kv_heads: {}", num_kv_heads);
-    log_debug(tt::LogOp, "Bkv: {}", Bkv);
-    log_debug(tt::LogOp, "St: {}", St);
-    log_debug(tt::LogOp, "DHt: {}", DHt);
-    log_debug(tt::LogOp, "vDHt: {}", vDHt);
-    log_debug(tt::LogOp, "PNHt: {}", PNHt);
-    log_debug(tt::LogOp, "Sk_chunk_t: {}", Sk_chunk_t);
-    log_debug(tt::LogOp, "k_chunk_size: {}", k_chunk_size);
+    // ========== Tile Dimensions ==========
+    const uint32_t St = S / TILE_HEIGHT;
+    const uint32_t DHt = DH / TILE_WIDTH;
+    const uint32_t vDHt = vDH / TILE_WIDTH;
+    const uint32_t PNHt = PNH / q_heads_parallel_factor / TILE_HEIGHT;
+    const uint32_t Sk_chunk_t = k_chunk_size / TILE_HEIGHT;
 
-    Program program = CreateProgram();
-
-    IDevice* device = input_tensor_q.device();
-
-    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
-    bool exp_approx_mode =
-        program_config.has_value()
-            ? (program_config->exp_approx_mode.has_value() ? program_config->exp_approx_mode.value() : true)
-            : true;
-
-    auto* q_buffer = input_tensor_q.buffer();
-    auto* k_buffer = input_tensor_k.buffer();
-    auto* v_buffer = input_tensor_v.buffer();
-    auto* out0_buffer = output_tensor.buffer();
-
-    bool use_cur_pos_tensor = cur_pos_tensor.has_value();
-    bool use_attention_mask = attn_mask.has_value();
-    bool use_attention_sink = attention_sink.has_value();
-
-    log_debug(tt::LogOp, "use_cur_pos_tensor: {}", use_cur_pos_tensor);
-    log_debug(tt::LogOp, "use_attention_mask: {}", use_attention_mask);
-    log_debug(tt::LogOp, "use_attention_sink: {}", use_attention_sink);
-
-    // Parallelization scheme
-    // We will assign cores to batches
-    // Split to cores
+    // ========== Grid & Core Configuration ==========
     CoreCoord grid_size = program_config.has_value() ? program_config->compute_with_storage_grid_size
                                                      : device->compute_with_storage_grid_size();
+    const uint32_t num_cores_available = grid_size.x * grid_size.y;
+    const uint32_t num_cores_in_grid =
+        device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
 
-    uint32_t num_cores_available = grid_size.x * grid_size.y;
-
-    CoreRangeSet core_grid;
     bool on_subcoregrid = false;
+    CoreRangeSet core_grid;
     if (program_config.has_value() && program_config->sub_core_grids.has_value()) {
         core_grid = program_config->sub_core_grids.value();
         TT_FATAL(
             core_grid.num_cores() == num_cores_available,
-            "Number of cores in sub_core_grids must match the number of cores available");
+            "sub_core_grids cores ({}) must match compute_with_storage_grid_size ({})",
+            core_grid.num_cores(),
+            num_cores_available);
         on_subcoregrid = true;
     } else {
         core_grid = CoreRangeSet(std::vector{CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1})});
     }
 
-    uint32_t num_cores_in_grid =
-        device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
     TT_FATAL(
         num_cores_available <= num_cores_in_grid,
-        "Expected number of cores available to be less than or equal to the number of cores in the grid, got {} and {}",
+        "Cores available ({}) exceeds grid size ({})",
         num_cores_available,
         num_cores_in_grid);
-    TT_FATAL(
-        num_cores_available >= B,
-        "Expect number of cores available to be greater or equal to batch size, got {} and {}",
-        num_cores_available,
-        B);
+    TT_FATAL(num_cores_available >= B, "Cores available ({}) must be >= batch size ({})", num_cores_available, B);
 
-    // balance the number of cores to use based on batch
-    uint32_t max_num_cores_for_compute =
-        program_config.has_value() ? program_config->max_cores_per_head_batch * B * num_kv_heads : num_cores_available;
-    uint32_t num_cores_per_batch = std::min(num_cores_available, max_num_cores_for_compute) / B;
-    //// for core assignment, it is the same whether there's 1 core for head or 1 core for many heads
-    uint32_t num_cores_per_head = std::max((uint32_t)1, num_cores_per_batch / num_kv_heads);
+    // ========== Core Allocation ==========
+    const uint32_t max_cores_per_head =
+        program_config.has_value() ? program_config->max_cores_per_head_batch : num_cores_available;
+    const uint32_t max_num_cores_for_compute = max_cores_per_head * B * num_kv_heads;
+    const uint32_t num_cores_per_batch = std::min(num_cores_available, max_num_cores_for_compute) / B;
+    const uint32_t num_cores_per_head = std::max(1u, num_cores_per_batch / num_kv_heads);
+    const uint32_t num_heads_per_core = std::max(1u, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch));
+    const uint32_t num_reducer_cores = num_kv_heads * B / num_heads_per_core;
+    const uint32_t num_output_cores = B;
+    const uint32_t num_active_cores = num_cores_per_head * num_kv_heads * B / num_heads_per_core;
 
-    uint32_t num_heads_per_core = std::max((uint32_t)1, (uint32_t)std::ceil((float)num_kv_heads / num_cores_per_batch));
-    uint32_t num_reducer_cores = num_kv_heads * B / num_heads_per_core;
-    uint32_t num_output_cores = B;
-    uint32_t num_active_cores = num_cores_per_head * num_kv_heads * B / num_heads_per_core;
-    //// recalculate num_cores_per_batch based on num_active_cores
-    num_cores_per_batch = num_active_cores / B;
-    // Calculate tree reduction parameters
-    uint32_t num_tree_reduction_rounds =
-        (num_cores_per_head <= 1) ? 0 : (32 - __builtin_clz(num_cores_per_head - 1));  // ceil(log2(num_cores_per_head))
-    log_debug(tt::LogOp, "Tree reduction enabled: num_tree_reduction_rounds: {}", num_tree_reduction_rounds);
+    // ========== Compute Kernel Config ==========
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    const bool exp_approx_mode = program_config.has_value() && program_config->exp_approx_mode.has_value()
+                                     ? program_config->exp_approx_mode.value()
+                                     : true;
 
+    // ========== Buffer Pointers & Metadata ==========
+    auto* q_buffer = input_tensor_q.buffer();
+    auto* k_buffer = input_tensor_k.buffer();
+    auto* v_buffer = input_tensor_v.buffer();
+    auto* out_buffer = output_tensor.buffer();
+
+    // Optional tensor buffers and metadata
+    Buffer* cur_pos_buffer = use_cur_pos_tensor ? cur_pos_tensor.value().buffer() : nullptr;
+    Buffer* page_table_buffer = is_paged_attention ? page_table_tensor.value().buffer() : nullptr;
+    const bool is_cur_pos_tensor_sharded = use_cur_pos_tensor && cur_pos_tensor.value().is_sharded();
+    const bool is_page_table_sharded = is_paged_attention && page_table_tensor.value().is_sharded();
+    const uint32_t cur_pos_stick_size = cur_pos_buffer ? cur_pos_buffer->aligned_page_size() : 0;
+    const uint32_t page_table_stick_size = page_table_buffer ? page_table_buffer->aligned_page_size() : 0;
+    const tt::DataFormat cur_pos_df = use_cur_pos_tensor
+                                          ? tt_metal::datatype_to_dataformat_converter(cur_pos_tensor.value().dtype())
+                                          : tt::DataFormat::Invalid;
+    const tt::DataFormat page_table_df =
+        is_paged_attention ? tt_metal::datatype_to_dataformat_converter(page_table_tensor.value().dtype())
+                           : tt::DataFormat::Invalid;
+
+    // ========== Tree Reduction Setup ==========
+    // For n cores, need ceil(log2(n)) rounds
+    const uint32_t num_tree_reduction_rounds = num_cores_per_head > 1 ? 32 - __builtin_clz(num_cores_per_head - 1) : 0;
     TT_FATAL(
         num_tree_reduction_rounds <= MAX_TREE_REDUCTION_ROUNDS,
-        "Flash Decode utilizes tree reduction for softmax calculation with a maximum of {} rounds, hence each KV head "
-        "can parallelize with a maximum of {} cores, but got {} cores per head.",
+        "Tree reduction max {} rounds ({} cores/head), got {} cores/head",
         MAX_TREE_REDUCTION_ROUNDS,
         1 << MAX_TREE_REDUCTION_ROUNDS,
         num_cores_per_head);
-
     TT_FATAL(
-        ((num_cores_per_head >= 1) && (num_heads_per_core == 1)) ||
-            ((num_cores_per_head == 1) && (num_heads_per_core >= 1)),
-        "This assertion should always be true, unless core assignment logic is wrong");
+        (num_cores_per_head >= 1 && num_heads_per_core == 1) || (num_cores_per_head == 1 && num_heads_per_core >= 1),
+        "Invalid core assignment: cores_per_head={}, heads_per_core={}",
+        num_cores_per_head,
+        num_heads_per_core);
 
-    // create core group, assume n batch and k_heads:
-    // this is a 1D list of cores sorted by batch_output1, worker, ..., batch_output2, worker, ..., batch_output n,
-    // worker, ... Within each batch, we will assign head reducers. e.g. the following mapping:
-    // (batch_output1, worker1,   worker2),   (worker3,       worker4,   worker5),   ..., (... worker3*k-1, worker3*k)
-    // (head_reducer1, h_worker1, h_worker2), (head_reducer2, h_worker1, h_worker2), ..., (head_reducerk, h_worker1,
-    // h_worker2) head_reducer2 to head_reducerk then send the result to head_reducer1, which is also the batch_output1
+    // ========== Group Indexing Mode ==========
+    // A core group can be laid out in either row-major or column-major order on the core grid.
+    // By default core groups are laid out in row-major order. But when Q heads is parallelized,
+    // column-major group indexing is used to keep batch groups spatially close for efficient K multicast along columns.
+    const bool use_col_major_group_indexing =
+        (q_heads_parallel_factor > 1) && (grid_size.y >= num_cores_per_head) && !on_subcoregrid && q_locally_available;
+
+    // ========== Core Group Assignment ==========
+    // Core layout depends on sharding and indexing mode:
+    // - Spatial indexing: simple linear order, spatial index computes batch/head from 2D position
+    // - Q-sharded (no spatial): reorder so reducers at i % num_cores_per_batch == 0
+    // - Neither: simple linear order with linear indexing
     std::vector<CoreCoord> core_group;
     std::vector<CoreCoord> core_group_idle;
+    core_group.reserve(num_active_cores);
+    core_group_idle.reserve(num_cores_available - num_active_cores);
+
     if (on_subcoregrid) {
-        if (is_q_sharded || is_output_sharded) {
-            auto cores_vec = corerange_to_cores(core_grid, num_cores_available, true);
-            int reducer_idx = 0;
-            int worker_idx = num_output_cores;
-            for (int i = 0; i < num_cores_available; ++i) {
-                if (i % num_cores_per_batch == 0 && reducer_idx < num_output_cores) {
-                    i < num_active_cores ? core_group.push_back(cores_vec[reducer_idx])
-                                         : core_group_idle.push_back(cores_vec[reducer_idx]);
-                    reducer_idx++;
-                } else {
-                    i < num_active_cores ? core_group.push_back(cores_vec[worker_idx])
-                                         : core_group_idle.push_back(cores_vec[worker_idx]);
-                    worker_idx++;
-                }
+        TT_FATAL(is_q_sharded || is_output_sharded, "Subcoregrids require sharded Q or output");
+        auto cores_vec = corerange_to_cores(core_grid, num_cores_available, true);
+        uint32_t reducer_idx = 0, worker_idx = num_output_cores;
+        for (uint32_t i = 0; i < num_cores_available; ++i) {
+            bool is_reducer = (i % num_cores_per_batch == 0) && (reducer_idx < num_output_cores);
+            CoreCoord core = is_reducer ? cores_vec[reducer_idx++] : cores_vec[worker_idx++];
+            (i < num_active_cores ? core_group : core_group_idle).push_back(core);
+        }
+    } else if ((is_q_sharded || is_output_sharded) && !use_col_major_group_indexing) {
+        // Q/output sharded without spatial indexing: reorder cores so reducers are at batch boundaries
+        // This ensures i % num_cores_per_batch == 0 identifies output/reducer cores
+        uint32_t reducer_idx = 0, worker_idx = num_output_cores;
+        for (uint32_t i = 0; i < num_cores_available; ++i) {
+            CoreCoord core;
+            if ((i % num_cores_per_batch == 0) && (reducer_idx < num_output_cores)) {
+                core = {reducer_idx % grid_size.x, reducer_idx / grid_size.x};
+                reducer_idx++;
+            } else {
+                core = {worker_idx % grid_size.x, worker_idx / grid_size.x};
+                worker_idx++;
             }
-        } else {
-            TT_FATAL(false, "We only support SDPA on subcoregrids with sharded Q and sharded output");
+            (i < num_active_cores ? core_group : core_group_idle).push_back(core);
         }
     } else {
-        if (is_q_sharded || is_output_sharded) {
-            int reducer_idx = 0;
-            int worker_idx = num_output_cores;
-
-            for (int i = 0; i < num_cores_available; ++i) {
-                CoreCoord core;
-                if (i % num_cores_per_batch == 0 && reducer_idx < num_output_cores) {
-                    core = {reducer_idx % grid_size.x, reducer_idx / grid_size.x};
-                    reducer_idx++;
-                } else {
-                    core = {worker_idx % grid_size.x, worker_idx / grid_size.x};
-                    worker_idx++;
-                }
-                if (i < num_active_cores) {
-                    core_group.push_back(core);
-                } else {
-                    core_group_idle.push_back(core);
-                }
-            }
-        } else {
-            for (int i = 0; i < num_cores_available; ++i) {
-                CoreCoord core = {i % grid_size.x, i / grid_size.x};
-                if (i < num_active_cores) {
-                    core_group.push_back(core);
-                } else {
-                    core_group_idle.push_back(core);
-                }
-            }
+        // Q in DRAM, no sharding: simple linear assignment
+        // or Q sharded out sharded but uses spatial indexing
+        for (uint32_t i = 0; i < num_cores_available; ++i) {
+            CoreCoord core = {i % grid_size.x, i / grid_size.x};
+            (i < num_active_cores ? core_group : core_group_idle).push_back(core);
         }
     }
 
-    log_debug(tt::LogOp, "Parallelization scheme:");
-    log_debug(tt::LogOp, "num_cores_available: {}", num_cores_available);
-    log_debug(tt::LogOp, "num_cores_per_batch: {}", num_cores_per_batch);
-    log_debug(tt::LogOp, "num_cores_per_head: {}", num_cores_per_head);
-    log_debug(tt::LogOp, "num_heads_per_core: {}", num_heads_per_core);
-    log_debug(tt::LogOp, "num_active_cores: {}", num_active_cores);
-    log_debug(tt::LogOp, "num_reducer_cores: {}", num_reducer_cores);
-    log_debug(tt::LogOp, "num_output_cores: {}", num_output_cores);
-    log_debug(tt::LogOp, "core_group: {}", core_group);
-    log_debug(tt::LogOp, "core_group_idle: {}", core_group_idle);
-    log_debug(tt::LogOp, "max_num_cores_for_compute: {}", max_num_cores_for_compute);
+    // ========== Physical Core Coordinate Maps ==========
+    // Col-major group index for reducer/output cores
+    const uint32_t num_groups_per_row = grid_size.x / num_cores_per_head;  // groups that fit in one row
+    const uint32_t num_group_rows = (num_output_cores + num_groups_per_row - 1) / num_groups_per_row;
+    auto get_col_major_group_idx = [&](uint32_t row_major_idx) -> uint32_t {
+        uint32_t group_row = row_major_idx / num_groups_per_row;
+        uint32_t group_col = row_major_idx % num_groups_per_row;
+        return group_col * num_group_rows + group_row;
+    };
 
-    // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
+    // Reducer cores (one per KV head group)
+    // With num_kv_heads=1, num_reducer_cores = B = num_output_cores (one reducer per batch)
+    std::vector<uint32_t> reduce_core_physical_xs(num_reducer_cores);
+    std::vector<uint32_t> reduce_core_physical_ys(num_reducer_cores);
+    uint32_t reducer_count = 0;
+    for (uint32_t i = 0; i < num_active_cores; ++i) {
+        if (i % num_cores_per_head != 0) {
+            continue;
+        }
+        auto physical = device->worker_core_from_logical_core(core_group[i]);
+        // Reducer index: for single KV head case, reducer index = batch index
+        // For multi KV head, would need: batch * num_kv_heads + head_within_batch
+        uint32_t idx = use_col_major_group_indexing ? get_col_major_group_idx(reducer_count) : reducer_count;
+        TT_FATAL(idx < num_reducer_cores, "Reducer spatial index {} out of bounds (max {})", idx, num_reducer_cores);
+        reduce_core_physical_xs[idx] = physical.x;
+        reduce_core_physical_ys[idx] = physical.y;
+        reducer_count++;
+    }
 
-    // If using dynamic chunk size, set it to some max number of tiles (less than DST for now)
+    // Output cores (one per batch)
+    std::vector<uint32_t> output_core_physical_xs(num_output_cores);
+    std::vector<uint32_t> output_core_physical_ys(num_output_cores);
+    uint32_t output_count = 0;
+    for (uint32_t i = 0; i < num_active_cores; ++i) {
+        if (i % num_cores_per_batch != 0) {
+            continue;
+        }
+        auto physical = device->worker_core_from_logical_core(core_group[i]);
+        uint32_t idx = use_col_major_group_indexing ? get_col_major_group_idx(output_count) : output_count;
+        TT_FATAL(idx < num_output_cores, "Output spatial index {} out of bounds (max {})", idx, num_output_cores);
+        output_core_physical_xs[idx] = physical.x;
+        output_core_physical_ys[idx] = physical.y;
+        output_count++;
+    }
+
+    // All active cores (for tree reduction lookups)
+    std::vector<uint32_t> reduction_group_core_xs(num_active_cores);
+    std::vector<uint32_t> reduction_group_core_ys(num_active_cores);
+    for (uint32_t i = 0; i < num_active_cores; ++i) {
+        auto physical = device->worker_core_from_logical_core(core_group[i]);
+        reduction_group_core_xs[i] = physical.x;
+        reduction_group_core_ys[i] = physical.y;
+    }
+
+    log_debug(
+        tt::LogOp,
+        "Column-major group indexing: enabled={}, cores_per_head={}, groups_per_row={}",
+        use_col_major_group_indexing,
+        num_cores_per_head,
+        num_groups_per_row);
+
+    // ========== Compute Configuration ==========
     const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;
     const uint32_t max_dynamic_chunk_size = dst_size;
     const uint32_t Sk_chunk_t_cb_size = Sk_chunk_t == 0 ? max_dynamic_chunk_size : Sk_chunk_t;
 
-    uint32_t q_tiles = PNHt * DHt;
-    uint32_t k_tiles = Sk_chunk_t_cb_size * DHt * 2;  // double buffer
-    uint32_t v_tiles = Sk_chunk_t_cb_size * vDHt * 2;  // double buffer
-    uint32_t qk_tiles = PNHt * Sk_chunk_t_cb_size;
-    uint32_t out_im_tiles = PNHt * vDHt;
-    uint32_t out0_t = PNHt * vDHt;
-    uint32_t scale_tiles = 1;
-    uint32_t statistics_tiles = PNHt;  // Single column of values in each iteration
-
-    // log all values
-    log_debug(tt::LogOp, "q_tiles: {}", q_tiles);
-    log_debug(tt::LogOp, "k_tiles: {}", k_tiles);
-    log_debug(tt::LogOp, "v_tiles: {}", v_tiles);
-    log_debug(tt::LogOp, "qk_tiles: {}", qk_tiles);
-    log_debug(tt::LogOp, "out0_t: {}", out0_t);
-    log_debug(tt::LogOp, "scale_tiles: {}", scale_tiles);
-    log_debug(tt::LogOp, "statistics_tiles: {}", statistics_tiles);
-
-    // Host code is responsible for determining matmul configuration
+    // Matmul block/subblock configuration for QK
     const uint32_t qk_in0_block_w = DHt;
-    const uint32_t qk_num_blocks = DHt / qk_in0_block_w;
-
-    uint32_t qk_out_subblock_w = 0;
-    uint32_t qk_out_subblock_h = 0;
-    uint32_t qk_in0_num_subblocks = 0;
-    uint32_t qk_in1_num_subblocks = 0;
+    const uint32_t qk_num_blocks = 1;
+    uint32_t qk_out_subblock_w = 0, qk_out_subblock_h = 0, qk_in0_num_subblocks = 0, qk_in1_num_subblocks = 0;
     if (Sk_chunk_t > 0) {
-        // max of Sk_chunk_t and dst_size
         qk_out_subblock_w = std::min(Sk_chunk_t, dst_size);
-        // If qk_out_subblock_w is full row of output, scale subblock_h so volume = dst_size. Otherwise it's 1 to
-        // maintain row-major intermediate buffer.
-        qk_out_subblock_h = (qk_out_subblock_w == Sk_chunk_t) ? (std::min(PNHt, dst_size / qk_out_subblock_w)) : 1;
-
+        qk_out_subblock_h = (qk_out_subblock_w == Sk_chunk_t) ? std::min(PNHt, dst_size / qk_out_subblock_w) : 1;
         qk_in0_num_subblocks = PNHt / qk_out_subblock_h;
         qk_in1_num_subblocks = Sk_chunk_t / qk_out_subblock_w;
     }
 
-    // now for out0
-    uint32_t out_in0_block_w = 0;
-    uint32_t out_num_blocks = 0;
-    if (Sk_chunk_t > 0) {
-        out_in0_block_w = Sk_chunk_t;
-        out_num_blocks = Sk_chunk_t / out_in0_block_w;
-    }
-
+    // Matmul block/subblock configuration for output (QK * V)
+    uint32_t out_in0_block_w = Sk_chunk_t > 0 ? Sk_chunk_t : 0;
+    uint32_t out_num_blocks = Sk_chunk_t > 0 ? 1 : 0;
     const uint32_t out_out_subblock_w = std::min(vDHt, dst_size);
     const uint32_t out_out_subblock_h =
-        (out_out_subblock_w == vDHt) ? (std::min(PNHt, dst_size / out_out_subblock_w)) : 1;
-
+        (out_out_subblock_w == vDHt) ? std::min(PNHt, dst_size / out_out_subblock_w) : 1;
     const uint32_t out_in0_num_subblocks = PNHt / out_out_subblock_h;
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
 
+    // DHt granularity for compute loops (must be power of 2)
     uint32_t dht_granularity = std::min(DHt, dst_size);
     uint32_t log2_dht_granularity = std::log2(dht_granularity);
-    // Sometimes DHt is not a power of 2, so granularity should be 1
-    if (dht_granularity != (1 << log2_dht_granularity)) {
+    if (dht_granularity != (1u << log2_dht_granularity)) {
         dht_granularity = 1;
         log2_dht_granularity = 0;
     }
-    TT_FATAL(
-        dht_granularity == (1 << log2_dht_granularity),
-        "dht_granularity must be a power of 2. Got {}.",
-        dht_granularity);
 
-    // log all values
-    log_debug(tt::LogOp, "dst_size: {}", dst_size);
-    log_debug(tt::LogOp, "qk_in0_block_w: {}", qk_in0_block_w);
-    log_debug(tt::LogOp, "qk_out_subblock_w: {}", qk_out_subblock_w);
-    log_debug(tt::LogOp, "qk_out_subblock_h: {}", qk_out_subblock_h);
-    log_debug(tt::LogOp, "qk_in0_num_subblocks: {}", qk_in0_num_subblocks);
-    log_debug(tt::LogOp, "qk_in1_num_subblocks: {}", qk_in1_num_subblocks);
-    log_debug(tt::LogOp, "qk_num_blocks: {}", qk_num_blocks);
-    log_debug(tt::LogOp, "out_in0_block_w: {}", out_in0_block_w);
-    log_debug(tt::LogOp, "out_out_subblock_w: {}", out_out_subblock_w);
-    log_debug(tt::LogOp, "out_out_subblock_h: {}", out_out_subblock_h);
-    log_debug(tt::LogOp, "out_in0_num_subblocks: {}", out_in0_num_subblocks);
-    log_debug(tt::LogOp, "out_in1_num_subblocks: {}", out_in1_num_subblocks);
-    log_debug(tt::LogOp, "out_num_blocks: {}", out_num_blocks);
-    log_debug(tt::LogOp, "dht_granularity: {}", dht_granularity);
-    log_debug(tt::LogOp, "log2_dht_granularity: {}", log2_dht_granularity);
+    // ========== Tile Counts for Circular Buffers ==========
+    const uint32_t q_tiles = PNHt * DHt;
+    const uint32_t k_tiles = Sk_chunk_t_cb_size * DHt * 2;   // double buffer
+    const uint32_t v_tiles = Sk_chunk_t_cb_size * vDHt * 2;  // double buffer
+    const uint32_t qk_tiles = PNHt * Sk_chunk_t_cb_size;
+    const uint32_t out_tiles = PNHt * vDHt;
+    const uint32_t scale_tiles = 1;
+    const uint32_t statistics_tiles = PNHt;
+    const uint32_t intermed_output_tiles = (out_tiles + 2 * PNHt) * (num_cores_per_head - 1);
 
-    // Create circular buffers
-    tt::DataFormat q_df = tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
-    tt::DataFormat k_df = tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
-    tt::DataFormat v_df = tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
-    tt::DataFormat mask_df = use_attention_mask ? tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
-                                                : tt::DataFormat::Float16_b;
-    tt::DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
-    tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
-    tt::DataFormat im_df = tt::DataFormat::Float16_b;
-    // tt::DataFormat im_df = tt::DataFormat::Float16_b;
-    tt::DataFormat stats_df = tt::DataFormat::Float16_b;
+    // ========== Data Formats ==========
+    const tt::DataFormat q_df = tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
+    const tt::DataFormat k_df = tt_metal::datatype_to_dataformat_converter(input_tensor_k.dtype());
+    const tt::DataFormat v_df = tt_metal::datatype_to_dataformat_converter(input_tensor_v.dtype());
+    const tt::DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+    const tt::DataFormat mask_df = use_attention_mask
+                                       ? tt_metal::datatype_to_dataformat_converter(attn_mask.value().dtype())
+                                       : tt::DataFormat::Float16_b;
+    const tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
+    const tt::DataFormat im_df = tt::DataFormat::Float16_b;
+    const tt::DataFormat stats_df = tt::DataFormat::Float16_b;
 
+    // ========== Tile Configurations ==========
     const auto half_tile = tt::tt_metal::Tile({16, 32});
     const auto full_tile = tt::tt_metal::Tile({32, 32});
-
-    auto q_tile = full_tile;
+    const bool use_half_tile = is_causal && num_q_heads <= 16 && q_df == tt::DataFormat::Float16_b;
+    const auto q_tile = use_half_tile ? half_tile : full_tile;
     const auto k_tile = full_tile;
     const auto v_tile = full_tile;
-    auto mask_tile = full_tile;
+    const auto mask_tile = use_half_tile ? half_tile : full_tile;
+    const auto out_tile = full_tile;
+    const auto scalar_tile = use_half_tile ? half_tile : full_tile;
+    const auto im_tile = use_half_tile ? half_tile : full_tile;
+    const auto stats_tile = use_half_tile ? half_tile : full_tile;
+    const uint32_t q_tile_size = q_tile.get_tile_size(q_df);
+    const uint32_t k_tile_size = k_tile.get_tile_size(k_df);
+    const uint32_t v_tile_size = v_tile.get_tile_size(v_df);
+    const uint32_t mask_tile_size = mask_tile.get_tile_size(mask_df);
+    const uint32_t out_tile_size = out_tile.get_tile_size(out_df);
+    const uint32_t scalar_tile_size = scalar_tile.get_tile_size(scalar_df);
+    const uint32_t im_tile_size = im_tile.get_tile_size(im_df);
+    const uint32_t stats_tile_size = stats_tile.get_tile_size(stats_df);
 
-    auto out_tile = full_tile;
+    // ========== Debug Logging ==========
+    log_debug(tt::LogOp, "Dimensions: B={}, PNH={}, S={}, DH={}, vDH={}, Bkv={}", B, PNH, S, DH, vDH, Bkv);
+    log_debug(tt::LogOp, "Tiles: St={}, DHt={}, vDHt={}, PNHt={}, Sk_chunk_t={}", St, DHt, vDHt, PNHt, Sk_chunk_t);
+    log_debug(
+        tt::LogOp, "Heads: kv={}, q={}, q_parallel_factor={}", num_kv_heads, num_q_heads, q_heads_parallel_factor);
+    log_debug(
+        tt::LogOp,
+        "Cores: available={}, active={}, per_batch={}, per_head={}, reducers={}, outputs={}",
+        num_cores_available,
+        num_active_cores,
+        num_cores_per_batch,
+        num_cores_per_head,
+        num_reducer_cores,
+        num_output_cores);
+    log_debug(tt::LogOp, "Tree reduction: {} rounds", num_tree_reduction_rounds);
+    log_debug(
+        tt::LogOp,
+        "Flags: paged={}, q_sharded={}, q_local={}, mask={}, sink={}, half_tile={}",
+        is_paged_attention,
+        is_q_sharded,
+        q_locally_available,
+        use_attention_mask,
+        use_attention_sink,
+        use_half_tile);
 
-    auto scalar_tile = full_tile;
-    auto im_tile = full_tile;
-    auto stats_tile = full_tile;
-
-    // TODO: Directly get q input as tensor with 16x32 tiny tiles #25059
-    // For now, use this flag in reader differentiate
-    // - In non-causal mode, mask can be an input tensor which needs proper handling to read as 16x32 tiles
-    // - Only support Float16_b since block float w/ shared exp needs special handling to read as 16x32 tiles
-    // In compute, need to find a proper way to get num_faces for sfpu functions
-    const bool use_half_tile = (is_causal and num_q_heads <= 16 and q_df == tt::DataFormat::Float16_b);
-
-    if (use_half_tile) {
-        q_tile = half_tile;
-        mask_tile = half_tile;
-        scalar_tile = half_tile;
-        im_tile = half_tile;
-        stats_tile = half_tile;
+    // Print reducer core coordinates
+    log_debug(tt::LogOp, "Reducer cores ({}):", num_reducer_cores);
+    for (uint32_t i = 0; i < num_reducer_cores; ++i) {
+        log_debug(
+            tt::LogOp, "  reducer[{}]: physical=({}, {})", i, reduce_core_physical_xs[i], reduce_core_physical_ys[i]);
     }
 
-    uint32_t q_tile_size = q_tile.get_tile_size(q_df);
-    uint32_t k_tile_size = k_tile.get_tile_size(k_df);
-    uint32_t v_tile_size = v_tile.get_tile_size(v_df);
-    uint32_t mask_tile_size = mask_tile.get_tile_size(mask_df);
-    uint32_t out_tile_size = out_tile.get_tile_size(out_df);
-    uint32_t scalar_tile_size = scalar_tile.get_tile_size(scalar_df);
-    uint32_t im_tile_size = im_tile.get_tile_size(im_df);
-    uint32_t stats_tile_size = stats_tile.get_tile_size(stats_df);
+    // Print output core coordinates
+    log_debug(tt::LogOp, "Output cores ({}):", num_output_cores);
+    for (uint32_t i = 0; i < num_output_cores; ++i) {
+        log_debug(
+            tt::LogOp, "  output[{}]: physical=({}, {})", i, output_core_physical_xs[i], output_core_physical_ys[i]);
+    }
 
-    uint32_t intermed_output_tiles = (out0_t + 2 * PNHt) * (num_cores_per_head - 1);
+    // Print reduction group core coordinates
+    log_debug(tt::LogOp, "Reduction group cores ({}):", num_active_cores);
+    for (uint32_t i = 0; i < num_active_cores; ++i) {
+        log_debug(
+            tt::LogOp, "  group[{}]: physical=({}, {})", i, reduction_group_core_xs[i], reduction_group_core_ys[i]);
+    }
 
-    uint32_t index_stick_size = 0;
-    bool is_cur_pos_tensor_sharded = false;
-    CBHandle cb_in8_id = 0;
-    if (use_cur_pos_tensor) {
-        auto* pos_buffer = cur_pos_tensor.value().buffer();
-        tt::DataFormat pos_df = tt_metal::datatype_to_dataformat_converter(cur_pos_tensor.value().dtype());
-        index_stick_size = pos_buffer->aligned_page_size();
-
-        // cb pos
-        auto c_in8_config = CircularBufferConfig(index_stick_size, {{CBIndex::c_8, pos_df}})
-                                .set_page_size(CBIndex::c_8, index_stick_size);
-        if (cur_pos_tensor.value().is_sharded()) {
-            is_cur_pos_tensor_sharded = true;
-            c_in8_config.set_globally_allocated_address(*pos_buffer);
+    // ========== Circular Buffer Creation ==========
+    // Unified helper: tile!=nullptr sets tile_dims, buffer!=nullptr sets globally allocated address
+    auto create_cb = [&](CBIndex idx,
+                         uint32_t total_size,
+                         tt::DataFormat df,
+                         uint32_t page_size,
+                         const tt::tt_metal::Tile* tile = nullptr,
+                         Buffer* buffer = nullptr) -> CBHandle {
+        auto config = CircularBufferConfig(total_size, {{idx, df}}).set_page_size(idx, page_size);
+        if (tile != nullptr) {
+            config.set_tile_dims(idx, *tile);
         }
-        cb_in8_id = CreateCircularBuffer(program, core_grid, c_in8_config);
-    }
-
-    uint32_t page_table_stick_size = 0;
-    uint32_t shard_size = 0;
-    bool is_page_table_sharded = false;
-    CBHandle cb_in9_id = 0;
-    if (is_paged_attention) {
-        auto* page_table_buffer = page_table_tensor.value().buffer();
-        is_page_table_sharded = page_table_tensor.value().is_sharded();
-        tt::DataFormat page_table_df = tt_metal::datatype_to_dataformat_converter(page_table_tensor.value().dtype());
-        page_table_stick_size = page_table_buffer->aligned_page_size();
-        shard_size = is_page_table_sharded ? B * page_table_stick_size : page_table_stick_size;
-        // cb page_table
-        auto c_in9_config = CircularBufferConfig(shard_size, {{CBIndex::c_9, page_table_df}})
-                                .set_page_size(CBIndex::c_9, page_table_stick_size);
-
-        if (is_page_table_sharded) {
-            c_in9_config.set_globally_allocated_address(*page_table_buffer);
+        if (buffer != nullptr) {
+            config.set_globally_allocated_address(*buffer);
         }
-        cb_in9_id = CreateCircularBuffer(program, core_grid, c_in9_config);
-    }
+        return CreateCircularBuffer(program, core_grid, config);
+    };
 
-    log_debug(tt::LogOp, "q_data_format: {}", q_df);
-    log_debug(tt::LogOp, "k_data_format: {}", k_df);
-    log_debug(tt::LogOp, "v_data_format: {}", v_df);
-    log_debug(tt::LogOp, "out_data_format: {}", out_df);
-    log_debug(tt::LogOp, "scalar_data_format: {}", scalar_df);
-    log_debug(tt::LogOp, "intermediate_data_format: {}", im_df);
-    log_debug(tt::LogOp, "statistics_data_format: {}", stats_df);
-
-    // CBs
-    // Q input
-    auto c_in0_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_0, q_df}})
-                            .set_page_size(CBIndex::c_0, q_tile_size)
-                            .set_tile_dims(CBIndex::c_0, q_tile);
-    CreateCircularBuffer(program, core_grid, c_in0_config);
-
-    // K input
-    auto c_in1_config =
-        CircularBufferConfig(k_tiles * k_tile_size, {{CBIndex::c_1, k_df}}).set_page_size(CBIndex::c_1, k_tile_size);
-    CreateCircularBuffer(program, core_grid, c_in1_config);
-
-    // V input
-    auto c_in2_config =
-        CircularBufferConfig(v_tiles * v_tile_size, {{CBIndex::c_2, v_df}}).set_page_size(CBIndex::c_2, v_tile_size);
-    CreateCircularBuffer(program, core_grid, c_in2_config);
-
-    // attn_mask input
-    auto c_in3_config = CircularBufferConfig(qk_tiles * mask_tile_size, {{CBIndex::c_3, mask_df}})
-                            .set_page_size(CBIndex::c_3, mask_tile_size)
-                            .set_tile_dims(CBIndex::c_3, mask_tile);
-    CreateCircularBuffer(program, core_grid, c_in3_config);
-
-    // attention_sink input (conditionally created based on use_attention_sink)
+    // Input CBs
+    auto cb_q_in_id = create_cb(
+        CBIndex::c_0, q_tiles * q_tile_size, q_df, q_tile_size, &q_tile, q_locally_available ? q_buffer : nullptr);
+    create_cb(CBIndex::c_1, k_tiles * k_tile_size, k_df, k_tile_size);                        // K input
+    create_cb(CBIndex::c_2, v_tiles * v_tile_size, v_df, v_tile_size);                        // V input
+    create_cb(CBIndex::c_3, qk_tiles * mask_tile_size, mask_df, mask_tile_size, &mask_tile);  // attn_mask
     if (use_attention_sink) {
-        auto c_in4_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_4, stats_df}})
-                                .set_page_size(CBIndex::c_4, stats_tile_size)
-                                .set_tile_dims(CBIndex::c_4, stats_tile);
-        CreateCircularBuffer(program, core_grid, c_in4_config);
+        create_cb(CBIndex::c_4, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    }
+    create_cb(CBIndex::c_5, scale_tiles * scalar_tile_size, scalar_df, scalar_tile_size, &scalar_tile);   // scale
+    create_cb(CBIndex::c_6, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);  // m_in
+    create_cb(CBIndex::c_7, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);  // l_in
+
+    // Optional input CBs (cur_pos and page_table - raw data, no tile dims)
+    CBHandle cb_cur_pos_id = 0;
+    if (use_cur_pos_tensor) {
+        cb_cur_pos_id = create_cb(
+            CBIndex::c_8,
+            cur_pos_stick_size,
+            cur_pos_df,
+            cur_pos_stick_size,
+            nullptr,
+            is_cur_pos_tensor_sharded ? cur_pos_buffer : nullptr);
+    }
+    CBHandle cb_page_table_id = 0;
+    if (is_paged_attention) {
+        uint32_t page_table_cb_size = is_page_table_sharded ? B * page_table_stick_size : page_table_stick_size;
+        cb_page_table_id = create_cb(
+            CBIndex::c_9,
+            page_table_cb_size,
+            page_table_df,
+            page_table_stick_size,
+            nullptr,
+            is_page_table_sharded ? page_table_buffer : nullptr);
+    }
+    create_cb(CBIndex::c_10, q_tiles * q_tile_size, q_df, q_tile_size, &q_tile);  // tilized Q
+
+    // Scalar/identity CBs
+    const uint32_t col_identity_tile_size = full_tile.get_tile_size(scalar_df);
+    create_cb(CBIndex::c_11, scale_tiles * col_identity_tile_size, scalar_df, col_identity_tile_size, &full_tile);
+    create_cb(CBIndex::c_12, scale_tiles * scalar_tile_size, scalar_df, scalar_tile_size, &scalar_tile);
+    if (sliding_window_size > 0) {
+        create_cb(CBIndex::c_13, qk_tiles * mask_tile_size, mask_df, mask_tile_size, &mask_tile);
     }
 
-    // identity scale input
-    auto c_in5_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{CBIndex::c_5, scalar_df}})
-                            .set_page_size(CBIndex::c_5, scalar_tile_size)
-                            .set_tile_dims(CBIndex::c_5, scalar_tile);
-    CreateCircularBuffer(program, core_grid, c_in5_config);
+    // Intermediate CBs
+    create_cb(CBIndex::c_24, qk_tiles * im_tile_size, im_df, im_tile_size, &im_tile);
+    create_cb(CBIndex::c_25, out_tiles * im_tile_size, im_df, im_tile_size, &im_tile);
+    create_cb(CBIndex::c_26, out_tiles * im_tile_size, im_df, im_tile_size, &im_tile);
+    create_cb(CBIndex::c_27, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_28, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_29, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_30, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_31, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_21, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_22, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_23, out_tiles * im_tile_size, im_df, im_tile_size, &im_tile);
 
-    // cb_m_in
-    auto c_in6_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_6, stats_df}})
-                            .set_page_size(CBIndex::c_6, stats_tile_size)
-                            .set_tile_dims(CBIndex::c_6, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_in6_config);
+    // Output CBs
+    create_cb(CBIndex::c_16, out_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_17, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_18, statistics_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    create_cb(CBIndex::c_19, intermed_output_tiles * stats_tile_size, stats_df, stats_tile_size, &stats_tile);
+    auto cb_out_final_id = create_cb(
+        CBIndex::c_20,
+        out_tiles * out_tile_size,
+        out_df,
+        out_tile_size,
+        &out_tile,
+        is_output_sharded ? out_buffer : nullptr);
 
-    // cb_l_in
-    auto c_in7_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_7, stats_df}})
-                            .set_page_size(CBIndex::c_7, stats_tile_size)
-                            .set_tile_dims(CBIndex::c_7, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_in7_config);
-
-    // tilizedQ input
-
-    auto c_tilized_q_config = CircularBufferConfig(q_tiles * q_tile_size, {{CBIndex::c_10, q_df}})
-                                  .set_page_size(CBIndex::c_10, q_tile_size)
-                                  .set_tile_dims(CBIndex::c_10, q_tile);
-    CreateCircularBuffer(program, core_grid, c_tilized_q_config);
-
-    // cb_col_identity
-    auto col_identity_tile = full_tile;
-    auto col_identity_tile_size = col_identity_tile.get_tile_size(scalar_df);
-
-    auto c_in11_config = CircularBufferConfig(scale_tiles * col_identity_tile_size, {{CBIndex::c_11, scalar_df}})
-                             .set_page_size(CBIndex::c_11, col_identity_tile_size)
-                             .set_tile_dims(CBIndex::c_11, col_identity_tile);
-    CreateCircularBuffer(program, core_grid, c_in11_config);
-
-    // cb zero config
-    auto c_zero_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{CBIndex::c_12, scalar_df}})
-                             .set_page_size(CBIndex::c_12, scalar_tile_size)
-                             .set_tile_dims(CBIndex::c_12, scalar_tile);
-    CreateCircularBuffer(program, core_grid, c_zero_config);
-
-    // sliding window mask input (conditionally created based on sliding_window_size)
-    if (sliding_window_size.has_value() && sliding_window_size.value() > 0) {
-        auto c_sliding_window_mask_config = CircularBufferConfig(qk_tiles * mask_tile_size, {{CBIndex::c_13, mask_df}})
-                                                .set_page_size(CBIndex::c_13, mask_tile_size)
-                                                .set_tile_dims(CBIndex::c_13, mask_tile);
-        CreateCircularBuffer(program, core_grid, c_sliding_window_mask_config);
-    }
-
-    // block padding mask (when block_size < TILE_HEIGHT, masks zero-padded rows in each K tile)
-    if (has_block_padding) {
-        auto c_block_pad_mask_config = CircularBufferConfig(qk_tiles * mask_tile_size, {{CBIndex::c_14, mask_df}})
-                                           .set_page_size(CBIndex::c_14, mask_tile_size)
-                                           .set_tile_dims(CBIndex::c_14, mask_tile);
-        CreateCircularBuffer(program, core_grid, c_block_pad_mask_config);
-    }
-
-    // cb_qk_im
-    auto c_intermed0_config = CircularBufferConfig(qk_tiles * im_tile_size, {{CBIndex::c_24, im_df}})
-                                  .set_page_size(CBIndex::c_24, im_tile_size)
-                                  .set_tile_dims(CBIndex::c_24, im_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed0_config);
-
-    // cb_out_im
-    auto c_intermed1_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{CBIndex::c_25, im_df}})
-                                  .set_page_size(CBIndex::c_25, im_tile_size)
-                                  .set_tile_dims(CBIndex::c_25, im_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed1_config);
-
-    // cb_out_accumulate_im
-    auto c_intermed2_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{CBIndex::c_26, im_df}})
-                                  .set_page_size(CBIndex::c_26, im_tile_size)
-                                  .set_tile_dims(CBIndex::c_26, im_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed2_config);
-
-    // cb_cur_max
-    auto c_intermed3_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_27, stats_df}})
-                                  .set_page_size(CBIndex::c_27, stats_tile_size)
-                                  .set_tile_dims(CBIndex::c_27, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed3_config);
-
-    // cb_prev_max
-    auto c_intermed4_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_28, stats_df}})
-                                  .set_page_size(CBIndex::c_28, stats_tile_size)
-                                  .set_tile_dims(CBIndex::c_28, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed4_config);
-
-    // cb_cur_sum
-    auto c_intermed5_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_29, stats_df}})
-                                  .set_page_size(CBIndex::c_29, stats_tile_size)
-                                  .set_tile_dims(CBIndex::c_29, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed5_config);
-
-    // cb_prev_sum
-    auto c_intermed6_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_30, stats_df}})
-                                  .set_page_size(CBIndex::c_30, stats_tile_size)
-                                  .set_tile_dims(CBIndex::c_30, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed6_config);
-
-    // cb_exp_max_diff
-    auto c_intermed7_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_31, stats_df}})
-                                  .set_page_size(CBIndex::c_31, stats_tile_size)
-                                  .set_tile_dims(CBIndex::c_31, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_intermed7_config);
-
-    // cb_prev_sum_2
-    auto c_out5_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_21, stats_df}})
-                             .set_page_size(CBIndex::c_21, stats_tile_size)
-                             .set_tile_dims(CBIndex::c_21, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_out5_config);
-
-    // cb_exp_max_diff_2
-    auto c_out6_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_22, stats_df}})
-                             .set_page_size(CBIndex::c_22, stats_tile_size)
-                             .set_tile_dims(CBIndex::c_22, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_out6_config);
-
-    // cb_out_accumulate_im_2
-    auto c_out7_config = CircularBufferConfig(out_im_tiles * im_tile_size, {{CBIndex::c_23, im_df}})
-                             .set_page_size(CBIndex::c_23, im_tile_size)
-                             .set_tile_dims(CBIndex::c_23, im_tile);
-    CreateCircularBuffer(program, core_grid, c_out7_config);
-
-    // Output
-    // cb_out_o
-    auto c_out0_config = CircularBufferConfig(out0_t * stats_tile_size, {{CBIndex::c_16, stats_df}})
-                             .set_page_size(CBIndex::c_16, stats_tile_size)
-                             .set_tile_dims(CBIndex::c_16, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_out0_config);
-
-    // cb_out_m
-    auto c_out1_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_17, stats_df}})
-                             .set_page_size(CBIndex::c_17, stats_tile_size)
-                             .set_tile_dims(CBIndex::c_17, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_out1_config);
-
-    // cb_out_l
-    auto c_out2_config = CircularBufferConfig(statistics_tiles * stats_tile_size, {{CBIndex::c_18, stats_df}})
-                             .set_page_size(CBIndex::c_18, stats_tile_size)
-                             .set_tile_dims(CBIndex::c_18, stats_tile);
-    CreateCircularBuffer(program, core_grid, c_out2_config);
-
-    // when there are worker cores
-    if (intermed_output_tiles > 0) {
-        // cb_intermed_out
-        auto c_out3_config = CircularBufferConfig(intermed_output_tiles * stats_tile_size, {{CBIndex::c_19, stats_df}})
-                                 .set_page_size(CBIndex::c_19, stats_tile_size)
-                                 .set_tile_dims(CBIndex::c_19, stats_tile);
-        CreateCircularBuffer(program, core_grid, c_out3_config);
-    }
-
-    // cb_out_final
-    auto c_out4_config = CircularBufferConfig(out0_t * out_tile_size, {{CBIndex::c_20, out_df}})
-                             .set_page_size(CBIndex::c_20, out_tile_size)
-                             .set_tile_dims(CBIndex::c_20, out_tile);
-    if (is_output_sharded) {
-        c_out4_config.set_globally_allocated_address(*out0_buffer);
-    }
-    auto cb_out4_id = CreateCircularBuffer(program, core_grid, c_out4_config);
-
-    // *** Create Kernels and Compile Time Args ***
-    // Reduce ops need to multiply by a scalar. We always want to multiply by 1.0f
-    class bfloat16 bfloat_identity_scalar(1.0f);
-    uint32_t packed_identity_scalar = pack_two_bfloat16_into_uint32({bfloat_identity_scalar, bfloat_identity_scalar});
-
-    class bfloat16 bfloat_zero_scalar(0.0f);
-    uint32_t packed_zero_scalar = pack_two_bfloat16_into_uint32({bfloat_zero_scalar, bfloat_zero_scalar});
+    // ========== Kernel Scalars ==========
+    const bfloat16 bfloat_identity_scalar(1.0f);
+    const bfloat16 bfloat_zero_scalar(0.0f);
+    const uint32_t packed_identity_scalar =
+        pack_two_bfloat16_into_uint32({bfloat_identity_scalar, bfloat_identity_scalar});
+    const uint32_t packed_zero_scalar = pack_two_bfloat16_into_uint32({bfloat_zero_scalar, bfloat_zero_scalar});
 
     union {
         float f;
         uint32_t u;
     } scale_union{};
-    scale_union.f = scale.value_or(1.0f);
+    scale_union.f = scale;
 
-    // Create core groups for reduce cores
-    std::vector<uint32_t> reduce_core_physical_xs;
-    std::vector<uint32_t> reduce_core_physical_ys;
-    uint32_t reduce_core_noc_x{};
-    uint32_t reduce_core_noc_y{};
-    reduce_core_physical_xs.reserve(num_reducer_cores);
-    reduce_core_physical_ys.reserve(num_reducer_cores);
-
-    for (uint32_t i = 0; i < num_active_cores; ++i) {
-        CoreCoord core = core_group[i];
-        uint32_t worker_id_for_reduce = (i % num_cores_per_head) - 1;
-        bool do_reduce = (worker_id_for_reduce == -1);
-        if (do_reduce) {
-            reduce_core_noc_x = core.x;
-            reduce_core_noc_y = core.y;
-            // get physical core
-            CoreCoord reduce_core = {(std::size_t)reduce_core_noc_x, (std::size_t)reduce_core_noc_y};
-            auto reduce_core_physical = device->worker_core_from_logical_core(reduce_core);
-            reduce_core_physical_xs.push_back((uint32_t)reduce_core_physical.x);
-            reduce_core_physical_ys.push_back((uint32_t)reduce_core_physical.y);
-        }
-    }
-
-    log_debug(tt::LogOp, "reduce_core_physical_xs: {}", reduce_core_physical_xs);
-    log_debug(tt::LogOp, "reduce_core_physical_ys: {}", reduce_core_physical_ys);
-
-    // Build physical core coordinates for each reduction group (for tree reduction)
-    // This allows each core to look up physical coordinates of its parent/children
-    // reduction_group_core_xs[group_idx * num_cores_per_head + core_idx_in_group]
-    std::vector<uint32_t> reduction_group_core_xs;
-    std::vector<uint32_t> reduction_group_core_ys;
-    reduction_group_core_xs.reserve(num_active_cores);
-    reduction_group_core_ys.reserve(num_active_cores);
-
-    for (uint32_t i = 0; i < num_active_cores; ++i) {
-        CoreCoord core = core_group[i];
-        auto physical_core = device->worker_core_from_logical_core(core);
-        reduction_group_core_xs.push_back((uint32_t)physical_core.x);
-        reduction_group_core_ys.push_back((uint32_t)physical_core.y);
-    }
-
-    log_debug(tt::LogOp, "reduction_group_core_xs: {}", reduction_group_core_xs);
-    log_debug(tt::LogOp, "reduction_group_core_ys: {}", reduction_group_core_ys);
-
-    // Create core groups for output cores
-    std::vector<uint32_t> output_core_physical_xs;
-    std::vector<uint32_t> output_core_physical_ys;
-    uint32_t output_core_noc_x{};
-    uint32_t output_core_noc_y{};
-    output_core_physical_xs.reserve(num_output_cores);  // num output cores is equal to batch size
-    output_core_physical_ys.reserve(num_output_cores);
-
-    for (uint32_t i = 0; i < num_active_cores; ++i) {
-        CoreCoord core = core_group[i];
-        uint32_t worker_id_for_output = (i % num_cores_per_batch) - 1;
-        bool do_output = (worker_id_for_output == -1);
-        if (do_output) {
-            output_core_noc_x = core.x;
-            output_core_noc_y = core.y;
-            // get physical core
-            CoreCoord output_core = {(std::size_t)output_core_noc_x, (std::size_t)output_core_noc_y};
-            auto output_core_physical = device->worker_core_from_logical_core(output_core);
-            output_core_physical_xs.push_back((uint32_t)output_core_physical.x);
-            output_core_physical_ys.push_back((uint32_t)output_core_physical.y);
-        }
-    }
-
-    log_debug(tt::LogOp, "output_core_physical_xs: {}", output_core_physical_xs);
-    log_debug(tt::LogOp, "output_core_physical_ys: {}", output_core_physical_ys);
-
-    // Common Compile time Args
+    // ========== Semaphores ==========
     auto reducer_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
     auto output_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
+    auto k_mcast_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
 
     // If q is sharded, directly read in q_chunk_size_bytes if q is row major or tilized but with full tiles
     // If q is tilized and want to use tiny tiles, this is ignored since we need to skip bottom half of tiles
     const uint32_t q_chunk_size_bytes =
         q_tiles * (tilize_q ? num_q_heads * TILE_WIDTH * input_tensor_q.element_size() : q_tile_size);
+    const uint32_t reuse_k = (tensor_args.v.has_value() ? 0 : 1) | (q_heads_parallel_factor > 1 ? 1 : 0);
 
-    const uint32_t reuse_k = tensor_args.v.has_value() ? 0 : 1;
-
+    // ========== Compile Time Arguments ==========
     std::vector<uint32_t> reader_compile_time_args_common = {
         B,
         PNHt,
@@ -788,7 +562,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         is_q_sharded,
         num_cores_per_batch,
         k_chunk_size,
-        index_stick_size,
+        cur_pos_stick_size,
         (uint32_t)is_paged_attention,
         num_kv_heads,
         page_block_size_t,
@@ -808,11 +582,14 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         is_cur_pos_tensor_sharded,
         is_page_table_sharded,
         full_tile.get_tile_size(q_df),
-        sliding_window_size.value_or(0),
+        sliding_window_size,
         original_block_size,
+        k_mcast_semaphore_id,
+        (uint32_t)q_locally_available,
+        (uint32_t)(q_heads_parallel_factor > 1),  // use_k_mcast
     };
-    tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
+    tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(attn_mask ? attn_mask->buffer() : nullptr).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(cur_pos_tensor ? cur_pos_tensor->buffer() : nullptr)
@@ -852,7 +629,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         is_causal,
         max_dynamic_chunk_size,
         q_heads_parallel_factor,
-        sliding_window_size.value_or(0),
+        sliding_window_size,
         num_tree_reduction_rounds,
         original_block_size,
     };
@@ -888,66 +665,39 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         q_heads_parallel_factor,
         use_half_tile,
         scale_union.u,
-        sliding_window_size.value_or(0),
+        sliding_window_size,
         num_tree_reduction_rounds,
         original_block_size,
+        (uint32_t)use_mla,  // reuse_k: if MLA, V = K
     };
 
-    // Determine granularity for compute loops
+    // ========== Compute Defines ==========
     std::map<std::string, std::string> compute_defines;
-    if (Sk_chunk_t > 0) {
-        const uint32_t sub_exp_granularity = std::min(Sk_chunk_t, dst_size);
-        const uint32_t log2_sub_exp_granularity = std::log2(sub_exp_granularity);
-        TT_FATAL(
-            sub_exp_granularity == (1 << log2_sub_exp_granularity),
-            "Sub-exp granularity ({}) must be a power of 2 (2^{})",
-            sub_exp_granularity,
-            log2_sub_exp_granularity);
-
-        const uint32_t mul_bcast_granularity = std::min(PNHt * Sk_chunk_t, dst_size);
-        const uint32_t log2_mul_bcast_granularity = std::log2(mul_bcast_granularity);
-        TT_FATAL(
-            mul_bcast_granularity == (1 << log2_mul_bcast_granularity),
-            "Mul-bcast granularity ({}) must be a power of 2 (2^{})",
-            mul_bcast_granularity,
-            log2_mul_bcast_granularity);
-
-        compute_defines["SUB_EXP_GRANULARITY"] = std::to_string(sub_exp_granularity);
-        compute_defines["LOG2_SUB_EXP_GRANULARITY"] = std::to_string(log2_sub_exp_granularity);
-        compute_defines["MUL_BCAST_GRANULARITY"] = std::to_string(mul_bcast_granularity);
-        compute_defines["LOG2_MUL_BCAST_GRANULARITY"] = std::to_string(log2_mul_bcast_granularity);
-
-        // Log these
-        log_debug(tt::LogOp, "sub_exp_granularity: {}", sub_exp_granularity);
-        log_debug(tt::LogOp, "log2_sub_exp_granularity: {}", log2_sub_exp_granularity);
-        log_debug(tt::LogOp, "mul_bcast_granularity: {}", mul_bcast_granularity);
-        log_debug(tt::LogOp, "log2_mul_bcast_granularity: {}", log2_mul_bcast_granularity);
-    } else {
-        compute_defines["DYNAMIC_CHUNK_SIZE"] = "1";
-    }
     compute_defines["EXP_APPROX_MODE"] = std::to_string(exp_approx_mode);
     compute_defines["DHT_GRANULARITY"] = std::to_string(dht_granularity);
     compute_defines["LOG2_DHT_GRANULARITY"] = std::to_string(log2_dht_granularity);
 
     if (Sk_chunk_t > 0) {
-        // Determine granularity for statistics computation
-        const uint32_t stats_granularity = std::min(Sk_chunk_t, dst_size);
-        // Find log2 of stats_granularity using std
-        const uint32_t log2_stats_granularity = std::log2(stats_granularity);
-        // Assert that this is a power of 2
-        TT_FATAL(
-            stats_granularity == (1 << log2_stats_granularity),
-            "stats_granularity must be a power of 2. Got {}.",
-            stats_granularity);
-
-        compute_defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
-        compute_defines["LOG2_STATS_GRANULARITY"] = std::to_string(log2_stats_granularity);
+        // Static chunk size: set granularities for softmax loops
+        auto add_granularity = [&](const char* name, uint32_t value) {
+            uint32_t log2_val = std::log2(value);
+            TT_FATAL(value == (1u << log2_val), "{} ({}) must be power of 2", name, value);
+            compute_defines[name] = std::to_string(value);
+            compute_defines[std::string("LOG2_") + name] = std::to_string(log2_val);
+        };
+        add_granularity("SUB_EXP_GRANULARITY", std::min(Sk_chunk_t, dst_size));
+        add_granularity("MUL_BCAST_GRANULARITY", std::min(PNHt * Sk_chunk_t, dst_size));
+        add_granularity("STATS_GRANULARITY", std::min(Sk_chunk_t, dst_size));
+    } else {
+        compute_defines["DYNAMIC_CHUNK_SIZE"] = "1";
     }
 
-    // Compute
+    // ========== Kernel Creation ==========
+    const std::string kernel_path = "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/";
+
     auto compute_kernels_id = CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp",
+        kernel_path + "compute/sdpa_flash_decode.cpp",
         core_grid,
         tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
@@ -956,42 +706,64 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             .compile_args = compute_compile_time_args_common,
             .defines = compute_defines});
 
-    // Reader
     auto reader_kernels_id = CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp",
+        kernel_path + "dataflow/reader_decode_all.cpp",
         core_grid,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args_common));
 
-    // Writer
     auto writer_kernels_id = CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp",
+        kernel_path + "dataflow/writer_decode_all.cpp",
         core_grid,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args_common));
 
-    uint32_t q_addr = q_buffer->address();
-    uint32_t k_addr = k_buffer->address();
-    uint32_t v_addr = v_buffer->address();
-    uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
-    uint32_t page_table_addr = is_paged_attention ? page_table_tensor.value().buffer()->address() : 0;
-    uint32_t attn_mask_addr = use_attention_mask ? attn_mask.value().buffer()->address() : 0;
-    uint32_t attention_sink_addr = use_attention_sink ? attention_sink.value().buffer()->address() : 0;
-    uint32_t out_addr = out0_buffer->address();
+    // ========== Buffer Addresses for Runtime Args ==========
+    const uint32_t q_addr = q_buffer->address();
+    const uint32_t k_addr = k_buffer->address();
+    const uint32_t v_addr = v_buffer->address();
+    const uint32_t out_addr = out_buffer->address();
+    const uint32_t pos_addr = use_cur_pos_tensor ? cur_pos_tensor.value().buffer()->address() : 0;
+    const uint32_t page_table_addr = is_paged_attention ? page_table_tensor.value().buffer()->address() : 0;
+    const uint32_t attn_mask_addr = use_attention_mask ? attn_mask.value().buffer()->address() : 0;
+    const uint32_t attention_sink_addr = use_attention_sink ? attention_sink.value().buffer()->address() : 0;
 
-    // Set rt args
+    // ========== Runtime Arguments ==========
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t worker_id_for_reduce = (i % num_cores_per_head) - 1;
-        uint32_t worker_id_for_output = (i % num_cores_per_batch) - 1;
-        bool do_reduce = (worker_id_for_reduce == -1);
-        bool do_output = (worker_id_for_output == -1);
-
-        uint32_t cur_head = (i % num_cores_per_batch) / num_cores_per_head;
-        uint32_t cur_batch = i / num_cores_per_batch;
-        uint32_t core_num_in_reduce = i % num_cores_per_head;
-        uint32_t core_num_in_output = i % num_cores_per_batch;
-
+        uint32_t cur_batch, cur_head, core_num_in_reduce, core_num_in_output;
+        if (use_col_major_group_indexing) {
+            uint32_t group_idx = i / num_cores_per_head;          // row-major group index
+            uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
+            uint32_t group_col = group_idx % num_groups_per_row;  // which column of groups
+            cur_batch = group_col * grid_size.y + group_row;      // column-major: batches go down columns first
+            cur_head = 0;                                         // single KV head when using this indexing
+            core_num_in_reduce =
+                i % num_cores_per_head;               // position within the reduction group (0 to num_cores_per_head-1)
+            core_num_in_output = core_num_in_reduce;  // same as reduce for single head
+        } else {
+            cur_head = (i % num_cores_per_batch) / num_cores_per_head;
+            cur_batch = i / num_cores_per_batch;
+            core_num_in_reduce = i % num_cores_per_head;
+            core_num_in_output = i % num_cores_per_batch;
+        }
+        uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? UINT32_MAX : core_num_in_reduce - 1;
+        uint32_t worker_id_for_output = (core_num_in_output == 0) ? UINT32_MAX : core_num_in_output - 1;
+        bool do_reduce = (worker_id_for_reduce == UINT32_MAX);
+        bool do_output = (worker_id_for_output == UINT32_MAX);
+        bool do_k_mcast = false;
+        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
+        if (q_heads_parallel_factor > 1) {
+            do_k_mcast = (core.y == 0 || core.y == 4);
+            num_dests = q_heads_parallel_factor - 1;
+            if (do_k_mcast && num_dests > 0) {
+                auto phys_start = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
+                auto phys_end = device->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
+                mcast_x = phys_start.x;
+                mcast_y0 = phys_start.y;
+                mcast_y1 = phys_end.y;
+            }
+        }
         uint32_t cur_pos =
             (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
 
@@ -1013,9 +785,22 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         log_debug(tt::LogOp, "tree_params.send_at_round: {}", tree_params.send_at_round);
         log_debug(tt::LogOp, "tree_params.num_children: {}", tree_params.num_children);
         log_debug(tt::LogOp, "tree_params.my_active_rounds: {}", tree_params.my_active_rounds);
+        log_debug(tt::LogOp, "do_k_mcast: {}", do_k_mcast);
+        log_debug(tt::LogOp, "mcast_x: {}", mcast_x);
+        log_debug(tt::LogOp, "mcast_y0: {}", mcast_y0);
+        log_debug(tt::LogOp, "mcast_y1: {}", mcast_y1);
+        log_debug(tt::LogOp, "num_dests: {}", num_dests);
 
         // Calculate base index for this reduction group's cores in the physical coordinate arrays
-        uint32_t reduction_group_base_idx = (cur_batch * num_cores_per_batch) + (cur_head * num_cores_per_head);
+        // reduction_group_core_xs/ys are populated in row-major order (by linear index i)
+        // So we use 'i' directly to find the start of this core's reduction group
+        uint32_t reduction_group_base_idx;
+        if (use_col_major_group_indexing) {
+            // For column-major indexing: the group starts at (i / num_cores_per_head) * num_cores_per_head
+            reduction_group_base_idx = (i / num_cores_per_head) * num_cores_per_head;
+        } else {
+            reduction_group_base_idx = (cur_batch * num_cores_per_batch) + (cur_head * num_cores_per_head);
+        }
         log_debug(tt::LogOp, "reduction_group_base_idx: {}", reduction_group_base_idx);
         // reader runtime args
         std::vector<uint32_t> reader_rt_args = {
@@ -1033,11 +818,17 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             cur_batch,
             core_num_in_reduce,
             core_num_in_output,
-            cur_pos};
+            cur_pos,
+            do_k_mcast,
+            mcast_x,
+            mcast_y0,
+            mcast_y1,
+            num_dests,
+        };
         reader_rt_args.insert(reader_rt_args.end(), output_core_physical_xs.begin(), output_core_physical_xs.end());
         reader_rt_args.insert(reader_rt_args.end(), output_core_physical_ys.begin(), output_core_physical_ys.end());
 
-        // writer runtime args
+        // writer runtime args (do_reduce is NOT included — writer doesn't use it)
         std::vector<uint32_t> writer_rt_args = {
             out_addr,
             worker_id_for_reduce,
@@ -1061,8 +852,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         for (unsigned int children : tree_params.children_per_round) {
             writer_rt_args.push_back(children);
         }
-        // Add reduction group physical core coordinates (for tree communication)
-        // First add the x coordinates for all cores in this reduction group
         for (uint32_t c = 0; c < num_cores_per_head; ++c) {
             writer_rt_args.push_back(reduction_group_core_xs[reduction_group_base_idx + c]);
         }
@@ -1095,7 +884,6 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         for (unsigned int children : tree_params.children_per_round) {
             compute_rt_args.push_back(children);
         }
-
         SetRuntimeArgs(program, reader_kernels_id, core, reader_rt_args);
         SetRuntimeArgs(program, writer_kernels_id, core, writer_rt_args);
         SetRuntimeArgs(program, compute_kernels_id, core, compute_rt_args);
@@ -1107,14 +895,14 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
             log_debug(tt::LogOp, "Setting core {} to idle", core);
 
             // Reader runtime args
-            // Base args (15)
-            std::vector<uint32_t> reader_rt_args(15, 0);
+            // Base args (20): includes K-mcast args [do_k_mcast, mcast_x, mcast_y0, mcast_y1, num_dests]
+            std::vector<uint32_t> reader_rt_args(20, 0);
 
             // Writer runtime args - need to match the size with tree reduction params
-            // Base args (10) + tree params (6) + children_per_round (MAX_TREE_REDUCTION_ROUNDS) + group coords
+            // Base args (9) + tree params (6) + children_per_round (MAX_TREE_REDUCTION_ROUNDS) + group coords
             // (2*num_cores_per_head)
             // + reducer coords + output coords
-            std::vector<uint32_t> writer_rt_args(10 + 6 + MAX_TREE_REDUCTION_ROUNDS + 2 * num_cores_per_head, 0);
+            std::vector<uint32_t> writer_rt_args(9 + 6 + MAX_TREE_REDUCTION_ROUNDS + 2 * num_cores_per_head, 0);
 
             // Compute runtime args - 65 indicates idle core
             // Base args (7) + tree params (5) + children_per_round (MAX_TREE_REDUCTION_ROUNDS)
@@ -1137,10 +925,13 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
          .num_cores_per_batch = num_cores_per_batch,
          .num_cores_per_head = num_cores_per_head,
          .num_output_cores = num_output_cores,
-         .cb_in8_id = cb_in8_id,
-         .cb_in9_id = cb_in9_id,
+         .cb_q_in_id = cb_q_in_id,
+         .cb_cur_pos_id = cb_cur_pos_id,
+         .cb_page_table_id = cb_page_table_id,
+         .is_q_sharded = is_q_sharded,
          .is_output_sharded = is_output_sharded,
-         .cb_out4_id = cb_out4_id,
+         .q_locally_available = q_locally_available,
+         .cb_out_final_id = cb_out_final_id,
          .B = B,
          .q_heads_parallel_factor = q_heads_parallel_factor,
          .use_cur_pos_tensor = use_cur_pos_tensor,
@@ -1148,7 +939,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
          .use_attention_sink = use_attention_sink,
          .is_paged_attention = is_paged_attention,
          .is_causal = is_causal,
-         .use_mla = use_mla}};
+         .use_mla = use_mla,
+         .use_col_major_group_indexing = use_col_major_group_indexing,
+         .grid_size = grid_size}};
 }
 
 void SdpaDecodeProgramFactory::override_runtime_arguments(
@@ -1166,10 +959,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     const auto& compute_kernels_id = shared_variables.compute_kernels_id;
     const auto& num_cores_per_batch = shared_variables.num_cores_per_batch;
     const auto& num_cores_per_head = shared_variables.num_cores_per_head;
-    const auto& cb_in8_id = shared_variables.cb_in8_id;
-    const auto& cb_in9_id = shared_variables.cb_in9_id;
+    const auto& cb_q_in_id = shared_variables.cb_q_in_id;
+    const auto& cb_cur_pos_id = shared_variables.cb_cur_pos_id;
+    const auto& cb_page_table_id = shared_variables.cb_page_table_id;
     const auto& is_output_sharded = shared_variables.is_output_sharded;
-    const auto& cb_out4_id = shared_variables.cb_out4_id;
+    const auto& q_locally_available = shared_variables.q_locally_available;
+    const auto& cb_out_final_id = shared_variables.cb_out_final_id;
     const auto& q_heads_parallel_factor = shared_variables.q_heads_parallel_factor;
     const auto& cur_pos_ids = operation_attributes.cur_pos;
     const bool use_cur_pos_tensor = shared_variables.use_cur_pos_tensor;
@@ -1177,6 +972,8 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     const bool use_attention_sink = shared_variables.use_attention_sink;
     const bool is_paged_attention = shared_variables.is_paged_attention;
     const bool is_causal = shared_variables.is_causal;
+    const bool use_col_major_group_indexing = shared_variables.use_col_major_group_indexing;
+    const auto& grid_size = shared_variables.grid_size;
 
     auto* q_buffer = tensor_args.q.buffer();
     auto* k_buffer = tensor_args.k.buffer();
@@ -1186,12 +983,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         v_buffer = tensor_args.v.value().buffer();
     }
 
-    auto* out0_buffer = tensor_return_value.buffer();
+    auto* out_buffer = tensor_return_value.buffer();
 
     uint32_t q_addr = q_buffer->address();
     uint32_t k_addr = k_buffer->address();
     uint32_t v_addr = v_buffer->address();
-    uint32_t out_addr = out0_buffer->address();
+    uint32_t out_addr = out_buffer->address();
 
     const auto& cur_pos_tensor = tensor_args.cur_pos_tensor;
     const auto& page_table_tensor = tensor_args.page_table_tensor;
@@ -1203,6 +1000,8 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     auto* page_table_buffer = is_paged_attention ? page_table_tensor.value().buffer() : nullptr;
     uint32_t page_table_stick_size = is_paged_attention ? page_table_buffer->aligned_page_size() : 0;
 
+    IDevice* dev = tensor_args.q.device();
+
     auto& reader_args_by_core = GetRuntimeArgs(program, reader_kernels_id);
     auto& writer_args_by_core = GetRuntimeArgs(program, writer_kernels_id);
     auto& compute_args_by_core = GetRuntimeArgs(program, compute_kernels_id);
@@ -1210,17 +1009,52 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
     // Set rt args
     for (uint32_t i = 0; i < num_active_cores; ++i) {
         CoreCoord core = core_group[i];
-        uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? UINT32_MAX : (i % num_cores_per_head) - 1;
-        uint32_t worker_id_for_output = ((i % num_cores_per_batch) == 0) ? UINT32_MAX : (i % num_cores_per_batch) - 1;
+        // Core role identification - must match create() exactly
+        uint32_t cur_batch, cur_head, core_num_in_reduce, core_num_in_output;
+        if (use_col_major_group_indexing) {
+            uint32_t num_groups_per_row = grid_size.x / num_cores_per_head;
+            uint32_t group_idx = i / num_cores_per_head;          // row-major group index
+            uint32_t group_row = group_idx / num_groups_per_row;  // which row of groups (0 to grid_size.y-1)
+            uint32_t group_col = group_idx % num_groups_per_row;  // which column of groups
+            cur_batch = group_col * grid_size.y + group_row;      // column-major: batches go down columns first
+            cur_head = 0;                                         // single KV head when using this indexing
+            core_num_in_reduce = i % num_cores_per_head;          // position within the reduction group
+            core_num_in_output = core_num_in_reduce;              // same as reduce for single head
+        } else {
+            // Must match create() exactly
+            cur_head = (i % num_cores_per_batch) / num_cores_per_head;
+            cur_batch = i / num_cores_per_batch;
+            core_num_in_reduce = i % num_cores_per_head;
+            core_num_in_output = i % num_cores_per_batch;
+        }
+
+        // Must match create() exactly
+        uint32_t worker_id_for_reduce = (num_cores_per_head == 0) ? UINT32_MAX : core_num_in_reduce - 1;
+        uint32_t worker_id_for_output = (core_num_in_output == 0) ? UINT32_MAX : core_num_in_output - 1;
         bool do_reduce = (worker_id_for_reduce == UINT32_MAX);
         bool do_output = (worker_id_for_output == UINT32_MAX);
-        uint32_t cur_head = (num_cores_per_head == 0) ? 0 : (i % num_cores_per_batch) / num_cores_per_head;
-        uint32_t cur_batch = i / num_cores_per_batch;
-        uint32_t core_num_in_reduce = (num_cores_per_head == 0) ? 0 : i % num_cores_per_head;
-        uint32_t core_num_in_output = i % num_cores_per_batch;
+        bool do_k_mcast = false;
+        uint32_t mcast_x = 0, mcast_y0 = 0, mcast_y1 = 0, num_dests = 0;
+        if (q_heads_parallel_factor > 1) {
+            do_k_mcast = (core.y == 0 || core.y == 4);
+            num_dests = q_heads_parallel_factor - 1;
+            if (do_k_mcast && num_dests > 0) {
+                auto phys_start = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + 1});
+                auto phys_end = dev->worker_core_from_logical_core(CoreCoord{core.x, core.y + num_dests});
+                mcast_x = phys_start.x;
+                mcast_y0 = phys_start.y;
+                mcast_y1 = phys_end.y;
+            }
+        }
         uint32_t cur_pos =
             (use_cur_pos_tensor || !is_causal) ? -1 : cur_pos_ids.at((uint32_t)(cur_batch / q_heads_parallel_factor));
-
+        uint32_t reduction_group_base_idx;
+        if (use_col_major_group_indexing) {
+            // For column-major indexing: the group starts at (i / num_cores_per_head) * num_cores_per_head
+            reduction_group_base_idx = (i / num_cores_per_head) * num_cores_per_head;
+        } else {
+            reduction_group_base_idx = (cur_batch * num_cores_per_batch) + (cur_head * num_cores_per_head);
+        }
         auto& reader_args = reader_args_by_core[core.x][core.y];
         auto& writer_args = writer_args_by_core[core.x][core.y];
         auto& compute_args = compute_args_by_core[core.x][core.y];
@@ -1243,6 +1077,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         reader_args[arg_idx++] = core_num_in_output;
         reader_args[arg_idx++] = cur_pos;
 
+        reader_args[arg_idx++] = do_k_mcast;  // do_k_mcast
+        reader_args[arg_idx++] = mcast_x;     // mcast_x
+        reader_args[arg_idx++] = mcast_y0;    // mcast_y0
+        reader_args[arg_idx++] = mcast_y1;    // mcast_y1
+        reader_args[arg_idx++] = num_dests;   // num_dests
+
         // writer runtime args
         arg_idx = 0;
         writer_args[arg_idx++] = out_addr;
@@ -1255,6 +1095,12 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         writer_args[arg_idx++] = core_num_in_reduce;
         writer_args[arg_idx++] = core_num_in_output;
         writer_args[arg_idx++] = cur_pos;
+        arg_idx++;  // is_tree_root
+        arg_idx++;  // parent_core_in_group
+        arg_idx++;  // send_at_round
+        arg_idx++;  // num_children
+        arg_idx++;  // my_active_rounds
+        writer_args[arg_idx++] = reduction_group_base_idx;
 
         // compute runtime args
         arg_idx = 0;
@@ -1266,14 +1112,17 @@ void SdpaDecodeProgramFactory::override_runtime_arguments(
         compute_args[arg_idx++] = core_num_in_output;
         compute_args[arg_idx++] = cur_pos;
     }
-    if (use_cur_pos_tensor and cur_pos_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, cb_in8_id, *cur_pos_tensor.value().buffer());
+    if (q_locally_available) {
+        UpdateDynamicCircularBufferAddress(program, cb_q_in_id, *q_buffer);
     }
-    if (is_paged_attention and page_table_tensor.value().is_sharded()) {
-        UpdateDynamicCircularBufferAddress(program, cb_in9_id, *page_table_tensor.value().buffer());
+    if (use_cur_pos_tensor && cur_pos_tensor.value().is_sharded()) {
+        UpdateDynamicCircularBufferAddress(program, cb_cur_pos_id, *cur_pos_tensor.value().buffer());
+    }
+    if (is_paged_attention && page_table_tensor.value().is_sharded()) {
+        UpdateDynamicCircularBufferAddress(program, cb_page_table_id, *page_table_tensor.value().buffer());
     }
     if (is_output_sharded) {
-        UpdateDynamicCircularBufferAddress(program, cb_out4_id, *out0_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out_final_id, *out_buffer);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
@@ -91,10 +91,13 @@ struct SdpaDecodeProgramFactory {
         uint32_t num_cores_per_batch = 0;
         uint32_t num_cores_per_head = 0;
         uint32_t num_output_cores = 0;
-        tt::tt_metal::CBHandle cb_in8_id{};
-        tt::tt_metal::CBHandle cb_in9_id{};
+        tt::tt_metal::CBHandle cb_q_in_id{};        // CB for Q input tensor (c_0)
+        tt::tt_metal::CBHandle cb_cur_pos_id{};     // CB for position indices tensor
+        tt::tt_metal::CBHandle cb_page_table_id{};  // CB for page table tensor (paged attention)
+        bool is_q_sharded = false;
         bool is_output_sharded = false;
-        tt::tt_metal::CBHandle cb_out4_id{};
+        bool q_locally_available = false;
+        tt::tt_metal::CBHandle cb_out_final_id{};  // CB for final output tensor
         uint32_t B = 0;
         uint32_t q_heads_parallel_factor = 0;
         bool use_cur_pos_tensor = false;
@@ -103,6 +106,8 @@ struct SdpaDecodeProgramFactory {
         bool is_paged_attention = false;
         bool is_causal = false;
         bool use_mla = false;
+        bool use_col_major_group_indexing = false;  // Column-major batch indexing for spatial locality
+        CoreCoord grid_size{0, 0};                  // Grid dimensions for spatial calculations
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.hpp
@@ -108,6 +108,8 @@ struct SdpaDecodeProgramFactory {
         bool use_mla = false;
         bool use_col_major_group_indexing = false;  // Column-major batch indexing for spatial locality
         CoreCoord grid_size{0, 0};                  // Grid dimensions for spatial calculations
+        uint32_t num_group_rows = 0;
+        uint32_t num_group_cols = 0;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -24,40 +24,30 @@ namespace ttnn::operations::transformer {
 void py_module(nb::module_& mod) {
     nb::class_<SDPAProgramConfig>(mod, "SDPAProgramConfig")
         .def(
-            nb::init<
-                CoreCoord,
-                std::optional<CoreRangeSet>,
-                std::size_t,
-                std::size_t,
-                std::optional<bool>,
-                uint32_t,
-                bool>(),
+            nb::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>, uint32_t>(),
             nb::kw_only(),
             nb::arg("compute_with_storage_grid_size"),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("q_chunk_size").noconvert(),
             nb::arg("k_chunk_size").noconvert(),
             nb::arg("exp_approx_mode") = nb::none(),
-            nb::arg("max_cores_per_head_batch") = 16,
-            nb::arg("q_locally_available") = false)
+            nb::arg("max_cores_per_head_batch") = 16)
         .def_rw("compute_with_storage_grid_size", &SDPAProgramConfig::compute_with_storage_grid_size)
         .def_rw("sub_core_grids", &SDPAProgramConfig::sub_core_grids)
         .def_rw("q_chunk_size", &SDPAProgramConfig::q_chunk_size)
         .def_rw("k_chunk_size", &SDPAProgramConfig::k_chunk_size)
         .def_rw("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode)
         .def_rw("max_cores_per_head_batch", &SDPAProgramConfig::max_cores_per_head_batch)
-        .def_rw("q_locally_available", &SDPAProgramConfig::q_locally_available)
         .def("__repr__", [](const SDPAProgramConfig& config) {
             return fmt::format(
                 "SDPAProgramConfig(compute_with_storage_grid_size={}, sub_core_grids={}, q_chunk_size={}, "
-                "k_chunk_size={}, exp_approx_mode={}, max_cores_per_head_batch={}, q_locally_available={})",
+                "k_chunk_size={}, exp_approx_mode={}, max_cores_per_head_batch={})",
                 config.compute_with_storage_grid_size,
                 config.sub_core_grids,
                 config.q_chunk_size,
                 config.k_chunk_size,
                 config.exp_approx_mode,
-                config.max_cores_per_head_batch,
-                config.q_locally_available);
+                config.max_cores_per_head_batch);
         });
 
     bind_attention_softmax(mod);

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -24,26 +24,40 @@ namespace ttnn::operations::transformer {
 void py_module(nb::module_& mod) {
     nb::class_<SDPAProgramConfig>(mod, "SDPAProgramConfig")
         .def(
-            nb::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>>(),
+            nb::init<
+                CoreCoord,
+                std::optional<CoreRangeSet>,
+                std::size_t,
+                std::size_t,
+                std::optional<bool>,
+                uint32_t,
+                bool>(),
             nb::kw_only(),
             nb::arg("compute_with_storage_grid_size"),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("q_chunk_size").noconvert(),
             nb::arg("k_chunk_size").noconvert(),
-            nb::arg("exp_approx_mode") = nb::none())
+            nb::arg("exp_approx_mode") = nb::none(),
+            nb::arg("max_cores_per_head_batch") = 16,
+            nb::arg("q_locally_available") = false)
         .def_rw("compute_with_storage_grid_size", &SDPAProgramConfig::compute_with_storage_grid_size)
         .def_rw("sub_core_grids", &SDPAProgramConfig::sub_core_grids)
         .def_rw("q_chunk_size", &SDPAProgramConfig::q_chunk_size)
         .def_rw("k_chunk_size", &SDPAProgramConfig::k_chunk_size)
         .def_rw("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode)
+        .def_rw("max_cores_per_head_batch", &SDPAProgramConfig::max_cores_per_head_batch)
+        .def_rw("q_locally_available", &SDPAProgramConfig::q_locally_available)
         .def("__repr__", [](const SDPAProgramConfig& config) {
             return fmt::format(
-                "SDPAProgramConfig(compute_with_storage_grid_size={}, sub_core_grids={}, q_chunk_size={}, k_chunk_size={}, exp_approx_mode={})",
+                "SDPAProgramConfig(compute_with_storage_grid_size={}, sub_core_grids={}, q_chunk_size={}, "
+                "k_chunk_size={}, exp_approx_mode={}, max_cores_per_head_batch={}, q_locally_available={})",
                 config.compute_with_storage_grid_size,
                 config.sub_core_grids,
                 config.q_chunk_size,
                 config.k_chunk_size,
-                config.exp_approx_mode);
+                config.exp_approx_mode,
+                config.max_cores_per_head_batch,
+                config.q_locally_available);
         });
 
     bind_attention_softmax(mod);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36008

### Problem description
Deepseek-specific optimizations needed for high batch (B=4)

### What has changed
- allow for sharded and replicated Q on all worker cores, eliminating latency for worker cores to read Q from reducer/output cores
- K multicast: K chunks are multicasted down a column where a column of cores share the same sequence length chunk and when these cores operate on different Q heads
- Column major allocation of core groups - previously the default behaviour the following:
   - for example a 64 core grid where num cores per head = 4, we form a 8 rows x 2 columns of core groups (16 groups of cores in total), [b0 h0, b0 h1, b0, h2, b0 h3, b1 h0 .... b4 h3] like so. Placing them in the default row major order would make it difficult to perform a rectangular multicast and reduction is not necessarily contiguous core group spatially, we now allow this feature such that spatially we achieve the following diagram below.  (note that currently KV chunks are still DRAM interleaved, there is not bank specific data movement done in this PR DRAM sharded KV cache is still WIP and being planned):
<img width="829" height="715" alt="Screenshot 2026-02-23 at 3 44 54 AM" src="https://github.com/user-attachments/assets/e8882a20-ef52-4825-8ae8-0cbc468bf9f6" />

### Perf improvements (Measured before tree reduce was merged)
```
with Q sharded + re-read V from K + contig sub core grids + K mcasting (aling/ds-sdpa)
seq len 1024 k chunk size 128 -> 96us
seq len 1024 k chunk size 256 -> 94us
seq len 128 k chunk size 128 -> 38us
seq len 128 k chunk size 32 -> 55us

baseline
seq len 1024 k chunk size 128 -> 173us
seq len 1024 k chunk size 256 -> 172us
seq len 128 k chunk size 128 -> 34us
seq len 128 k chunk size 32 -> 92us
```

### Checklist
- [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22520806096)
- [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/22520808486)
- [BH demo](https://github.com/tenstorrent/tt-metal/actions/runs/22520845270)
- [Llama Galaxy demo](https://github.com/tenstorrent/tt-metal/actions/runs/22520870171)
- [GPT OSS demo](https://github.com/tenstorrent/tt-metal/actions/runs/22520989791)
- [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22557275812)