### PR TITLE
Allow falling back to Linear topology is a 1x4 submesh is used in T3K or Galaxy

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1484,12 +1484,21 @@ class ModelArgs:
             ttnn.cluster.ClusterType.P300_X2,
             ttnn.cluster.ClusterType.P150_X4,
             ttnn.cluster.ClusterType.P150_X8,
+        ]:
+            return ttnn.Topology.Ring
+        elif ttnn.cluster.get_cluster_type() in [
             ttnn.cluster.ClusterType.T3K,
             ttnn.cluster.ClusterType.GALAXY,
         ]:
-            return ttnn.Topology.Ring
-        elif self.num_devices > 1:  # All other multi chip devices
+            if self.num_devices >= 8:
+                return ttnn.Topology.Ring
+            else:
+                # e.g., 1x4 submesh does not support ring topology; fallback to linear
+                return ttnn.Topology.Linear
+
+        if self.num_devices > 1:  # All other multi chip devices
             return ttnn.Topology.Linear
+
         return None
 
     def prepare_residual_tensor_decode(self, x, input_mem_cfg, force_replicated=False, on_host=False):


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Failed TTTv2 unit test is observed: https://github.com/tenstorrent/tt-metal/actions/runs/21309057931/job/61342667991

One key observation is that the only failed test cases are `test_mlp_1d_vs_reference_from_model_args` with `1x4` submesh device. This points to a change in TTTv1 being the root cause of the failed tests.

### What's changed
After tracing the failed test to #36278, it is clear that 1x4 submesh device would now be configured to use Ring topology but the hardware lacks the physical links to make that happen.

The solution is to add a check on the number of devices on a mesh device, allowing a fall back to Linear topology if the mesh device is found to have less than 8 devices.

### Checklist

- [x] BH multi card: https://github.com/tenstorrent/tt-metal/actions/runs/21311202178
- [x] T3K unit test: https://github.com/tenstorrent/tt-metal/actions/runs/21311208401
- [x] T3K demo test: https://github.com/tenstorrent/tt-metal/actions/runs/21311216898
- [x] T3K e2e test: https://github.com/tenstorrent/tt-metal/actions/runs/21370312216