### PR TITLE
#0: Shrink mcast grid when running on harvested devices for deepseek blitz unit test

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -28,7 +28,7 @@ struct Core {
     static constexpr bool is_matmul2_core = get_named_compile_time_arg_val("is_matmul2_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
 // ============================================================================
 // NCRISC (Reader + Mcast Receiver) - ReaderConfigDescriptor compiles as NCRISC
 // Named compile-time args: rmsnorm reader, mcast receiver, matmul reader, gather sender
@@ -362,4 +362,3 @@ KERNEL_ENTRY {
         matmul2(matmul2_args);
     }
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/deepseek_moe_gate/kernels/deepseek_moe_gate_compute.cpp
@@ -15,9 +15,7 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "../../../kernel_includes/tt_metal/include/compute_kernel_api/deepseek_moe_gate.h"
 
-namespace NAMESPACE {
-
-void MAIN {
+void kernel_main() {
     constexpr uint32_t input_cb = get_compile_time_arg_val(0);
     constexpr uint32_t bias_cb = get_compile_time_arg_val(1);
     constexpr uint32_t input_indices_cb = get_compile_time_arg_val(2);
@@ -65,4 +63,3 @@ void MAIN {
 
     tile_regs_release();
 }
-}  // namespace NAMESPACE

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
@@ -41,8 +41,7 @@
  *     apply optional SFPU activation
  *     pack subblock_w output tiles
  */
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     // Compile time args
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
@@ -123,4 +122,3 @@ void MAIN {
     // Pop in0 (only once at the end)
     cb_pop_front(cb_id_in0, num_tiles_k);
 }
-}  // namespace NAMESPACE

--- a/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
@@ -15,7 +15,7 @@ struct Core {
     static constexpr bool is_receiver_core = get_named_compile_time_arg_val("is_receiver_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
     using Gather = deepseek_b1_ops::Gather;
 
 // ============================================================================
@@ -81,4 +81,3 @@ KERNEL_ENTRY {
     Gather::Op<Core::is_sender_core, Core::is_receiver_core, true> gather;
     gather(gather_args);
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_kernel.cpp
@@ -17,7 +17,7 @@ struct Core {
     static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
 // ============================================================================
 // Define args per RISC (different compile-time arg layout per processor)
 // ============================================================================
@@ -74,4 +74,3 @@ KERNEL_ENTRY {
     deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_active_core, true, true> matmul;
     matmul(matmul_args);
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
@@ -20,7 +20,7 @@ struct Core {
     static constexpr bool is_receiver_core = get_named_compile_time_arg_val("is_receiver_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
     using Mcast = deepseek_b1_ops::Mcast;
 
 // ============================================================================
@@ -97,4 +97,3 @@ KERNEL_ENTRY {
     mcast(mcast_args);
     mcast.teardown();
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
@@ -17,7 +17,7 @@ struct Core {
     static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
 // ============================================================================
 // Define args per RISC (different compile-time arg layout per processor)
 // ============================================================================
@@ -82,4 +82,3 @@ KERNEL_ENTRY {
     deepseek_b1_ops::RMSNorm::Op<RMSNormCTArgs, Core::is_active_core, true> rmsnorm;
     rmsnorm(rmsnorm_args);
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -19,7 +19,7 @@ struct Core {
     static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
 };
 
-KERNEL_ENTRY {
+void kernel_main() {
 // ============================================================================
 // Define args per RISC (different compile-time arg layout per processor)
 // ============================================================================
@@ -81,4 +81,3 @@ KERNEL_ENTRY {
     deepseek_b1_ops::Rope::Op<RopeCTArgs, Core::is_active_core> rope;
     rope(rope_args);
 }
-KERNEL_END

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
@@ -22,7 +22,7 @@ from models.demos.deepseek_v3_b1.micro_ops.gather.op import GatherSingleCore
     [
         (
             32,
-            ttnn.CoreCoord(11, 8),
+            ttnn.CoreCoord(11, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 4),
                 ttnn.CoreCoord(11, 7),
@@ -31,7 +31,7 @@ from models.demos.deepseek_v3_b1.micro_ops.gather.op import GatherSingleCore
         ),  # q_a_proj output, if on 48 cores (could also do 6x8 instead of 12x4 grid)
         (
             32,
-            ttnn.CoreCoord(11, 8),
+            ttnn.CoreCoord(11, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
                 ttnn.CoreCoord(11, 7),
@@ -49,7 +49,7 @@ from models.demos.deepseek_v3_b1.micro_ops.gather.op import GatherSingleCore
         ),  # kv_a_proj output, 16 cores (Gather only a subset for kv_a_layernorm)
         (
             128,
-            ttnn.CoreCoord(11, 8),
+            ttnn.CoreCoord(11, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(4, 0),
                 ttnn.CoreCoord(11, 7),
@@ -62,6 +62,9 @@ def test_gather(device, width_per_core, gather_core, gather_grid, noc):
     """Test TTNN gather operation from multiple cores to single core"""
     # Truncate number of columns to 11 for P100 for testing
     if gather_core.x >= device.compute_with_storage_grid_size().x:
+        logger.warning(
+            f"Truncating gather_core.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
+        )
         gather_core = ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, gather_core.y)
         gather_grid = ttnn.CoreRange(
             gather_grid.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, gather_grid.end.y)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
@@ -66,6 +66,10 @@ def test_gather(device, width_per_core, gather_core, gather_grid, noc):
             f"Truncating gather_core.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
         )
         gather_core = ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, gather_core.y)
+    if gather_grid.end.x >= device.compute_with_storage_grid_size().x:
+        logger.warning(
+            f"Truncating gather_grid.end.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
+        )
         gather_grid = ttnn.CoreRange(
             gather_grid.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, gather_grid.end.y)
         )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
@@ -76,9 +76,20 @@ def test_mcast(device, width, mcast_core, mcast_receivers, mcast_grid, noc):
     """Test TTNN mcast operation from single core to multiple cores"""
     # Truncate number of columns to 11 for P100 for testing
     if mcast_core.x >= device.compute_with_storage_grid_size().x:
+        logger.warning(
+            f"Truncating mcast_core.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
+        )
         mcast_core = ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, mcast_core.y)
         mcast_grid = ttnn.CoreRange(
             mcast_grid.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, mcast_grid.end.y)
+        )
+        mcast_receivers = ttnn.CoreRangeSet(
+            {
+                cr
+                if cr.end.x < device.compute_with_storage_grid_size().x
+                else ttnn.CoreRange(cr.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, cr.end.y))
+                for cr in mcast_receivers.ranges()
+            }
         )
 
     # Tensor dimensions

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
@@ -80,14 +80,22 @@ def test_mcast(device, width, mcast_core, mcast_receivers, mcast_grid, noc):
             f"Truncating mcast_core.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
         )
         mcast_core = ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, mcast_core.y)
+    if mcast_grid.end.x >= device.compute_with_storage_grid_size().x:
+        logger.warning(
+            f"Truncating mcast_grid.end.x to {device.compute_with_storage_grid_size().x - 1} due to insufficient grid size"
+        )
         mcast_grid = ttnn.CoreRange(
             mcast_grid.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, mcast_grid.end.y)
         )
         mcast_receivers = ttnn.CoreRangeSet(
             {
-                cr
-                if cr.end.x < device.compute_with_storage_grid_size().x
-                else ttnn.CoreRange(cr.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, cr.end.y))
+                (
+                    cr
+                    if cr.end.x < device.compute_with_storage_grid_size().x
+                    else ttnn.CoreRange(
+                        cr.start, ttnn.CoreCoord(device.compute_with_storage_grid_size().x - 1, cr.end.y)
+                    )
+                )
                 for cr in mcast_receivers.ranges()
             }
         )

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_op_api.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_op_api.hpp
@@ -25,19 +25,6 @@ inline constexpr bool is_trisc = true;
 #endif
 
 // ============================================================================
-// Unified kernel entry point macro
-// ============================================================================
-#if defined(COMPILE_FOR_TRISC)
-#define KERNEL_ENTRY      \
-    namespace NAMESPACE { \
-    void MAIN
-#define KERNEL_END }
-#else
-#define KERNEL_ENTRY void kernel_main()
-#define KERNEL_END
-#endif
-
-// ============================================================================
 // Type helper: Select type based on current core
 // Usage: using RTArgs = SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
 // Note: ReaderConfigDescriptor -> NCRISC, WriterConfigDescriptor -> BRISC


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
CI resources have more harvesting than the target BH galaxy chip. In order to have some regression testing we need to run on smaller grid sizes.

### What's changed
Update mcast test to shrink core ranges when on a smaller grid. Add missing warnings so user knows when this happens in the test.
Minor cleanup of kernel entries.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/blitz-test)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/blitz-test)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/blitz-test)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/blitz-test)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/blitz-test)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/blitz-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/blitz-test)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs