### PR TITLE
Fix max_tile to binary_max_tile Transition

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -9,6 +9,7 @@
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/matmul.h"
 #include "compute_kernel_api/reduce_custom.h"
+#include "compute_kernel_api/binary_max_min.h"
 
 void kernel_main() {
     constexpr uint32_t qk_im_cb = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
     cb_wait_front(qk_im_cb, num_tiles);
     cb_reserve_back(out_max_cb, rows);
 
-    max_tile_init();
+    binary_max_tile_init();
     constexpr uint32_t reduce_dst_idx = 0;
     constexpr uint32_t prev_max_dst_idx = 1;
 
@@ -53,7 +53,7 @@ void kernel_main() {
         if (do_eltwise) {
             copy_tile_to_dst_init_short(prev_max_cb);
             copy_tile(prev_max_cb, i, prev_max_dst_idx);
-            max_tile(reduce_dst_idx, prev_max_dst_idx, static_cast<int>(VectorMode::C));
+            binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx);
         }
 
         pack_tile(reduce_dst_idx, out_max_cb);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_c/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_c/compute.cpp
@@ -29,8 +29,11 @@ void kernel_main() {
     reconfig_data_format(qk_im_cb, scale_cb);
     pack_reconfig_data_format(out_max_cb);
 
-    reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, qk_im_cb, scale_cb, Sq_chunk_t, Sk_chunk_t>(
-        out_max_cb, prev_max_cb, do_eltwise);
+    // Use the runtime version of reduce_c to match actual SDPA decode usage
+    // This version takes cols as a runtime parameter (4th function param)
+    // instead of a template parameter
+    reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, qk_im_cb, scale_cb, Sq_chunk_t>(
+        out_max_cb, prev_max_cb, Sk_chunk_t, do_eltwise);
 
     // Ensure outputs are produced before exiting
     cb_wait_front(out_max_cb, Sq_chunk_t);

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -299,6 +299,10 @@ TEST_F(UnitMeshCQSingleCardFixture, NIGHTLY_SdpaReduceC) {
     /**
      * Parameters to sweep over for correctness.
      */
+    // std::vector<uint32_t> q_chunk_sizes = {1};
+    // std::vector<uint32_t> k_chunk_sizes = {1};
+    // std::vector<bool> fp32_dest_acc_ens = {true};
+    // std::vector<bool> do_eltwise = {true};
     std::vector<uint32_t> q_chunk_sizes = {1, 2, 4, 8};
     std::vector<uint32_t> k_chunk_sizes = {1, 2, 4, 8, 16};
     std::vector<bool> fp32_dest_acc_ens = {false, true};

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/README.md
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/README.md
@@ -16,17 +16,17 @@ Instead of creating a new `llk_math_eltwise_unary_sfpu_<op>.h` for each op, use 
 
 ```cpp
 #include "llk_math_eltwise_unary_sfpu_macros.h"
-#include "ckernel_sfpu_max.h"
+#include "binary_max_min.h"
 
 namespace ckernel {
     // Init function for max
     template <bool fast_and_approx = true>
-    ALWI void max_tile_init() {
+    ALWI void binary_max_tile_init() {
         MATH(SFPU_UNARY_KERNEL_INIT(max, fast_and_approx));
     }
     // Compute function for max
     template <bool fast_and_approx = true>
-    ALWI void max_tile(uint32_t idst) {
+    ALWI void binary_max_tile(uint32_t idst) {
         MATH(SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_max, RC, fast_and_approx, idst));
     }
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`max_tile` doesn't exist anymore. This [commit](https://github.com/tenstorrent/tt-metal/commit/15ecb8c4792f11f4eba48c095434452d57f1ed63#diff-99f9ccbeb569d0ac24c12897d2d0a508d30c62945bcd164daf66e15b252793a6) failed to fix SDPA test kernel.

### What's changed
Renamed occurrences of `max_tile` to `binary_max_tile` in SDPA test kernel.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ncvetkovic/max_tile_fixup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/max_tile_fixup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/max_tile_fixup)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/max_tile_fixup)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/max_tile_fixup)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/max_tile_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/max_tile_fixup)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs