### PR TITLE
Change fn_init Signature to Match New llk_init Signature

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/chain_llk.hpp
@@ -27,7 +27,7 @@ public:
         }
     }
 };
-using fn_init = void(uint32_t, uint32_t);
+using fn_init = void(uint32_t, uint32_t, uint32_t);
 using fn_compute = void(uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
 struct LLK_Node {
     fn_init* llk_init;
@@ -87,7 +87,7 @@ void unroll_llk() {
 
     reconfig_data_format(cur_llk.CB_A, cur_llk.CB_B);
     pack_reconfig_data_format(cur_llk.CB_OUT);
-    cur_llk.llk_init(cur_llk.CB_A, cur_llk.CB_B);
+    cur_llk.llk_init(cur_llk.CB_A, cur_llk.CB_B, __builtin_LINE());
     for (uint32_t i = 0; i < cb_iterations; i++) {
         if constexpr (cur_llk.debug_mode == 1) {
             // UNPACK(DPRINT << "=============START NODE==============" << ENDL());


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Init function signature changed because of the Sentinel, so this fails:
`pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_distributed_layernorm_post_allgather.py::test_layernorm_part_2_with_program_cache` (Nightly L2).

### What's changed
Added the third argument. The test passes now.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/21358306622
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/21358309632
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/21358317123/ (kinda broken but I think that all relevant tests pass)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/21319855076
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
