### PR TITLE
Add duplicate prevention for copilot-autofix PRs

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -387,6 +387,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Authenticate first (required for all gh commands)
+          if [ -z "$COPILOT_OAUTH_TOKEN" ]; then
+            echo "::error::COPILOT_OAUTH_TOKEN secret not set. \
+              Run 'gh auth login' locally, then 'gh auth token' and add as secret."
+            exit 1
+          fi
+          echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
+
           # Check for issues
           if [ ! -f "/tmp/codechecker_issues.json" ]; then
             echo "No issues found"
@@ -404,12 +412,15 @@ jobs:
           echo "Found $ISSUE_COUNT issues"
           echo "has-issues=true" >> "$GITHUB_OUTPUT"
 
-          # Authenticate with OAuth token (required for agent-task)
-          if [ -z "$COPILOT_OAUTH_TOKEN" ]; then
-            echo "::error::COPILOT_OAUTH_TOKEN secret not set. Run 'gh auth login' locally, then 'gh auth token' and add as secret."
-            exit 1
+          # Check for existing open Copilot PRs to avoid duplicates
+          OPEN_COPILOT_PRS=$(gh pr list --repo "${{ github.repository }}" \
+            --state open --label "copilot-autofix" --json number --jq 'length' 2>/dev/null || echo "0")
+          if [ "$OPEN_COPILOT_PRS" -gt 0 ]; then
+            echo "⏭️ Skipping: $OPEN_COPILOT_PRS open Copilot PR(s) already exist"
+            echo "Review and merge existing PRs before creating new ones."
+            echo "has-issues=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          echo "$COPILOT_OAUTH_TOKEN" | gh auth login --with-token
 
           # Build prompt
           LIMIT="${{ inputs.copilot-max-fixes }}"
@@ -442,6 +453,10 @@ jobs:
           if [ -n "$PR_NUMBER" ]; then
             echo "pr-url=https://github.com/${{ github.repository }}/pull/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
             echo "pr-created=true" >> "$GITHUB_OUTPUT"
+            # Add label to track Copilot PRs and prevent duplicates
+            gh pr edit "$PR_NUMBER" -R "${{ github.repository }}" --add-label "copilot-autofix" || true
+            # Mark PR as ready for review (not draft) so CI runs automatically
+            gh pr ready "$PR_NUMBER" -R "${{ github.repository }}" || true
             gh pr comment "$PR_NUMBER" -R "${{ github.repository }}" --body "/codeowners ping" || true
           else
             echo "pr-created=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
This PR adds duplicate prevention logic to the copilot-autofix workflow, preventing multiple copilot-autofix PRs from being opened simultaneously.

## Changes
- Added check for existing open PRs with `copilot-autofix` label before creating new ones
- Automatically add `copilot-autofix` label to newly created PRs for tracking
- Mark PRs as ready for review automatically so CI runs
- Reordered authentication to happen first (before issue checks) to match UMD implementation

## Implementation Details
This feature was ported from the working implementation in `tt_metal/third_party/umd/.github/workflows/code-analysis.yaml`. The implementation:
1. Checks for existing open PRs with the `copilot-autofix` label using `gh pr list`
2. Skips creating a new PR if any exist, with a helpful message
3. Labels new PRs with `copilot-autofix` for tracking
4. Marks PRs as ready (not draft) so CI runs automatically

## Testing
- Verified the code matches the UMD implementation exactly
- No linting errors
- Follows the same pattern as the proven UMD workflow