### PR TITLE
Fix reduce_to_root test

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
@@ -24,7 +24,7 @@ struct OutputCBs {
     uint32_t m_cb;
 };
 
-template <uint32_t scale_fp32>
+template <uint32_t scale_fp32, uint32_t Sq_chunk_t, uint32_t vDHt>
 inline OutputCBs reduce_fct(
     uint32_t cb_out_o,
     uint32_t cb_out_accumulate_im_2,
@@ -43,8 +43,6 @@ inline OutputCBs reduce_fct(
     uint32_t cb_s2_temp,
     uint32_t cb_l1_temp,
     uint32_t cb_l2_temp,
-    uint32_t Sq_chunk_t,
-    uint32_t vDHt,
     uint32_t loop_size) {
     constexpr int mode = VectorMode::R;
     const uint32_t out_tiles = Sq_chunk_t * vDHt;
@@ -65,10 +63,10 @@ inline OutputCBs reduce_fct(
     max_block<mode>(cb_m_in, cb_prev_max, cb_m_temp, Sq_chunk_t);
 
     // P1 = exp((m1 - m_new) * scale) - store in cb_exp_max_diff_2
-    sub_exp_block<scale_fp32, mode>(cb_m_in, cb_m_temp, cb_exp_max_diff_2, Sq_chunk_t);
+    sub_exp_block<scale_fp32>(cb_m_in, cb_m_temp, cb_exp_max_diff_2, Sq_chunk_t);
 
     // P2 = exp((m2 - m_new) * scale) - store in cb_exp_max_diff
-    sub_exp_block<scale_fp32, mode>(cb_prev_max, cb_m_temp, cb_exp_max_diff, Sq_chunk_t);
+    sub_exp_block<scale_fp32>(cb_prev_max, cb_m_temp, cb_exp_max_diff, Sq_chunk_t);
 
     // s1 * P1 (element-wise)
     mul_block_inplace(cb_s1_temp, cb_exp_max_diff_2, Sq_chunk_t);
@@ -80,10 +78,10 @@ inline OutputCBs reduce_fct(
     add_block_inplace<true>(cb_s1_temp, cb_s2_temp, Sq_chunk_t);
 
     //  l1 * P1 -> cb_l1_temp (broadcast column 0 of P1)
-    mul_block_bcast_cols(cb_out_accumulate_im, cb_exp_max_diff_2, cb_l1_temp, Sq_chunk_t, vDHt);
+    mul_block_bcast_cols<Sq_chunk_t, vDHt, true, false>(cb_out_accumulate_im, cb_exp_max_diff_2, cb_l1_temp);
 
     //  l2 * P2 -> cb_l2_temp (broadcast column 0 of P2)
-    mul_block_bcast_cols(cb_out_accumulate_im_2, cb_exp_max_diff, cb_l2_temp, Sq_chunk_t, vDHt);
+    mul_block_bcast_cols<Sq_chunk_t, vDHt, true, false>(cb_out_accumulate_im_2, cb_exp_max_diff, cb_l2_temp);
 
     //  l_new = l1 * P1 + l2 * P2
     add_block_inplace<true>(cb_l1_temp, cb_l2_temp, out_tiles);
@@ -136,7 +134,7 @@ void MAIN {
 
     mm_init(cb_out_accumulate_im, cb_out_accumulate_im, cb_out_accumulate_im);
 
-    OutputCBs output_cbs = reduce_fct<scale_fp32>(
+    OutputCBs output_cbs = reduce_fct<scale_fp32, Sq_chunk_t, vDHt>(
         cb_out_o,
         cb_out_accumulate_im_2,
         cb_out_accumulate_im,
@@ -154,8 +152,6 @@ void MAIN {
         cb_s2_temp,
         cb_l1_temp,
         cb_l2_temp,
-        Sq_chunk_t,
-        vDHt,
         loop_size);
 
     if (loop_size == 1) {
@@ -181,7 +177,7 @@ void MAIN {
         cb_pop_front(cb_prev_sum_2, Sq_chunk_t);
 
         // do final reduction
-        OutputCBs output_cbs2 = reduce_fct<scale_fp32>(
+        OutputCBs output_cbs2 = reduce_fct<scale_fp32, Sq_chunk_t, vDHt>(
             cb_out_o,
             int_l_cb,
             cb_out_accumulate_im,
@@ -199,14 +195,12 @@ void MAIN {
             cb_s2_temp,
             cb_l1_temp,
             cb_l2_temp,
-            Sq_chunk_t,
-            vDHt,
             loop_size);
 
         // final division
         move_block<false>(output_cbs2.s_cb, cb_s_temp, Sq_chunk_t);
-        recip_block_inplace<vector_mode>(cb_s_temp, Sq_chunk_t);
-        mul_block_bcast_cols_inplace(output_cbs2.l_cb, cb_s_temp, Sq_chunk_t, vDHt);
+        recip_block_inplace(cb_s_temp, Sq_chunk_t);
+        mul_block_bcast_cols_inplace<Sq_chunk_t, vDHt>(output_cbs2.l_cb, cb_s_temp);
 
         move_block<true>(output_cbs2.l_cb, cb_out_o, out_chunk_tiles);
         move_block<true>(output_cbs2.m_cb, cb_cur_max, Sq_chunk_t);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/compute_kernel.cpp
@@ -16,7 +16,7 @@
 #include "compute_kernel_api/matmul.h"
 #include "compute_kernel_api/reduce.h"
 #include "ttnn/operations/transformer/sdpa_decode/device/kernels/rt_args_common.hpp"
-#include "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp"
+#include "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp"
 
 struct OutputCBs {
     uint32_t l_cb;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -410,11 +410,11 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
         cb_pop_front(in1_cb, rows);
     } else {
 #ifdef DHT_GRANULARITY
-        uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
-        uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
+        constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+        constexpr uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
 #else
-        uint32_t dst_tiles = 1;
-        uint32_t granularity = cols;
+        constexpr uint32_t dst_tiles = 1;
+        constexpr uint32_t granularity = cols;
 #endif
         PACK((llk_pack_reconfig_l1_acc(pack_accumulate)));
         if (!pack_accumulate) {
@@ -462,11 +462,11 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
     constexpr uint32_t num_tiles = rows * cols;
 
 #ifdef DHT_GRANULARITY
-    uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
-    uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
+    constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+    constexpr uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
 #else
-    uint32_t dst_tiles = 1;
-    uint32_t granularity = cols;
+    constexpr uint32_t dst_tiles = 1;
+    constexpr uint32_t granularity = cols;
 #endif
 
     mul_bcast_cols_init_short(in0_cb, in1_cb);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -409,9 +409,13 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
         }
         cb_pop_front(in1_cb, rows);
     } else {
-        constexpr uint32_t dst_tiles = DHT_GRANULARITY;
-        constexpr uint32_t granularity = cols >> LOG2_DHT_GRANULARITY;
-
+#ifdef DHT_GRANULARITY
+        uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+        uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
+#else
+        uint32_t dst_tiles = 1;
+        uint32_t granularity = cols;
+#endif
         PACK((llk_pack_reconfig_l1_acc(pack_accumulate)));
         if (!pack_accumulate) {
             cb_reserve_back(out_cb, num_tiles);
@@ -456,8 +460,15 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
     // Postcondition: in1_cb has rows consumed
 
     constexpr uint32_t num_tiles = rows * cols;
-    constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
-    constexpr uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
+
+#ifdef DHT_GRANULARITY
+    uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
+    uint32_t granularity = (cols >= DHT_GRANULARITY) ? (cols >> LOG2_DHT_GRANULARITY) : 1;
+#else
+    uint32_t dst_tiles = 1;
+    uint32_t granularity = cols;
+#endif
+
     mul_bcast_cols_init_short(in0_cb, in1_cb);
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, rows);


### PR DESCRIPTION
### Problem description
The `reduce_to_root` test which is part of the Blackhole nightly CI tests started failing because an `sdpa_decode` header file moved to a different location [triage report](https://github.com/tenstorrent/tt-metal/actions/runs/21315782197).

### What's changed
Updated the header file path in the include.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sosborne/reduce_to_root-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sosborne/reduce_to_root-test-fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sosborne/reduce_to_root-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sosborne/reduce_to_root-test-fix)
- [x] [![Blackhole Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml/badge.svg?branch=sosborne/reduce_to_root-test-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml?query=branch:sosborne/reduce_to_root-test-fix)