### PR TITLE
[Bug fix] Bit 11 handling

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
@@ -26,10 +26,6 @@ inline void llk_unpack_A_rmsnorm_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    // // TODO NC: Move to TRISC1 tt-metal#36411
-    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-    //     llk_unpack_dbg_feature_disable();
-    // }
 
     _llk_unpack_A_rmsnorm_init_<num_tiles, BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_rmsnorm_api.h
@@ -26,10 +26,10 @@ inline void llk_unpack_A_rmsnorm_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-        llk_unpack_dbg_feature_disable();
-    }
+    // // TODO NC: Move to TRISC1 tt-metal#36411
+    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+    //     llk_unpack_dbg_feature_disable();
+    // }
 
     _llk_unpack_A_rmsnorm_init_<num_tiles, BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,

--- a/models/demos/resblock/kernels/compute.cpp
+++ b/models/demos/resblock/kernels/compute.cpp
@@ -26,7 +26,8 @@ FORCE_INLINE void init_copy_tile_after_matmul() {
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)));
     // Switch math from matmul mode to datacopy mode
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false, false, UnpackToDestEn>(
+        icb)));
     // Reconfigure math HW for unary operation (same CB for both srcA and srcB)
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -61,7 +61,7 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
         unpack_to_dest>(num_faces, dst_format, is_32bit_input_flag);
 }
 
-template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
+template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
@@ -70,5 +70,5 @@ inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand =
 
     const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
 
-    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>(is_32bit_input_flag);
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, is_fp32_dest_acc_en>(is_32bit_input_flag);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -47,16 +47,28 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
+
+    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
+    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
+
+    const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
     _llk_math_eltwise_unary_datacopy_init_<
         type,
         is_fp32_dest_acc_en,
         src_b_bcast_type,
         tilize,
         is_int_fpu_en,
-        unpack_to_dest>(num_faces, dst_format);
+        unpack_to_dest>(num_faces, dst_format, is_32bit_input_flag);
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_uninit() {
-    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>();
+inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+
+    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
+    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
+
+    const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
+
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>(is_32bit_input_flag);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -41,13 +41,19 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
-    bool tilize = false>
+    bool tilize = false,
+    bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, tilize, is_int_fpu_en>(
-        num_faces, dst_format);
+    _llk_math_eltwise_unary_datacopy_init_<
+        type,
+        is_fp32_dest_acc_en,
+        src_b_bcast_type,
+        tilize,
+        is_int_fpu_en,
+        unpack_to_dest>(num_faces, dst_format);
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -337,12 +337,15 @@ TT_ALWAYS_INLINE void llk_pack_relu_config(const std::uint32_t config) { _llk_pa
 
 inline void llk_pack_reconfig_l1_acc(const std::uint32_t enable) { _llk_pack_reconfig_l1_acc_(enable); }
 
-template <bool untilize = false, ReduceDim dim>
+template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void llk_pack_reduce_mask_config() {
-    _llk_pack_reduce_mask_config_<untilize, dim>();
+    _llk_pack_reduce_mask_config_<untilize, dim, enforce_fp32_accumulation>();
 }
 
-inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
+template <bool enforce_fp32_accumulation = false>
+inline void llk_pack_reduce_mask_clear() {
+    _llk_pack_reduce_mask_clear_<enforce_fp32_accumulation>();
+}
 
 // FIXME-WH-UPLIFT
 template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -96,11 +96,11 @@ inline void llk_unpack_AB_reduce_init(
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    if constexpr (enforce_fp32_accumulation) {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        _llk_unpack_dbg_feature_disable_();
-    }
+    // // TODO NC: Move to TRISC1 tt-metal#36411
+    // if constexpr (enforce_fp32_accumulation) {
+    //     // Set necessary config regs for MOVB2D hi16/lo16 to work
+    //     _llk_unpack_dbg_feature_disable_();
+    // }
     _llk_unpack_AB_reduce_init_<dim, BType, enforce_fp32_accumulation>(
         face_r_dim, num_faces, narrow_tile, transpose, within_face_16x16_transpose);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -96,11 +96,7 @@ inline void llk_unpack_AB_reduce_init(
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
-    // // TODO NC: Move to TRISC1 tt-metal#36411
-    // if constexpr (enforce_fp32_accumulation) {
-    //     // Set necessary config regs for MOVB2D hi16/lo16 to work
-    //     _llk_unpack_dbg_feature_disable_();
-    // }
+
     _llk_unpack_AB_reduce_init_<dim, BType, enforce_fp32_accumulation>(
         face_r_dim, num_faces, narrow_tile, transpose, within_face_16x16_transpose);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -41,10 +41,6 @@ inline void llk_unpack_A_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    // // TODO NC: Move to TRISC1 tt-metal#36411
-    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-    //     llk_unpack_dbg_feature_disable();
-    // }
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -41,10 +41,10 @@ inline void llk_unpack_A_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-        llk_unpack_dbg_feature_disable();
-    }
+    // // TODO NC: Move to TRISC1 tt-metal#36411
+    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+    //     llk_unpack_dbg_feature_disable();
+    // }
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -143,7 +143,4 @@ inline void llk_unpack_reconfig_data_format(
         srcb_old_operand, srcb_new_operand);
 }
 
-// TODO NC: Remove as a part of tt-metal#36411
-inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
-
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -56,7 +56,7 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
         num_faces, dst_format, is_32bit_input_flag);
 }
 
-template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
+template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
@@ -65,7 +65,7 @@ inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand =
 
     const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
 
-    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>(is_32bit_input_flag);
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, is_fp32_dest_acc_en>(is_32bit_input_flag);
 }
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -41,18 +41,31 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
-    bool tilize = false /*unused*/>
+    bool tilize = false /*unused*/,
+    bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(
-        num_faces, dst_format);
+
+    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
+    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
+
+    const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
+    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, unpack_to_dest>(
+        num_faces, dst_format, is_32bit_input_flag);
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_uninit() {
-    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>();
+inline void llk_math_eltwise_unary_datacopy_uninit(const std::uint32_t operand = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+
+    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
+    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
+
+    const bool is_32bit_input_flag = is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format);
+
+    _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>(is_32bit_input_flag);
 }
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -388,12 +388,15 @@ TT_ALWAYS_INLINE void llk_pack_relu_config(const std::uint32_t config) { _llk_pa
 
 inline void llk_pack_reconfig_l1_acc(const std::uint32_t enable) { _llk_pack_reconfig_l1_acc_(enable); }
 
-template <bool untilize = false, ReduceDim dim>
+template <bool untilize = false, ReduceDim dim, bool enforce_fp32_accumulation = false>
 inline void llk_pack_reduce_mask_config() {
-    _llk_pack_reduce_mask_config_<untilize, dim>();
+    _llk_pack_reduce_mask_config_<untilize, dim, enforce_fp32_accumulation>();
 }
 
-inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }
+template <bool enforce_fp32_accumulation = false>
+inline void llk_pack_reduce_mask_clear() {
+    _llk_pack_reduce_mask_clear_<enforce_fp32_accumulation>();
+}
 
 // FIXME-WH-UPLIFT
 template <ReduceDim dim, bool is_fp32_dest_acc_en, bool at_kernel_start = false, bool revert = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -97,10 +97,10 @@ inline void llk_unpack_AB_reduce_init(
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
     // TODO NC: Move to TRISC1 tt-metal#36411
-    if constexpr (enforce_fp32_accumulation) {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        _llk_unpack_dbg_feature_disable_();
-    }
+    // if constexpr (enforce_fp32_accumulation) {
+    //     // Set necessary config regs for MOVB2D hi16/lo16 to work
+    //     _llk_unpack_dbg_feature_disable_();
+    // }
 
     _llk_unpack_AB_reduce_init_<dim, BType, enforce_fp32_accumulation>(
         face_r_dim, num_faces, narrow_tile, transpose, within_face_16x16_transpose);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -96,11 +96,6 @@ inline void llk_unpack_AB_reduce_init(
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    // if constexpr (enforce_fp32_accumulation) {
-    //     // Set necessary config regs for MOVB2D hi16/lo16 to work
-    //     _llk_unpack_dbg_feature_disable_();
-    // }
 
     _llk_unpack_AB_reduce_init_<dim, BType, enforce_fp32_accumulation>(
         face_r_dim, num_faces, narrow_tile, transpose, within_face_16x16_transpose);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -41,10 +41,11 @@ inline void llk_unpack_A_init(
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-    if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-        // TODO NC: Move to TRISC1 tt-metal#36411
-        llk_unpack_dbg_feature_disable();
-    }
+
+    // TODO NC: Move to TRISC1 tt-metal#36411
+    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
+    //     llk_unpack_dbg_feature_disable();
+    // }
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -42,11 +42,6 @@ inline void llk_unpack_A_init(
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
 
-    // TODO NC: Move to TRISC1 tt-metal#36411
-    // if (unpack_to_dest && is_32bit_input(operand_unpack_src_format, operand_unpack_dst_format)) {
-    //     llk_unpack_dbg_feature_disable();
-    // }
-
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -143,7 +143,4 @@ inline void llk_unpack_reconfig_data_format(
         srcb_old_operand, srcb_new_operand);
 }
 
-// TODO NC: Remove as a part of tt-metal#36411
-inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
-
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -75,8 +75,7 @@ ALWI void unary_bcast(uint32_t icb, uint32_t in_tile_index, uint32_t dst_tile_in
 
     if (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, true>(icb, in_tile_index)));
-        MATH(
-            (llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, bcast_type, true, false, true>(dst_tile_index, icb)));
+        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, bcast_type, true>(dst_tile_index, icb)));
     } else {
         UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(icb, in_tile_index)));
         MATH((llk_math_eltwise_unary_datacopy<B2D, DST_ACCUM_MODE, bcast_type, false>(dst_tile_index, icb)));

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -75,7 +75,8 @@ ALWI void unary_bcast(uint32_t icb, uint32_t in_tile_index, uint32_t dst_tile_in
 
     if (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, true>(icb, in_tile_index)));
-        MATH((llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, bcast_type, true>(dst_tile_index, icb)));
+        MATH(
+            (llk_math_eltwise_unary_datacopy<A2D, DST_ACCUM_MODE, bcast_type, true, false, true>(dst_tile_index, icb)));
     } else {
         UNPACK((llk_unpack_A<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(icb, in_tile_index)));
         MATH((llk_math_eltwise_unary_datacopy<B2D, DST_ACCUM_MODE, bcast_type, false>(dst_tile_index, icb)));
@@ -93,11 +94,7 @@ ALWI void unary_bcast_uninit(uint32_t icb) {
 
     UNPACK((llk_unpack_A_uninit<bcast_type>(icb)));
 
-    if (enable_unpack_to_dest) {
-        MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, true>()));
-    } else {
-        MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, false>()));
-    }
+    MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, DST_ACCUM_MODE>()));
 #endif
 }
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -43,7 +43,13 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
     if (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, true>(
             false, false /*transpose within 16x16 face*/, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, bcast_type>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              A2D,
+              DST_ACCUM_MODE,
+              bcast_type,
+              true /*enable 32bit dst*/,
+              false,
+              true>(icb)));
     } else {
         UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(
             false, false /*transpose within 16x16 face*/, icb)));
@@ -122,7 +128,13 @@ void reconfigure_unary_bcast(uint32_t old_icb, uint32_t new_icb, uint32_t old_oc
     }
 
     if (unpacker_dst_format_change || bcast_type_change) {
-        MATH((llk_math_eltwise_unary_datacopy_init<data_copy_type, DST_ACCUM_MODE, new_bcast_type>(new_icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              data_copy_type,
+              DST_ACCUM_MODE,
+              new_bcast_type,
+              false,
+              false,
+              enable_unpack_to_dest>(new_icb)));
     }
 #endif
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -47,8 +47,8 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
               A2D,
               DST_ACCUM_MODE,
               bcast_type,
-              true /*enable 32bit dst*/,
-              false,
+              false /*is_int_fpu_en*/,
+              false /*tilize*/,
               true>(icb)));
     } else {
         UNPACK((llk_unpack_A_init<bcast_type, false, EltwiseBinaryReuseDestType::NONE, false>(

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -26,7 +26,8 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
     PACK((llk_pack_init<false>(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false>()));
 
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false, false, UnpackToDestEn>(
+        icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
 }

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -111,7 +111,13 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __
     state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false, false, icb)));  // init must be after configure
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          UnpackToDestEn,
+          false,
+          UnpackToDestEn>(icb)));
     pack_untilize_dest_init<block_ct_dim, full_ct_dim>(ocb);
 }
 

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -111,13 +111,8 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __
     state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         false, false, icb)));  // init must be after configure
-    MATH((llk_math_eltwise_unary_datacopy_init<
-          A2D,
-          DST_ACCUM_MODE,
-          BroadcastType::NONE,
-          UnpackToDestEn,
-          false,
-          UnpackToDestEn>(icb)));
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false, false, UnpackToDestEn>(
+        icb)));
     pack_untilize_dest_init<block_ct_dim, full_ct_dim>(ocb);
 }
 

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -51,7 +51,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t 
     state_configure(icb, icb_scaler, ocb, call_line);
     UNPACK((llk_unpack_AB_reduce_init<reduce_dim, BroadcastType::NONE, enforce_fp32_accumulation>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, enforce_fp32_accumulation>()));
-    PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
+    PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim, enforce_fp32_accumulation>()));
 }
 
 // clang-format off
@@ -80,7 +80,7 @@ ALWI void reduce_uninit(uint32_t icb = 0) {
     // See _llk_math_reduce_init_ for more details
     MATH((llk_math_reduce_uninit<enforce_fp32_accumulation>(icb)));
 #endif
-    PACK((llk_pack_reduce_mask_clear()));
+    PACK((llk_pack_reduce_mask_clear<enforce_fp32_accumulation>()));
 }
 
 // clang-format off

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -36,7 +36,13 @@ ALWI void copy_tile_to_dst_init_short(
     state_configure(cbid, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, transpose_within_16x16_face, cbid)));
-    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          UnpackToDestEn,
+          false,
+          UnpackToDestEn>(cbid)));
 }
 /**
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -36,13 +36,8 @@ ALWI void copy_tile_to_dst_init_short(
     state_configure(cbid, call_line);
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
         transpose, transpose_within_16x16_face, cbid)));
-    MATH((llk_math_eltwise_unary_datacopy_init<
-          A2D,
-          DST_ACCUM_MODE,
-          BroadcastType::NONE,
-          UnpackToDestEn,
-          false,
-          UnpackToDestEn>(cbid)));
+    MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE, false, false, UnpackToDestEn>(
+        cbid)));
 }
 /**
  * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -39,7 +39,8 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
           DST_ACCUM_MODE,
           BroadcastType::NONE,
           false /*is_int_en*/,
-          true /*tilize en*/>(icb)));
+          true /*tilize en*/,
+          UnpackToDestEn>(icb)));
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<false /*untilize*/, false /*zero output*/, true /*tilize en*/>(ocb)));
 #endif

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -38,12 +38,24 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, true>(icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              false,
+              false,
+              UnpackToDestEn>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
         UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb)));
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              false,
+              false,
+              false /*unpack to dest*/>(icb)));
     }
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb, icb)));
@@ -67,11 +79,23 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
     if (is_int32) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(
             true, false, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              false,
+              false,
+              UnpackToDestEn>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              false,
+              false,
+              false /*unpack to dest*/>(icb)));
     }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -30,8 +30,8 @@ ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transp
           DST_ACCUM_MODE,
           BroadcastType::NONE,
           false,  // is_int_fpu_en
-          false   // tilize
-          >(cbid)));
+          false,  // tilize
+          UnpackToDestEn>(cbid)));
 }
 
 /**


### PR DESCRIPTION
### Ticket
Link to Github Issue
[DST bit 11 issue](https://github.com/tenstorrent/tt-metal/issues/36411)

### Problem description
Since we were setting up DST bit 11 on the `TRISC0 (Unpacker)` and had to reset (enable dbg feature) on TRISC1 (Math). The idea was to move handling of the bit only in Math and just by doing that avoid redundant reg writes. 

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

Status: Changes on tt-llk

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/runs/21334685517/job/61404951120)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/#36411-bit-11)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/#36411-bit-11)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/#36411-bit-11)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/#36411-bit-11)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/#36411-bit-11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/#36411-bit-11)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
