### PR TITLE
[skip ci] Remove Dead Code - Fabric1DLineDeviceInitFixture and Fabric1DRingDeviceInitFixture classes

### DIFF
--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -121,16 +121,6 @@ public:
     }
 };
 
-class Fabric1DLineDeviceInitFixture : public Fabric1DFixture {
-public:
-    Fabric1DLineDeviceInitFixture() : Fabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D) {}
-};
-
-class Fabric1DRingDeviceInitFixture : public Fabric1DFixture {
-public:
-    Fabric1DRingDeviceInitFixture() : Fabric1DFixture(tt::tt_fabric::FabricConfig::FABRIC_1D_RING) {}
-};
-
 template <typename ProgramContainer>
 static void build_and_enqueue(
     const std::vector<std::shared_ptr<MeshDevice>>& devices, ProgramContainer& programs, bool enqueue_only = false) {


### PR DESCRIPTION
### Ticket
N/A - Code cleanup

### Problem description
The classes `Fabric1DLineDeviceInitFixture` and `Fabric1DRingDeviceInitFixture` were introduced during the migration to Mesh APIs but were never actually used in any tests. These are dead code that add unnecessary maintenance burden.

### What's changed
- Removed `Fabric1DLineDeviceInitFixture` class from `test_fabric_edm_common.hpp`
- Removed `Fabric1DRingDeviceInitFixture` class from `test_fabric_edm_common.hpp`

These classes were convenience wrappers that pre-configured the fabric topology, but tests use `Fabric1DFixture` directly with the appropriate `FabricConfig` parameter instead (e.g., `MeshFabric1DFixture test_fixture(tt::tt_fabric::FabricConfig::FABRIC_1D)`).

**Verification:**
- Confirmed no usages exist in the codebase via grep/search
- No linting errors introduced
- Base class `Fabric1DFixture` remains intact and functional

### Checklist
- [x] Code compiles and passes linting
- [x] No existing functionality is affected (removed classes were unused)
- [ ] New/Existing tests provide coverage for changes (N/A - code removal only)