### PR TITLE
[skip ci] Update code analysis workflow: adopt UMD defaults

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -2,7 +2,8 @@ name: "Code analysis"
 
 on:
   schedule:
-    - cron: "0 2 * * 2,4,6" # Static analysis: 6 PM PST Mon/Wed/Fri (2 AM UTC Tue/Thu/Sat)
+    # Run daily at 6 PM PST (2 AM UTC next day)
+    - cron: "0 2 * * *"
   workflow_call:
     inputs:
       distro:
@@ -33,7 +34,7 @@ on:
         type: boolean
         default: false
       copilot-max-fixes:
-        description: "Maximum number of issues for Copilot to fix (default: 15)"
+        description: "Maximum number of issues for Copilot to fix (default: 1)"
         required: false
         type: string
         default: ""
@@ -67,7 +68,7 @@ on:
         type: boolean
         default: false
       copilot-max-fixes:
-        description: "Maximum number of issues for Copilot to fix (default: 15)"
+        description: "Maximum number of issues for Copilot to fix (default: 1)"
         required: false
         type: string
         default: ""
@@ -422,9 +423,9 @@ jobs:
             exit 0
           fi
 
-          # Build prompt
+          # Build prompt - default to 1 issue for focused, quality fixes
           LIMIT="${{ inputs.copilot-max-fixes }}"
-          LIMIT="${LIMIT:-15}"
+          LIMIT="${LIMIT:-1}"  # Default: 1 issue per run
 
           {
             echo "Fix these Clang Static Analyzer issues:"


### PR DESCRIPTION
### Problem description
The main code analysis workflow had different defaults than the UMD version:
- Schedule ran only 3x/week instead of daily
- Copilot auto-fix defaulted to fixing 15 issues per PR, which creates large, hard-to-review PRs

### What's changed
Adopted the UMD workflow defaults for better consistency and quality:
- **Schedule**: Changed from 3x/week (Mon/Wed/Fri) to daily runs at 6 PM PST
- **Copilot max fixes**: Changed default from 15 to 1 issue per PR for focused, quality fixes
- Updated comments to match UMD workflow style

This ensures:
- More frequent static analysis coverage
- Smaller, more reviewable PRs from Copilot auto-fixes
- Consistency between main and UMD workflows

### Checklist
- [x] Changes are limited to workflow configuration only
- [x] No code changes that would require tests