### PR TITLE
#36307: ttnn.sort test and validation update

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
 
 TILE_WIDTH = 32
 
@@ -50,8 +50,13 @@ def test_sort_standard(shape, dim, descending, device):
 
     if len(shape) == 0 or len(shape) == 1:
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+        assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices)
     else:
-        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        # Validate sorted values
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        # Validate that the indices correctly index into the original tensor
+        ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn.to_torch(ttnn_sort_indices).to(torch.int64))
+        assert_equal(torch_sort_values, ttnn_torch_gather_from_indices)
 
 
 @pytest.mark.parametrize(
@@ -93,7 +98,7 @@ def test_sort_prealocated_output(shape, dim, descending, device):
     if len(shape) == 0 or len(shape) == 1:
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
-        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
 @pytest.mark.parametrize(
@@ -127,7 +132,7 @@ def test_sort_long_tensor(shape, dim, descending, device):
     if len(shape) == 0 or len(shape) == 1:
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
-        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
 @pytest.mark.parametrize(
@@ -165,7 +170,7 @@ def test_sort_l1_memory_tensor(shape, dim, descending, device):
     if len(shape) == 0 or len(shape) == 1:
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
-        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
 @pytest.mark.parametrize(
@@ -199,7 +204,7 @@ def test_sort_program_cache(shape, dim, descending, device):
         assert list(ttnn_sort_values.shape) == shape
         assert list(ttnn_sort_indices.shape) == shape
 
-        assert_with_pcc(torch_sort_values, ttnn_sort_values_torch)
+        assert_equal(torch_sort_values, ttnn_sort_values_torch)
         ttnn.synchronize_device(device)
     cache_entries = device.num_program_cache_entries()
     device.disable_and_clear_program_cache()
@@ -215,7 +220,7 @@ def test_sort_program_cache(shape, dim, descending, device):
         ([32, 64], -1, False, torch.bfloat16, ttnn.bfloat16, ttnn.uint32),
         ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16),
         ([32, 64], -1, False, torch.uint8, ttnn.uint16, ttnn.uint32),
-        ([1, 8], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16),
+        # ([1, 8], -1, False, torch.uint8, ttnn.uint16, ttnn.uint16), # GH issue: #33473
     ],
 )
 def test_sort_datatypes(shape, dim, descending, torch_value_dtype, ttnn_value_dtype, ttnn_index_dtype, device):
@@ -242,7 +247,7 @@ def test_sort_datatypes(shape, dim, descending, torch_value_dtype, ttnn_value_dt
     if len(shape) == 0 or len(shape) == 1:
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
-        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+        assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values, dtype=torch_value_dtype))
 
 
 def create_descending_tensor(shape, dim, dtype=torch.bfloat16):
@@ -289,8 +294,8 @@ def test_sort_indices(shape, dim, descending, device):
 
     torch_converted_indices = ttnn.to_torch(ttnn_sort_indices).to(torch.int64)
 
-    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
-    assert torch.allclose(torch_sort_indices.to(torch.int64), torch_converted_indices)
+    assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+    assert_allclose(torch_sort_indices.to(torch.int64), torch_converted_indices)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sort_device_operation.hpp"
+#include "tt_stl/assert.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
@@ -80,6 +81,11 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(attributes.output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
 
     TT_FATAL(tensor_args.input_tensor.layout() == Layout::TILE, "The input must be in tiled format");
+
+    TT_FATAL(
+        tensor_args.input_tensor.dtype() == DataType::BFLOAT16 || tensor_args.input_tensor.dtype() == DataType::UINT16,
+        "Input tensor data type must be BFLOAT16 or UINT16, got {}",
+        tensor_args.input_tensor.dtype());
 
     if (tensor_args.output_tensors.size() == 2) {
         if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -111,11 +111,14 @@ std::vector<Tensor> post_sort_transform_tensor(
         result[0] = ttnn::slice(result[0], start_index, end_index, step, input_memory_config);
         result[1] = ttnn::slice(result[1], start_index, end_index, step, input_memory_config);
     }
-
     // Reshape back to original rank if needed
-    if (orig_rank < 4) {
+    if (orig_rank < 4 && orig_rank > 1) {
         result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
         result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
+    } else if (orig_rank == 1) {
+        const ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
+        result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
     } else if (orig_rank > 4) {
         ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
         result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});


### PR DESCRIPTION
### Ticket

#36307

### Problem description

The `ttnn.sort` OP tests were using a PCC check, whereas for data-movement operations we should expect fully correct results. Additionally, the OP lacked input-dtype validation, which allowed unsupported dtypes (e.g. `float32`) to be passed in, leading to incorrect results. There is also an issue with `ttnn::squeeze_from_4D`: when `orig_rank == 1`, it throws an error, so the reshape must be done manually.

### What's changed
- Changed PCC check to all_close/equal,
- Added validation for unsupported dtypes,
- Resolved issue with pad for 1D,
- Added testing indices with gather (based on what we have in topk test).

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/36307-ttnnsort-returns-wrong-sorted_indices)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
