### PR TITLE
[HANG DETECTION] Relaxing hang detection timeout for specific test

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -35,7 +35,7 @@ inputs:
     type: boolean
   hang-detection-timeout:
     description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
-    default: 5.0
+    default: 10.0
     type: float
 runs:
   using: "composite"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -35,7 +35,7 @@ inputs:
     type: boolean
   hang-detection-timeout:
     description: 'Timeout in seconds when dispatcher is not making progress before tt-triage is called automatically'
-    default: 10.0
+    default: 5.0
     type: float
 runs:
   using: "composite"

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -61,7 +61,7 @@ jobs:
             { name: "distributed", cmd: './build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter=*', nightly: true, auto-triage: true },  # Only runs on Nightly-L2
             { name: "eth, misc, and user kernel path", cmd: './build/test/tt_metal/unit_tests_eth && ./build/test/tt_metal/unit_tests_misc && rm -rf /tmp/kernels && mkdir -p /tmp/kernels && TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*', nightly: true, auto-triage: true },
             { name: "tools", cmd: './tests/scripts/run_tools_tests.sh && ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=* && ./build/test/tt_metal/unit_tests_inspector --gtest_filter=* && TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES=1 ./build/test/tt_metal/unit_tests_noc_debugging --gtest_filter=*', nightly: true, auto-triage: false },  # Only runs on Nightly-L2
-            { name: "ttnn tensor accessor", cmd: './build/test/ttnn/unit_tests_ttnn_accessor', nightly: true, auto-triage: true },
+            { name: "ttnn tensor accessor", cmd: './build/test/ttnn/unit_tests_ttnn_accessor', nightly: true, auto-triage: true, hang-detection-timeout: 10.0 },
             { name: "Nightly data movement", cmd: './build/test/tt_metal/unit_tests_data_movement --gtest_filter=$GTEST_FILTER', nightly: true, auto-triage: true },
             { name: "Nightly TTNN university lab examples", cmd: './build/test/ttnn/lab_examples/test_lab_eltwise_binary', nightly: true, auto-triage: true },
           ]]
@@ -134,6 +134,7 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           auto-triage: ${{ !inputs.enable-watcher && matrix.test-group.auto-triage }}
+          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout || 5.0 }}
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167
         if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -134,7 +134,8 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           auto-triage: ${{ !inputs.enable-watcher && matrix.test-group.auto-triage }}
-          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout }}
+          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout || 5.0 }}
+
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167
         if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -134,7 +134,7 @@ jobs:
           enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts }}
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
           auto-triage: ${{ !inputs.enable-watcher && matrix.test-group.auto-triage }}
-          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout || 5.0 }}
+          hang-detection-timeout: ${{ matrix.test-group.hang-detection-timeout }}
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167
         if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}


### PR DESCRIPTION
### Problem description
Following test `AccessorTests/AccessorBenchmarks.ManualPagesIterationInterleaved/3 `contains kernel which has duration ~8.4 seconds. Since hang detection timeout was made more strict with this [commit](https://github.com/tenstorrent/tt-metal/pull/36228) we have [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/21347951084/job/61476352839) failing with hang that detected kernel duration longer than 5s but the hang is not reproducible in local. Relaxing the timeout gives us green group of tensor accessor tests. 

### What's changed
Relaxing the hang detection timeout for specific group of tests (tensor accessor tests within cpp unit tests)

### Checklist

- [x] [![L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/tensor_accessor_hang_investigation)](https://github.com/tenstorrent/tt-metal/actions/runs/21397272787) Tensor Accessor tests pass, All C++ test that fail are fixed with different PR
