### PR TITLE
Add KV Cache Branch

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// KV Cache Branch unified kernel
+// Single kernel file, compiles correctly for all RISC cores
+// Each RISC has its own CTArgs struct with different compile-time arg layout
+//
+// Implements: Matmul + RMSNorm + Rope
+// TODO: Implements: <list operations here, e.g., Matmul + Mcast + Gather>
+// TODO: Define RISC responsibilities:
+// - NCRISC: <describe data movement operations>
+// - BRISC: <describe data movement operations>
+// - TRISC: <describe compute operations>
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/rmsnorm.hpp"
+#include "../../../unified_kernels/rope.hpp"
+
+// Compile-time role flags for dead code elimination via if constexpr
+// Defined at namespace scope (local classes cannot have static data members)
+struct Core {
+    static constexpr bool is_dkv_matmul_core = get_named_compile_time_arg_val("is_dkv_matmul_core") == 1;
+    static constexpr bool is_kv_rmsnorm_core = get_named_compile_time_arg_val("is_kv_rmsnorm_core") == 1;
+    static constexpr bool is_knope_core = get_named_compile_time_arg_val("is_knope_core") == 1;
+    static constexpr bool is_krope_core = get_named_compile_time_arg_val("is_krope_core") == 1;
+};
+
+void kernel_main() {
+// ============================================================================
+// NCRISC (Reader) - ReaderConfigDescriptor compiles as NCRISC
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+
+    // Matmul reader args (NCRISC is no-op)
+    deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
+
+    // Gather sender args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_src_cb"),
+        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("dkv_gather_row_major"),
+        get_write_ptr(get_named_compile_time_arg_val(
+            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    };
+
+    using KV_RMSNormCTArgs =
+        deepseek_b1_ops::RMSNorm::ReaderCTArgs<get_named_compile_time_arg_val("kv_rmsnorm_num_faces")>;
+    // kv cache rmsnorm reader args
+    deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{
+        get_named_compile_time_arg_val("kv_rmsnorm_scalars_cb"),
+        get_arg_val<uint32_t>(0),  // scalar (1/sqrt(512)) #TODO: fix id when used in pre sdpa
+    };
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<get_named_compile_time_arg_val("Wt")>;
+    constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
+    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
+    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
+
+    // Reader args: CB indices for sharded input signaling
+    deepseek_b1_ops::Rope::ReaderArgs k_rope_args{
+        .in_cb = k_rope_input_cb,
+        .cos_cb = cos_cb,
+        .sin_cb = sin_cb,
+        .trans_mat_cb = trans_mat_cb,
+    };
+
+// ============================================================================
+// BRISC (Writer) - WriterConfigDescriptor compiles as BRISC
+// Named compile-time args: TODO
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+
+    // Matmul writer args (BRISC is no-op)
+    deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
+
+    // Gather receiver args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    };
+
+    deepseek_b1_ops::RMSNorm::WriterArgs kv_rmsnorm_args{};
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::WriterCTArgs;
+
+    // Writer args (empty - no-op)
+    deepseek_b1_ops::Rope::WriterArgs k_rope_args{};
+
+// ============================================================================
+// TRISC (Compute) - ComputeConfigDescriptor compiles as TRISC
+// Named compile-time args: TODO
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    using DKV_MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("dkv_matmul_out_w_per_core")>;
+
+    // Matmul compute args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Matmul::ComputeArgs dkv_matmul_args{
+        get_named_compile_time_arg_val("dkv_matmul_in0"),
+        get_named_compile_time_arg_val("dkv_matmul_in1"),
+        get_named_compile_time_arg_val("dkv_matmul_out"),
+        get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
+    };
+
+    // Gather compute args (no-op for TRISC)
+    deepseek_b1_ops::Gather::ComputeArgs dkv_gather_args{};
+
+    // CTArgs type aliases (required for Op templates)
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+
+    // RMSNorm compute runtime args
+    deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
+        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_scalars_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_interm_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        get_arg_val<uint32_t>(0),  // epsilon
+    };
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::ComputeCTArgs<get_named_compile_time_arg_val("Wt")>;
+
+    // CB indices (passed as runtime args to ComputeArgs)
+    constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
+    constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
+    constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
+    constexpr uint32_t rotated_in_interm_cb = get_named_compile_time_arg_val("rotated_in_interm_cb");
+    constexpr uint32_t cos_interm_cb = get_named_compile_time_arg_val("cos_interm_cb");
+    constexpr uint32_t sin_interm_cb = get_named_compile_time_arg_val("sin_interm_cb");
+    constexpr uint32_t k_rope_output_cb = get_named_compile_time_arg_val("out_cb");
+
+    // Compute args: all CB indices
+    deepseek_b1_ops::Rope::ComputeArgs k_rope_args{
+        .in_cb = k_rope_input_cb,
+        .cos_cb = cos_cb,
+        .sin_cb = sin_cb,
+        .trans_mat_cb = trans_mat_cb,
+        .rotated_in_interm_cb = rotated_in_interm_cb,
+        .cos_interm_cb = cos_interm_cb,
+        .sin_interm_cb = sin_interm_cb,
+        .out_cb = k_rope_output_cb,
+    };
+#endif
+#if defined(COMPILE_FOR_NCRISC)
+    // Setup sharded persistent buffers
+    if constexpr (Core::is_dkv_matmul_core) {
+        // Matmul activations (in0)
+        constexpr uint32_t dkv_matmul_in0 = get_named_compile_time_arg_val("dkv_matmul_in0");
+        constexpr uint32_t dkv_matmul_k_num_tiles = get_named_compile_time_arg_val("dkv_matmul_k_num_tiles");
+        unified_kernels::setup_sharded_buffer(dkv_matmul_in0, dkv_matmul_k_num_tiles);
+
+        // Matmul weights (in1)
+        constexpr uint32_t dkv_matmul_in1 = get_named_compile_time_arg_val("dkv_matmul_in1");
+        constexpr uint32_t dkv_matmul_out_w_per_core = get_named_compile_time_arg_val("dkv_matmul_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(dkv_matmul_in1, dkv_matmul_k_num_tiles * dkv_matmul_out_w_per_core);
+    }
+    if constexpr (Core::is_kv_rmsnorm_core) {
+        // RMSNorm gamma (sharded weights)
+        constexpr uint32_t kv_rmsnorm_gamma_cb = get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb");
+        constexpr uint32_t kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles");
+        unified_kernels::setup_sharded_buffer(kv_rmsnorm_gamma_cb, kv_rmsnorm_num_tiles);
+    }
+    if constexpr (Core::is_krope_core) {
+        constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
+        constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+        constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
+        constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
+        unified_kernels::setup_sharded_buffer(cos_cb, Wt);
+        unified_kernels::setup_sharded_buffer(sin_cb, Wt);
+        unified_kernels::setup_sharded_buffer(trans_mat_cb, 1);
+    }
+#endif
+
+    // ========================================================================
+    // DKV Matmul
+    // ========================================================================
+    {
+        DeviceZoneScopedN("DKV_MATMUL");
+        // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
+        deepseek_b1_ops::Matmul::Op<DKV_MatmulCTArgs, Core::is_dkv_matmul_core, true, false> dkv_matmul;
+        dkv_matmul(dkv_matmul_args);
+    }
+    // ========================================================================
+    // Gather: dkv matmul cores (senders) -> input core (receiver)
+    // NCRISC sends from knope grid of dkv matmul cores, BRISC receives on rmsnorm grid, TRISC no-op
+    // ========================================================================
+    {
+        DeviceZoneScopedN("DKV_GATHER");
+        deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+        dkv_gather(dkv_gather_args);
+    }
+
+    // ========================================================================
+    // RMSNorm: Apply RMSNorm to the gathered data
+    {
+        DeviceZoneScopedN("KV_RMSNORM");
+        deepseek_b1_ops::RMSNorm::Op<KV_RMSNormCTArgs, Core::is_kv_rmsnorm_core, true> kv_rmsnorm;
+        kv_rmsnorm(kv_rmsnorm_args);
+    }
+
+    // ========================================================================
+    // Rope: Apply Rope to the gathered data
+    // ========================================================================
+    {
+        DeviceZoneScopedN("K_ROPE");
+        deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> k_rope;
+        k_rope(k_rope_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -1,0 +1,550 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+from models.demos.deepseek_v3_b1.utils import float_to_bfloat16_packed, float_to_uint32
+
+
+class KVCacheBranch:
+    """
+    KV Cache Branch fused operation implementation using ttnn.generic_op.
+
+    This class implements the KV cache branch operations as a fused execution:
+    """
+
+    @staticmethod
+    def golden(
+        input_tensor,
+        W_dkv_rope_tensor,
+        gamma_tensor,
+        cos_tensor,
+        sin_tensor,
+        position_ids_tensor,
+        epsilon=1e-6,
+    ):
+        """
+        PyTorch reference implementation for validation.
+
+        Args:
+            input_tensor: Input tensor (torch.Tensor)
+            W_dkv_rope_tensor: W_dkv_rope tensor (torch.Tensor)
+
+        Returns:
+            Output tensor with KV cache branch operations applied
+        """
+
+        def rmsnorm(x, gamma):
+            variance = x.pow(2).mean(-1, keepdim=True)
+            normalized = x * torch.rsqrt(variance + epsilon)
+            return normalized * gamma
+
+        nope = 512
+        rope = 64
+        compressed_kv = input_tensor @ W_dkv_rope_tensor
+        compressed_kv, k_rope = torch.split(compressed_kv, [nope, rope], dim=-1)
+        kv = rmsnorm(compressed_kv, gamma_tensor)
+        k_rope = RopeSingleCore.golden(k_rope, cos_tensor, sin_tensor, position_ids_tensor).squeeze((0, 1))
+
+        full_kv_cache_tensor = torch.cat([kv, k_rope], dim=-1)
+        return full_kv_cache_tensor
+
+    @staticmethod
+    def op(
+        input_tensor,
+        dkv_matmul_weights_tensor,
+        gamma_tensor,
+        cos_tensor,
+        sin_tensor,
+        trans_mat_tensor,
+        output_tensor,
+        epsilon=1e-6,
+        fp32_dest_acc_en=False,
+    ):
+        """
+        Execute KV cache branch fused operation using generic_op.
+
+        Args:
+            input_tensor: Input tensor (must be sharded)
+            dkv_matmul_weights_tensor: DKV Matmul weights tensor (must be width sharded)
+            gamma_tensor: Gamma tensor (must be sharded)
+            cos_tensor: Cos tensor (must be sharded)
+            sin_tensor: Sin tensor (must be sharded)
+            epsilon: Epsilon for RMSNorm
+            fp32_dest_acc_en: Whether to enable FP32 accumulation in compute kernel
+
+        Returns:
+            Output tensor with KV cache branch operations applied
+        """
+        # Get tensor properties
+        data_format = input_tensor.dtype
+
+        # Get core grid from input tensor's memory config
+        input_core_grid = input_tensor.memory_config().shard_spec.grid
+
+        device = input_tensor.device()
+
+        # DKV Matmul (9x2)
+        dkv_matmul_weights_memory_config = dkv_matmul_weights_tensor.memory_config()
+        dkv_matmul_weights_core_grid = dkv_matmul_weights_memory_config.shard_spec.grid
+
+        # Calculate per-core width in tiles for matmul (from shard spec)
+        # Get shard width directly from shard_spec and divide by tile width from tensor
+        dkv_matmul_weights_tile = dkv_matmul_weights_tensor.get_tile()
+        dkv_matmul_weights_shard_shape = dkv_matmul_weights_memory_config.shard_spec.shape
+        dkv_matmul_weights_shard_width = dkv_matmul_weights_shard_shape[1]  # Width dimension
+        dkv_matmul_out_w = (
+            dkv_matmul_weights_shard_width // dkv_matmul_weights_tile.tile_shape[1]
+        )  # Per-core width in tiles
+
+        # Semaphore IDs for gather synchronization
+        # Senders on NCRISC use NOC_0, receiver on BRISC uses NOC_1
+        # Only use noc0 semaphore since senders are on NOC_0 (default for NCRISC)
+        gather_noc0_receiver_semaphore_id = 2
+        gather_noc1_receiver_semaphore_id = 3
+
+        kv_numel = 512
+        kv_rmsnorm_num_tiles = kv_numel // (16 * 32)  # 512 / 512 = 1 tile (16x32)
+        kv_rmsnorm_num_faces = 2  # 16x32 tiles have 2 faces (16/16 * 32/16 = 1 * 2)
+        inv_sqrt_numel = 1.0 / math.sqrt(float(kv_numel))
+        kv_scalar_packed = float_to_bfloat16_packed(inv_sqrt_numel)
+        epsilon_packed = float_to_uint32(epsilon)
+
+        # CB indices
+        # CONSOLIDATE!!!!!!!!!
+        # Tile sizes: 1x32 = 64 bytes (BF16), 16x32 = 1024 bytes (BF16), 32x32 = 2048 bytes (BF16)
+
+        rmsnorm_scalars_cb = 8  # 16x32 tile, 1024 bytes (1 tile for reduction scalar)
+        cos_cb = 1  # 1x32 tile, 64 bytes (sharded, Wt tiles per core)
+        sin_cb = 2  # 1x32 tile, 64 bytes (sharded, Wt tiles per core)
+        trans_mat_cb = 3  # 1x32 tile, 64 bytes (sharded, 1 tile per core) - actually 32x32 for matmul
+        rotated_input_interm_cb = 4  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
+        cos_interm_cb = 5  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
+        sin_interm_cb = 6  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
+        dkv_matmul_input_cb = 16  # 1x32 tile, 64 bytes (224 tiles = 1x7168)
+        dkv_matmul_output_cb = 7  # 1x32 tile, 64 bytes (1 tile per core for rope input)
+        dkv_matmul_weights_cb = 10  # 32x32 tile, 2048 bytes (sharded weights)
+        kv_rmsnorm_input_cb = 11  # 16x32 tile, 1024 bytes (gathered data, 1 tile)
+        kv_rmsnorm_interm_cb = 12  # 16x32 tile, 1024 bytes (1 tile intermediate)
+        kv_rmsnorm_gamma_cb = 13  # 16x32 tile, 1024 bytes (sharded gamma, 1 tile)
+        kv_rmsnorm_output_cb = 14  # 16x32 tile, 1024 bytes (sharded output, 1 tile)
+        k_rope_output_cb = 15  # 1x32 tile, 64 bytes (Wt tiles output) - SAME AS KV in merged
+
+        # DKV Matmul
+        dkv_matmul_k_num_tiles = 7168 // 32
+        # Note: kv_rmsnorm_num_tiles already defined above (line 118) using 16x32 tiles
+        # kv_rmsnorm_num_faces = 2 for 16x32 tiles (1 * 2 = 2 faces)
+        TILE_1x32 = ttnn.Tile((1, 32))
+        dkv_matmul_input_page_size = TILE_1x32.get_tile_size(input_tensor.dtype)
+        dkv_matmul_ncrisc_named_compile_time_args = [
+            ("dkv_matmul_in0", dkv_matmul_input_cb),
+            ("dkv_matmul_in1", dkv_matmul_weights_cb),
+            ("dkv_matmul_k_num_tiles", dkv_matmul_k_num_tiles),
+            ("dkv_matmul_out_w_per_core", dkv_matmul_out_w),
+        ]
+        dkv_matmul_brisc_named_compile_time_args = [
+            ("dkv_matmul_out", dkv_matmul_output_cb),
+        ]
+        dkv_matmul_trisc_named_compile_time_args = [
+            ("dkv_matmul_in0", dkv_matmul_input_cb),
+            ("dkv_matmul_in1", dkv_matmul_weights_cb),
+            ("dkv_matmul_out", dkv_matmul_output_cb),
+            ("dkv_matmul_k_num_tiles", dkv_matmul_k_num_tiles),
+            ("dkv_matmul_out_w_per_core", dkv_matmul_out_w),
+        ]
+
+        # KV RMSNorm
+        # RMSNorm compute compile-time args (named args for TRISC)
+        rmsnorm_compute_named_compile_time_args = [
+            ("rmsnorm_fp32_acc", 1 if fp32_dest_acc_en else 0),
+            ("rmsnorm_rsqrt_fast_approx", 0),
+        ]
+
+        kv_rmsnorm_ncrisc_named_compile_time_args = [
+            ("kv_rmsnorm_input_cb", kv_rmsnorm_input_cb),
+            ("kv_rmsnorm_interm_cb", kv_rmsnorm_interm_cb),
+            ("kv_rmsnorm_gamma_cb", kv_rmsnorm_gamma_cb),
+            ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
+            ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
+            ("kv_rmsnorm_num_faces", kv_rmsnorm_num_faces),
+            ("kv_rmsnorm_scalars_cb", rmsnorm_scalars_cb),
+        ]
+        kv_rmsnorm_trisc_named_compile_time_args = [
+            ("kv_rmsnorm_input_cb", kv_rmsnorm_input_cb),
+            ("kv_rmsnorm_scalars_cb", rmsnorm_scalars_cb),
+            ("kv_rmsnorm_interm_cb", kv_rmsnorm_interm_cb),
+            ("kv_rmsnorm_gamma_cb", kv_rmsnorm_gamma_cb),
+            ("kv_rmsnorm_output_cb", kv_rmsnorm_output_cb),
+            ("kv_rmsnorm_num_tiles", kv_rmsnorm_num_tiles),
+        ]
+
+        # ========================================================================
+        # Gather setup: k nope matmul cores (senders) -> kv rmsnorm core (receiver)
+        # Sender runs on NCRISC (NOC_0 default), Receiver runs on BRISC (NOC_1 default)
+        # ========================================================================
+        dkv_gather_receiver_core = gamma_tensor.memory_config().shard_spec.grid.ranges()[0].start
+        dkv_gather_sender_grid = dkv_matmul_weights_core_grid.subtract(cos_tensor.memory_config().shard_spec.grid)
+
+        # Get NOC coordinates for gather destination (receiver core)
+        dkv_gather_dest_noc_core = device.worker_core_from_logical_core(dkv_gather_receiver_core)
+
+        # Get number of sender cores (matmul grid)
+        dkv_gather_sender_cores_list = ttnn.corerange_to_cores(dkv_gather_sender_grid, row_wise=True)
+        dkv_gather_num_senders = len(dkv_gather_sender_cores_list)
+
+        # All senders use NOC_0 (default for NCRISC), so noc0_num_senders = all, noc1_num_senders = 0
+        dkv_gather_noc0_num_senders = dkv_gather_num_senders
+        dkv_gather_noc1_num_senders = 0
+
+        # Get sender grid dimensions for computing per-core offset in kernel
+        # Use logical coordinates since kernel uses UnifiedCoreDescriptor with my_logical_x_/y_
+        dkv_gather_sender_grid_ranges = list(dkv_gather_sender_grid.ranges())
+        dkv_gather_sender_grid_range = dkv_gather_sender_grid_ranges[0]
+        dkv_gather_sender_grid_start_x = dkv_gather_sender_grid_range.start.x
+        dkv_gather_sender_grid_start_y = dkv_gather_sender_grid_range.start.y
+        dkv_gather_sender_grid_end_x = dkv_gather_sender_grid_range.end.x
+        dkv_gather_sender_grid_end_y = dkv_gather_sender_grid_range.end.y
+
+        # Gather sender compile-time args (named args for NCRISC on matmul cores)
+        # SenderCTArgs: dest_noc_x, dest_noc_y, data_size_bytes, receiver_semaphore_id
+        # Plus grid info for computing per-core offset
+        dkv_gather_src_num_pages = dkv_matmul_out_w  # dkv matmul output tiles per core (must match matmul cb_push_back)
+        dkv_gather_data_size_bytes = dkv_gather_src_num_pages * dkv_matmul_input_page_size
+        dkv_gather_sender_named_compile_time_args = [
+            ("dkv_gather_dest_noc_x", dkv_gather_dest_noc_core.x),
+            ("dkv_gather_dest_noc_y", dkv_gather_dest_noc_core.y),
+            ("dkv_gather_data_size_bytes", dkv_gather_data_size_bytes),
+            ("dkv_gather_receiver_semaphore_id", gather_noc0_receiver_semaphore_id),
+            ("dkv_gather_src_cb", dkv_matmul_output_cb),  # Source CB for gather (dkv matmul output)
+            ("dkv_gather_src_num_pages", dkv_gather_src_num_pages),
+            ("dkv_gather_sender_grid_start_x", dkv_gather_sender_grid_start_x),
+            ("dkv_gather_sender_grid_start_y", dkv_gather_sender_grid_start_y),
+            ("dkv_gather_sender_grid_end_x", dkv_gather_sender_grid_end_x),
+            ("dkv_gather_sender_grid_end_y", dkv_gather_sender_grid_end_y),
+            ("dkv_gather_row_major", 1),  # 1 = row-major linearization
+            ("dkv_gather_dst_cb", kv_rmsnorm_input_cb),  # Destination CB: write directly to kv_rmsnorm_input_cb
+        ]
+
+        # Gather receiver compile-time args (named args for BRISC on kv rmsnorm core)
+        # ReceiverCTArgs: noc0_num_senders, noc1_num_senders, noc0_receiver_semaphore_id, noc1_receiver_semaphore_id
+        # Plus destination CB info for reserve/push
+        # Writes directly to kv_rmsnorm_input_cb
+        dkv_gather_receiver_named_compile_time_args = [
+            ("dkv_gather_noc0_num_senders", dkv_gather_noc0_num_senders),
+            ("dkv_gather_noc1_num_senders", dkv_gather_noc1_num_senders),
+            ("dkv_gather_noc0_receiver_semaphore_id", gather_noc0_receiver_semaphore_id),
+            ("dkv_gather_noc1_receiver_semaphore_id", gather_noc1_receiver_semaphore_id),
+            ("dkv_gather_dst_cb", kv_rmsnorm_input_cb),
+            ("dkv_gather_dst_num_pages", dkv_gather_src_num_pages),
+        ]
+
+        # ROPE
+        krope_ncrisc_named_compile_time_args = [
+            ("in_cb", dkv_matmul_output_cb),
+            ("cos_cb", cos_cb),
+            ("sin_cb", sin_cb),
+            ("trans_mat_cb", trans_mat_cb),
+            ("Wt", 1),
+        ]
+        krope_trisc_named_compile_time_args = [
+            ("in_cb", dkv_matmul_output_cb),
+            ("cos_cb", cos_cb),
+            ("sin_cb", sin_cb),
+            ("trans_mat_cb", trans_mat_cb),
+            ("rotated_in_interm_cb", rotated_input_interm_cb),
+            ("cos_interm_cb", cos_interm_cb),
+            ("sin_interm_cb", sin_interm_cb),
+            ("out_cb", k_rope_output_cb),
+            ("Wt", 1),
+        ]
+
+        # Create tile descriptor for proper tile dimensions
+
+        # CB X: DKV Matmul input buffer (1x7168 with 1x32 tiles = 224 tiles)
+        # matmul_input_total_size = 14336  # 224 * 64 bytes
+        # matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+        # dkv_matmul_input_total_size = matmul_input_total_size
+        # dkv_matmul_input_page_size = 64
+        # dkv_matmul_input_cb_format = ttnn.CBFormatDescriptor(
+        #    buffer_index=dkv_matmul_input_cb,
+        #    data_format=data_format,
+        #    page_size=dkv_matmul_input_page_size,
+        #    tile=matmul_input_tile_descriptor,
+        # )
+        # dkv_matmul_input_cb_core_ranges = input_core_grid
+        # dkv_matmul_input_cb_descriptor = ttnn.CBDescriptor(
+        #    total_size=dkv_matmul_input_total_size,
+        #    format_descriptors=[dkv_matmul_input_cb_format],
+        # )
+        dkv_matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(dkv_matmul_input_cb, input_tensor)
+        # CB X: DKV Matmul output buffer (1x224 with 1x32 tiles = 7 tiles)
+        dkv_matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+        dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
+        dkv_matmul_output_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=dkv_matmul_output_cb,
+            data_format=data_format,
+            page_size=dkv_matmul_output_page_size,
+            tile=dkv_matmul_output_tile_descriptor,
+        )
+        dkv_matmul_output_cb_descriptor = ttnn.CBDescriptor(
+            total_size=dkv_matmul_output_page_size,
+            core_ranges=dkv_matmul_weights_core_grid,
+            format_descriptors=[dkv_matmul_output_cb_format],
+        )
+
+        # CB X: DKV Matmul weights buffer
+        dkv_matmul_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            dkv_matmul_weights_cb, dkv_matmul_weights_tensor
+        )
+
+        # CB X: KV RMSNorm input buffer (on rmsnorm core, receives gathered data)
+        TILE_16x32 = ttnn.Tile((16, 32))
+        kv_rmsnorm_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
+        kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor.dtype)
+        kv_rmsnorm_input_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=kv_rmsnorm_input_cb,
+            data_format=data_format,
+            page_size=kv_rmsnorm_page_size,
+            tile=kv_rmsnorm_tile_descriptor,
+        )
+        kv_rmsnorm_input_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * kv_rmsnorm_page_size,
+            core_ranges=dkv_gather_sender_grid,
+            format_descriptors=[kv_rmsnorm_input_cb_format],
+        )
+
+        # CB X: KV RMSNorm gamma buffer
+        kv_rmsnorm_gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(kv_rmsnorm_gamma_cb, gamma_tensor)
+        kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
+        kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
+
+        # CB X: KV RMSNorm intermediate buffer (16x32 tiles)
+        kv_rmsnorm_interm_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=kv_rmsnorm_interm_cb,
+            data_format=data_format,
+            page_size=kv_rmsnorm_page_size,
+            tile=kv_rmsnorm_tile_descriptor,
+        )
+        kv_rmsnorm_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
+            core_ranges=gamma_tensor.memory_config().shard_spec.grid,
+            format_descriptors=[kv_rmsnorm_interm_cb_format],
+        )
+
+        # CB X: KV RMSNorm output buffer
+        # kv_rmsnorm_output_cb_format = ttnn.CBFormatDescriptor(
+        #    buffer_index=kv_rmsnorm_output_cb,
+        #    data_format=data_format,
+        #    page_size=kv_rmsnorm_page_size,
+        #    tile=kv_rmsnorm_tile_descriptor,
+        # )
+        # kv_rmsnorm_output_cb_descriptor = ttnn.CBDescriptor(
+        #    total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
+        #    core_ranges=gamma_tensor.memory_config().shard_spec.grid,
+        #    format_descriptors=[kv_rmsnorm_output_cb_format],
+        # )
+        # for testing
+        kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(kv_rmsnorm_output_cb, output_tensor)
+        kv_rmsnorm_output_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
+        kv_rmsnorm_output_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
+
+        # CB X: RMSNorm scalars buffer (1 tile for reduction scalar)
+        rmsnorm_scalars_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=rmsnorm_scalars_cb,
+            data_format=data_format,
+            page_size=kv_rmsnorm_page_size,
+            tile=kv_rmsnorm_tile_descriptor,
+        )
+        rmsnorm_scalars_cb_descriptor = ttnn.CBDescriptor(
+            total_size=kv_rmsnorm_page_size,
+            core_ranges=gamma_tensor.memory_config().shard_spec.grid,
+            format_descriptors=[rmsnorm_scalars_cb_format],
+        )
+
+        krope_tile_size = TILE_1x32.get_tile_size(data_format)
+        krope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+        krope_core_grid = cos_tensor.memory_config().shard_spec.grid
+        # CB X: Cos (sharded tensor)
+        cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(cos_cb, cos_tensor)
+        # CB X: Sin (sharded tensor)
+        sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(sin_cb, sin_tensor)
+        # CB X: Trans_mat (sharded tensor)
+        trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(trans_mat_cb, trans_mat_tensor)
+
+        # CB X: Rotated input intermediate (not backed by tensor)
+        rotated_interm_format = ttnn.CBFormatDescriptor(
+            buffer_index=rotated_input_interm_cb,
+            data_format=data_format,
+            page_size=krope_tile_size,
+            tile=krope_tile_descriptor,
+        )
+        rotated_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * krope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[rotated_interm_format],
+        )
+
+        # CB X: Cos intermediate (not backed by tensor)
+        cos_interm_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_interm_cb,
+            data_format=data_format,
+            page_size=krope_tile_size,
+            tile=krope_tile_descriptor,
+        )
+        cos_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * krope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[cos_interm_format],
+        )
+
+        # CB X: Sin intermediate (not backed by tensor)
+        sin_interm_format = ttnn.CBFormatDescriptor(
+            buffer_index=sin_interm_cb,
+            data_format=data_format,
+            page_size=krope_tile_size,
+            tile=krope_tile_descriptor,
+        )
+        sin_interm_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * krope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[sin_interm_format],
+        )
+
+        k_rope_output_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=k_rope_output_cb,
+            data_format=data_format,
+            page_size=krope_tile_size,
+            tile=krope_tile_descriptor,
+        )
+        k_rope_output_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * krope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[k_rope_output_cb_format],
+        )
+        # ========================================================================
+        # Semaphore descriptors
+        # ========================================================================
+
+        # Gather semaphores (ID 2 and 3 - two semaphores for NOC0 and NOC1, but only NOC0 is used)
+        gather_noc0_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather_noc0_receiver_semaphore_id,
+            core_ranges=input_core_grid,
+            initial_value=0,
+        )
+
+        gather_noc1_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather_noc1_receiver_semaphore_id,
+            core_ranges=input_core_grid,
+            initial_value=0,
+        )
+
+        # ========================================================================
+        # Kernel descriptors
+        # ========================================================================
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp",
+            core_ranges=input_core_grid,
+            # NCRISC named compile-time args:
+            ncrisc_named_compile_time_args=dkv_matmul_ncrisc_named_compile_time_args
+            + kv_rmsnorm_ncrisc_named_compile_time_args
+            + dkv_gather_sender_named_compile_time_args
+            + krope_ncrisc_named_compile_time_args,
+            # NCRISC common runtime args:
+            ncrisc_common_runtime_args=[
+                kv_scalar_packed,
+            ],
+            # BRISC named compile-time args
+            brisc_named_compile_time_args=dkv_gather_receiver_named_compile_time_args
+            + dkv_matmul_brisc_named_compile_time_args,
+            # TRISC named compile-time args
+            trisc_named_compile_time_args=kv_rmsnorm_trisc_named_compile_time_args
+            + dkv_matmul_trisc_named_compile_time_args
+            + rmsnorm_compute_named_compile_time_args
+            + krope_trisc_named_compile_time_args,
+            # TRISC common runtime args: epsilon (used by rmsnorm compute)
+            trisc_common_runtime_args=[
+                epsilon_packed,
+            ],
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=False,
+                fp32_dest_acc_en=fp32_dest_acc_en,
+                dst_full_sync_en=fp32_dest_acc_en,
+            ),
+            # Per-core compile-time role differentiation
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_dkv_matmul_core",
+                    core_range=dkv_matmul_weights_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_kv_rmsnorm_core",
+                    core_range=gamma_tensor.memory_config().shard_spec.grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_knope_core",
+                    core_range=dkv_gather_sender_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_krope_core",
+                    core_range=krope_core_grid,  # TODO: could be wrong if shared cos tensor with q rope
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+        )
+
+        # Create program descriptor
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors(),
+            cbs=[
+                dkv_matmul_input_cb_descriptor,
+                dkv_matmul_output_cb_descriptor,
+                dkv_matmul_weights_cb_descriptor,
+                rmsnorm_scalars_cb_descriptor,
+                kv_rmsnorm_input_cb_descriptor,
+                kv_rmsnorm_interm_cb_descriptor,
+                kv_rmsnorm_gamma_cb_descriptor,
+                kv_rmsnorm_output_cb_descriptor,
+                cos_cb_descriptor,
+                sin_cb_descriptor,
+                trans_mat_cb_descriptor,
+                rotated_interm_cb_descriptor,
+                cos_interm_cb_descriptor,
+                sin_interm_cb_descriptor,
+                k_rope_output_cb_descriptor,
+            ],
+            semaphores=[
+                gather_noc0_receiver_semaphore_descriptor,  # ID 2
+                gather_noc1_receiver_semaphore_descriptor,  # ID 3
+            ],
+        )
+
+        # Execute generic op
+        io_tensors = [
+            input_tensor,
+            dkv_matmul_weights_tensor,
+            gamma_tensor,
+            cos_tensor,
+            sin_tensor,
+            trans_mat_tensor,
+            output_tensor,
+        ]
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+        return output

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -12,6 +12,7 @@
 // TRISC: Performs RoPE compute
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
 #include "../../../unified_kernels/rope.hpp"
 
 // Compile-time role flags for dead code elimination via if constexpr
@@ -31,6 +32,11 @@ void kernel_main() {
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
     constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
+    constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
+    unified_kernels::setup_sharded_buffer(in_cb, Wt);
+    unified_kernels::setup_sharded_buffer(cos_cb, Wt);
+    unified_kernels::setup_sharded_buffer(sin_cb, Wt);
+    unified_kernels::setup_sharded_buffer(trans_mat_cb, 1);
 
     // Reader args: CB indices for sharded input signaling
     deepseek_b1_ops::Rope::ReaderArgs rope_args{

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -106,12 +106,12 @@ class RopeSingleCore:
         shard_spec = input_tensor.memory_config().shard_spec
         shard_shape = shard_spec.shape
 
-        # Calculate dimensions in tiles
-        # With tiny tiles: shard_shape[0] = n_heads, shard_shape[1] = head_dim
-        head_dim_t = shard_shape[1] // ttnn.TILE_SIZE  # head_dim in tiles (Wt)
-
         # Get core grid from shard spec
         core_grid = shard_spec.grid
+
+        # Calculate dimensions in tiles
+        # With tiny tiles: shard_shape[0] = n_heads, shard_shape[1] = head_dim
+        head_dim_per_core_t = shard_shape[1] // ttnn.TILE_SIZE  # head_dim in tiles (Wt)
 
         # Calculate tile sizes
         # For tiny tiles, the tile height matches the shard height (num_q_heads_per_core)
@@ -121,7 +121,7 @@ class RopeSingleCore:
         tile_size = tile.get_tile_size(data_format)
 
         # Number of tiles for intermediate buffers
-        num_interm_tiles = head_dim_t  # Intermediate buffers sized for one head row
+        num_interm_tiles = head_dim_per_core_t  # Intermediate buffers sized for one head row
 
         # CB indices (matching C++ implementation)
         input_cb = 0  # c_0
@@ -204,7 +204,7 @@ class RopeSingleCore:
             ("cos_cb", cos_cb),
             ("sin_cb", sin_cb),
             ("trans_mat_cb", trans_mat_cb),
-            ("Wt", head_dim_t),
+            ("Wt", head_dim_per_core_t),
         ]
 
         # Named compile-time args for BRISC (empty - no-op)
@@ -220,7 +220,7 @@ class RopeSingleCore:
             ("cos_interm_cb", cos_interm_cb),
             ("sin_interm_cb", sin_interm_cb),
             ("out_cb", output_cb),
-            ("Wt", head_dim_t),
+            ("Wt", head_dim_per_core_t),
         ]
 
         # Unified kernel descriptor

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN KV Cache Branch Test
+Tests KV cache branch fused operation
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
+from models.demos.deepseek_v3_b1.fused_ops.kv_cache_branch.op import KVCacheBranch
+
+
+@pytest.mark.parametrize("epsilon", [1e-6])
+@pytest.mark.parametrize("use_fp32", [True])
+def test_kv_cache_branch(device, epsilon, use_fp32):
+    """Test TTNN KV cache branch fused operation"""
+
+    position_id = 0
+    max_seq_len = 8192
+    batch = 1
+
+    # Input tensor shapes
+    input_shape = (1, 7168)
+    W_dkv_rope_shape = (7168, 576)
+
+    # Rope config
+    rope_head_dim = 64
+    rope_num_heads = 1
+
+    # Create input PyTorch tensors
+    torch.manual_seed(0)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_W_dkv_rope = torch.randn(W_dkv_rope_shape, dtype=torch.bfloat16)
+    torch_gamma = torch.randn((1, 512), dtype=torch.bfloat16)
+
+    # ROPE
+    base = 10000.0
+    inv_freq = 1.0 / (base ** (torch.arange(0, rope_head_dim, 2, dtype=torch.float32) / rope_head_dim))
+    t = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+
+    # Meta-style: stack [cos(t), cos(t)] interleaved
+    torch_cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)  # [max_seq_len, head_dim]
+    torch_sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)  # [max_seq_len, head_dim]
+    position_ids = torch.tensor([position_id])  # positions 0, 1, 2, ...
+    position_ids_expanded = position_ids.unsqueeze(1)  # [batch, 1]
+
+    logger.info(f"Done creating torch tensors.")
+
+    # TT setup
+    # Grid configuration
+    spec_start_offset = (0, 8)  # Offset for the operation grid
+    spec_grid = (9, 2)  # Grid dimensions for the operation
+
+    spec_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(spec_start_offset[0], spec_start_offset[1]),
+                ttnn.CoreCoord(spec_grid[0] + spec_start_offset[0] - 1, spec_grid[1] + spec_start_offset[1] - 1),
+            )
+        }
+    )
+    rms_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(spec_start_offset[0], spec_start_offset[1]),
+                ttnn.CoreCoord(spec_start_offset[0], spec_start_offset[1]),
+            )
+        }
+    )
+    rope_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(8 + spec_start_offset[0], spec_start_offset[1]),
+                ttnn.CoreCoord(8 + spec_start_offset[0], 1 + spec_start_offset[1]),
+            )
+        }
+    )
+
+    # Validate grid fits within device
+    device_grid_size = device.compute_with_storage_grid_size()
+    assert (
+        spec_grid[0] + spec_start_offset[0] <= device_grid_size.x
+    ), f"spec_grid.x ({spec_grid[0]}) + spec_start_offset.x ({spec_start_offset[0]}) must be <= device_grid_size.x ({device_grid_size.x})"
+    assert (
+        spec_grid[1] + spec_start_offset[1] <= device_grid_size.y
+    ), f"spec_grid.y ({spec_grid[1]}) + spec_start_offset.y ({spec_start_offset[1]}) must be <= device_grid_size.y ({device_grid_size.y})"
+
+    tile = ttnn.Tile([1, 32])
+
+    num_cores = spec_crs.num_cores()
+    torch_input_replicated = torch_input.expand(num_cores, -1).contiguous()
+
+    input_shard_spec = ttnn.ShardSpec(
+        spec_crs,
+        (1, 7168),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    # Create input tensor sharded on spec grid
+    ttnn_input = ttnn.from_torch(
+        torch_input_replicated,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=tile,
+    )
+
+    # DKV Matmul
+    shard_width = W_dkv_rope_shape[1] // num_cores
+    assert (
+        W_dkv_rope_shape[1] % num_cores == 0
+    ), f"W_dkv_rope_shape[1] ({W_dkv_rope_shape[1]}) must be divisible by grid size ({num_cores})"
+    assert shard_width == 32, f"Expected shard width of 32, got {shard_width}"
+
+    W_dkv_rope_shard_shape = (W_dkv_rope_shape[0], shard_width)
+    W_dkv_rope_shard_spec = ttnn.ShardSpec(
+        spec_crs,
+        W_dkv_rope_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    W_dkv_rope_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, W_dkv_rope_shard_spec
+    )
+
+    # Shuffle torch_W_dkv_rope to match the krope/nope core setup
+    # Row 0: N N N N N N N N R  (cores 0-7 are N, core 8 is R)
+    # Row 1: N N N N N N N N R  (cores 9-16 are N, core 17 is R)
+    # We want the last 64 columns (512-575) to be on R cores (8 and 17)
+    # Original shard order: [0, 1, ..., 7, 8, 9, ..., 15, 16, 17]
+    # New shard order:      [0, 1, ..., 7, 16, 8, 9, ..., 15, 17]
+    # This puts shard 16 (cols 512-543) at position 8 (R core in row 0)
+    num_shards = 18
+    shard_width = 32
+    new_shard_order = [0, 1, 2, 3, 4, 5, 6, 7, 16, 8, 9, 10, 11, 12, 13, 14, 15, 17]
+    torch_W_dkv_rope_shards = torch_W_dkv_rope.reshape(7168, num_shards, shard_width)
+    torch_W_dkv_rope_shuffled = torch_W_dkv_rope_shards[:, new_shard_order, :].reshape(7168, 576)
+
+    ttnn_W_dkv_rope = ttnn.from_torch(
+        torch_W_dkv_rope_shuffled,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=W_dkv_rope_mem_config,
+    )
+
+    # GAMMA
+    gamma_shard_spec = ttnn.ShardSpec(
+        rms_crs,
+        (1, 512),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    gamma_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gamma_shard_spec)
+
+    ttnn_gamma = ttnn.from_torch(
+        torch_gamma,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=gamma_mem_config,
+        tile=tile,
+    )
+
+    # ROPE
+    # Cos/sin indexed by position: [1, batch, 1, head_dim]
+    # Shape stays [1, 1, 1, head_dim] - broadcast multiply will use row 0
+    rope_tile = ttnn.Tile((rope_num_heads, ttnn.TILE_SIZE))
+    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
+    cos_selected = torch_cos[position_ids].unsqueeze(0).unsqueeze(2)
+    sin_selected = torch_sin[position_ids].unsqueeze(0).unsqueeze(2)
+
+    # Use same tiny tile as input - data in row 0, rows 1+ are padding
+    cos_sin_shard_spec = ttnn.ShardSpec(
+        rope_crs,
+        (rope_num_heads, rope_head_dim // 2),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    cos_sin_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
+    )
+
+    tt_cos = ttnn.from_torch(
+        cos_selected,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=cos_sin_mem_config,
+        tile=rope_tile,
+    )
+    tt_sin = ttnn.from_torch(
+        sin_selected,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=cos_sin_mem_config,
+        tile=rope_tile,
+    )
+
+    # Transformation matrix - replicate 32x32 for each rope core
+    trans_mat = get_rot_transformation_mat()  # (1, 1, 32, 32)
+    num_rope_cores = rope_crs.num_cores()
+    trans_mat_replicated = trans_mat.repeat(1, 1, batch, num_rope_cores)  # (1, 1, batch*32, 32*num_rope_cores)
+    trans_shard_spec = ttnn.ShardSpec(
+        rope_crs,
+        (ttnn.TILE_SIZE, ttnn.TILE_SIZE),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    trans_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
+
+    tt_trans_replicated = ttnn.from_torch(
+        trans_mat_replicated,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=trans_mem_config,
+        tile=trans_tile,
+    )
+
+    # Create output tensor
+    output_shape = (1, 512)
+    output_shard_shape = (1, 512)
+    output_shard_spec = ttnn.ShardSpec(
+        rms_crs,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    output_tile = ttnn.Tile([1, 32])
+    torch_output = torch.zeros(output_shape, dtype=torch.bfloat16)
+    ttnn_output = ttnn.from_torch(
+        torch_output,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=tile,
+    )
+
+    logger.info(f"Created tensors sharded on single core with shard shape {output_shard_shape}")
+    logger.info(f"Done creating TT tensors.")
+    logger.info("Running KV cache branch operation...")
+    ttnn_result = KVCacheBranch.op(
+        ttnn_input,
+        ttnn_W_dkv_rope,
+        ttnn_gamma,
+        tt_cos,
+        tt_sin,
+        tt_trans_replicated,
+        ttnn_output,
+    )
+
+    # Convert back to torch for verification
+    output_torch = ttnn.to_torch(ttnn_result)
+
+    expected_shape = (1, 512)
+    assert output_torch.shape == expected_shape, f"Expected shape {expected_shape}, got {output_torch.shape}"
+
+    logger.info("Running KV cache branch golden reference...")
+    # Compute reference output using PyTorch
+    torch_expected = KVCacheBranch.golden(
+        torch_input,
+        torch_W_dkv_rope,
+        torch_gamma,
+        torch_cos,
+        torch_sin,
+        position_ids_expanded,
+        epsilon=epsilon,
+    )
+
+    torch_expected = torch_expected[:, :512]
+    max_diff = torch.max(torch.abs(output_torch - torch_expected)).item()
+    mean_diff = torch.mean(torch.abs(output_torch - torch_expected)).item()
+    logger.info(f"Max absolute difference: {max_diff}")
+    logger.info(f"Mean absolute difference: {mean_diff}")
+
+    from models.common.utility_functions import comp_pcc
+
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.98)
+    logger.info(pcc_message)
+    assert passing, pcc_message
+
+    logger.info("✓ KV cache branch test passed!)")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
@@ -20,15 +20,16 @@ from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
 
 
 @pytest.mark.parametrize(
-    "batch, num_heads, head_dim, position_id",
+    "batch, num_heads, head_dim, position_id, grid_size",
     [
-        (1, 1, 32, 5),  # Minimal single-core test
-        (1, 2, 64, 5),  # DeepSeek V3 Q rope (multiple heads)
+        (1, 1, 32, 5, (1, 1)),  # Minimal single-core test
+        (1, 1, 64, 5, (1, 2)),  # Multicore test
+        (1, 2, 64, 5, (1, 1)),  # DeepSeek V3 Q rope (multiple heads)
     ],
-    ids=["minimal", "q_rope"],
+    ids=["minimal", "multicore", "q_rope"],
 )
 @pytest.mark.parametrize("pcc", [0.999])
-def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
+def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size, pcc):
     """
     Test RoPE in decode mode on a single core.
 
@@ -69,14 +70,18 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
     # Create HEIGHT_SHARDED memory config for input
     # Use tiny tiles: tile height = num_heads (no padding to 32)
     tiny_tile = ttnn.Tile((num_heads, ttnn.TILE_SIZE))
-    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    # Create core grid from grid_size parameter
+    start_x, start_y = 0, 0  # Starting offset
+    end_x = start_x + grid_size[0] - 1
+    end_y = start_y + grid_size[1] - 1
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(start_x, start_y), ttnn.CoreCoord(end_x, end_y))})
 
     input_shard_spec = ttnn.ShardSpec(
         core_grid,
-        (num_heads, head_dim),
+        (num_heads, head_dim // (core_grid.num_cores())),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
     # Create TTNN input tensor with HEIGHT_SHARDED memory and tiny tile
     tt_x = ttnn.from_torch(
@@ -97,11 +102,11 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
     # Broadcast multiply reads row 0 and broadcasts to all rows
     cos_sin_shard_spec = ttnn.ShardSpec(
         core_grid,
-        (num_heads, head_dim),
+        (num_heads, head_dim // (core_grid.num_cores())),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
     )
 
     tt_cos = ttnn.from_torch(
@@ -124,7 +129,7 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
     # Transformation matrix - standard 32x32 tile (rotation matrix)
     trans_mat = get_rot_transformation_mat()
     # Repeat for batch dimension
-    trans_mat = trans_mat.repeat(1, 1, batch, 1)
+    trans_mat_replicated = trans_mat.repeat(1, 1, batch, core_grid.num_cores())
 
     trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
     trans_shard_spec = ttnn.ShardSpec(
@@ -132,10 +137,10 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
         (ttnn.TILE_SIZE, ttnn.TILE_SIZE),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    trans_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
+    trans_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
 
-    tt_trans = ttnn.from_torch(
-        trans_mat,
+    tt_trans_replicated = ttnn.from_torch(
+        trans_mat_replicated,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -159,7 +164,7 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, pcc):
         tt_x,
         tt_cos,
         tt_sin,
-        tt_trans,
+        tt_trans_replicated,
         tt_out,
     )
 
@@ -245,7 +250,7 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         (num_heads, head_dim),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
     tt_x = ttnn.from_torch(
         x_ttnn,

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -94,24 +94,7 @@ struct Rope {
 
     private:
         void impl(const RTArgs& args) {
-#if defined(COMPILE_FOR_NCRISC)
-            constexpr uint32_t Ht = 1;
-            constexpr uint32_t Wt = CTArgs::Wt;
-
-            for (uint32_t ht = 0; ht < Ht; ht++) {
-                cb_reserve_back(args.in_cb, Wt);
-                cb_push_back(args.in_cb, Wt);
-            }
-
-            cb_reserve_back(args.trans_mat_cb, 1);
-            cb_push_back(args.trans_mat_cb, 1);
-
-            cb_reserve_back(args.sin_cb, Wt);
-            cb_push_back(args.sin_cb, Wt);
-
-            cb_reserve_back(args.cos_cb, Wt);
-            cb_push_back(args.cos_cb, Wt);
-#elif defined(COMPILE_FOR_TRISC)
+#if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t Wt = CTArgs::Wt;
             constexpr uint32_t Ht = 1;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35525


### Problem description
KV cache was not implemented. 

### What's changed
Add fused kv cache calculations.
Fix rope kernel to be fusible, add multicore test.
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aliu/deepseek-blitz)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aliu/deepseek-blitz)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aliu/deepseek-blitz)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aliu/deepseek-blitz)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aliu/deepseek-blitz)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aliu/deepseek-blitz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aliu/deepseek-blitz)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
