### PR TITLE
Add fabric node id pinnings to galaxy multiprocess tests

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_mesh_graph_descriptor.textproto
@@ -25,5 +25,45 @@ graph_descriptors {
     channels { count: 2 }
   }
 }
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 4
+  }
+}
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_mesh_graph_descriptor.textproto
@@ -25,7 +25,7 @@ graph_descriptors {
     channels { count: 2 }
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 0
     chip_id: 0
@@ -45,7 +45,7 @@ pinnings {
     asic_location: 4
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 1
     chip_id: 0

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_z_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_z_mesh_graph_descriptor.textproto
@@ -26,5 +26,45 @@ graph_descriptors {
     assign_z_direction: true
   }
 }
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 4
+  }
+}
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_z_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_galaxy_4x4_z_mesh_graph_descriptor.textproto
@@ -26,7 +26,7 @@ graph_descriptors {
     assign_z_direction: true
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 0
     chip_id: 0
@@ -46,7 +46,7 @@ pinnings {
     asic_location: 4
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 1
     chip_id: 0

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
@@ -39,5 +39,85 @@ graph_descriptors {
     channels { count: 1 policy: RELAXED }
   }
 }
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 8
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_2x4_mesh_graph_descriptor.textproto
@@ -65,7 +65,7 @@ pinnings {
     chip_id: 0
   }
   physical_asic_position {
-    tray_id: 2
+    tray_id: 3
     asic_location: 1
   }
 }
@@ -75,37 +75,37 @@ pinnings {
     chip_id: 7
   }
   physical_asic_position {
+    tray_id: 3
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 0
+  }
+  physical_asic_position {
     tray_id: 2
-    asic_location: 8
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 2
-    chip_id: 0
-  }
-  physical_asic_position {
-    tray_id: 3
-    asic_location: 1
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 2
-    chip_id: 7
-  }
-  physical_asic_position {
-    tray_id: 3
-    asic_location: 8
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 3
-    chip_id: 0
-  }
-  physical_asic_position {
-    tray_id: 4
     asic_location: 1
   }
 }
@@ -115,7 +115,7 @@ pinnings {
     chip_id: 7
   }
   physical_asic_position {
-    tray_id: 4
+    tray_id: 2
     asic_location: 8
   }
 }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_2x8_2x4_3_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_2x8_2x4_3_mesh.textproto
@@ -44,5 +44,45 @@ graph_descriptors {
     channels { count: 4 policy: RELAXED }
   }
 }
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 5
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x2_multi_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x2_multi_mesh.textproto
@@ -43,6 +43,85 @@ graph_descriptors {
     channels { count: 2 }
   }
 }
-
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 8
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x2_multi_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x2_multi_mesh.textproto
@@ -69,7 +69,7 @@ pinnings {
     chip_id: 0
   }
   physical_asic_position {
-    tray_id: 2
+    tray_id: 3
     asic_location: 1
   }
 }
@@ -79,37 +79,37 @@ pinnings {
     chip_id: 7
   }
   physical_asic_position {
+    tray_id: 3
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 7
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 8
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 3
+    chip_id: 0
+  }
+  physical_asic_position {
     tray_id: 2
-    asic_location: 8
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 2
-    chip_id: 0
-  }
-  physical_asic_position {
-    tray_id: 3
-    asic_location: 1
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 2
-    chip_id: 7
-  }
-  physical_asic_position {
-    tray_id: 3
-    asic_location: 8
-  }
-}
-pinnings {
-  logical_fabric_node_id {
-    mesh_id: 3
-    chip_id: 0
-  }
-  physical_asic_position {
-    tray_id: 4
     asic_location: 1
   }
 }
@@ -119,7 +119,7 @@ pinnings {
     chip_id: 7
   }
   physical_asic_position {
-    tray_id: 4
+    tray_id: 2
     asic_location: 8
   }
 }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_2x4_3_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_2x4_3_mesh.textproto
@@ -43,6 +43,35 @@ graph_descriptors {
     channels { count: 4 policy: RELAXED }
   }
 }
-
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 2
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 8
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
@@ -24,5 +24,45 @@ graph_descriptors {
     channels { count: 2 }
   }
 }
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 1
+    asic_location: 1
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 0
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 2
+    asic_location: 4
+  }
+}
+pinnings{
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 0
+  }
+  physical_asic_position {
+    tray_id: 3
+    asic_location: 4
+  }
+}
+pinnings {
+  logical_fabric_node_id {
+    mesh_id: 1
+    chip_id: 15
+  }
+  physical_asic_position {
+    tray_id: 4
+    asic_location: 1
+  }
+}
 # --- Instantiation ----------------------------------------------------------
 top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_galaxy_split_4x4_multi_mesh.textproto
@@ -24,7 +24,7 @@ graph_descriptors {
     channels { count: 2 }
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 0
     chip_id: 0
@@ -44,7 +44,7 @@ pinnings {
     asic_location: 4
   }
 }
-pinnings{
+pinnings {
   logical_fabric_node_id {
     mesh_id: 1
     chip_id: 0


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36292)

### Problem description
Need to add pinnings to galaxy multiprocess mgds to ensure that traffic between nodes behaves as expected

### What's changed
Added fabric node id pinnings to glx multiprocess tests
Resolves #36292 
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/add-pinnings-to-glx-multiprocess-tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
