### PR TITLE
Add strided K-tile access to custom b=1 MM for out_w > 1

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -75,7 +75,8 @@ inline void llk_unpack_AB_custom_mm(
     const std::uint32_t operandB,
     const std::uint32_t tile_index_a,
     const std::uint32_t tile_index_b,
-    const std::uint32_t kt_dim = 1) {
+    const std::uint32_t kt_dim = 1,
+    const std::uint32_t in1_k_stride = 1) {
     // In0/InA -> srcB (supports partial face)
     // In1/InB -> srcA
 
@@ -90,6 +91,6 @@ inline void llk_unpack_AB_custom_mm(
 
     WAYPOINT("UPMW");
     _llk_unpack_AB_custom_mm_(
-        base_address_a, base_address_b, tile_index_a, tile_index_b, tile_size_a, tile_size_b, kt_dim);
+        base_address_a, base_address_b, tile_index_a, tile_index_b, tile_size_a, tile_size_b, kt_dim, in1_k_stride);
     WAYPOINT("UPMD");
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -84,6 +84,7 @@ ALWI void custom_mm_block_init(
  * | idst           | The index of the tile in DST REG to which the result C will be written. | uint32_t | Must be less than the acquired size of DST REG | True     |
  * | transpose      | The transpose flag for performing transpose operation on tiles in B.    | bool     | Must be true or false                          | True     |
  * | kt_dim         | The inner dimension (K reduction dimension).                            | uint32_t | Must be equal to block A column dimension      | True     |
+ * | in1_k_stride   | Stride between K tiles in in1 CB (default 1 for contiguous K tiles).    | uint32_t | >= 1                                           | False    |
  */
 // clang-format on
 template <bool partial_acc = false>
@@ -94,8 +95,9 @@ ALWI void custom_mm_block(
     uint32_t in1_tile_index,
     uint32_t idst,
     const uint32_t transpose,
-    uint32_t kt_dim) {
-    UNPACK((llk_unpack_AB_custom_mm(in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim)));
+    uint32_t kt_dim,
+    uint32_t in1_k_stride = 1) {
+    UNPACK((llk_unpack_AB_custom_mm(in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, in1_k_stride)));
     MATH((llk_math_custom_mm<MATH_FIDELITY, partial_acc>(idst, transpose, kt_dim)));
 }
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
@@ -51,7 +51,7 @@ from models.demos.deepseek_v3_b1.micro_ops.matmul.op import MatmulSingleCore
         (1, 512, 128, ttnn.bfloat16, ttnn.bfloat8_b),  # V out
         (1, 8192, 64, ttnn.bfloat16, ttnn.bfloat8_b),  # Out
         # MoE (bfloat16 srcB/in0, bfloat8_b srcA/in1 - potentially bfloat4_b if accurate enough)
-        (1, 7168, 64, ttnn.bfloat16, ttnn.bfloat4_b),  # Gate proj + up proj (out_w=2)
+        (1, 7168, 64, ttnn.bfloat16, ttnn.bfloat4_b),  # Dense MLP: W_up (out_w=2)
         (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Gate proj + up proj
         (1, 2048, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Down proj
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
@@ -51,6 +51,7 @@ from models.demos.deepseek_v3_b1.micro_ops.matmul.op import MatmulSingleCore
         (1, 512, 128, ttnn.bfloat16, ttnn.bfloat8_b),  # V out
         (1, 8192, 64, ttnn.bfloat16, ttnn.bfloat8_b),  # Out
         # MoE (bfloat16 srcB/in0, bfloat8_b srcA/in1 - potentially bfloat4_b if accurate enough)
+        (1, 7168, 64, ttnn.bfloat16, ttnn.bfloat4_b),  # Gate proj + up proj (out_w=2)
         (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Gate proj + up proj
         (1, 2048, 32, ttnn.bfloat16, ttnn.bfloat4_b),  # Down proj
     ],

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -106,58 +106,49 @@ struct Matmul {
             // Reserve output tiles
             cb_reserve_back(args.out, out_w);
 
-            if constexpr (out_w == 1) {
-                // Use optimized custom_mm API for single output tile with K-dimension reduction
+            if constexpr (out_w <= 8) {
+                // Use optimized custom_mm API for up to 8 output tiles (half-DST)
                 custom_mm_block_init(args.in0, args.in1, args.out, transpose, args.k_num_tiles);
 
                 tile_regs_acquire();
 
-                // Single call handles all K tiles internally via MOP replay
-                custom_mm_block(args.in0, args.in1, 0, 0, 0, transpose, args.k_num_tiles);
+                for (uint32_t w = 0; w < out_w; w++) {
+                    custom_mm_block(args.in0, args.in1, 0, w, w, transpose, args.k_num_tiles, out_w);
+                }
 
                 tile_regs_commit();
 
-                // Pack output tile
                 tile_regs_wait();
-                pack_tile(0, args.out, 0);
+                for (uint32_t w = 0; w < out_w; w++) {
+                    pack_tile(w, args.out, w);
+                }
                 tile_regs_release();
             } else {
-                // Use standard matmul API for multiple output tiles
-                // Process in blocks of up to 256 tiles (max DST size)
-                mm_block_init(args.in0, args.in1, args.out, transpose, out_subblock_w, out_subblock_h, in0_block_w);
+                // Use optimized custom_mm API with blocking for out_w > 8
+                // Process in blocks of 8 tiles (half-DST with SyncHalf mode)
+                constexpr uint32_t dst_tiles = 8;  // Half-DST for reliable blocking
+                constexpr uint32_t num_blocks = (out_w + dst_tiles - 1) / dst_tiles;
 
-                constexpr uint32_t max_dst_size = 256;
-                constexpr uint32_t num_blocks = (out_w + max_dst_size - 1) / max_dst_size;
-
-                uint32_t block_start = 0;
                 for (uint32_t block = 0; block < num_blocks; block++) {
-                    uint32_t block_end = (block_start + max_dst_size < out_w) ? block_start + max_dst_size : out_w;
-                    uint32_t block_size = block_end - block_start;
+                    uint32_t block_start = block * dst_tiles;
+                    uint32_t tiles_in_block = ((block_start + dst_tiles) < out_w) ? dst_tiles : (out_w - block_start);
+
+                    // Re-init for each block to reset MOP state
+                    custom_mm_block_init(args.in0, args.in1, args.out, transpose, args.k_num_tiles);
 
                     tile_regs_acquire();
 
-                    uint32_t in1_k_offset = block_start;  // Tracks k * out_w + block_start
-                    for (uint32_t k = 0; k < args.k_num_tiles; k++) {
-                        uint32_t in1_idx = in1_k_offset;
-                        for (uint32_t dst_idx = 0; dst_idx < block_size; dst_idx++) {
-                            matmul_tiles(args.in0, args.in1, k, in1_idx, dst_idx);
-                            in1_idx++;
-                        }
-                        in1_k_offset += out_w;
+                    for (uint32_t w = 0; w < tiles_in_block; w++) {
+                        custom_mm_block(args.in0, args.in1, 0, block_start + w, w, transpose, args.k_num_tiles, out_w);
                     }
 
                     tile_regs_commit();
 
-                    // Pack output tiles for this block
                     tile_regs_wait();
-                    uint32_t out_idx = block_start;
-                    for (uint32_t dst_idx = 0; dst_idx < block_size; dst_idx++) {
-                        pack_tile(dst_idx, args.out, out_idx);
-                        out_idx++;
+                    for (uint32_t w = 0; w < tiles_in_block; w++) {
+                        pack_tile(w, args.out, block_start + w);
                     }
                     tile_regs_release();
-
-                    block_start += max_dst_size;
                 }
             }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `custom_mm_block` LLK only supported contiguous K-tile access, limiting its use to `out_w == 1` matmuls in the DeepSeek blitz kernel.

### What's changed
- Added `in1_k_stride` parameter to the unpack API (`llk_unpack_AB_custom_mm`) to support strided weight tile access for row-major layouts
- Extended `custom_mm_block` to handle `out_w <= 16` by iterating over output columns with proper K-tile stride (`out_w`)
- Added test case for `out_w=2` shape (1x7168x64) to verify the new strided access

### CI Runs
- [x] [All post commit]() CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/21408887054
- [x] New/Existing tests provide coverage for changes

Edit BH Post-Commit: https://github.com/tenstorrent/tt-metal/actions/runs/21409399265