### PR TITLE
Disable in1 reuse and serpentine schedule in minimal matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -151,10 +151,7 @@ void MAIN {
     constexpr uint32_t M_num_subblocks = M_block_tiles / subblock_h;
     constexpr uint32_t N_num_subblocks = N_block_tiles / subblock_w;
 
-    bool n_forward = true;
-
     bool reuse_in0_block = false;
-    bool reuse_in1_block = false;
 
     uint32_t current_M_block_tiles = M_block_tiles;
     uint32_t current_N_block_tiles = N_block_tiles;
@@ -168,8 +165,7 @@ void MAIN {
         current_subblock_h = std::min(current_M_block_tiles, subblock_h);
 
         for (uint32_t n_block_iter = 0; n_block_iter < N_blocks_per_core; n_block_iter++) {
-            uint32_t n_tile = n_forward ? N_start_tile + n_block_iter * N_block_tiles
-                                        : N_start_tile + (N_blocks_per_core - 1 - n_block_iter) * N_block_tiles;
+            uint32_t n_tile = N_start_tile + n_block_iter * N_block_tiles;
             uint32_t n_tile_end = std::min(n_tile + N_block_tiles, N_end_tile);
             current_N_block_tiles = n_tile_end - n_tile;
             current_subblock_w = std::min(current_N_block_tiles, subblock_w);
@@ -202,29 +198,19 @@ void MAIN {
 
                 if (k_block == K_num_blocks - 1) {
                     /**
-                     * On next iteration we're going to get some reuse on in0 or in1
-                     * Therefore you should not pop one of them
+                     * On next iteration we might get reuse on in0
                      *
                      */
                     if (n_block_iter < N_blocks_per_core - 1) {
                         // going to stride on N, so reuse in0
                         reuse_in0_block = true;
                     }
-#ifndef FUSE_AG
-                    else {
-                        // going to stride on M, so reuse in1
-                        reuse_in1_block = true;
-                    }
-#endif
                 }
                 if (!reuse_in0_block) {
                     cb_pop_front(in0_cb, in0_block_num_tiles);
                 }
-                if (!reuse_in1_block) {
-                    cb_pop_front(in1_cb, in1_block_num_tiles);
-                }
+                cb_pop_front(in1_cb, in1_block_num_tiles);
                 reuse_in0_block = false;
-                reuse_in1_block = false;
                 if (k_block == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
@@ -243,9 +229,6 @@ void MAIN {
 #endif
             cb_pop_front(intermediate_cb, out_block_num_tiles);
         }
-#ifndef FUSE_AG
-        n_forward = !n_forward;
-#endif
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -128,15 +128,11 @@ void kernel_main() {
         get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
 
     /**
-     * This is a Serpentine (Boustrophedon) output block ordering.
-     * It enables reuse of one of the input blocks for the last output block.
-     * Starting at output block (0,0), go east until the end, then south one block, then west until the end, then south
-     * one block, and repeat. At the same time, alternate between K striding forwards or backwards in order to enable
-     * reuse.
+     * This is a Row-Major output block ordering.
+     * It enables reuse of the last in0 block when striding the output block N dimension.
      */
 
     bool k_forward = true;
-    bool n_forward = true;
     bool reuse_block = false;
 
     uint32_t defer_write_m_tile = 0;
@@ -158,9 +154,9 @@ void kernel_main() {
 
         // When striding M block, in0 gets no reuse
         reuse_block = false;
+        k_forward = true;
         for (uint32_t n_block_iter = 0; n_block_iter < N_blocks_per_core; n_block_iter++) {
-            uint32_t n_tile = n_forward ? N_start_tile + n_block_iter * N_block_tiles
-                                        : N_start_tile + (N_blocks_per_core - 1 - n_block_iter) * N_block_tiles;
+            uint32_t n_tile = N_start_tile + n_block_iter * N_block_tiles;
             uint32_t n_tile_end = std::min(n_tile + N_block_tiles, N_end_tile);
 
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
@@ -315,9 +311,6 @@ void kernel_main() {
                 }
             }
         }
-#ifndef FUSE_AG
-        n_forward = !n_forward;
-#endif
     }
     noc_async_write_barrier();
     noc_async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
@@ -122,8 +122,8 @@ void bind_minimal_matmul(nb::module_& mod) {
 
         Notes on Implementation
         -----------------------
-        - Data movement reads A in MxK blocks and B in KxN blocks with serpentine ordering and reuse across
-          subblocks to reduce NOC pressure; writes are deferred to reduce congestion.
+        - Data movement reads A in MxK blocks and B in KxN blocks in row-major order with in0 reuse when
+          striding across N blocks; writes are deferred to reduce congestion.
         - K is processed in blocks of size `K_block_size`, with zero-padding as needed when K is not a multiple.
         - If `fused_activation` is provided, it is applied per tile just before packing to the output buffer.
         )doc",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35167

### Problem description
Llama found that with identical rows of activations, output rows of minimal matmul did not exactly match.
It turns out that this is because our serpentine ordering of output blocks, combined with in1_reuse, can cause M_block rows to stride K_block in a different direction than other M_block rows, allowing floating point non-associativity to lead to slightly different results across rows.

### What's changed
Since disabling in1_reuse has no measurable impact on performance and disabling it allows us to ensure that for identical activation rows the output rows will be identical, this PR changes the output block ordering to row-major and disables in1_reuse.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:cglagovich/35167)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/35167)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/35167)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/35167)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/35167)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/35167)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/35167)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
