### PR TITLE
Add support for N300x2 in TTT and TT metal

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1341,7 +1341,7 @@ def test_demo_text(
 
     # Benchmark targets
     supported_models = ["Llama-3.2-1B", "Llama-3.2-3B", "Llama-3.1-8B", "Llama-3.2-11B", "Llama-3.1-70B", "Mistral-7B"]
-    supported_devices = ["N150", "P100", "P150", "P300", "N300", "P150x4", "P150x8", "BHGLX", "T3K", "TG"]
+    supported_devices = ["N150", "P100", "P150", "P300", "N300", "N150x4", "P150x4", "P150x8", "BHGLX", "T3K", "TG"]
 
     tt_device_name = determine_device_name(mesh_device)  # submesh device should not decide performance target
     model_name = model_args[0].base_model_name

--- a/models/tt_transformers/tt/ccl.py
+++ b/models/tt_transformers/tt/ccl.py
@@ -42,6 +42,7 @@ def get_num_links(mesh_device, cluster_axis=None):
         "P300": (2, 2),
         "BHGLX": (4, 3),
         "TG": (4, 3),
+        "N150x4": (1, 1),
     }
     device_links = link_dict[device_name]
     # When cluster_axis is None, query links across all axes and return the minimum.

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -174,6 +174,7 @@ target_sources(
             fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.textproto
+            fabric/mesh_graph_descriptors/n300_x2_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto
             fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.textproto

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_x2_mesh_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_x2_mesh_graph_descriptor.textproto
@@ -1,0 +1,12 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: WORMHOLE_B0
+  device_topology { dims: [ 4, 1 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { mesh { mesh_descriptor: "M0" mesh_id: 0 } }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/metal-internal-workflows/issues/784

### Problem description
N300 x 2 system to be supported in TTT, we needed a new mesh graph descriptor and new device types defined in TTT.

### What's changed
- created a new mesh graph descriptor called `tt_metal/fabric/mesh_graph_descriptors/n300_x2_mesh_graph_descriptor.textproto` with 4 in the first dim, there is an existing `n300 2x2` mesh graph descriptor however the dimensions are different for the system described in the issue, so users can override the MGD via the `` env var
- added `n150x4` as device type to TTT, although the real cluster type is N300x2 it would depend on whether we want to permanently support this cluster type as n300x2 then it would require additional changes in `cluster.hpp` and other places then TTT can make the distinction between n150x4 and n300x2 but for now n150x4 is sufficient to run models such as Llama 3.1 8b with TP=4 configuration.  

### Checklist
- currently this system is not in CI, pending CI pipeline runs
