### PR TITLE
[skip ci] Temporarily disable analyze-nd-failures scheduled runs

### DIFF
--- a/.github/workflows/analyze-nd-failures.yaml
+++ b/.github/workflows/analyze-nd-failures.yaml
@@ -1,9 +1,9 @@
 name: Analyze ND Failures
 
 on:
-  schedule:
-    # Run every hour at minute 0
-    - cron: '0 * * * *'
+  # schedule:
+  #   # Run every hour at minute 0
+  #   - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       update_mode:


### PR DESCRIPTION
### Ticket
N/A - Temporary fix while investigating duplication issue

### Problem description
The analyze-nd-failures workflow appears to have a duplication bug that needs investigation. To prevent the issue from recurring every hour via the scheduled runs, we're temporarily disabling the schedule trigger.

### What's changed
- Commented out the `schedule` trigger in `.github/workflows/analyze-nd-failures.yaml`
- The workflow can still be run manually via `workflow_dispatch` trigger
- This is a temporary measure until the duplication bug can be properly investigated and fixed

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/disable-analyze-nd-failures-temporarily)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/disable-analyze-nd-failures-temporarily)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/disable-analyze-nd-failures-temporarily)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/disable-analyze-nd-failures-temporarily)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/disable-analyze-nd-failures-temporarily)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/disable-analyze-nd-failures-temporarily)
- [x] New/Existing tests provide coverage for changes (N/A - workflow configuration change only)