### PR TITLE
[tt-triage] Dump lightweight asserts code private memory PC fix

### DIFF
--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -134,6 +134,7 @@ def dump_lightweight_asserts(
         pc = risc_debug.get_pc()
         code_private_memory = risc_debug.get_code_private_memory()
         if code_private_memory is not None and code_private_memory.contains_private_address(0x80000000 | pc):
+            pc |= 0x80000000
             dispatcher_core_data = callstack_provider.dispatcher_data.get_cached_core_data(location, risc_name)
             elf = callstack_provider.elfs_cache[dispatcher_core_data.kernel_path].elf
             text_section = elf.get_section_by_name(".text")


### PR DESCRIPTION
Fix `dump_lightweight_asserts.py` to correctly handle PCs in ERISC/NCRISC code private memory (IRAM) on Wormhole by treating truncated 31‑bit debug‑bus PCs (masked with 0x7FFFFFFF) as IRAM addresses and reading instructions from the ELF instead of over NOC. This prevents spurious unsafe access at address 0x7fc0xxxx errors and restores proper lightweight assert dumps (assert line + callstack + locals) for ERISC kernels.

Example access that is caught by our safe mode:
    Device 30: eth [1-0 (e0,1)]: erisc: Failed to dump lightweight asserts: 1-0 (e0,1), unsafe access at address 0x7fc00fd0. Attempted to read from address range [0x7fc00fd0, 0x7fc00fd3] 
    
    Missing from dump_callstacks:
    │ 5   │ 9-0 (e0,0)  │ erisc  │ 23        │ fabric_erisc_router                      │ 0         │ GO         │ False   │ X        │ 0x7fc00d04 │ PC was not in range of any provided ELF files. Probably context switch occurred and PC is contained in base ERISC firmware.