### PR TITLE
Add deprecated warning for NOC blitz write

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -352,6 +352,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
+[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -352,8 +352,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
-[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
+[[deprecated("unused function, use async write instead")]]
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -291,8 +291,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
-[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
+[[deprecated("unused function, use async write instead")]]
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -291,6 +291,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
+[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -339,6 +339,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
+[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -339,8 +339,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     }
 }
 
-[[deprecated("unused function, use async write instead")]]
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
+[[deprecated("unused function, use async write instead")]]
 inline __attribute__((always_inline)) void ncrisc_noc_blitz_write_setup(
     uint32_t noc, uint32_t cmd_buf, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, uint32_t num_times_to_write) {
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {


### PR DESCRIPTION
### Problem description
NOC blitz write is part of noc_non_blocking API files but it is not used and not needed. Adding deprecated warning before deleting the file in a month. 

### What's changed
Just deprecated tag, non functional changes yet.  


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0126-blitz-write-depracated-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0126-blitz-write-depracated-warning)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
