### PR TITLE
[skip ci] Re-enable QB2 in BH nightly (partial revert of 5385c2f)

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests.yaml
@@ -65,10 +65,10 @@ jobs:
             runner-label: P300-viommu
             extra-tag: pipeline-yyz2-lfc
             num_devices: 2
-          # - name: QuietBox Global Edition tests
-          #   runner-label: BH-QB-GE
-          #   extra-tag: pipeline-perf
-          #   num_devices: 4
+          - name: QuietBox Global Edition tests
+            runner-label: BH-QB-GE
+            extra-tag: pipeline-perf
+            num_devices: 4
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-multi-card-unit-tests.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests.yaml
@@ -30,8 +30,8 @@ jobs:
             runner-label: BH-LoudBox
           - name: P300 unit tests
             runner-label: P300-viommu
-          # - name: QuietBox Global Edition unit tests
-          #   runner-label: BH-QB-GE
+          - name: QuietBox Global Edition unit tests
+            runner-label: BH-QB-GE
     with:
       arch: blackhole
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -121,7 +121,8 @@ jobs:
             {"name": "Quietbox (4xP150) tests", "runner-label": "BH-LLMBox", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "llmbox"},
             {"name": "DeskBox (2xP150) tests", "runner-label": "BH-DeskBox", "extra-tag": "pipeline-functional", "num_devices": 2, "key": "deskbox"},
             {"name": "LoudBox (8xP150) tests", "runner-label": "BH-LoudBox", "extra-tag": "pipeline-functional", "num_devices": 8, "key": "loudbox"},
-            {"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"}
+            {"name": "P300 (1xP300) tests", "runner-label": "P300-viommu", "extra-tag": "pipeline-yyz2-lfc", "num_devices": 2, "key": "p300"},
+            {"name": "QuietBox 2 (2xP300) tests", "runner-label": "BH-QB-GE", "extra-tag": "pipeline-perf", "num_devices": 4, "key": "quietbox_2"}
           ]'
 
           # If schedule, include all systems


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36030

### What's changed
Both QB2's back online, revert change in nightly pipeline only to gauge stability.