### PR TITLE
CI: Explicit Exit Code After TT-Triage Dispatch Timeout

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -112,7 +112,6 @@ runs:
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress 1>&2" >> $GITHUB_ENV
         echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
-        echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
         echo "TT_METAL_EXIT_ON_DISPATCH_TIMEOUT=1" >> $GITHUB_ENV
         echo "TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE=124" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -112,4 +112,7 @@ runs:
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress 1>&2" >> $GITHUB_ENV
         echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
+        echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
+        echo "TT_METAL_EXIT_ON_DISPATCH_TIMEOUT=1" >> $GITHUB_ENV
+        echo "TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE=124" >> $GITHUB_ENV
       shell: bash

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -32,8 +32,8 @@ from ttexalens.coordinate import OnChipCoordinate
 
 triage.progress_disabled = True  # Disable progress bars for tests
 
-# Exit code used when runtime detects dispatch timeout
-# Read from environment variable to match what runtime will use
+# Exit code used when runtime detects dispatch timeout.
+# Default is 124, but it is configurable via TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE.
 TIMEOUT_EXIT_CODE = int(os.environ.get("TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE", "124"))
 
 # Mapping of hang application paths to their expected test results

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -32,6 +32,10 @@ from ttexalens.coordinate import OnChipCoordinate
 
 triage.progress_disabled = True  # Disable progress bars for tests
 
+# Exit code used when runtime detects dispatch timeout
+# Read from environment variable to match what runtime will use
+TIMEOUT_EXIT_CODE = int(os.environ.get("TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE", "124"))
+
 # Mapping of hang application paths to their expected test results
 HANG_APP_ADD_2_INTEGERS = "tools/tests/triage/hang_apps/add_2_integers_hang/triage_hang_app_add_2_integers_hang"
 HANG_APP_EXPECTED_RESULTS = {
@@ -80,11 +84,19 @@ def cause_hang_with_app(request):
     build_dir = os.path.join(metal_home, "build")
     app_path_str = os.path.join(build_dir, app)
     os.environ.pop("TT_METAL_LOGS_PATH", None)
+
+    # Set up environment for timeout tests
+    test_env = {**os.environ, **app_configuration.get("env", {})}
+    # Enable exit on dispatch timeout only for auto-timeout tests (those with TT_METAL_OPERATION_TIMEOUT_SECONDS)
+    if app_configuration.get("auto_timeout", False):
+        test_env["TT_METAL_EXIT_ON_DISPATCH_TIMEOUT"] = "1"
+        test_env["TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE"] = str(TIMEOUT_EXIT_CODE)
+
     proc = subprocess.Popen(
         [app_path_str] + args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={**os.environ, **app_configuration.get("env", {})},
+        env=test_env,
     )
     auto_timeout = app_configuration.get("auto_timeout", False)
     if auto_timeout:
@@ -94,12 +106,14 @@ def cause_hang_with_app(request):
         except subprocess.TimeoutExpired:
             pass
 
-        # Check if the process has exited
-        if proc.returncode != 0:
+        # Check if the process has exited with expected code
+        # Exit code 0 = successful timeout handling in application
+        # Exit code 124 = timeout detected by runtime (std::_Exit in metal_context.cpp)
+        if proc.returncode not in [0, TIMEOUT_EXIT_CODE]:
             # Print process output for debugging
-            print("The application did not hang as expected.")
+            print(f"The application exited with unexpected code {proc.returncode}.")
             print_process_output(proc)
-            raise RuntimeError("The application did not hang as expected.")
+            raise RuntimeError(f"The application exited with unexpected code {proc.returncode}.")
     else:
         time.sleep(timeout)
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <algorithm>
 #include <mutex>

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1945,6 +1945,11 @@ void MetalContext::on_dispatch_timeout_detected() {
                     tt::LogMetal, "Timeout command '{}' returned non-zero exit code: {}", command, WEXITSTATUS(result));
             }
         }
+
+        // Exit application if enabled via environment variable
+        if (rtoptions_.get_exit_on_dispatch_timeout()) {
+            std::_Exit(rtoptions_.get_dispatch_timeout_exit_code());
+        }
     }
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -910,7 +910,17 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: 124 (standard timeout exit code)
         // Usage: export TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE=124
         case EnvVarID::TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE: {
-            this->dispatch_timeout_exit_code = std::stoul(value);
+            try {
+                int parsed_value = std::stoi(value);
+                if (parsed_value < 0 || parsed_value > 255) {
+                    TT_THROW("TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE must be in range [0, 255]: {}", value);
+                }
+                this->dispatch_timeout_exit_code = parsed_value;
+            } catch (const std::invalid_argument&) {
+                TT_THROW("Invalid TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE: {}", value);
+            } catch (const std::out_of_range&) {
+                TT_THROW("TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE value out of range: {}", value);
+            }
             break;
         }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -126,7 +126,6 @@ enum class EnvVarID {
     TT_METAL_NOC_DEBUG_DUMP,                       // Enable experimental NOC debug dump to detect missing barriers
     TT_METAL_EXIT_ON_DISPATCH_TIMEOUT,             // Exit application on dispatch timeout with exit code
     TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE,           // Exit code to use when exiting on dispatch timeout
-    TT_METAL_DEVICE_DEBUG_DUMP_ENABLED,            // Enable experimental debug dump mode for profiler
     TT_METAL_DISPATCH_PROGRESS_UPDATE_MS,          // Dispatch kernel progress update period in milliseconds
 
     // ========================================

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -123,7 +123,9 @@ enum class EnvVarID {
     TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
     TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
     TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE,  // Terminal command to execute on dispatch timeout.
-    TT_METAL_NOC_DEBUG_DUMP,                       // Enable experimental NOC debug dump to detect missing barriers
+    TT_METAL_EXIT_ON_DISPATCH_TIMEOUT,             // Exit application on dispatch timeout with exit code
+    TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE,           // Exit code to use when exiting on dispatch timeout
+    TT_METAL_DEVICE_DEBUG_DUMP_ENABLED,            // Enable experimental debug dump mode for profiler
     TT_METAL_DISPATCH_PROGRESS_UPDATE_MS,          // Dispatch kernel progress update period in milliseconds
 
     // ========================================
@@ -893,6 +895,24 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE:
             this->dispatch_timeout_command_to_execute = std::string(value);
             break;
+
+        // TT_METAL_EXIT_ON_DISPATCH_TIMEOUT
+        // Exit application on dispatch timeout with exit code.
+        // Default: false (disabled)
+        // Usage: export TT_METAL_EXIT_ON_DISPATCH_TIMEOUT=1
+        case EnvVarID::TT_METAL_EXIT_ON_DISPATCH_TIMEOUT: {
+            this->exit_on_dispatch_timeout = is_env_enabled(value);
+            break;
+        }
+
+        // TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE
+        // Exit code to use when exiting on dispatch timeout.
+        // Default: 124 (standard timeout exit code)
+        // Usage: export TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE=124
+        case EnvVarID::TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE: {
+            this->dispatch_timeout_exit_code = std::stoul(value);
+            break;
+        }
 
         // TT_METAL_DISPATCH_PROGRESS_UPDATE_MS
         // Dispatch kernel progress update period in milliseconds.

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -123,6 +123,7 @@ enum class EnvVarID {
     TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
     TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
     TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE,  // Terminal command to execute on dispatch timeout.
+    TT_METAL_NOC_DEBUG_DUMP,                       // Enable experimental NOC debug dump to detect missing barriers
     TT_METAL_EXIT_ON_DISPATCH_TIMEOUT,             // Exit application on dispatch timeout with exit code
     TT_METAL_DISPATCH_TIMEOUT_EXIT_CODE,           // Exit code to use when exiting on dispatch timeout
     TT_METAL_DEVICE_DEBUG_DUMP_ENABLED,            // Enable experimental debug dump mode for profiler

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -306,7 +306,7 @@ class RunTimeOptions {
     bool exit_on_dispatch_timeout = false;
 
     // Exit code to use when exiting on dispatch timeout (default: standard timeout code)
-    uint32_t dispatch_timeout_exit_code = 124;
+    int dispatch_timeout_exit_code = 124;
 
     // Dump JIT build commands to stdout for debugging
     bool dump_build_commands = false;
@@ -562,7 +562,7 @@ public:
     void set_jit_analytics_enabled(bool enable) { jit_analytics_enabled = enable; }
 
     bool get_exit_on_dispatch_timeout() const { return exit_on_dispatch_timeout; }
-    uint32_t get_dispatch_timeout_exit_code() const { return dispatch_timeout_exit_code; }
+    int get_dispatch_timeout_exit_code() const { return dispatch_timeout_exit_code; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
     bool get_riscv_debug_info_enabled() const { return riscv_debug_info_enabled; }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -302,6 +302,12 @@ class RunTimeOptions {
     // Disable XIP dump
     bool disable_xip_dump = false;
 
+    // Exit application on dispatch timeout with exit code
+    bool exit_on_dispatch_timeout = false;
+
+    // Exit code to use when exiting on dispatch timeout (default: standard timeout code)
+    uint32_t dispatch_timeout_exit_code = 124;
+
     // Dump JIT build commands to stdout for debugging
     bool dump_build_commands = false;
 
@@ -554,6 +560,9 @@ public:
 
     bool get_jit_analytics_enabled() const { return jit_analytics_enabled; }
     void set_jit_analytics_enabled(bool enable) { jit_analytics_enabled = enable; }
+
+    bool get_exit_on_dispatch_timeout() const { return exit_on_dispatch_timeout; }
+    uint32_t get_dispatch_timeout_exit_code() const { return dispatch_timeout_exit_code; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
     bool get_riscv_debug_info_enabled() const { return riscv_debug_info_enabled; }


### PR DESCRIPTION

### Problem description
Currently, when a dispatch timeout is detected, TT-Triage is invoked and completes successfully, but the subsequent exit attempt can trigger bugs (e.g. exceptions thrown in destructors), causing the process to abort and always return an abort exit code. This makes it difficult in CI to identify that TT-Triage ran and to inspect its results.

### What's changed
This change adds support for exiting with a configurable, explicit exit code after a TT-Triage dispatch timeout and enables this behavior by default in CI, providing clear signaling that TT-Triage was triggered and completed and making the results easy to find and inspect.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=miacim/exit_error_code)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:miacim/exit_error_code)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=miacim/exit_error_code)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:miacim/exit_error_code)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=miacim/exit_error_code)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:miacim/exit_error_code)

