### PR TITLE
Capture missing write barriers at end of kernel

### DIFF
--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -40,8 +40,8 @@ public:
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
         return noc_debug_state->get_issues(core, processor_id)
-            .has_issue(NOCDebugIssueType(
-                NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*is_mcast=*/true, /*is_semaphore=*/true));
+            .has_issue(
+                NOCDebugIssueType(NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*mcast=*/true, /*semaphore=*/true));
     }
 
     bool has_unflushed_write_mcast_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
@@ -51,8 +51,8 @@ public:
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
         return noc_debug_state->get_issues(core, processor_id)
-            .has_issue(NOCDebugIssueType(
-                NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*is_mcast=*/true, /*is_semaphore=*/false));
+            .has_issue(
+                NOCDebugIssueType(NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*mcast=*/true, /*semaphore=*/false));
     }
 
     template <typename T>

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -20,7 +20,8 @@ public:
             return false;
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
-        return noc_debug_state->get_issues(core, processor_id).has_issue(NOCDebugIssueType::WRITE_FLUSH_BARRIER);
+        return noc_debug_state->get_issues(core, processor_id)
+            .has_base_issue(NOCDebugIssueBaseType::WRITE_FLUSH_BARRIER);
     }
 
     bool has_read_barrier_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
@@ -29,7 +30,7 @@ public:
             return false;
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
-        return noc_debug_state->get_issues(core, processor_id).has_issue(NOCDebugIssueType::READ_BARRIER);
+        return noc_debug_state->get_issues(core, processor_id).has_base_issue(NOCDebugIssueBaseType::READ_BARRIER);
     }
 
     bool has_unflushed_semaphore_mcast_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
@@ -39,7 +40,8 @@ public:
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
         return noc_debug_state->get_issues(core, processor_id)
-            .has_issue(NOCDebugIssueType::UNFLUSHED_SEMAPHORE_MCAST_AT_END);
+            .has_issue(NOCDebugIssueType(
+                NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*is_mcast=*/true, /*is_semaphore=*/true));
     }
 
     bool has_unflushed_write_mcast_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
@@ -49,7 +51,8 @@ public:
         }
         tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
         return noc_debug_state->get_issues(core, processor_id)
-            .has_issue(NOCDebugIssueType::UNFLUSHED_WRITE_MCAST_AT_END);
+            .has_issue(NOCDebugIssueType(
+                NOCDebugIssueBaseType::UNFLUSHED_WRITE_AT_END, /*is_mcast=*/true, /*is_semaphore=*/false));
     }
 
     template <typename T>

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -32,6 +32,26 @@ public:
         return noc_debug_state->get_issues(core, processor_id).has_issue(NOCDebugIssueType::READ_BARRIER);
     }
 
+    bool has_unflushed_semaphore_mcast_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
+        auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state();
+        if (!noc_debug_state) {
+            return false;
+        }
+        tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
+        return noc_debug_state->get_issues(core, processor_id)
+            .has_issue(NOCDebugIssueType::UNFLUSHED_SEMAPHORE_MCAST_AT_END);
+    }
+
+    bool has_unflushed_write_mcast_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
+        auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state();
+        if (!noc_debug_state) {
+            return false;
+        }
+        tt_cxy_pair core{chip_id, {virtual_core.x, virtual_core.y}};
+        return noc_debug_state->get_issues(core, processor_id)
+            .has_issue(NOCDebugIssueType::UNFLUSHED_WRITE_MCAST_AT_END);
+    }
+
     template <typename T>
     void RunTestOnDevice(
         const std::function<void(T*, std::shared_ptr<distributed::MeshDevice>)>& run_function,

--- a/tests/tt_metal/tt_metal/test_kernels/misc/noc_debugging/async_mcast_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/noc_debugging/async_mcast_semaphore.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t semaphore_id = 0;
+    uint32_t semaphore_addr = get_semaphore(semaphore_id);
+
+    const uint64_t multicast_noc_addr =
+        get_noc_multicast_addr(MCAST_START_X, MCAST_START_Y, MCAST_END_X, MCAST_END_Y, 0);
+
+    volatile tt_l1_ptr uint32_t* semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+
+    noc_async_write_multicast_loopback_src(
+        L1_BUFFER_ADDR, multicast_noc_addr | L1_BUFFER_ADDR, WRITE_SIZE, NUM_DEST_CORES, false);
+
+#if defined(USE_WRITE_MCAST_BARRIER)
+    noc_async_write_barrier();
+#endif
+
+    *semaphore_ptr = 1;
+
+    noc_semaphore_set_multicast_loopback_src(
+        semaphore_addr, multicast_noc_addr | semaphore_addr, NUM_DEST_CORES, false);
+
+#if defined(USE_SEMAPHORE_MCAST_BARRIER)
+    noc_async_write_barrier();
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/noc_debugging/async_mcast_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/noc_debugging/async_mcast_semaphore.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     noc_async_write_multicast_loopback_src(
         L1_BUFFER_ADDR, multicast_noc_addr | L1_BUFFER_ADDR, WRITE_SIZE, NUM_DEST_CORES, false);
 
-#if defined(USE_WRITE_MCAST_BARRIER)
-    noc_async_write_barrier();
+#if defined(USE_WRITE_MCAST_FLUSH)
+    noc_async_writes_flushed();
 #endif
 
     *semaphore_ptr = 1;
@@ -27,7 +27,7 @@ void kernel_main() {
     noc_semaphore_set_multicast_loopback_src(
         semaphore_addr, multicast_noc_addr | semaphore_addr, NUM_DEST_CORES, false);
 
-#if defined(USE_SEMAPHORE_MCAST_BARRIER)
-    noc_async_write_barrier();
+#if defined(USE_SEMAPHORE_MCAST_FLUSH)
+    noc_async_writes_flushed();
 #endif
 }

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 
 #include <fmt/base.h>
+#include <fmt/ranges.h>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -264,14 +265,7 @@ void NOCDebugState::print_aggregated_errors() const {
     }
     for (const auto& [core_key, core_issues] : issues_by_core) {
         if (!core_issues.write_barrier_issues.empty()) {
-            std::string issues_str;
-            for (size_t i = 0; i < core_issues.write_barrier_issues.size(); ++i) {
-                if (i > 0) {
-                    issues_str += ", ";
-                }
-                issues_str += core_issues.write_barrier_issues[i];
-            }
-            log_error(tt::LogMetal, "  {} [{}]", core_key, issues_str);
+            log_error(tt::LogMetal, "  {} [{}]", core_key, fmt::join(core_issues.write_barrier_issues, ", "));
         }
     }
 

--- a/tt_metal/impl/debug/noc_debugging.cpp
+++ b/tt_metal/impl/debug/noc_debugging.cpp
@@ -284,7 +284,6 @@ void NOCDebugState::print_aggregated_errors() const {
 
     log_error(tt::LogMetal, "========== NOC Debug Summary ==========");
 
-    // Print write barrier issues (during execution)
     for (const auto& [core_key, core_issues] : issues_by_core) {
         if (!core_issues.write_barrier_issues.empty()) {
             log_error(tt::LogMetal, "Missing write barrier/flush (same src addr written multiple times):");
@@ -304,7 +303,6 @@ void NOCDebugState::print_aggregated_errors() const {
         }
     }
 
-    // Print read barrier issues (during execution)
     bool has_read_barrier = false;
     for (const auto& [core_key, core_issues] : issues_by_core) {
         if (core_issues.has_read_barrier) {
@@ -321,7 +319,6 @@ void NOCDebugState::print_aggregated_errors() const {
         }
     }
 
-    // Print unflushed writes at kernel end
     for (const auto& [core_key, core_issues] : issues_by_core) {
         if (!core_issues.unflushed_write_issues.empty()) {
             log_error(tt::LogMetal, "Unflushed async writes at kernel end (missing noc_async_write_barrier):");

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -102,7 +102,7 @@ struct NOCDebugIssue {
 
     void set_issue(const NOCDebugIssueType& issue_type) { issues.insert(issue_type); }
 
-    bool has_issue(const NOCDebugIssueType& issue_type) const { return issues.count(issue_type) > 0; }
+    bool has_issue(const NOCDebugIssueType& issue_type) const { return issues.contains(issue_type); }
 
     bool any_issue() const { return !issues.empty(); }
 

--- a/tt_metal/impl/debug/noc_debugging.hpp
+++ b/tt_metal/impl/debug/noc_debugging.hpp
@@ -94,21 +94,7 @@ struct NOCDebugIssueType {
     NOCDebugIssueType(NOCDebugIssueBaseType type, bool mcast = false, bool semaphore = false) :
         base_type(type), is_mcast(mcast), is_semaphore(semaphore) {}
 
-    bool operator==(const NOCDebugIssueType& other) const {
-        return base_type == other.base_type && is_mcast == other.is_mcast && is_semaphore == other.is_semaphore;
-    }
-
-    bool operator!=(const NOCDebugIssueType& other) const { return !(*this == other); }
-
-    bool operator<(const NOCDebugIssueType& other) const {
-        if (base_type != other.base_type) {
-            return base_type < other.base_type;
-        }
-        if (is_mcast != other.is_mcast) {
-            return is_mcast < other.is_mcast;
-        }
-        return is_semaphore < other.is_semaphore;
-    }
+    auto operator<=>(const NOCDebugIssueType& other) const = default;
 };
 
 struct NOCDebugIssue {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -86,7 +86,11 @@ NOCDebugEvent make_noc_debug_event(
         case EMD::NocEventType::WRITE_: [[fallthrough]];
         case EMD::NocEventType::WRITE_MULTICAST: [[fallthrough]];
         case EMD::NocEventType::SEMAPHORE_SET_MULTICAST: [[fallthrough]];
-        case EMD::NocEventType::SEMAPHORE_SET_REMOTE:
+        case EMD::NocEventType::SEMAPHORE_SET_REMOTE: {
+            bool is_semaphore = event.noc_xfer_type == EMD::NocEventType::SEMAPHORE_SET_MULTICAST ||
+                                event.noc_xfer_type == EMD::NocEventType::SEMAPHORE_SET_REMOTE;
+            bool is_mcast = event.noc_xfer_type == EMD::NocEventType::WRITE_MULTICAST ||
+                            event.noc_xfer_type == EMD::NocEventType::SEMAPHORE_SET_MULTICAST;
             return NOCDebugEvent(NocWriteEvent{
                 trailer.getSrcAddr(),
                 trailer.getDstAddr(),
@@ -97,7 +101,12 @@ NOCDebugEvent make_noc_debug_event(
                 event.dst_x,
                 event.dst_y,
                 static_cast<bool>(event.posted),
-                event.noc_type == EMD::NocType::NOC_1});
+                event.noc_type == EMD::NocType::NOC_1,
+                is_semaphore,
+                is_mcast,
+                event.mcast_end_dst_x,
+                event.mcast_end_dst_y});
+        }
         case EMD::NocEventType::READ_BARRIER_END:
             return NOCDebugEvent(NocReadBarrierEvent{src_x, src_y, event.noc_type == EMD::NocType::NOC_1});
         case EMD::NocEventType::WRITE_BARRIER_END: [[fallthrough]];

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -1146,6 +1146,10 @@ void ReadMeshDeviceProfilerResults(
         if (auto& profiler_state_manager = MetalContext::instance().profiler_state_manager()) {
             profiler_state_manager->signal_debug_dump_read();
         }
+        if (auto& noc_debug_state = MetalContext::instance().noc_debug_state()) {
+            noc_debug_state->finish_cores();
+            noc_debug_state->print_aggregated_errors();
+        }
         return;
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/29601

### Problem description
Some issues in the past such as https://github.com/tenstorrent/tt-metal/issues/32489 involved a missing write barrier at the end of the kernel which was ND and could not be caught with Watcher.

The new debugger (enabled with `TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1`) involves logging Noc transactions and counter registers. This method can detect some more advanced classes of errors such as missing read/write barriers, back-to-back reads or writes to the same addresses without barriers, etc.

In it's current state, back-to-back reads/writes on the same address without barriers can be detected within a kernel but not at the end of a kernel / between kernels.

### What's changed
- Add a check for capturing missing barriers at the end of the kernel.
- Add unit tests into NOCDebuggingFixture which replicates a similar scenario as the Deepseek hang
- Note: This relies on the user to call `ReadMeshDeviceProfilerResults` which will call `finish` on the device right now. This will be improved in a follow-up PR which will rely on using the "BRISC-KERNEL" zone to detect the start and end of the kernel in the NOC event timeline.

### Checklist

APC
[![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang%2Fnoc-debug-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)

https://github.com/tenstorrent/tt-metal/actions/runs/21459276559

Blackhole
[![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang%2Fnoc-debug-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml)

CPP Unit Tests
[![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang%2Fnoc-debug-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml)

- [x] New/Existing tests provide coverage for changes

Manual Testing:

Revert the [fix](https://github.com/tenstorrent/tt-metal/pull/33710/files) to the Deepseek hang. Run the unit test for the problematic kernel and confirm the issue is detected.


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
