### PR TITLE
Matmul - Initial Batched Sharded DRAM Implementation

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -103,6 +103,7 @@ Matrix Multiplication
    ttnn.MatmulMultiCoreReuseMultiCastProgramConfig
    ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig
    ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+   ttnn.MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig
 
 
 Pointwise Unary

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -521,25 +521,41 @@ def test_matmul_batched_hs_dram_sharded_config(device):
     torch.manual_seed(0)
 
     # Dimensions for batched matmul
-    # B must be divisible by 12 (number of DRAM banks)
-    num_dram_banks = 12
-    num_cores_x, num_cores_y = 4, 3  # 4x3 = 12 compute cores (valid on Wormhole)
+    # Use 12 batches on 6x2 L1 grid (12 cores total)
+    num_dram_banks = 12  # Wormhole has 12 DRAM banks
+    num_cores_x, num_cores_y = 6, 2  # 6x2 = 12 L1 cores
     num_cores = num_cores_x * num_cores_y
-    batch = 12  # Total batches (divisible by 12)
+    batch = 12  # Total batches = num_dram_banks
     m, n, k = 32, 64, 32  # Each matmul: [M, N] x [N, K] = [M, K]
     tile_h, tile_w = 32, 32
-    batches_per_core = batch // num_dram_banks  # 1 batch per core/bank
+    batches_per_core = batch // num_cores  # 1 batch per core
 
     # Shapes: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
     in0_shape = [1, batch, m, n]
     in1_shape = [1, batch, n, k]
     out_shape = [1, batch, m, k]
 
-    # Create torch tensors
-    in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
-    in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
+    # Create simple identifiable patterns:
+    # - in0[b] = identity matrix (so output = in1)
+    # - in1[b] = all values are (b+1), so batch 0 is all 1s, batch 1 is all 2s, ..., batch 11 is all 12s
+    # Expected output: out[b] = identity @ (b+1) = all (b+1)
+    in0 = torch.zeros(in0_shape, dtype=torch.bfloat16)
+    in1 = torch.zeros(in1_shape, dtype=torch.bfloat16)
+    for b in range(batch):
+        # Create identity matrix for in0[b]
+        # Since M=32, N=64, we create a 32x32 identity in the first 32 columns
+        for i in range(m):
+            in0[0, b, i, i] = 1.0
+        # Fill in1[b] with batch number (1-indexed: 1, 2, 3, ..., 12)
+        in1[0, b, :, :] = float(b + 1)
 
-    # L1 shard grid: 4x3 = 12 compute cores (valid 2D grid on Wormhole)
+    print(f"\n=== Debug: Simplified identifiable patterns ===")
+    print(f"in0[b] = identity matrix")
+    print(f"in1[b] = all (b+1), so batch 0 is all 1s, batch 11 is all 12s")
+    print(f"Expected output: out[b] = identity @ (b+1) = all (b+1)")
+    print(f"So batch 0 output should be all 1s, batch 6 should be all 7s, batch 11 should be all 12s")
+
+    # L1 shard grid: 6x2 = 12 compute cores (fits on Wormhole)
     l1_shard_grid = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
     )
@@ -614,6 +630,7 @@ def test_matmul_batched_hs_dram_sharded_config(device):
         in1_t,
         program_config=program_config,
         memory_config=out_memory_config,
+        # memory_config=ttnn.DRAM_MEMORY_CONFIG,
         dtype=ttnn.bfloat16,
     )
 
@@ -622,7 +639,57 @@ def test_matmul_batched_hs_dram_sharded_config(device):
     # PyTorch batched matmul
     pt_out = torch.matmul(in0, in1)
 
-    expected_pcc = 0.99
+    # Debug: print values from each batch
+    # Expected: identity @ (b+1) = all (b+1)
+    print("\n=== Debug: Output values per batch ===")
+    print(f"Expected: batch b should output all (b+1) values")
+    print(f"Grid: {num_cores_x}x{num_cores_y}")
+
+    for b in range(batch):
+        expected_val = b + 1  # Simple: just the batch number (1-indexed)
+        pt_val = pt_out[0, b, 0, 0].item()
+        tt_val = output_tensor[0, b, 0, 0].item()
+        row = b // num_cores_x
+        col = b % num_cores_x
+
+        # Check if TT output matches expected value
+        match = "✓" if abs(tt_val - expected_val) < 0.5 else "✗"
+
+        # If mismatch, try to identify which batch this actually is
+        computed_batch = "?"
+        if abs(tt_val - expected_val) >= 0.5:
+            for test_b in range(batch):
+                if abs(tt_val - (test_b + 1)) < 0.5:
+                    computed_batch = f"batch {test_b}"
+                    break
+        else:
+            computed_batch = "correct"
+
+        print(
+            f"Batch {b:2d} (row={row},col={col}): expected={expected_val:4.0f}, PT={pt_val:6.1f}, TT={tt_val:6.1f} {match} ({computed_batch})"
+        )
+
+    # Detailed analysis for batches 6-11 (row 1 of 6x2 grid)
+    print("\n=== Detailed comparison of batches 6-11 (second row of grid) ===")
+    for b in range(batch):
+        print(f"\n--- Batch {b} ---")
+        print(f"Expected: all {b+1}s")
+        print(f"PT output (first 8 elements): {pt_out[0, b, 0, :8].tolist()}")
+        print(f"TT output (first 8 elements): {output_tensor[0, b, 0, :8].tolist()}")
+
+    # Check if the INPUT tensors were sharded correctly
+    # Read back in0 and check where each batch's data ended up
+    print("\n=== Checking in0 shard distribution ===")
+    in0_readback = ttnn.to_torch(in0_t)
+    print("in0 first element of each batch (should be b+1):")
+    for b in range(batch):
+        val = in0_readback[0, b, 0, 0].item()
+        expected = b + 1
+        match = "✓" if abs(val - expected) < 0.5 else f"✗ (got {val})"
+        print(f"  Batch {b}: expected={expected}, got={val:.1f} {match}")
+
+    # Lower PCC threshold due to bfloat8_b weights (lower precision than bfloat16)
+    expected_pcc = 0.97
     pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
     logger.info(f"Batch-sharded DRAM matmul test: {pcc_message}")
     assert_with_pcc(pt_out, output_tensor, expected_pcc)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -541,11 +541,6 @@ def test_matmul_batched_dram_sharded(device, test_case):
     in1 = torch.zeros(in1_shape_padded, dtype=torch.bfloat16)
     in1[:, :batch, :n, :k] = in1_orig
 
-    print(f"\n=== Batch-sharded DRAM matmul test ===")
-    print(f"original: batch={batch}, m={m}, n={n}, k={k}")
-    print(f"padded:   batch={batch_padded}, m={m_padded}, n={n_padded}, k={k_padded}")
-    print(f"in0_shape: {in0_shape_padded}, in1_shape: {in1_shape_padded}, out_shape: {out_shape_padded}")
-
     # in0 L1 shard grid
     in0_shard_grid = ttnn.CoreRangeSet(
         {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(in0_core_grid_x - 1, in0_core_grid_y - 1))}
@@ -574,8 +569,6 @@ def test_matmul_batched_dram_sharded(device, test_case):
         device=device,
         memory_config=in0_memory_config,
     )
-    print(f"Created in0_t (batch-sharded in L1 on {num_in0_cores} cores)")
-    print(f"in0_shape: {in0_shape_padded}, shard_shape: {in0_shard_shape}")
 
     # in1: DRAM sharded by batch across 12 DRAM banks
     # Each DRAM bank gets batches_per_dram_bank complete [N_padded, K_padded] matrices

--- a/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/matmul/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
         device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
         device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
         device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+        device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
         device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
         # sparse
         device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -981,7 +981,8 @@ MatmulProgramConfig get_program_config(
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (
                 not std::is_same_v<ProgramConfigType, MatmulMultiCoreProgramConfig> and
-                not std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+                not std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig> and
+                not std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
                 TT_FATAL(
                     program_config.compute_with_storage_grid_size.x <=
                         input_tensor_a.device()->compute_with_storage_grid_size().x,

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -60,6 +60,13 @@ struct MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
     std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
 };
 
+struct MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig {
+    std::size_t in0_block_w{};
+    std::size_t per_core_M{};
+    std::size_t per_core_N{};
+    std::optional<ttnn::operations::unary::UnaryWithParam> fused_activation;
+};
+
 struct MatmulMultiCoreProgramConfig {};
 
 using MatmulProgramConfig = std::variant<
@@ -67,6 +74,7 @@ using MatmulProgramConfig = std::variant<
     MatmulMultiCoreReuseProgramConfig,
     MatmulMultiCoreReuseMultiCastProgramConfig,
     MatmulMultiCoreReuseMultiCast1DProgramConfig,
-    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>;
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig,
+    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>;
 
 }  // namespace ttnn::operations::matmul

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -497,7 +497,7 @@ create_program_batch_sharded(
 
     // First, set idle args for non-worker cores in the bounding box
     for (const auto& core : all_cores_in_rect_grid_vec) {
-        bool is_worker = worker_cores_set.find(core) != worker_cores_set.end();
+        bool is_worker = worker_cores_set.contains(core);
 
         if (!is_worker) {
             // Idle core - set minimal args (1 arg each)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -1,0 +1,1136 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "hostdevcommon/common_values.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+
+using namespace tt;
+
+using ttnn::operations::unary::UnaryOpType;
+using ttnn::operations::unary::UnaryWithParam;
+
+namespace ttnn::prim {
+namespace reuse_batched_hs_dram_sharded_optimized_helpers {
+
+// This type of access pattern cannot be copied.
+// Treat it as a one off patch to restore functionality that
+// was adjusted to fix one P0 causing another P0.
+// TODO: Proper fix will be implemented in Issue #32205
+tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {
+    ttnn::distributed::MeshDevice* device = a.device();
+    const ttnn::distributed::MeshDeviceView& view = device->get_view();
+    if (!view.contains(coord) || !view.is_local(coord)) {
+        return device;
+    }
+    return a.device()->get_device(coord);
+}
+
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+    uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
+
+    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
+    uint32_t noc_max_page_size;
+    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+        noc_max_page_size = 8192;
+    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+        noc_max_page_size = 16384;
+    } else {
+        TT_FATAL(false, "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported.");
+    }
+
+    page_size = (noc_max_page_size / tile_size) * tile_size;
+    while (total_size % page_size != 0 && page_size >= tile_size) {
+        page_size -= tile_size;
+    }
+    num_pages = total_size / page_size;
+}
+
+void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
+    for (const CoreCoord& item : v2) {
+        if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
+            commons.push_back(item);
+        }
+    }
+
+    for (const CoreCoord& item : commons) {
+        v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
+    }
+}
+
+void get_optimal_dram_bank_to_reader_assignment(
+    tt::tt_metal::IDevice* device,
+    std::vector<CoreCoord>& all_worker_cores_ordered,
+    CoreRangeSet& all_worker_cores,
+    tt_metal::NOC noc) {
+    all_worker_cores_ordered = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+    std::set<CoreRange> all_cores_set;
+    for (const auto& worker_core : all_worker_cores_ordered) {
+        all_cores_set.insert(CoreRange(worker_core));
+    }
+    all_worker_cores = CoreRangeSet(all_cores_set);
+}
+
+std::pair<tt::tt_metal::Program, MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::shared_variables_t>
+create_program_dram_sharded(
+    tt::tt_metal::IDevice* device,
+    const CoreRangeSet& input_all_storage_cores,
+    const CoreRangeSet& output_all_storage_cores,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    uint32_t in0_block_w,
+    uint32_t in0_last_ktile_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N_storage,
+    std::optional<UnaryWithParam> fused_activation,
+    tt_metal::Buffer* in0_buffer,
+    tt_metal::Buffer* in1_buffer,
+    tt_metal::Buffer* bias_buffer,
+    tt_metal::Buffer* out_buffer,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const tt::tt_metal::Tile& bias_tile,
+    const tt::tt_metal::Tile& output_tile,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool untilize_out,
+    bool skip_compute,
+    bool skip_in0_mcast,
+    bool skip_write_back) {
+    log_debug(tt::LogOp, "math_fidelity: {}", math_fidelity);
+    log_debug(tt::LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
+    log_debug(tt::LogOp, "math_approx_mode: {}", math_approx_mode);
+    log_debug(tt::LogOp, "packer_l1_acc: {}", packer_l1_acc);
+    log_debug(tt::LogOp, "M: {}, K: {}, N: {}", M, K, N);
+    log_debug(tt::LogOp, "per_core_M: {}, per_core_N_storage: {}", per_core_M, per_core_N_storage);
+
+    // currently only support transpose of the full tile
+    bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
+
+    tt_metal::Program program{};
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_mcast_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
+
+    CoreCoord top_left_core = {(std::size_t)start_core_x, (std::size_t)start_core_y};
+    CoreCoord bottom_right_core = {
+        (std::size_t)start_core_x + compute_with_storage_grid_size.x - 1,
+        (std::size_t)start_core_y + compute_with_storage_grid_size.y - 1};
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
+    tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    CoreCoord start_core_noc = top_left_core_physical;
+    CoreCoord end_core_noc = bottom_right_core_physical;
+    if (in0_noc == tt::tt_metal::NOC::NOC_1) {
+        std::swap(start_core_noc, end_core_noc);
+    }
+
+    // get the dram readers
+    std::vector<CoreCoord> all_worker_cores_ordered;
+    CoreRangeSet all_worker_cores;
+    get_optimal_dram_bank_to_reader_assignment(device, all_worker_cores_ordered, all_worker_cores, in1_noc);
+
+    // dram banks
+    uint32_t num_dram_banks = all_worker_cores_ordered.size();
+    for ([[maybe_unused]] auto core : corerange_to_cores(all_worker_cores)) {
+        log_debug(tt::LogOp, "all_worker_cores_log: {}", core);
+    }
+    for ([[maybe_unused]] auto core : all_worker_cores_ordered) {
+        log_debug(tt::LogOp, "all_worker_cores_ordered: {}", core);
+    }
+
+    uint32_t per_core_N_compute = (N + num_dram_banks - 1) / num_dram_banks;
+    uint32_t per_core_N_in1_sender = per_core_N_compute;
+    auto subblock_hw = operations::matmul::bmm_op_utils::get_matmul_subblock_params(
+        per_core_M, per_core_N_compute, false, false, fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    uint32_t max_subblock_w = fp32_dest_acc_en ? 4 : 8;
+    // it is bad for compute, pad per_core_N_compute
+    if (out_subblock_h == 1 and out_subblock_w < max_subblock_w) {
+        uint32_t num_subblock_w_per_core_N = per_core_N_compute / out_subblock_w;
+        uint32_t num_iter = max_subblock_w - out_subblock_w;
+        uint32_t new_out_subblock_w = out_subblock_w;
+        uint32_t preferred_out_subblock_w = out_subblock_w;
+
+        for (uint32_t i = 0; i < num_iter; ++i) {
+            new_out_subblock_w += 1;
+            uint32_t new_num_subblock_w_per_core_N = (per_core_N_compute + new_out_subblock_w - 1) / new_out_subblock_w;
+
+            if (new_num_subblock_w_per_core_N < num_subblock_w_per_core_N) {
+                num_subblock_w_per_core_N = new_num_subblock_w_per_core_N;
+                preferred_out_subblock_w = new_out_subblock_w;
+            }
+        }
+        out_subblock_w = preferred_out_subblock_w;
+        per_core_N_compute = out_subblock_w * num_subblock_w_per_core_N;
+    }
+
+    log_debug(
+        tt::LogOp,
+        "per_core_M: {}, per_core_N_compute: {}, per_core_N_in1_sender: {}",
+        per_core_M,
+        per_core_N_compute,
+        per_core_N_in1_sender);
+    log_debug(tt::LogOp, "out_subblock_h: {}, out_subblock_w: {}", out_subblock_h, out_subblock_w);
+
+    uint32_t num_blocks = K / in0_block_w;
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+
+    // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    uint32_t bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
+    uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
+
+    uint32_t in0_block_tiles = per_core_M * in0_block_w;
+    uint32_t in0_CB_tiles = in0_block_tiles;
+    if (B * num_blocks > 1) {
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
+    }
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
+    uint32_t in1_block_tiles = per_core_N_in1_sender * in0_block_w;
+    uint32_t in1_CB_tiles = in1_block_tiles;
+    if (B * num_blocks > 1) {
+        in1_CB_tiles = in1_CB_tiles * 3;  // tripple buffer
+    }
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
+
+    uint32_t out_block_tiles = per_core_M * per_core_N_compute;
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
+    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
+    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
+
+    uint32_t out_reshard_block_tiles = per_core_M * per_core_N_storage;
+    uint32_t out_reshard_CB_tiles = out_reshard_block_tiles;  // No double buffer
+    uint32_t out_reshard_CB_size = out_reshard_CB_tiles * output_single_tile_size;
+
+    uint32_t in0_shard_width_in_tiles = in0_buffer->shard_spec().shape()[1] / in0_tile.get_tile_shape()[1];
+    uint32_t in2_block_tiles = per_core_M * in0_shard_width_in_tiles;
+    uint32_t in2_CB_tiles = in2_block_tiles;
+    uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
+
+    uint32_t in3_block_tiles = per_core_N_in1_sender;
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
+    uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
+
+    // get the max page size based on num tiles
+    uint32_t in1_buffer_page_size, in1_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in1_block_tiles, in1_single_tile_size, in1_buffer_page_size, in1_buffer_num_pages);
+
+    uint32_t bias_buffer_page_size, bias_buffer_num_pages;
+    get_max_page_size_and_num_pages(
+        device, in3_block_tiles, bias_single_tile_size, bias_buffer_page_size, bias_buffer_num_pages);
+
+    uint32_t num_worker_cores = num_dram_banks;
+
+    // move conflict coord from mcast receiver to mcast sender
+    std::vector<CoreCoord> input_all_storage_cores_vec = corerange_to_cores(input_all_storage_cores);
+    std::vector<CoreCoord> all_worker_cores_vec = corerange_to_cores(all_worker_cores);
+    std::vector<CoreCoord> storage_worker_common;
+    move_common_entries(input_all_storage_cores_vec, all_worker_cores_vec, storage_worker_common);
+
+    std::vector<CoreRange> input_all_storage_cores_range;
+    input_all_storage_cores_range.reserve(input_all_storage_cores_vec.size());
+    std::transform(
+        input_all_storage_cores_vec.begin(),
+        input_all_storage_cores_vec.end(),
+        std::back_inserter(input_all_storage_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::vector<CoreRange> all_worker_cores_range;
+    all_worker_cores_range.reserve(all_worker_cores_vec.size());
+    std::transform(
+        all_worker_cores_vec.begin(),
+        all_worker_cores_vec.end(),
+        std::back_inserter(all_worker_cores_range),
+        [](const CoreCoord& coord) { return CoreRange(coord); });
+
+    std::set<CoreRange> input_all_storage_cores_set(
+        input_all_storage_cores_range.begin(), input_all_storage_cores_range.end());
+    std::set<CoreRange> all_worker_cores_set(all_worker_cores_range.begin(), all_worker_cores_range.end());
+    CoreRangeSet mcast_senders = CoreRangeSet(input_all_storage_cores_set);
+    CoreRangeSet mcast_receivers = CoreRangeSet(all_worker_cores_set);
+
+    for ([[maybe_unused]] auto core : corerange_to_cores(mcast_senders)) {
+        log_debug(tt::LogOp, "mcast_senders: {}", core);
+    }
+    for ([[maybe_unused]] auto core : corerange_to_cores(mcast_receivers)) {
+        log_debug(tt::LogOp, "mcast_receivers: {}", core);
+    }
+
+    // all cores
+    std::set<CoreRange> all_cores_set;
+    all_cores_set.insert(mcast_senders.ranges().begin(), mcast_senders.ranges().end());
+    all_cores_set.insert(mcast_receivers.ranges().begin(), mcast_receivers.ranges().end());
+    CoreRangeSet all_cores = CoreRangeSet(all_cores_set);
+
+    for ([[maybe_unused]] auto core : corerange_to_cores(all_cores)) {
+        log_debug(tt::LogOp, "all_cores: {}", core);
+    }
+
+    // grid bounding box
+    CoreRange bounding_box = all_cores.bounding_box();
+    std::set<CoreRange> bounding_box_set;
+    bounding_box_set.insert(bounding_box);
+    CoreRangeSet all_cores_in_rect_grid(bounding_box_set);
+    std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
+    log_debug(tt::LogOp, "bounding_box: {}", bounding_box);
+
+    // Mcast args
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_sender_valid_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, VALID);
+
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
+
+    uint32_t num_blocks_per_shard = num_blocks / input_all_storage_cores_vec.size();
+    log_debug(tt::LogOp, "num_blocks_per_shard: {}", num_blocks_per_shard);
+    if (per_core_M > 1) {
+        TT_FATAL(
+            num_blocks_per_shard == 1,
+            "currently not support per_core_M larger than 1, while split one shard into multiple blocks (per_core_M "
+            "{}, num_blocks_per_shard {})",
+            per_core_M,
+            num_blocks_per_shard);
+    }
+
+    std::vector<uint32_t> in0_sender_compile_time_args = {
+        (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+        (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
+        (std::uint32_t)in0_last_ktile_w,                            // in0_last_ktile_w
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
+        (std::uint32_t)num_worker_cores,  // in0_mcast_num_dests
+        (std::uint32_t)num_mcast_cores,   // in0_mcast_num_cores
+        // block
+        (std::uint32_t)num_blocks,
+        // mcast noc coords
+        (std::uint32_t)start_core_noc.x,
+        (std::uint32_t)start_core_noc.y,
+        (std::uint32_t)end_core_noc.x,
+        (std::uint32_t)end_core_noc.y,
+        // semahpre valid
+        (std::uint32_t)in0_mcast_sender_valid_semaphore_id,
+        //
+        (std::uint32_t)num_blocks_per_shard};
+
+    std::vector<uint32_t> in1_sender_writer_compile_time_args = {
+        (std::uint32_t)in1_buffer_page_size,
+        (std::uint32_t)in1_buffer_num_pages,
+        // in1 block args
+        (std::uint32_t)per_core_N_in1_sender,                // in1_block_w
+        (std::uint32_t)per_core_N_in1_sender * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,                                    // num_blocks
+        (std::uint32_t)out_block_tiles,                               // out_block_num_tiles
+        (std::uint32_t)per_core_N_compute * output_single_tile_size,  // out_tensor_stride_w_bytes
+        (std::uint32_t)per_core_N_storage * output_single_tile_size,  // out_reshard_tensor_stride_w_bytes
+        (std::uint32_t)per_core_M};
+    if (bias_buffer != nullptr) {
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_page_size);
+        in1_sender_writer_compile_time_args.push_back(bias_buffer_num_pages);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
+    }
+
+    std::map<std::string, std::string> mm_kernel_defines;
+    std::map<std::string, std::string> mm_kernel_in0_sender_define;
+    std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
+    if (bias_buffer != nullptr) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
+    }
+    if (fused_activation.has_value()) {
+        if (fused_activation.value().op_type == UnaryOpType::RELU) {
+            mm_kernel_defines["PACK_RELU"] = "1";
+        } else {
+            using ttnn::operations::unary::utils::get_defines;
+            mm_kernel_defines.merge(get_defines(
+                fused_activation.value().op_type,
+                fused_activation.value().params,
+                "ACTIVATION",
+                "i",
+                tt_metal::dataformat_to_datatype_converter(output_data_format)));
+        }
+    }
+    if (packer_l1_acc_en) {
+        mm_kernel_defines["PACKER_L1_ACC"] = "1";
+    }
+    if (fp32_dest_acc_en) {
+        mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
+    mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+
+    if (skip_compute) {
+        mm_kernel_defines["SKIP_COMPUTE"] = "1";
+    }
+    if (skip_in0_mcast) {
+        mm_kernel_in0_sender_define["SKIP_MCAST"] = "1";
+    }
+    if (skip_write_back) {
+        mm_kernel_in1_sender_writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
+    mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
+    if (in1_transpose_tile) {
+        mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+
+    auto mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp",
+        all_cores_in_rect_grid,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_define});
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp",
+        all_cores_in_rect_grid,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines});
+
+    // Compute kernel compile time args
+    uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
+
+    uint32_t in1_num_subblocks = (per_core_N_compute / out_subblock_w);
+    uint32_t in1_per_core_w = per_core_N_in1_sender;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
+
+    std::vector<uint32_t> compute_kernel_args = {
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
+
+        in1_num_subblocks,  // in1_num_subblocks
+        in1_block_tiles,    // in1_block_num_tiles
+        in1_per_core_w,     // in1_per_core_w
+
+        num_blocks,  // num_blocks
+        1,           // out_num_blocks_x
+        1,           // out_num_blocks_y
+
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
+
+        untilize_out,  // untilize_out
+        false,         // get_batch_from_reader
+        false,         // in0_transpose_tile
+    };
+
+    // Create compute kernel
+    auto mm_kernel = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
+        // all_worker_cores,
+        all_cores_in_rect_grid,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines});
+
+    log_debug(LogOp, "in1_single_tile_size: {}", in1_single_tile_size);
+
+    // Create circular buffers
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size)
+            .set_tile_dims(src1_cb_index, in1_tile);
+    tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src1_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt_metal::CircularBufferConfig src2_cb_config =
+        tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+            .set_page_size(src2_cb_index, in0_single_tile_size)
+            .set_tile_dims(src2_cb_index, in0_tile)
+            .set_globally_allocated_address(*in0_buffer);
+    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src2_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src2_cb_index,
+        in0_single_tile_size,
+        in2_CB_size / in0_single_tile_size,
+        in2_CB_size);
+
+    uint32_t output_cb_index = tt::CBIndex::c_4;
+    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // output
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format},
+        };
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile);
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, interm0_cb_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
+    } else {
+        log_debug(tt::LogOp, "inplace interm and outout cb");
+        // share buffer
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                               .set_tile_dims(output_cb_index, output_tile)
+                               .set_tile_dims(interm0_cb_index, output_tile);
+    }
+    tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, output_cb_config);
+    log_debug(
+        tt::LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
+
+    // resharded output
+    uint32_t output_reshard_cb_index = tt::CBIndex::c_6;
+    std::map<uint8_t, tt::DataFormat> output_reshard_cb_data_format_spec{
+        {output_reshard_cb_index, output_data_format},
+    };
+    tt_metal::CircularBufferConfig output_reshard_cb_config =
+        tt_metal::CircularBufferConfig(out_reshard_CB_size, output_reshard_cb_data_format_spec)
+            .set_page_size(output_reshard_cb_index, output_single_tile_size)
+            .set_tile_dims(output_reshard_cb_index, output_tile);
+    output_reshard_cb_config = output_reshard_cb_config.set_globally_allocated_address(*out_buffer);
+    auto cb_output_reshard = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, output_reshard_cb_config);
+
+    if (bias_buffer != nullptr) {
+        uint32_t src3_cb_index = tt::CBIndex::c_3;
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size)
+                .set_tile_dims(src3_cb_index, bias_tile);
+        tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, cb_src3_config);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
+    }
+
+    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+
+    std::vector<uint32_t> in0_mcast_sender_noc_x;
+    std::vector<uint32_t> in0_mcast_sender_noc_y;
+    std::vector<CoreCoord> mcast_senders_coords = corerange_to_cores(mcast_senders);
+    std::sort(mcast_senders_coords.begin(), mcast_senders_coords.end(), [](const CoreCoord& a, const CoreCoord& b) {
+        if (a.y != b.y) {
+            return a.y < b.y;
+        }
+        return a.x < b.x;
+    });
+    in0_mcast_sender_noc_x.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    in0_mcast_sender_noc_y.reserve(mcast_senders_coords.size());
+    for (auto core : mcast_senders_coords) {
+        in0_mcast_sender_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    uint32_t sender_id = 0;
+    for (auto core : mcast_senders_coords) {
+        std::vector<uint32_t> mm_in0_sender_args;
+
+        // mcast sender - 1, mcast sender + compute core - 2
+        uint32_t worker_core_type;
+        if (find(storage_worker_common.begin(), storage_worker_common.end(), core) != storage_worker_common.end()) {
+            worker_core_type = 2;
+        } else {
+            worker_core_type = 1;
+        }
+
+        mm_in0_sender_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_sender_args.push_back((std::uint32_t)sender_id);
+        mm_in0_sender_args.push_back(
+            (std::uint32_t)((core == input_all_storage_cores_vec.back()) and (in0_last_ktile_w > 0)));
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_sender_args.insert(
+            mm_in0_sender_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);
+        reader_kernel_ids.push_back(mm_kernel_in0_sender_id);
+
+        sender_id++;
+    }
+
+    std::vector<CoreCoord> mcast_receiver_coords = corerange_to_cores(mcast_receivers);
+    for (auto core : mcast_receiver_coords) {
+        // in0 receivers rt args
+        std::vector<uint32_t> mm_in0_receiver_args;
+        // mcast receiver - 3
+        uint32_t worker_core_type = 3;
+        mm_in0_receiver_args.push_back((std::uint32_t)worker_core_type);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);
+        mm_in0_receiver_args.push_back((std::uint32_t)0);  // in0_last_ktile_w
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_x.begin(), in0_mcast_sender_noc_x.end());
+        mm_in0_receiver_args.insert(
+            mm_in0_receiver_args.end(), in0_mcast_sender_noc_y.begin(), in0_mcast_sender_noc_y.end());
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_receiver_args);
+        reader_kernel_ids.push_back(mm_kernel_in0_sender_id);
+    }
+
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(mcast_senders_coords.begin(), mcast_senders_coords.end(), core) == mcast_senders_coords.end() and
+            std::find(mcast_receiver_coords.begin(), mcast_receiver_coords.end(), core) ==
+                mcast_receiver_coords.end()) {
+            // in0 receivers rt args
+            std::vector<uint32_t> mm_in0_idle_args;
+            // idle core - 0
+            uint32_t worker_core_type = 0;
+            mm_in0_idle_args.push_back((std::uint32_t)worker_core_type);
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_idle_args);
+        }
+    }
+
+    uint32_t bank_id = 0;
+    std::vector<uint32_t> bank_ids;
+    uint32_t curr_storage_core_idx = 0;
+    uint32_t per_core_N_storage_curr_stride = 0;
+
+    uint32_t worker_core_stride = 0;
+    uint32_t storage_core_stride = 0;
+    uint32_t curr_worker_core = 0;
+    uint32_t curr_storage_core = 0;
+
+    // for all the cores in the rect grid, we send one rt arg to determine if they are worker core
+    for (auto core : all_cores_in_rect_grid_vec) {
+        if (std::find(all_worker_cores.ranges().begin(), all_worker_cores.ranges().end(), core) ==
+            all_worker_cores.ranges().end()) {  // not worker
+            // in1 reader rt args
+            bool is_worker_core = false;
+            std::vector<uint32_t> mm_in1_sender_writer_args;
+            mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);
+
+            // compute rt args
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_compute_args);
+        } else {
+            // compute rt args
+            bool is_worker_core = true;
+            std::vector<uint32_t> mm_compute_args;
+            mm_compute_args.push_back((std::uint32_t)is_worker_core);
+
+            tt_metal::SetRuntimeArgs(program, mm_kernel, core, mm_compute_args);
+        }
+    }
+
+    std::vector<uint32_t> output_noc_x;
+    std::vector<uint32_t> output_noc_y;
+    std::vector<CoreCoord> output_coords = corerange_to_cores(output_all_storage_cores, std::nullopt, true);
+    output_noc_x.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
+    }
+    output_noc_y.reserve(output_coords.size());
+    for (auto core : output_coords) {
+        output_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
+    }
+
+    uint32_t num_cores_written_back = (N + per_core_N_storage - 1) / per_core_N_storage;
+    uint32_t expected_max_total_width = num_cores_written_back * per_core_N_storage;
+    log_debug(tt::LogOp, "per_core_N_storage: {}", per_core_N_storage);
+    log_debug(tt::LogOp, "num_cores_written_back: {}", num_cores_written_back);
+    uint32_t total_tensor_width_written_back = 0;
+    for (uint32_t i = 0; i < all_worker_cores_ordered.size(); ++i) {
+        auto core = all_worker_cores_ordered[i];
+
+        // in1 reader rt args
+        bool is_worker_core = true;
+        std::vector<uint32_t> mm_in1_sender_writer_args;
+        mm_in1_sender_writer_args.push_back((std::uint32_t)is_worker_core);
+        mm_in1_sender_writer_args.push_back(in1_buffer->address());
+        if (bias_buffer != nullptr) {
+            mm_in1_sender_writer_args.push_back(bias_buffer->address());
+        } else {
+            mm_in1_sender_writer_args.push_back(0);
+        }
+
+        uint32_t vc = bank_id & 0x3;
+        bank_ids.push_back(bank_id);
+        for (uint32_t j = 0; j < i; ++j) {
+            auto core_prev = all_worker_cores_ordered[j];
+
+            if (core_prev.y == core.y and ((bank_id & 0x3) == (bank_ids[j] & 0x3))) {  // same vc and same row
+                vc = (vc + 1) & 0x3;
+                break;
+            }
+        }
+        mm_in1_sender_writer_args.push_back((std::uint32_t)bank_id);
+        mm_in1_sender_writer_args.push_back((std::uint32_t)vc);
+
+        bank_id = (bank_id + 1) % num_dram_banks;
+
+        if (per_core_N_in1_sender < per_core_N_storage) {
+            if (curr_storage_core_idx < num_cores_written_back) {
+                uint32_t remaining_per_core_N_storage = (per_core_N_storage - per_core_N_storage_curr_stride);
+                uint32_t per_core_N_reshard_1 = (remaining_per_core_N_storage > per_core_N_in1_sender)
+                                                    ? per_core_N_in1_sender
+                                                    : remaining_per_core_N_storage;
+                uint32_t per_core_N_reshard_2 = per_core_N_in1_sender - per_core_N_reshard_1;
+
+                if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                    mm_in1_sender_writer_args.push_back(2);
+                } else {
+                    mm_in1_sender_writer_args.push_back(1);
+                }
+
+                log_debug(
+                    tt::LogOp,
+                    "curr worker core: {}, send back: {} tiles to storage core: {}, coord: {}",
+                    i,
+                    per_core_N_reshard_1,
+                    curr_storage_core_idx,
+                    output_coords[curr_storage_core_idx]);
+
+                mm_in1_sender_writer_args.push_back(
+                    per_core_N_storage_curr_stride * output_single_tile_size);  // reshard_tensor_start_offset
+                mm_in1_sender_writer_args.push_back(
+                    per_core_N_reshard_1 * output_single_tile_size);                       // per_core_N_reshard_bytes_1
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx]);  // output_noc_y
+
+                total_tensor_width_written_back += per_core_N_reshard_1;
+
+                if (per_core_N_reshard_2 != 0 and (curr_storage_core_idx + 1) < num_cores_written_back) {
+                    log_debug(
+                        tt::LogOp,
+                        "curr worker core: {}, send back: {} tiles to storage core: {}, coord: {}",
+                        i,
+                        per_core_N_reshard_2,
+                        curr_storage_core_idx + 1,
+                        output_coords[curr_storage_core_idx + 1]);
+
+                    mm_in1_sender_writer_args.push_back(
+                        per_core_N_reshard_2 * output_single_tile_size);  // per_core_N_reshard_bytes_2
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core_idx + 1]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core_idx + 1]);  // output_noc_y
+
+                    total_tensor_width_written_back += per_core_N_reshard_2;
+                }
+
+                curr_storage_core_idx += (per_core_N_storage_curr_stride + per_core_N_in1_sender) / per_core_N_storage;
+                per_core_N_storage_curr_stride =
+                    (per_core_N_storage_curr_stride + per_core_N_in1_sender) % per_core_N_storage;
+            }
+        } else {
+            uint32_t num_cores_write_back = 0;
+
+            if (curr_storage_core < num_cores_written_back) {
+                num_cores_write_back++;
+
+                worker_core_stride = per_core_N_storage - storage_core_stride;
+
+                log_debug(
+                    tt::LogOp,
+                    "curr worker core: {}, send back: {} tiles to storage core: {}, coord: {}",
+                    curr_worker_core,
+                    worker_core_stride,
+                    curr_storage_core,
+                    output_coords[curr_storage_core]);
+
+                mm_in1_sender_writer_args.push_back(
+                    storage_core_stride * output_single_tile_size);  // reshard_tensor_start_offset
+                mm_in1_sender_writer_args.push_back(
+                    worker_core_stride * output_single_tile_size);                     // per_core_N_reshard
+                mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                if (worker_core_stride >= per_core_N_in1_sender) {
+                    curr_worker_core += 1;
+                }
+
+                total_tensor_width_written_back += worker_core_stride;
+
+                while (curr_worker_core <= i and curr_storage_core < num_cores_written_back) {
+                    num_cores_write_back++;
+
+                    bool increment_worker_core = (worker_core_stride + per_core_N_storage) >= per_core_N_in1_sender;
+                    uint32_t current_worker_stride_total =
+                        increment_worker_core ? per_core_N_in1_sender : worker_core_stride + per_core_N_storage;
+                    uint32_t current_worker_write_back_tiles = current_worker_stride_total - worker_core_stride;
+
+                    log_debug(
+                        tt::LogOp,
+                        "curr worker core: {}, send back: {} tiles to storage core: {}, coord: {}",
+                        curr_worker_core,
+                        current_worker_write_back_tiles,
+                        curr_storage_core,
+                        output_coords[curr_storage_core]);
+
+                    if (increment_worker_core) {
+                        curr_worker_core += 1;
+                    }
+
+                    mm_in1_sender_writer_args.push_back(
+                        current_worker_write_back_tiles * output_single_tile_size);        // per_core_N_reshard
+                    mm_in1_sender_writer_args.push_back(output_noc_x[curr_storage_core]);  // output_noc_x
+                    mm_in1_sender_writer_args.push_back(output_noc_y[curr_storage_core]);  // output_noc_y
+
+                    total_tensor_width_written_back += current_worker_write_back_tiles;
+
+                    storage_core_stride = current_worker_write_back_tiles % per_core_N_storage;
+                    curr_storage_core += current_worker_write_back_tiles / per_core_N_storage;
+                    worker_core_stride = current_worker_stride_total;
+                }
+            }
+
+            mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + 5, num_cores_write_back);
+        }
+
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);
+        writer_kernel_ids.push_back(mm_kernel_in1_sender_writer_id);
+    }
+
+    TT_FATAL(
+        total_tensor_width_written_back <= expected_max_total_width,
+        "more datums written back to sharded tensor, L1 corruption, expected: {}, actual: {}",
+        expected_max_total_width,
+        total_tensor_width_written_back);
+
+    return {
+        std::move(program),
+        MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::shared_variables_t{
+            writer_kernel_ids, all_worker_cores_ordered, cb_src2, cb_output_reshard}};
+}
+}  // namespace reuse_batched_hs_dram_sharded_optimized_helpers
+
+std::pair<tt::tt_metal::Program, MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::shared_variables_t>
+matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
+    const ttnn::MeshCoordinate& mesh_coord,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value,
+    const ttnn::prim::MatmulParams& operation_attributes) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    const auto& a = input_tensors.at(0);
+    const auto& b = input_tensors.at(1);
+    const auto& bias = optional_input_tensors.at(0);
+    const auto& output = output_tensors.at(0);
+    const auto& ashape = a.padded_shape();
+    const auto& bshape = b.padded_shape();
+    auto in0_tile = a.tensor_spec().tile();
+    auto in1_tile = b.tensor_spec().tile();
+    auto in0_tile_shape = in0_tile.get_tile_shape();
+    auto in1_tile_shape = in1_tile.get_tile_shape();
+    // cannot use the output tensor tile directly as that might be changed by user override
+    auto output_tile = tt::tt_metal::Tile({in0_tile.get_tile_shape()[0], in1_tile.get_tile_shape()[1]});
+
+    // CB dataformats
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());          // in0
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());          // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
+
+    tt_metal::Buffer* bias_buffer = nullptr;
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
+    if (bias.has_value()) {
+        const auto& c = bias.value();
+        TT_FATAL(
+            c.storage_type() == StorageType::DEVICE,
+            "Bias tensor must be on device, got storage type: {}",
+            c.storage_type());
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+
+        bias_buffer = c.buffer();
+
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+    }
+
+    tt::tt_metal::IDevice* device =
+        reuse_batched_hs_dram_sharded_optimized_helpers::get_device_for_dram_banks(a, mesh_coord);
+
+    TT_FATAL(
+        a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
+    CoreRangeSet input_all_cores_storage = a.shard_spec().value().grid;
+    CoreRangeSet output_all_cores_storage = output.shard_spec().value().grid;
+
+    uint32_t in0_single_tile_size = in0_tile.get_tile_size(in0_data_format);
+    uint32_t in1_single_tile_size = in1_tile.get_tile_size(in1_data_format);
+    tt_metal::Buffer* in0_buffer = a.buffer();
+    tt_metal::Buffer* in1_buffer = b.buffer();
+    TT_FATAL(
+        in0_buffer->size() % in0_single_tile_size == 0,
+        "Input A buffer size ({}) must be divisible by single tile size ({})",
+        in0_buffer->size(),
+        in0_single_tile_size);
+    TT_FATAL(
+        in1_buffer->size() % in1_single_tile_size == 0,
+        "Input B buffer size ({}) must be divisible by single tile size ({})",
+        in1_buffer->size(),
+        in1_single_tile_size);
+
+    TT_FATAL(
+        ashape[-1] == bshape[-2],
+        "Dimension K (A.shape[-1] = {}, B.shape[-2] = {}) must match for matmul",
+        ashape[-1],
+        bshape[-2]);
+    TT_FATAL(
+        ashape[-2] % in0_tile_shape[0] == 0,
+        "A.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        ashape[-2],
+        in0_tile_shape[0]);
+    TT_FATAL(
+        ashape[-1] % in0_tile_shape[1] == 0,
+        "A.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        ashape[-1],
+        in0_tile_shape[1]);
+    TT_FATAL(
+        bshape[-2] % in1_tile_shape[0] == 0,
+        "B.shape[-2] ({}) must be divisible by tile shape[0] ({})",
+        bshape[-2],
+        in1_tile_shape[0]);
+    TT_FATAL(
+        bshape[-1] % in1_tile_shape[1] == 0,
+        "B.shape[-1] ({}) must be divisible by tile shape[1] ({})",
+        bshape[-1],
+        in1_tile_shape[1]);
+
+    const auto& compute_kernel_config = operation_attributes.compute_kernel_config.value();
+    const auto& program_config =
+        std::get<operations::matmul::MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
+            operation_attributes.program_config.value());
+    const auto& in0_block_w = program_config.in0_block_w;
+    const auto& per_core_M = program_config.per_core_M;
+    const auto& per_core_N = program_config.per_core_N;
+    const auto& fused_activation = program_config.fused_activation;
+
+    const auto& untilize_out = operation_attributes.untilize_out;
+    const bool skip_compute = false;
+    const bool skip_in0_mcast = false;
+    const bool skip_write_back = false;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Matmul Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
+    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
+    uint32_t B = 1;
+    uint32_t Mt = get_batch_size(ashape) * ashape[-2] / in0_tile_shape[0];
+    uint32_t Kt = ashape[-1] / in0_tile_shape[1];
+    uint32_t Nt = bshape[-1] / in1_tile_shape[1];
+    uint32_t in0_last_ktile_w = a.logical_shape()[-1] % in0_tile_shape[1];
+
+    TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Buffer* out_buffer = output.buffer();
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    return reuse_batched_hs_dram_sharded_optimized_helpers::create_program_dram_sharded(
+        device,
+        input_all_cores_storage,
+        output_all_cores_storage,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        B,
+        Mt,
+        Nt,
+        Kt,
+        in0_block_w,
+        in0_last_ktile_w,
+        per_core_M,
+        per_core_N,
+        fused_activation,
+        in0_buffer,
+        in1_buffer,
+        bias_buffer,
+        out_buffer,
+        in0_tile,
+        in1_tile,
+        bias.has_value() ? bias->tensor_spec().tile() : output_tile,
+        output_tile,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out,
+        skip_compute,
+        skip_in0_mcast,
+        skip_write_back);
+}
+
+MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::cached_mesh_workload_t
+MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_mesh_workload(
+    const ttnn::prim::MatmulParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    for (const auto& mesh_coord_range : tensor_coords.ranges()) {
+        for (const auto& mesh_coord : mesh_coord_range) {
+            const ttnn::MeshCoordinateRange mesh_coord_range{mesh_coord, mesh_coord};
+            auto [program, shared_variable] = matmul_multi_core_reuse_batched_hs_dram_sharded_optimized_(
+                mesh_coord, tensor_args, tensor_return_value, operation_attributes);
+            shared_variables[mesh_coord_range] = shared_variable;
+            workload.add_program(mesh_coord_range, std::move(program));
+        }
+    }
+    return {std::move(workload), std::move(shared_variables)};
+}
+
+void MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const ttnn::prim::MatmulParams& /*operation_attributes*/,
+    const ttnn::prim::MatmulInputs& tensor_args,
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    const auto& input_tensors = tensor_args.input_tensors;
+    const auto& optional_input_tensors = tensor_args.optional_input_tensors;
+    const auto& output_tensors = tensor_return_value;
+
+    for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
+        TT_FATAL(
+            input_tensors.size() + optional_input_tensors.size() == 3,
+            "Total number of input tensors (required + optional) must be 3, but got {} + {} = {}",
+            input_tensors.size(),
+            optional_input_tensors.size(),
+            input_tensors.size() + optional_input_tensors.size());
+        TT_FATAL(output_tensors.size() == 1, "Number of output tensors must be 1, but got {}", output_tensors.size());
+
+        auto* src_buffer_a = input_tensors.at(0).buffer();
+        auto* src_buffer_b = input_tensors.at(1).buffer();
+        const auto& bias_tensor = optional_input_tensors.at(0);
+
+        auto* dst_buffer = output_tensors.at(0).buffer();
+        auto shared_variables = cached_workload.shared_variables.at(mesh_coord_range);
+
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_src2, *src_buffer_a);
+        UpdateDynamicCircularBufferAddress(program, shared_variables.cb_output_reshard, *dst_buffer);
+
+        const auto& all_worker_cores_ordered = shared_variables.all_worker_cores_ordered;
+        const auto& writer_kernel_ids = shared_variables.writer_kernel_ids;
+
+        for (uint32_t i = 0; i < all_worker_cores_ordered.size(); ++i) {
+            auto core = all_worker_cores_ordered[i];
+            auto writer_kernel_id = writer_kernel_ids[i];
+            auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            writer_runtime_args[1] = src_buffer_b->address();
+            if (bias_tensor.has_value()) {
+                writer_runtime_args[2] = bias_tensor.value().buffer()->address();
+            } else {
+                writer_runtime_args[2] = 0;
+            }
+        }
+    }
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -161,10 +161,14 @@ create_program_batch_sharded(
     log_debug(tt::LogOp, "num_input_storage_cores: {}", num_input_storage_cores);
     log_debug(tt::LogOp, "num_output_storage_cores: {}", num_output_storage_cores);
 
+    // Currently, both input and output storage cores must match the number of workers (DRAM banks).
+    // This is because the factory uses a 1:1 mapping: worker[i] reads from input_storage[i] and
+    // writes to output_storage[i]. Supporting different numbers would require more complex mapping, where multiple
+    // workers read from the same storage core.
     TT_FATAL(
         num_input_storage_cores == num_workers,
         "Input storage cores ({}) must match number of workers/DRAM banks ({}). "
-        "For batch sharding, use an L1 shard grid with {} cores.",
+        "Use an L1 shard grid with {} cores.",
         num_input_storage_cores,
         num_workers,
         num_workers);
@@ -172,7 +176,7 @@ create_program_batch_sharded(
     TT_FATAL(
         num_output_storage_cores == num_workers,
         "Output storage cores ({}) must match number of workers/DRAM banks ({}). "
-        "For batch sharding, use an L1 shard grid with {} cores.",
+        "Use an L1 shard grid with {} cores.",
         num_output_storage_cores,
         num_workers,
         num_workers);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
+
+namespace ttnn::prim {
+
+struct MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory {
+    struct shared_variables_t {
+        std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
+        std::vector<CoreCoord> all_worker_cores_ordered;
+        tt::tt_metal::CBHandle cb_src2{};
+        tt::tt_metal::CBHandle cb_output_reshard{};
+    };
+
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const ttnn::prim::MatmulParams& operation_attributes,
+        const ttnn::prim::MatmulInputs& tensor_args,
+        std::vector<ttnn::Tensor>& tensor_return_value);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -11,6 +11,7 @@ namespace ttnn::prim {
 
 struct MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory {
     struct shared_variables_t {
+        std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
         std::vector<tt::tt_metal::KernelHandle> writer_kernel_ids;
         std::vector<CoreCoord> all_worker_cores_ordered;
         tt::tt_metal::CBHandle cb_src2{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -22,26 +22,6 @@
 // Have to keep a copy because cannot import ttnn into tests/tt_metal.
 
 namespace NAMESPACE {
-inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    DPRINT << "======" << ENDL();
-    for (uint16_t r = 0; r < 32; ++r) {
-        DPRINT << (uint)r << " : "
-               << TileSlice(
-                      cb_id,
-                      tile_id,
-                      SliceRange{
-                          .h0 = (uint8_t)r,
-                          .h1 = (uint8_t)(r + 1),
-                          .hs = (uint8_t)1,
-                          .w0 = (uint8_t)0,
-                          .w1 = (uint8_t)32,
-                          .ws = (uint8_t)1},
-                      true,
-                      untilize)
-               << ENDL();
-    }
-    DPRINT << "++++++" << ENDL();
-}
 
 /**
  * @brief Transposes a block of tiles from one circular buffer to another.
@@ -305,9 +285,6 @@ void MAIN {
                                 // accumulation is done by iterating matmul_block across inner dim
                                 // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride
                                 // in0
-                                DPRINT << "matmul_block" << ENDL();
-                                UNPACK(print_full_tile(in0_cb_id, in0_index));
-                                UNPACK(print_full_tile(in1_cb_id, in1_index));
                                 matmul_block(
                                     in0_cb_id,
                                     in1_cb_id,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -22,6 +22,26 @@
 // Have to keep a copy because cannot import ttnn into tests/tt_metal.
 
 namespace NAMESPACE {
+inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
+    DPRINT << "======" << ENDL();
+    for (uint16_t r = 0; r < 32; ++r) {
+        DPRINT << (uint)r << " : "
+               << TileSlice(
+                      cb_id,
+                      tile_id,
+                      SliceRange{
+                          .h0 = (uint8_t)r,
+                          .h1 = (uint8_t)(r + 1),
+                          .hs = (uint8_t)1,
+                          .w0 = (uint8_t)0,
+                          .w1 = (uint8_t)32,
+                          .ws = (uint8_t)1},
+                      true,
+                      untilize)
+               << ENDL();
+    }
+    DPRINT << "++++++" << ENDL();
+}
 
 /**
  * @brief Transposes a block of tiles from one circular buffer to another.
@@ -285,6 +305,9 @@ void MAIN {
                                 // accumulation is done by iterating matmul_block across inner dim
                                 // in0_block_w is passed as innder dim (kt) to matmul_block, interally used to stride
                                 // in0
+                                DPRINT << "matmul_block" << ENDL();
+                                UNPACK(print_full_tile(in0_cb_id, in0_index));
+                                UNPACK(print_full_tile(in1_cb_id, in1_index));
                                 matmul_block(
                                     in0_cb_id,
                                     in1_cb_id,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -13,7 +13,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
-#include "api/debug/dprint.h"
 
 void kernel_main() {
     // COMPILE TIME ARGS

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,27 +14,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/debug/dprint.h"
-
-inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    DPRINT << "======" << ENDL();
-    for (uint16_t r = 0; r < 32; ++r) {
-        DPRINT << (uint)r << " : "
-               << TileSlice(
-                      cb_id,
-                      tile_id,
-                      SliceRange{
-                          .h0 = (uint8_t)r,
-                          .h1 = (uint8_t)(r + 1),
-                          .hs = (uint8_t)1,
-                          .w0 = (uint8_t)0,
-                          .w1 = (uint8_t)32,
-                          .ws = (uint8_t)1},
-                      true,
-                      untilize)
-               << ENDL();
-    }
-    DPRINT << "++++++" << ENDL();
-}
 
 void kernel_main() {
     // COMPILE TIME ARGS
@@ -62,8 +41,6 @@ void kernel_main() {
     uint64_t remote_shard_base_noc_addr = get_noc_addr(input_storage_noc_x, input_storage_noc_y, input_shard_l1_addr);
 
     // Process each batch
-    DPRINT << "in0 reader: NOC reading from storage core (" << input_storage_noc_x << ", " << input_storage_noc_y << ")"
-           << ENDL();
     for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
         uint32_t batch_offset = batch * in0_tensor_stride_batch_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Batch-sharded DRAM matmul - in0 reader kernel
-// For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
 // Each worker handles B/num_workers batches independently
 // Input A is L1 sharded by batch on INPUT STORAGE CORES
 // Workers are on OPTIMAL DRAM READER CORES (different from storage cores)
@@ -18,7 +18,7 @@ void kernel_main() {
     // COMPILE TIME ARGS
     constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);   // tiles per block (M * in0_block_w)
     constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);  // bytes per block
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);            // N / in0_block_w (K blocks in inner loop)
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);            // K / in0_block_w (K blocks in inner loop)
     constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(3);  // B / num_cores
     constexpr uint32_t in0_tensor_stride_batch_bytes = get_compile_time_arg_val(4);  // bytes per batch in in0
     constexpr uint32_t in0_shard_size_bytes = get_compile_time_arg_val(5);           // full shard size in bytes

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Batch-sharded DRAM matmul - in0 reader kernel
+// For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
+// Each worker handles B/num_workers batches independently
+// Input A is L1 sharded by batch - each core has B/num_cores complete [M, N] matrices
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);   // tiles per block (M * in0_block_w)
+    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);  // bytes per block
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);            // N / in0_block_w (K blocks in inner loop)
+    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(3);  // B / num_cores
+    constexpr uint32_t in0_tensor_stride_batch_bytes = get_compile_time_arg_val(4);  // bytes per batch in in0
+
+    // RUNTIME ARGS
+    const uint32_t worker_core_type = get_arg_val<uint32_t>(0);
+    if (worker_core_type == 0) {
+        return;  // idle core
+    }
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in2 = 2;  // Sharded CB for in0
+
+    // Read from sharded L1 buffer and push to compute CB
+    uint32_t l1_read_addr = get_read_ptr(cb_id_in2);
+
+    // Process each batch
+    for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
+        uint32_t batch_read_addr = l1_read_addr + batch * in0_tensor_stride_batch_bytes;
+
+        // Process K blocks within each batch
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+            // Copy block from sharded buffer to compute CB
+            uint64_t src_noc_addr = get_noc_addr(batch_read_addr);
+            noc_async_read(src_noc_addr, l1_write_addr, in0_block_size_bytes);
+            noc_async_read_barrier();
+
+            cb_push_back(cb_id_in0, in0_block_num_tiles);
+            batch_read_addr += in0_block_size_bytes;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Batch-sharded DRAM matmul - in1 reader and output writer kernel
-// For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
+// For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
 // Each worker handles B/num_workers batches independently
 // Input B (weights) is DRAM sharded by batch - each bank has B/12 complete [N, K] matrices
 // Output is NOC written to OUTPUT STORAGE CORES (different from worker cores)

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -6,7 +6,7 @@
 // For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
 // Each worker handles B/num_workers batches independently
 // Input B (weights) is DRAM sharded by batch - each bank has B/12 complete [N, K] matrices
-// Output is written back to L1 sharded by batch
+// Output is NOC written to OUTPUT STORAGE CORES (different from worker cores)
 
 #include <stdint.h>
 
@@ -49,6 +49,11 @@ void kernel_main() {
     const uint32_t dram_bank_id = get_arg_val<uint32_t>(3);
     const uint32_t vc = get_arg_val<uint32_t>(4);
 
+    // Output storage core coordinates and L1 address (where to NOC write output)
+    const uint32_t output_storage_noc_x = get_arg_val<uint32_t>(5);
+    const uint32_t output_storage_noc_y = get_arg_val<uint32_t>(6);
+    const uint32_t output_shard_l1_addr = get_arg_val<uint32_t>(7);
+
     // COMPILE TIME ARGS
     constexpr uint32_t in1_page_size = get_compile_time_arg_val(0);
     constexpr uint32_t in1_num_pages = get_compile_time_arg_val(1);
@@ -58,22 +63,31 @@ void kernel_main() {
     constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(5);            // M * K
     constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(6);           // B / num_cores
     constexpr uint32_t in1_tensor_stride_batch_bytes = get_compile_time_arg_val(7);  // bytes per batch in in1
-    // constexpr uint32_t out_tensor_stride_batch_bytes = get_compile_time_arg_val(8);  // no longer needed
+    constexpr uint32_t out_tensor_stride_batch_bytes = get_compile_time_arg_val(8);  // bytes per batch in output
+    constexpr uint32_t out_shard_size_bytes = get_compile_time_arg_val(9);           // full output shard size
 
 #ifdef FUSE_BIAS
-    constexpr uint32_t in3_page_size = get_compile_time_arg_val(9);
-    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(10);
-    constexpr uint32_t in3_block_tiles = get_compile_time_arg_val(11);  // K tiles for bias
+    constexpr uint32_t in3_page_size = get_compile_time_arg_val(10);
+    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(11);
+    constexpr uint32_t in3_block_tiles = get_compile_time_arg_val(12);  // K tiles for bias
     constexpr uint32_t cb_id_in3 = 3;
 #endif
 
     constexpr uint32_t cb_id_in1 = 1;
-    constexpr uint32_t cb_id_out = tt::CBIndex::c_4;
+    constexpr uint32_t cb_id_out = tt::CBIndex::c_4;  // Local output CB (compute writes here)
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr uint32_t out_single_tile_size_bytes = get_tile_size(cb_id_out);
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
+    constexpr uint32_t out_block_size_bytes = out_block_num_tiles * out_single_tile_size_bytes;
 
     // DRAM read setup
     uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
+
+    // Output reshard setup - build NOC address for remote output storage core
+    uint64_t remote_out_base_noc_addr = get_noc_addr(output_storage_noc_x, output_storage_noc_y, output_shard_l1_addr);
+
+    DPRINT << "in1 writer: NOC writing to storage core (" << output_storage_noc_x << ", " << output_storage_noc_y << ")"
+           << ENDL();
 
     // Process each batch
     for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
@@ -86,8 +100,6 @@ void kernel_main() {
             uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
 
             // Read weight block from DRAM
-            uint64_t dram_read_addr = in1_base_addr + in1_batch_offset + l1_read_addr_in1;
-
             uint32_t remaining_bytes = in1_block_size_bytes;
             uint32_t curr_l1_addr = l1_write_addr_in1;
             uint32_t curr_dram_offset = l1_read_addr_in1;
@@ -102,10 +114,6 @@ void kernel_main() {
 
             noc_async_read_barrier();
             cb_push_back(cb_id_in1, in1_block_num_tiles);
-            // DPRINT << "Reader BMM Tile Layout In1 Sender Dram Sharded Height" << ENDL();
-            // print_full_tile(cb_id_in1, 0);
-            // print_full_tile(cb_id_in1, 1);
-            // This looks normal - it's full (b+1)
             l1_read_addr_in1 += in1_block_size_bytes;
         }
 
@@ -114,22 +122,27 @@ void kernel_main() {
         cb_reserve_back(cb_id_in3, in3_block_tiles);
         uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
         uint64_t in3_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
-        // Bias might be shared across batches or per-batch - read accordingly
         noc_async_read(in3_addr, l1_write_addr_in3, in3_block_tiles * get_tile_size(cb_id_in3));
         noc_async_read_barrier();
         cb_push_back(cb_id_in3, in3_block_tiles);
 #endif
 
         // Wait for compute to finish this batch
-        // CB4 is now directly backed by the output buffer, so compute writes directly there
-        // No copy needed - just wait for compute to finish and pop
         cb_wait_front(cb_id_out, out_block_num_tiles);
 
-        // Note: We don't need to copy to CB6 anymore since CB4 is backed by the output buffer
-        // The compute already wrote to the correct location via CB4
-        DPRINT << "Printing output tiles" << ENDL();
-        print_full_tile(cb_id_out, 0);
-        // print_full_tile(cb_id_out, 1);
+#ifdef OUT_SHARDED
+        // NOC write output to remote output storage core (CB6)
+        uint32_t local_out_read_addr = get_read_ptr(cb_id_out);
+        uint32_t out_batch_offset = batch * out_tensor_stride_batch_bytes;
+        uint64_t remote_out_noc_addr = remote_out_base_noc_addr + out_batch_offset;
+
+        noc_async_write(local_out_read_addr, remote_out_noc_addr, out_block_size_bytes);
+        noc_async_write_barrier();
+#endif
+
+        // DPRINT << "Batch " << batch << " output written to remote storage" << ENDL();
+        // print_full_tile(cb_id_out, 0);
+
         cb_pop_front(cb_id_out, out_block_num_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Batch-sharded DRAM matmul - in1 reader and output writer kernel
+// For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
+// Each worker handles B/num_workers batches independently
+// Input B (weights) is DRAM sharded by batch - each bank has B/12 complete [N, K] matrices
+// Output is written back to L1 sharded by batch
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+void kernel_main() {
+    // RUNTIME ARGS
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    if (not is_worker_core) {
+        return;
+    }
+
+    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(1);
+#ifdef FUSE_BIAS
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(2);
+#endif
+    const uint32_t dram_bank_id = get_arg_val<uint32_t>(3);
+    const uint32_t vc = get_arg_val<uint32_t>(4);
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t in1_page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t in1_block_w = get_compile_time_arg_val(2);                    // K tiles per block
+    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(3);            // in0_block_w * K
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);                     // N / in0_block_w
+    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(5);            // M * K
+    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(6);           // B / num_cores
+    constexpr uint32_t in1_tensor_stride_batch_bytes = get_compile_time_arg_val(7);  // bytes per batch in in1
+    constexpr uint32_t out_tensor_stride_batch_bytes = get_compile_time_arg_val(8);  // bytes per batch in output
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t in3_page_size = get_compile_time_arg_val(9);
+    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(10);
+    constexpr uint32_t in3_block_tiles = get_compile_time_arg_val(11);  // K tiles for bias
+    constexpr uint32_t cb_id_in3 = 3;
+#endif
+
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t cb_id_out = tt::CBIndex::c_4;
+    constexpr uint32_t cb_id_out_reshard = tt::CBIndex::c_6;
+    constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
+    constexpr uint32_t out_single_tile_size_bytes = get_tile_size(cb_id_out);
+    constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
+
+    // DRAM read setup
+    uint64_t in1_base_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in1_tensor_addr);
+
+    // Process each batch
+    for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
+        uint32_t in1_batch_offset = batch * in1_tensor_stride_batch_bytes;
+        uint32_t l1_read_addr_in1 = 0;
+
+        // Read all N blocks of weights for this batch
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+            uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+
+            // Read weight block from DRAM
+            uint64_t dram_read_addr = in1_base_addr + in1_batch_offset + l1_read_addr_in1;
+
+            uint32_t remaining_bytes = in1_block_size_bytes;
+            uint32_t curr_l1_addr = l1_write_addr_in1;
+            uint32_t curr_dram_offset = l1_read_addr_in1;
+
+            while (remaining_bytes > 0) {
+                uint32_t read_size = (remaining_bytes > in1_page_size) ? in1_page_size : remaining_bytes;
+                noc_async_read(in1_base_addr + in1_batch_offset + curr_dram_offset, curr_l1_addr, read_size);
+                curr_l1_addr += read_size;
+                curr_dram_offset += read_size;
+                remaining_bytes -= read_size;
+            }
+
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in1, in1_block_num_tiles);
+            l1_read_addr_in1 += in1_block_size_bytes;
+        }
+
+#ifdef FUSE_BIAS
+        // Read bias for this batch (if fused)
+        cb_reserve_back(cb_id_in3, in3_block_tiles);
+        uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
+        uint64_t in3_addr = get_noc_addr_from_bank_id<true>(dram_bank_id, in3_tensor_addr);
+        // Bias might be shared across batches or per-batch - read accordingly
+        noc_async_read(in3_addr, l1_write_addr_in3, in3_block_tiles * get_tile_size(cb_id_in3));
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in3, in3_block_tiles);
+#endif
+
+        // Wait for compute to finish this batch
+        cb_wait_front(cb_id_out, out_block_num_tiles);
+
+#ifndef SKIP_WRITE_BACK
+        // Write output to sharded L1 buffer
+        uint32_t l1_read_addr_out = get_read_ptr(cb_id_out);
+        uint32_t l1_write_addr_out = get_write_ptr(cb_id_out_reshard) + batch * out_tensor_stride_batch_bytes;
+
+        // Copy output to reshard buffer (local write for batch-sharded - no cross-core transfer)
+        noc_async_write(
+            l1_read_addr_out, get_noc_addr(l1_write_addr_out), out_block_num_tiles * out_single_tile_size_bytes);
+        noc_async_write_barrier();
+#endif
+
+        cb_pop_front(cb_id_out, out_block_num_tiles);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,28 +12,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
-#include "api/debug/dprint.h"
-
-inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
-    DPRINT << "======" << ENDL();
-    for (uint16_t r = 0; r < 32; ++r) {
-        DPRINT << (uint)r << " : "
-               << TileSlice(
-                      cb_id,
-                      tile_id,
-                      SliceRange{
-                          .h0 = (uint8_t)r,
-                          .h1 = (uint8_t)(r + 1),
-                          .hs = (uint8_t)1,
-                          .w0 = (uint8_t)0,
-                          .w1 = (uint8_t)32,
-                          .ws = (uint8_t)1},
-                      true,
-                      untilize)
-               << ENDL();
-    }
-    DPRINT << "++++++" << ENDL();
-}
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -86,9 +64,6 @@ void kernel_main() {
     // Output reshard setup - build NOC address for remote output storage core
     uint64_t remote_out_base_noc_addr = get_noc_addr(output_storage_noc_x, output_storage_noc_y, output_shard_l1_addr);
 
-    DPRINT << "in1 writer: NOC writing to storage core (" << output_storage_noc_x << ", " << output_storage_noc_y << ")"
-           << ENDL();
-
     // Process each batch
     for (uint32_t batch = 0; batch < num_batches_per_core; ++batch) {
         uint32_t in1_batch_offset = batch * in1_tensor_stride_batch_bytes;
@@ -139,9 +114,6 @@ void kernel_main() {
         noc_async_write(local_out_read_addr, remote_out_noc_addr, out_block_size_bytes);
         noc_async_write_barrier();
 #endif
-
-        // DPRINT << "Batch " << batch << " output written to remote storage" << ENDL();
-        // print_full_tile(cb_id_out, 0);
 
         cb_pop_front(cb_id_out, out_block_num_tiles);
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -609,7 +609,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                                      operations::matmul::
                                          MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>) {
                 // Batch-sharded DRAM matmul validations
-                // For batched matmul: [1, B, M, N] x [1, B, N, K] = [1, B, M, K]
+                // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
                 // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
                 // Input A: HEIGHT_SHARDED in L1 (batch-sharded, each core has B/12 complete [M, N] matrices)
                 // Input B: HEIGHT_SHARDED in DRAM (batch-sharded, each bank has B/12 complete [N, K] matrices)

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.hpp"
+#include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp"
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp"
 
 namespace ttnn::prim {
@@ -25,7 +26,8 @@ struct MatmulDeviceOperation {
         MatmulMeshWorkloadMultiCoreReuseOptimizedProgramFactory,
         MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory,
         MatmulMeshWorkloadMultiCoreReuseMcast2DProgramFactory,
-        MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory>;
+        MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory,
+        MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>;
 
     static program_factory_t select_program_factory(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -4,6 +4,9 @@
 
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 
+#include <algorithm>
+#include <set>
+
 #include "tt-metalium/allocator.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 
@@ -227,3 +230,64 @@ tt::tt_metal::Tile get_matmul_tile(const Tensor& input_tensor, bool transpose) {
 }
 
 }  // namespace ttnn::operations::matmul::utilities
+
+namespace ttnn::prim {
+namespace dram_sharded_helpers {
+
+tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {
+    ttnn::distributed::MeshDevice* device = a.device();
+    const ttnn::distributed::MeshDeviceView& view = device->get_view();
+    if (!view.contains(coord) || !view.is_local(coord)) {
+        return device;
+    }
+    return a.device()->get_device(coord);
+}
+
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages) {
+    uint64_t total_size = static_cast<uint64_t>(num_tiles) * tile_size;
+
+    // TODO(#32477): Remove hardcoding when NOC_MAX_BURST_SIZE is available from HAL
+    uint32_t noc_max_page_size;
+    if (device->arch() == tt::ARCH::WORMHOLE_B0) {
+        noc_max_page_size = 8192;
+    } else if (device->arch() == tt::ARCH::BLACKHOLE) {
+        noc_max_page_size = 16384;
+    } else {
+        TT_FATAL(false, "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported.");
+    }
+
+    page_size = (noc_max_page_size / tile_size) * tile_size;
+    while (total_size % page_size != 0 && page_size >= tile_size) {
+        page_size -= tile_size;
+    }
+    num_pages = total_size / page_size;
+}
+
+void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
+    for (const CoreCoord& item : v2) {
+        if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
+            commons.push_back(item);
+        }
+    }
+
+    for (const CoreCoord& item : commons) {
+        v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
+    }
+}
+
+void get_optimal_dram_bank_to_reader_assignment(
+    tt::tt_metal::IDevice* device,
+    std::vector<CoreCoord>& all_worker_cores_ordered,
+    CoreRangeSet& all_worker_cores,
+    tt::tt_metal::NOC noc) {
+    all_worker_cores_ordered = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+    std::set<CoreRange> all_cores_set;
+    for (const auto& worker_core : all_worker_cores_ordered) {
+        all_cores_set.insert(CoreRange(worker_core));
+    }
+    all_worker_cores = CoreRangeSet(all_cores_set);
+}
+
+}  // namespace dram_sharded_helpers
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -254,7 +254,9 @@ void get_max_page_size_and_num_pages(
     } else if (device->arch() == tt::ARCH::BLACKHOLE) {
         noc_max_page_size = 16384;
     } else {
-        TT_FATAL(false, "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported.");
+        TT_THROW(
+            "Unsupported architecture for DRAM sharded matmul. Only Wormhole and Blackhole are supported. Got: {}",
+            device->arch());
     }
 
     page_size = (noc_max_page_size / tile_size) * tile_size;

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -288,6 +288,4 @@ void get_optimal_dram_bank_to_reader_assignment(
     }
     all_worker_cores = CoreRangeSet(all_cores_set);
 }
-
-} // namespace ttnn::prim::dram_sharded_helpers
-
+}  // namespace ttnn::prim::dram_sharded_helpers

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -231,8 +231,8 @@ tt::tt_metal::Tile get_matmul_tile(const Tensor& input_tensor, bool transpose) {
 
 }  // namespace ttnn::operations::matmul::utilities
 
-namespace ttnn::prim {
-namespace dram_sharded_helpers {
+
+namespace ttnn::prim::dram_sharded_helpers {
 
 tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord) {
     ttnn::distributed::MeshDevice* device = a.device();

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -289,5 +289,5 @@ void get_optimal_dram_bank_to_reader_assignment(
     all_worker_cores = CoreRangeSet(all_cores_set);
 }
 
-}  // namespace dram_sharded_helpers
-}  // namespace ttnn::prim
+} // namespace ttnn::prim::dram_sharded_helpers
+

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <vector>
+
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
@@ -151,3 +154,26 @@ inline ttnn::Shape get_matmul_tensor_logical_shape(const Tensor& input_tensor, b
 }
 
 }  // namespace ttnn::operations::matmul::utilities
+
+namespace ttnn::prim {
+namespace dram_sharded_helpers {
+
+// This type of access pattern cannot be copied.
+// Treat it as a one off patch to restore functionality that
+// was adjusted to fix one P0 causing another P0.
+// TODO: Proper fix will be implemented in Issue #32205
+tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const ttnn::MeshCoordinate& coord);
+
+void get_max_page_size_and_num_pages(
+    tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages);
+
+void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons);
+
+void get_optimal_dram_bank_to_reader_assignment(
+    tt::tt_metal::IDevice* device,
+    std::vector<CoreCoord>& all_worker_cores_ordered,
+    CoreRangeSet& all_worker_cores,
+    tt::tt_metal::NOC noc);
+
+}  // namespace dram_sharded_helpers
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -155,9 +155,7 @@ inline ttnn::Shape get_matmul_tensor_logical_shape(const Tensor& input_tensor, b
 
 }  // namespace ttnn::operations::matmul::utilities
 
-namespace ttnn::prim {
-namespace dram_sharded_helpers {
-
+namespace ttnn::prim::dram_sharded_helpers {
 // This type of access pattern cannot be copied.
 // Treat it as a one off patch to restore functionality that
 // was adjusted to fix one P0 causing another P0.
@@ -175,5 +173,4 @@ void get_optimal_dram_bank_to_reader_assignment(
     CoreRangeSet& all_worker_cores,
     tt::tt_metal::NOC noc);
 
-}  // namespace dram_sharded_helpers
-}  // namespace ttnn::prim
+}  // namespace ttnn::prim::dram_sharded_helpers

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -456,6 +456,51 @@ void py_module(nb::module_& mod) {
             additional memory round-trips in DRAM-based operations.
         )doc");
 
+    auto matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config =
+        tt_serializable_class<MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
+            mod, "MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig", R"doc(
+        This program config is a specialized config for batched DRAM sharded operations.
+    )doc");
+
+    matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config
+        .def(
+            nb::init<std::size_t, std::size_t, std::size_t, std::optional<UnaryWithParam>>(),
+            nb::kw_only(),
+            nb::arg("in0_block_w").noconvert(),
+            nb::arg("per_core_M").noconvert(),
+            nb::arg("per_core_N").noconvert(),
+            nb::arg("fused_activation") = nb::none())
+        .def_rw("in0_block_w", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::in0_block_w, R"doc(
+            Block width for both input tensors along the K dimension (shared inner dimension).
+
+            Determines the data granularity by specifying how many tiles wide each block is
+            along the inner dimension for both input_tensor_a and input_tensor_b in batched DRAM-sharded
+            operations. This parameter must be chosen to align with the DRAM sharding
+            strategy and optimize memory bandwidth utilization for both tensors.
+        )doc")
+        .def_rw("per_core_M", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::per_core_M, R"doc(
+            Number of output tiles each core processes along the M dimension.
+
+            Determines how the M dimension is distributed across cores in batched DRAM-sharded
+            scenarios. This must align with the DRAM sharding pattern to ensure optimal
+            performance and avoid memory access conflicts.
+        )doc")
+        .def_rw("per_core_N", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::per_core_N, R"doc(
+            Number of output tiles each core processes along the N dimension.
+
+            Determines how the N dimension is distributed across cores in batched DRAM-sharded
+            scenarios. This parameter affects the multicast efficiency and must be
+            compatible with the DRAM sharding configuration.
+        )doc")
+        .def_rw(
+            "fused_activation", &MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig::fused_activation, R"doc(
+            Optional fused activation function to apply during computation.
+
+            If specified, the activation function is applied directly during the batched DRAM-sharded
+            matmul operation. This can provide significant performance benefits by avoiding
+            additional memory round-trips in DRAM-based operations.
+        )doc");
+
     ttnn::bind_function<"matmul">(
         mod,
         R"doc(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -459,7 +459,7 @@ void py_module(nb::module_& mod) {
     auto matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config =
         tt_serializable_class<MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig>(
             mod, "MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig", R"doc(
-        This program config is a specialized config for batched DRAM sharded operations.
+        This program config is a specialised config for batched DRAM sharded operations, where the inputs are sharded along the batch dimension.
     )doc");
 
     matmul_multi_core_reuse_multicast_batched_dram_sharded_program_config
@@ -624,6 +624,9 @@ void py_module(nb::module_& mod) {
                 * - MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
                   - Width Sharded (L1)
                   - Width Sharded (DRAM)
+                * - MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig
+                  - Height Sharded (L1)
+                  - Height Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
                   - Interleaved (L1/DRAM)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -385,6 +385,7 @@ from ttnn.operations.matmul import (
     MatmulMultiCoreReuseMultiCastProgramConfig,
     MatmulMultiCoreReuseMultiCast1DProgramConfig,
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig,
+    MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig,
 )
 
 from ttnn.operations.normalization import (

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -16,6 +16,9 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig = ttnn._ttnn.operations.matmul.Matm
 MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig = (
     ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
 )
+MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig = (
+    ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig
+)
 
 
 def _golden_function(


### PR DESCRIPTION
### Ticket
#35134

### Problem description
Deepseek MLA has two batched DRAM sharded matmuls. The inputs/outputs to these matmuls need to be height sharded for the ops surrounding the matmuls. This combination (batched, DRAM height sharded) could not be performed efficiently as the existing DRAM sharding matmul lacked batch support and required width sharding (which was also not the best for the input shapes). Performing these matmuls using other available matmul configs was functional, but significantly slower than the roofline estimates.

### What's changed
This PR adds the initial implementation of a batched height sharded matmul. A new program config/factory and readers are added, and the existing compute kernel is reused. The new matmul shards the batch dimension across the 12 (for WH) DRAM banks, with workers independently assigned to B/12 batches. Where B is not a multiple of 12, it must be padded up to the next multiple of 12, and then the output is sliced to restore the desired output. 

This new matmul  is primarily tested on the two batched matmuls required for the MLA block, taking roughly 19 and 63 microseconds respectively, which is an order of magnitude faster than the prior implementation and comparable to our derated roofline estimate of 23us and 62us. This is sufficient as an initial implementation, but further optimisations and features will be added.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:DS_HS_Batched_DRAM_MM)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:DS_HS_Batched_DRAM_MM)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:DS_HS_Batched_DRAM_MM)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:DS_HS_Batched_DRAM_MM)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:DS_HS_Batched_DRAM_MM)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=DS_HS_Batched_DRAM_MM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:DS_HS_Batched_DRAM_MM)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
