### PR TITLE
[skip ci] Remove test_suite_bh_pcie_didt_tests from blackhole_loudbox

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -295,7 +295,6 @@ test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_loudbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"
 
 hw_topology_test_suites["blackhole_p300"]="


### PR DESCRIPTION
### Ticket
https://tenstorrent.atlassian.net/browse/SYS-2951

### Problem description
DIDT tests flaky on upstream systems

### What's changed
Remove tests (requested by syseng, follow-on to https://github.com/tenstorrent/tt-metal/pull/36519)
