### PR TITLE
Ripping out TP CCLs in MoE and SharedExpert

### DIFF
--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py
@@ -101,7 +101,13 @@ class DecoderBlock2DBase(DecoderBlockBase):
         mlp_norm_out = DistributedRMSNorm.forward_prefill(x, cfg["mlp_norm"])
 
         # MLP
-        mlp_out = cls.forward_mlp_prefill(mlp_norm_out, cfg["mlp"])
+        # Check if is_mlp_tensor_parallel is in the config (for MoEDecoderBlock2D)
+        if "is_mlp_tensor_parallel" in cfg:
+            mlp_out = cls.forward_mlp_prefill(
+                mlp_norm_out, cfg["mlp"], is_mlp_tensor_parallel=cfg["is_mlp_tensor_parallel"]
+            )
+        else:
+            mlp_out = cls.forward_mlp_prefill(mlp_norm_out, cfg["mlp"])
         ttnn.deallocate(mlp_norm_out)
 
         # MLP Residual
@@ -140,7 +146,13 @@ class DecoderBlock2DBase(DecoderBlockBase):
 
         # MLP
         mlp_norm_out = ttnn.to_memory_config(mlp_norm_out, **cfg["mlp_reshard"])
-        mlp_out = cls.forward_mlp_decode(mlp_norm_out, cfg["mlp"])
+        # Check if is_mlp_tensor_parallel is in the config (for MoEDecoderBlock2D)
+        if "is_mlp_tensor_parallel" in cfg:
+            mlp_out = cls.forward_mlp_decode(
+                mlp_norm_out, cfg["mlp"], is_mlp_tensor_parallel=cfg["is_mlp_tensor_parallel"]
+            )
+        else:
+            mlp_out = cls.forward_mlp_decode(mlp_norm_out, cfg["mlp"])
         ttnn.deallocate(mlp_norm_out)
 
         # MLP Residual


### PR DESCRIPTION
Link To Issue
https://github.com/tenstorrent/tt-metal/issues/36608

## Summary

This PR rips out the AG and RS CCL from the Routed Expert and shared expert. Opens the door for parallelizing both. Did this in a configurable way with a parameter.

## Key Changes

### 1. Added `is_tensor_parallel` parameter to MoE and MLP components
- **MoE.forward()**, **MoE.forward_prefill()**, **MoE.forward_decode()**: New `is_tensor_parallel` parameter (default=True) controls whether to perform all_gather at input and reduce_scatter at output
- **MLP/SharedExpert forward functions**: Similar `is_tensor_parallel` parameter for consistent interface

### 2. Added `is_mlp_tensor_parallel` parameter to MoEDecoderBlock2D
- Controls tensor parallelism strategy at the MLP level
- **True** (default): Each component (MoE, SharedExpert) handles its own all_gather/reduce_scatter
- **False**: Single all_gather at MLP input, both components compute, then single reduce_scatter at output

### 3. Updated test infrastructure
- Added `is_mlp_tensor_parallel` parameter to `test_decoder_block.py`
- Test parametrization for both configurations
- Performance measurement support with trace mode


## Future Optimization Opportunity

By ripping out the CCL operations from SharedExpert when `is_tensor_parallel=False`, we can enable parallelization between SharedExpert and routed experts computation. This would allow:

1. **Overlapping computation**: SharedExpert and MoE experts could compute simultaneously after the single all_gather
2. **Reduced synchronization**: Only one synchronization point at the final reduce_scatter
3. **Better hardware utilization**: Parallel execution paths for the two types of experts

This optimization could potentially improve the performance of the `is_mlp_tensor_parallel=False` configuration, making it competitive with or better than the default strategy.

## Testing

- ✅ Functional tests pass for both configurations
- ✅ PCC meets requirements (>0.9899) for both strategies
- ✅ Performance benchmarked with trace mode
- ✅ Backward compatibility maintained (default behavior unchanged)

## How to Test

```bash
# Test both configurations
pytest models/demos/deepseek_v3/tests/test_decoder_block.py::test_forward_pass -k "MoEDecoderBlock2D" -xvs

# Test specific configuration
pytest models/demos/deepseek_v3/tests/test_decoder_block.py::test_forward_pass -k "MoEDecoderBlock2D and False" -xvs
```

## Files Changed

- `models/demos/deepseek_v3/tt/moe.py`: Added is_tensor_parallel parameter
- `models/demos/deepseek_v3/tt/mlp/mlp.py`: Added is_tensor_parallel parameter
- `models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py`: Added is_mlp_tensor_parallel logic
- `models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d_base.py`: Pass through parameter
- `models/demos/deepseek_v3/tests/test_decoder_block.py`: Test infrastructure updates