### PR TITLE
Fix: Handle timeouts and missing jobs in workflow-status action

### DIFF
--- a/.github/actions/workflow-status/action.yml
+++ b/.github/actions/workflow-status/action.yml
@@ -33,10 +33,16 @@ runs:
 
           // Check optional jobs (treat skipped as success)
           for (const job of optionalJobs) {
-            const result = needs[job]?.result || "success"; // Default to success if missing
+            const result = needs[job]?.result;
+            if (result === undefined) {
+              core.setFailed(`Optional job '${job}' is not found in needs context or has no result. This may indicate a configuration error (job not in needs list or typo in job name).`);
+              continue;
+            }
             console.log(`Job: ${job}, Result: ${result}`);
-            if (result === "failure") {
-              core.setFailed(`Optional job '${job}' failed.`);
+            // Treat failure, cancelled (timeout), and timed_out as failures
+            // Skipped jobs are OK (treated as success)
+            if (result === "failure" || result === "cancelled" || result === "timed_out") {
+              core.setFailed(`Optional job '${job}' failed or timed out (result: ${result}).`);
             }
           }
 


### PR DESCRIPTION
### Ticket
Related to issue where optional jobs timing out were incorrectly treated as success, causing PR Gate to pass when it should have failed.

Reference: https://github.com/tenstorrent/tt-metal/actions/runs/21413069805/job/61655549440?pr=36567#step:6:25

### Problem description
The workflow-status action had two critical bugs:

1. **Timeout handling**: Optional jobs that timed out were not being caught. When a job times out, GitHub Actions reports the result as `"cancelled"` (or `"timed_out"`), not `"failure"`. The code only checked for `result === "failure"`, so timeouts were silently ignored and the PR gate incorrectly passed.

2. **Dangerous default**: The code had `|| "success"` as a default for missing jobs, which silently treated configuration errors (typos, missing jobs from needs list) as success. This could hide real configuration problems.

### What's changed
- **Fixed timeout detection**: Now checks for `"failure"`, `"cancelled"`, and `"timed_out"` job results to properly catch timeouts
- **Removed dangerous default**: Removed the `|| "success"` default and added explicit error handling for missing jobs
- **Better error messages**: Added clear error messages when jobs are missing from the needs context (configuration errors)

The fix ensures that:
- Optional jobs that timeout will now cause the PR gate to fail (as intended)
- Configuration errors (typos, missing jobs) are caught early with clear error messages
- Skipped jobs are still correctly treated as success (they have `result: "skipped"` which isn't in the failure check)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/workflow-status-timeout-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/workflow-status-timeout-handling)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/workflow-status-timeout-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/workflow-status-timeout-handling)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/workflow-status-timeout-handling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/workflow-status-timeout-handling)
- [x] New/Existing tests provide coverage for changes (N/A - This is a bug fix for CI/CD logic, tested by the workflow itself)