### PR TITLE
[skip ci] Update workflow-status reporting

### DIFF
--- a/.github/actions/workflow-status/action.yml
+++ b/.github/actions/workflow-status/action.yml
@@ -35,7 +35,7 @@ runs:
           for (const job of optionalJobs) {
             const result = needs[job]?.result || "success"; // Default to success if missing
             console.log(`Job: ${job}, Result: ${result}`);
-            if (result === "failure") {
+            if (result === "failure" || result === "cancelled") {
               core.setFailed(`Optional job '${job}' failed.`);
             }
           }


### PR DESCRIPTION
Github Actions treats timeout failures of jobs as cancelled instead of failed in the `needs.<job_id>.result` context. There is no way to change GH Actions behaviour. 

Intended behaviour of `optional-jobs` in PR and Merge gate status step is to report status failure if any `optional-job` ran and failed OR timed out.
However, if an optional-job fails due to timeout, GHA treats the job as cancelled instead of failed, allowing gate status step to pass.
Example: https://github.com/tenstorrent/tt-metal/actions/runs/21413069805/job/61655549440?pr=36567#step:6:25

This PR forces GHA to equate `cancelled` as `failure` when evaluating gate status.