### PR TITLE
Update Physical Validation Scripts To Use Cabling and Deployment Desc…

### DIFF
--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -41,7 +41,7 @@ for i in {1..50}; do
 
         echo ""
         echo "Running cluster validation..."
-        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/4xBH_4x32_intrapod/fsd.textproto --send-traffic --num-iterations 10
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto --deployment-descriptor-path /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto --send-traffic --num-iterations 10
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -42,7 +42,7 @@ for i in {1..50}; do
 
         echo ""
         echo "Running cluster validation..."
-        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --factory-descriptor-path /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto --send-traffic --num-iterations 10
+        ./tools/scaleout/exabox/mpi-docker --image $DOCKER_IMAGE --empty-entrypoint --host $HOSTS ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto --deployment-descriptor-path /data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto --send-traffic --num-iterations 10
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
     } 2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Modifying `run_validation_*.sh` scripts to use cabling and deployment descriptors. As this will scale as the size of the datacenter scales and the plan is to keep merging cabling descriptors over time.

### What's changed
`run_validation_*.sh`  uses cabling and deployment descriptors.
