### PR TITLE
[skip ci] Switch ClangSA results repository to organization repo

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -492,11 +492,11 @@ jobs:
       - name: Add .nojekyll
         run: touch site/.nojekyll
 
-      - name: Publish to blozano-tt/clangsa-results (gh-pages)
+      - name: Publish to tenstorrent/tt-metal-clangsa-results (gh-pages)
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.CLANGSA_RESULTS_PAT }}
-          external_repository: blozano-tt/clangsa-results
+          external_repository: tenstorrent/tt-metal-clangsa-results
           publish_branch: gh-pages
           publish_dir: site
           force_orphan: true


### PR DESCRIPTION
### Ticket
Per request from @jbakerTT 

### Problem description
The Clang Static Analyzer results were being published to a personal repository (`blozano-tt/clangsa-results`) instead of the organization repository.

### What's changed
Updated the GitHub Actions workflow to publish ClangSA HTML reports to the organization repository `tenstorrent/tt-metal-clangsa-results` instead of the personal repository.

**Changes:**
- Updated `external_repository` parameter in `publish-clangsa-pages` job from `blozano-tt/clangsa-results` to `tenstorrent/tt-metal-clangsa-results`
- Updated the step name to reflect the new repository

This ensures the ClangSA results are published to the correct organization repository for better visibility and maintenance.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-switch-clangsa-repo)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-switch-clangsa-repo)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-switch-clangsa-repo)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-switch-clangsa-repo)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-switch-clangsa-repo)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-switch-clangsa-repo)
- [x] New/Existing tests provide coverage for changes (N/A - workflow configuration change only)