### PR TITLE
Memory Optimization for Intermesh Routing Table Generation

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/routing_table_generator.hpp
@@ -53,7 +53,7 @@ private:
     // Direct lookup table: [src_mesh][src_chip][dst_mesh] -> exit chip_id in src_mesh
     std::vector<std::vector<std::vector<ChipId>>> exit_node_lut_;
 
-    std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> get_paths_to_all_meshes(
+    std::vector<std::vector<std::pair<ChipId, MeshId>>> get_first_hops_to_all_meshes(
         MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const;
     void generate_intramesh_routing_table(const IntraMeshConnectivity& intra_mesh_connectivity);
     // when generating intermesh routing table, we use the intramesh connectivity table to find the shortest path to

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -133,19 +133,16 @@ void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConn
     }
 }
 
-// Shortest Path
-// TODO: Put into mesh algorithms?
-std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> RoutingTableGenerator::get_paths_to_all_meshes(
+// Returns first hop to reach each destination mesh from source mesh.
+// first_hops[dst_mesh] = vector of (exit_chip_in_source_mesh, immediate_next_mesh) pairs
+// This is more memory efficient than storing full paths (exponential space complexity) since we only need the first hop.
+std::vector<std::vector<std::pair<ChipId, MeshId>>> RoutingTableGenerator::get_first_hops_to_all_meshes(
     MeshId src, const InterMeshConnectivity& inter_mesh_connectivity) const {
-    // TODO: add more tests for this
     std::uint32_t num_meshes = inter_mesh_connectivity.size();
-    // avoid vector<bool> specialization
     std::vector<std::uint8_t> visited(num_meshes, false);
 
-    // paths[target_mesh_id][path_count][next_chip and next_mesh];
-    std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> paths;
-    paths.resize(num_meshes);
-    paths[*src] = {{{}}};
+    // first_hops[target_mesh_id] = vector of (exit_chip, next_mesh) pairs representing first hop options
+    std::vector<std::vector<std::pair<ChipId, MeshId>>> first_hops(num_meshes);
 
     std::vector<std::uint32_t> dist(num_meshes, std::numeric_limits<std::uint32_t>::max());
     dist[*src] = 0;
@@ -153,54 +150,68 @@ std::vector<std::vector<std::vector<std::pair<ChipId, MeshId>>>> RoutingTableGen
     std::queue<MeshId> q;
     q.push(src);
     visited[*src] = true;
-    // BFS
+
+    // BFS to find shortest paths
     while (!q.empty()) {
         MeshId current_mesh_id = q.front();
         q.pop();
 
-        // Captures paths at the chip level
         for (ChipId chip_in_mesh = 0; chip_in_mesh < inter_mesh_connectivity[*current_mesh_id].size(); chip_in_mesh++) {
             for (const auto& [connected_mesh_id, edge] : inter_mesh_connectivity[*current_mesh_id][chip_in_mesh]) {
                 if (!visited[*connected_mesh_id]) {
                     q.push(connected_mesh_id);
                     visited[*connected_mesh_id] = true;
                 }
-                if (dist[*connected_mesh_id] > dist[*current_mesh_id] + 1) {
-                    dist[*connected_mesh_id] = dist[*current_mesh_id] + 1;
-                    paths[*connected_mesh_id] = paths[*current_mesh_id];
-                    for (auto& path : paths[*connected_mesh_id]) {
-                        path.push_back({chip_in_mesh, connected_mesh_id});
+
+                std::uint32_t new_dist = dist[*current_mesh_id] + 1;
+                if (dist[*connected_mesh_id] > new_dist) {
+                    // Found shorter path - update distance and first hops
+                    dist[*connected_mesh_id] = new_dist;
+                    if (current_mesh_id == src) {
+                        // Direct neighbor: first hop is (chip_in_source, connected_mesh)
+                        first_hops[*connected_mesh_id] = {{chip_in_mesh, connected_mesh_id}};
+                    } else {
+                        // Multi-hop: inherit first hops from intermediate mesh
+                        first_hops[*connected_mesh_id] = first_hops[*current_mesh_id];
                     }
-                } else if (dist[*connected_mesh_id] == dist[*current_mesh_id] + 1) {
-                    // another possible path discovered
-                    for (auto path : paths[*current_mesh_id]) {
-                        path.push_back({chip_in_mesh, connected_mesh_id});
-                        paths[*connected_mesh_id].push_back(path);
+                } else if (dist[*connected_mesh_id] == new_dist) {
+                    // Same distance - add alternative first hops
+                    if (current_mesh_id == src) {
+                        first_hops[*connected_mesh_id].push_back({chip_in_mesh, connected_mesh_id});
+                    } else {
+                        // Only inherit from each intermediate mesh once.
+                        // Multiple chips in the same intermediate mesh connecting to the same destination
+                        // would give identical first hops - avoid adding duplicates.
+                        // Check if we've already inherited from current_mesh by checking if its first hop
+                        // is already present in connected_mesh's first hops.
+                        bool already_inherited = false;
+                        if (!first_hops[*current_mesh_id].empty() && !first_hops[*connected_mesh_id].empty()) {
+                            const auto& hop_to_check = first_hops[*current_mesh_id][0];
+                            already_inherited = std::find(
+                                                    first_hops[*connected_mesh_id].begin(),
+                                                    first_hops[*connected_mesh_id].end(),
+                                                    hop_to_check) != first_hops[*connected_mesh_id].end();
+                        }
+                        if (!already_inherited) {
+                            for (const auto& hop : first_hops[*current_mesh_id]) {
+                                first_hops[*connected_mesh_id].push_back(hop);
+                            }
+                        }
                     }
                 }
             }
         }
     }
-    /*
-    for (MeshId mesh_id = 0; mesh_id < num_meshes; mesh_id++) {
-        std::cout << "Path: from src " << src << " to " << mesh_id << " : ";
-        for (const auto& path: paths[mesh_id]) {
-          std::cout << std::endl;
-          for (const auto& id: path) {
-              std::cout << " chip " << id.first << " mesh " << id.second << " ";
-          }
-        }
-        std::cout << std::endl;
-    }*/
-    return paths;
+    return first_hops;
 }
 
 void RoutingTableGenerator::generate_intermesh_routing_table(
     const InterMeshConnectivity& inter_mesh_connectivity, const IntraMeshConnectivity& /*intra_mesh_connectivity*/) {
+    const auto& mesh_graph = topology_mapper_.get_mesh_graph();
+
     for (std::uint32_t src_mesh_id_val = 0; src_mesh_id_val < this->inter_mesh_table_.size(); src_mesh_id_val++) {
         MeshId src_mesh_id{src_mesh_id_val};
-        auto paths = get_paths_to_all_meshes(src_mesh_id, inter_mesh_connectivity);
-        const auto& mesh_graph = topology_mapper_.get_mesh_graph();
+        auto first_hops = get_first_hops_to_all_meshes(src_mesh_id, inter_mesh_connectivity);
         MeshShape mesh_shape = mesh_graph.get_mesh_shape(src_mesh_id);
         std::uint32_t ew_size = mesh_shape[1];
         for (ChipId src_chip_id = 0; src_chip_id < this->inter_mesh_table_[src_mesh_id_val].size(); src_chip_id++) {
@@ -213,23 +224,21 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
                     this->exit_node_lut_[src_mesh_id_val][src_chip_id][dst_mesh_id_val] = src_chip_id;
                     continue;
                 }
-                auto& candidate_paths = paths[dst_mesh_id_val];
+                auto& candidate_first_hops = first_hops[dst_mesh_id_val];
                 std::uint32_t min_load = std::numeric_limits<std::uint32_t>::max();
                 std::uint32_t min_distance = std::numeric_limits<std::uint32_t>::max();
-                if (candidate_paths.empty()) {
+                if (candidate_first_hops.empty()) {
                     this->inter_mesh_table_[src_mesh_id_val][src_chip_id][dst_mesh_id_val] = RoutingDirection::NONE;
                     this->exit_node_lut_[src_mesh_id_val][src_chip_id][dst_mesh_id_val] =
                         std::numeric_limits<ChipId>::max();
                     continue;
                 }
-                // TODO: This exit_chip_id doesn't make sense since it is always chip 0
-                ChipId exit_chip_id = candidate_paths[0][1].first;
-                MeshId next_mesh_id = candidate_paths[0][1].second;
-                for (auto& path : candidate_paths) {
-                    // First element is itself, second is next mesh
-                    TT_ASSERT(!path.empty(), "Expecting at least two entries in path");
-                    ChipId candidate_exit_chip_id = path[1].first;  // first element is the first hop to target mesh
-                    MeshId candidate_next_mesh_id = path[1].second;
+                // Initialize with first candidate
+                ChipId exit_chip_id = candidate_first_hops[0].first;
+                MeshId next_mesh_id = candidate_first_hops[0].second;
+                for (const auto& hop : candidate_first_hops) {
+                    ChipId candidate_exit_chip_id = hop.first;
+                    MeshId candidate_next_mesh_id = hop.second;
                     if (candidate_exit_chip_id == src_chip_id) {
                         // optimization for latency, always use src chip if it is an exit chip to next mesh, regardless
                         // of load on the edge
@@ -274,7 +283,7 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
                 } else {
                     // Use direction to exit chip from the intermesh routing table
                     this->inter_mesh_table_[src_mesh_id_val][src_chip_id][dst_mesh_id_val] =
-                        this->intra_mesh_table_[src_mesh_id_val][src_chip_id].at(exit_chip_id);
+                        this->intra_mesh_table_[src_mesh_id_val][src_chip_id][exit_chip_id];
                     // Update weight for exit chip to next mesh and src chip to exit chip
                     // inter_mesh_connectivity[src_mesh_id][exit_chip_id][next_mesh_id].weight += 1;
                     // for (auto& edge: intra_mesh_connectivity[src_mesh_id][src_chip_id]) {
@@ -289,6 +298,17 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
                 mesh_to_exit_nodes_[dst_mesh_id].push_back(FabricNodeId(MeshId{src_mesh_id}, exit_chip_id));
             }
         }
+    }
+
+    // Deduplicate mesh_to_exit_nodes_ - many chips share the same exit chip
+    for (auto& [mesh_id, exit_nodes] : mesh_to_exit_nodes_) {
+        std::sort(exit_nodes.begin(), exit_nodes.end(), [](const FabricNodeId& a, const FabricNodeId& b) {
+            if (a.mesh_id != b.mesh_id) {
+                return *a.mesh_id < *b.mesh_id;
+            }
+            return a.chip_id < b.chip_id;
+        });
+        exit_nodes.erase(std::unique(exit_nodes.begin(), exit_nodes.end()), exit_nodes.end());
     }
 }
 


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- As part of intermesh routing table setup, `RoutingTableGenerator::generate_intermesh_routing_table` currently stores all the paths from each exit node to each mesh in the cluster
- This leads to exponential time + space complexity. For a pipeline, the space complexity here is `O(4^D)`, where `D` is the pipeline depth
- For the Blitz pipeline setup, this is intractable (terabytes of memory are required for a 48 stage pipeline)

### What's changed
- Instead of storing the entire path from each exit node to every mesh, store the first hop (neighbour/intermediate mesh) needed to get to the target mesh
- This works because our exit node selection algorithm only considers the distance to the first hop (exit node), routing to the destination mesh

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/routing_table_optimization)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/routing_table_optimization)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/routing_table_optimization)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/routing_table_optimization)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/routing_table_optimization)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/routing_table_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/routing_table_optimization)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
