### PR TITLE
Add custom Compute API for fused eltwise mul + reduce_scalar operation

### DIFF
--- a/tests/tt_metal/tt_metal/llk/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/llk/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TESTS_LLK_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_cumsum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_dropout_sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_golden_impls.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_mul_reduce_scalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_pack_rows.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reconfig.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reduce.cpp

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+
+#include "test_golden_impls.hpp"
+#include "tt_metal/impl/data_format/bfloat16_utils.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/packing.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+using std::vector;
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace mul_reduce_scalar {
+
+namespace {
+
+void run_mul_reduce_scalar_test(IDevice* device, uint32_t num_tiles = 1, float b_value = 1.0f) {
+    uint32_t single_tile_size = 2 * 1024;
+
+    log_info(LogTest, "Testing multiply + reduce scalar with {} tiles", num_tiles);
+    log_info(LogTest, "Using random values for A and 1.0 for all B values");
+    log_info(LogTest, "Expected: REDUCE_SCALAR sums all A[i] * 1.0 = sum of all A[i] across all tiles");
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+    CoreCoord core = {0, 0};
+
+    auto create_buffer_config = [&device](uint32_t size, uint32_t page_size) {
+        return tt_metal::InterleavedBufferConfig{
+            .device = device, .size = size, .page_size = page_size, .buffer_type = tt_metal::BufferType::DRAM};
+    };
+
+    uint32_t input_buffer_size = num_tiles * single_tile_size;
+    auto src0_dram_buffer = CreateBuffer(create_buffer_config(input_buffer_size, single_tile_size));
+    auto src1_dram_buffer = CreateBuffer(create_buffer_config(input_buffer_size, single_tile_size));
+    auto dst_dram_buffer = CreateBuffer(create_buffer_config(single_tile_size, single_tile_size));
+
+    uint32_t cb_tiles = std::max(8u, num_tiles);
+    auto create_cb_config = [&single_tile_size](uint32_t cb_index, uint32_t num_tiles) {
+        return tt_metal::CircularBufferConfig(num_tiles * single_tile_size, {{cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_index, single_tile_size);
+    };
+
+    tt_metal::CreateCircularBuffer(program, core, create_cb_config(tt::CBIndex::c_0, cb_tiles));
+    tt_metal::CreateCircularBuffer(program, core, create_cb_config(tt::CBIndex::c_1, cb_tiles));
+    tt_metal::CreateCircularBuffer(program, core, create_cb_config(tt::CBIndex::c_16, cb_tiles));
+
+    // Reader kernel - reads tiles for both input tensors
+    auto dual_reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+    // Writer kernel - writes 1 output tile
+    auto unary_writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    // Compute kernel - performs multiply + reduce scalar operation
+    std::map<std::string, std::string> compute_defines = {{"REDUCE_OP", "PoolType::SUM"}};
+    auto mul_reduce_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp",
+        core,
+        tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,  // Highest precision (4x slower)
+            .compile_args = {},
+            .defines = compute_defines});
+
+    // Reader kernel args: src0_addr, src0_bank_id, src1_addr, src1_bank_id, num_tiles
+    const std::array<uint32_t, 5> reader_args = {
+        src0_dram_buffer->address(),  // src0_addr
+        0,                            // src0_bank_id
+        src1_dram_buffer->address(),  // src1_addr
+        0,                            // src1_bank_id
+        num_tiles                     // num_tiles
+    };
+
+    // Writer kernel args: dst_addr, dst_bank, num_tiles
+    const std::array<uint32_t, 3> writer_args = {
+        dst_dram_buffer->address(),  // dst_addr
+        0,                           // dst_bank
+        1                            // num_tiles (1 tile output)
+    };
+
+    SetRuntimeArgs(program, dual_reader_kernel, core, reader_args);
+    SetRuntimeArgs(program, unary_writer_kernel, core, writer_args);
+
+    // Compute kernel runtime args: num_tiles
+    SetRuntimeArgs(
+        program,
+        mul_reduce_kernel,
+        core,
+        {
+            num_tiles  // num_tiles
+        });
+
+    // Generate test data
+    // Use fixed seed for reproducibility
+    uint32_t seed = 12345;
+    uint32_t byte_size = num_tiles * single_tile_size;
+
+    // A: random values, B: all 1.0 for easier debugging (result = sum of A)
+    std::vector<uint32_t> packed_input0 =
+        generate_packed_uniform_random_vector<uint32_t, bfloat16>(0, 1.0f, byte_size / sizeof(bfloat16), seed);
+
+    // Create B with all 1.0 values
+    bfloat16 one_bf16 = bfloat16(1.0f);
+    uint16_t one_u16 = std::bit_cast<uint16_t>(one_bf16);
+    std::vector<uint32_t> packed_input1(byte_size / sizeof(uint32_t));
+    for (size_t i = 0; i < packed_input1.size(); ++i) {
+        // Pack two bfloat16 values (both 1.0) into one uint32_t
+        packed_input1[i] = (static_cast<uint32_t>(one_u16) << 16) | one_u16;
+    }
+
+    std::vector<uint32_t> src0_vec = packed_input0;
+    std::vector<uint32_t> src1_vec = packed_input1;
+
+    tt_metal::detail::WriteToBuffer(*src0_dram_buffer, src0_vec);
+    tt_metal::detail::WriteToBuffer(*src1_dram_buffer, src1_vec);
+    tt_metal::detail::LaunchProgram(device, program, true, true);
+
+    std::vector<uint32_t> result_vec;
+    tt_metal::detail::ReadFromBuffer(*dst_dram_buffer, result_vec);
+
+    auto u16_src0_vec = u16_from_u32_vector(src0_vec);
+    auto u16_src1_vec = u16_from_u32_vector(src1_vec);
+
+    // Compute golden reference for REDUCE_SCALAR across ALL tiles
+    float golden_scalar = 0.0f;
+    // Process ALL tiles' worth of data
+    for (size_t i = 0; i < u16_src0_vec.size(); ++i) {
+        float val0 = static_cast<float>(std::bit_cast<bfloat16>(u16_src0_vec[i]));
+        float val1 = static_cast<float>(std::bit_cast<bfloat16>(u16_src1_vec[i]));
+        golden_scalar += val0 * val1;
+    }
+
+    auto u16_result_vec = u16_from_u32_vector(result_vec);
+
+    // For REDUCE_SCALAR, the result is stored in the first element of the output tile
+    float device_scalar = static_cast<float>(std::bit_cast<bfloat16>(u16_result_vec[0]));
+
+    log_info(LogTest, "Golden scalar: {}", golden_scalar);
+    log_info(LogTest, "Device scalar: {}", device_scalar);
+    log_info(LogTest, "Difference: {}", std::abs(device_scalar - golden_scalar));
+    log_info(
+        LogTest, "Relative error: {:.2f}%", 100.0f * std::abs(device_scalar - golden_scalar) / std::abs(golden_scalar));
+
+    // Use relative tolerance for random values
+    float tolerance = std::max(0.01f * std::abs(golden_scalar), 0.1f);
+    EXPECT_NEAR(device_scalar, golden_scalar, tolerance);
+}
+
+}  // namespace
+
+TEST_F(MeshDeviceSingleCardFixture, MulReduceScalar1Tile) {
+    IDevice* device = devices_[0]->get_devices()[0];
+    run_mul_reduce_scalar_test(device, 1, 1.0f);
+}
+
+TEST_F(MeshDeviceSingleCardFixture, MulReduceScalar2Tiles) {
+    IDevice* device = devices_[0]->get_devices()[0];
+    run_mul_reduce_scalar_test(device, 2, 1.0f);
+}
+
+TEST_F(MeshDeviceSingleCardFixture, MulReduceScalar3Tiles) {
+    IDevice* device = devices_[0]->get_devices()[0];
+    run_mul_reduce_scalar_test(device, 3, 1.0f);
+}
+
+TEST_F(MeshDeviceSingleCardFixture, MulReduceScalar7Tiles) {
+    IDevice* device = devices_[0]->get_devices()[0];
+    run_mul_reduce_scalar_test(device, 7, 1.0f);
+}
+
+TEST_F(MeshDeviceSingleCardFixture, MulReduceScalar8Tiles) {
+    IDevice* device = devices_[0]->get_devices()[0];
+    run_mul_reduce_scalar_test(device, 8, 1.0f);
+}
+}  // namespace mul_reduce_scalar

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -38,9 +38,7 @@ using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-namespace tt::tt_metal {
-
-namespace unit_tests::compute::mul_reduce_scalar {
+namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar {
 
 struct MulReduceScalarConfig {
     uint32_t num_tiles = 1;
@@ -121,14 +119,14 @@ bool run_mul_reduce_scalar_test(IDevice* device, const MulReduceScalarConfig& co
     SetRuntimeArgs(program, mul_reduce_kernel, core, {config.num_tiles});
 
     uint32_t byte_size = config.num_tiles * TILE_BYTE_SIZE;
-    auto packed_input0 =
-        generate_packed_uniform_random_vector<uint32_t, bfloat16>(0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
+    auto packed_input0 = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
 
     bfloat16 one_bf16 = bfloat16(1.0f);
     uint16_t one_u16 = std::bit_cast<uint16_t>(one_bf16);
     std::vector<uint32_t> packed_input1(byte_size / sizeof(uint32_t));
-    for (size_t i = 0; i < packed_input1.size(); ++i) {
-        packed_input1[i] = (static_cast<uint32_t>(one_u16) << 16) | one_u16;
+    for (uint32_t& val : packed_input1) {
+        val = (static_cast<uint32_t>(one_u16) << 16) | one_u16;
     }
 
     tt_metal::detail::WriteToBuffer(*src0_dram_buffer, packed_input0);
@@ -167,9 +165,7 @@ bool run_mul_reduce_scalar_test(IDevice* device, const MulReduceScalarConfig& co
     return pass;
 }
 
-}  // namespace unit_tests::compute::mul_reduce_scalar
-
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar
 
 using namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar;
 

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -167,7 +167,7 @@ bool run_mul_reduce_scalar_test(IDevice* device, const MulReduceScalarConfig& co
 using namespace tt::tt_metal::unit_tests::compute::mul_reduce_scalar;
 
 // Test fixture that automatically skips if not on Blackhole
-class MulReduceScalarTest : public MeshDeviceSingleCardFixture {
+class MulReduceScalarTest : public MeshDeviceSingleCardFixture, public testing::WithParamInterface<int> {
 protected:
     void SetUp() override {
         MeshDeviceSingleCardFixture::SetUp();
@@ -177,27 +177,16 @@ protected:
     }
 };
 
-TEST_F(MulReduceScalarTest, MulReduceScalar1Tile) {
+// Single parametrized test
+TEST_P(MulReduceScalarTest, MulReduceScalar) {
     IDevice* device = devices_[0]->get_devices()[0];
-    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = 1}));
+    int num_tiles = GetParam();
+    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = num_tiles}));
 }
 
-TEST_F(MulReduceScalarTest, MulReduceScalar2Tiles) {
-    IDevice* device = devices_[0]->get_devices()[0];
-    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = 2}));
-}
-
-TEST_F(MulReduceScalarTest, MulReduceScalar3Tiles) {
-    IDevice* device = devices_[0]->get_devices()[0];
-    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = 3}));
-}
-
-TEST_F(MulReduceScalarTest, MulReduceScalar7Tiles) {
-    IDevice* device = devices_[0]->get_devices()[0];
-    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = 7}));
-}
-
-TEST_F(MulReduceScalarTest, MulReduceScalar8Tiles) {
-    IDevice* device = devices_[0]->get_devices()[0];
-    ASSERT_TRUE(run_mul_reduce_scalar_test(device, {.num_tiles = 8}));
-}
+// Instantiate the test suite with different tile counts
+INSTANTIATE_TEST_SUITE_P(
+    MulReduceScalarTests,
+    MulReduceScalarTest,
+    testing::Values(1, 2, 3, 7, 8),
+    [](const testing::TestParamInfo<int>& info) { return "MulReduceScalar_" + std::to_string(info.param) + "_Tiles"; });

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     // Initialize hardware before any operations
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
 
-    // Wait for num_tiles from each input (ready for future multiple tiles support)
+    // Wait for num_tiles from each input
     cb0.wait_front(num_tiles);
     cb1.wait_front(num_tiles);
 
@@ -32,10 +32,7 @@ void kernel_main() {
     tile_regs_acquire();
 
     // Perform fused multiply + reduce scalar
-    ckernel::mul_reduce_scalar_tile<REDUCE_OP>(
-        tt::CBIndex::c_0,  // Input A circular buffer
-        tt::CBIndex::c_1,  // Input B circular buffer
-        num_tiles);        // Number of tiles to process
+    ckernel::mul_reduce_scalar_tile<REDUCE_OP>(tt::CBIndex::c_0, tt::CBIndex::c_1, num_tiles);
 
     tile_regs_commit();
     tile_regs_wait();
@@ -51,7 +48,7 @@ void kernel_main() {
 
     // Push output tile
     cb16.push_back(1);
-    // UNPACK(tt::compute::common::print_full_tile(tt::CBIndex::c_16, 0););
-    //  Uninitialize the operation
+
+    // Uninitialize the operation
     ckernel::mul_reduce_scalar_uninit();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 
 #include "compute_kernel_api/experimental/mul_reduce_scalar.h"
-#include "api/debug/dprint_tensix.h"
-#include "api/debug/dprint_pages.h"
 #include "experimental/circular_buffer.h"
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -9,8 +9,7 @@
 #include "api/debug/dprint_pages.h"
 #include "experimental/circular_buffer.h"
 
-namespace NAMESPACE {
-void MAIN {
+void kernel_main() {
     const uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);    // Input A
@@ -56,4 +55,3 @@ void MAIN {
     //  Uninitialize the operation
     ckernel::mul_reduce_scalar_uninit();
 }
-}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/experimental/mul_reduce_scalar.h"
+#include "api/debug/dprint_tensix.h"
+#include "api/debug/dprint_pages.h"
+#include "experimental/circular_buffer.h"
+
+namespace NAMESPACE {
+void MAIN {
+    const uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    experimental::CircularBuffer cb0(tt::CBIndex::c_0);    // Input A
+    experimental::CircularBuffer cb1(tt::CBIndex::c_1);    // Input B
+    experimental::CircularBuffer cb16(tt::CBIndex::c_16);  // Output (reduced)
+
+    // Initialize hardware before any operations
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+
+    // Wait for num_tiles from each input (ready for future multiple tiles support)
+    cb0.wait_front(num_tiles);
+    cb1.wait_front(num_tiles);
+
+    // Reserve space for output
+    cb16.reserve_back(1);
+
+    // Initialize the multiply + reduce scalar operation
+    ckernel::mul_reduce_scalar_init<REDUCE_OP>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+
+    tile_regs_acquire();
+
+    // Perform fused multiply + reduce scalar
+    ckernel::mul_reduce_scalar_tile<REDUCE_OP>(
+        tt::CBIndex::c_0,  // Input A circular buffer
+        tt::CBIndex::c_1,  // Input B circular buffer
+        0,                 // Input A tile index
+        0,                 // Input B tile index
+        num_tiles);        // Number of tiles to process
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // Pack the result (MUST be tile index 0)
+    pack_tile(0, tt::CBIndex::c_16);
+
+    tile_regs_release();
+
+    // Release input tiles (ready for future multiple tiles support)
+    cb0.pop_front(num_tiles);
+    cb1.pop_front(num_tiles);
+
+    // Push output tile
+    cb16.push_back(1);
+    // UNPACK(tt::compute::common::print_full_tile(tt::CBIndex::c_16, 0););
+    //  Uninitialize the operation
+    ckernel::mul_reduce_scalar_uninit();
+}
+}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/mul_reduce_scalar.cpp
@@ -28,7 +28,7 @@ void MAIN {
     cb16.reserve_back(1);
 
     // Initialize the multiply + reduce scalar operation
-    ckernel::mul_reduce_scalar_init<REDUCE_OP>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    ckernel::mul_reduce_scalar_init(tt::CBIndex::c_0, tt::CBIndex::c_1);
 
     tile_regs_acquire();
 
@@ -36,8 +36,6 @@ void MAIN {
     ckernel::mul_reduce_scalar_tile<REDUCE_OP>(
         tt::CBIndex::c_0,  // Input A circular buffer
         tt::CBIndex::c_1,  // Input B circular buffer
-        0,                 // Input A tile index
-        0,                 // Input B tile index
         num_tiles);        // Number of tiles to process
 
     tile_regs_commit();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
@@ -17,11 +17,11 @@ void kernel_main() {
 
     constexpr uint32_t single_tile_size = 2 * 1024;
 
-    const InterleavedAddrGenFast<true> s0 = {
-        .bank_base_address = src0_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
-
-    const InterleavedAddrGenFast<true> s1 = {
-        .bank_base_address = src1_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
+    // Create TensorAccessors for the input buffers
+    constexpr auto s0_args = TensorAccessorArgs<0>();
+    const auto s0 = TensorAccessor(s0_args, src0_addr, single_tile_size);
+    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
+    const auto s1 = TensorAccessor(s1_args, src1_addr, single_tile_size);
 
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         cb_reserve_back(cb_id_in0, 1);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
@@ -2,41 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
+#include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {
-    // Runtime arguments - matching test_mul_reduce_scalar.cpp:100-105
-    uint32_t src0_addr = get_arg_val<uint32_t>(0);     // src0_dram_buffer->address()
-    uint32_t src0_bank_id = get_arg_val<uint32_t>(1);  // 0
-    uint32_t src1_addr = get_arg_val<uint32_t>(2);     // src1_dram_buffer->address()
-    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);  // 0
-    uint32_t num_tiles = get_arg_val<uint32_t>(4);     // num_tiles
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t src1_addr = get_arg_val<uint32_t>(2);
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);
+    uint32_t num_tiles = get_arg_val<uint32_t>(4);
 
-    // Circular buffer indices
-    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
 
-    // Single tile size in bytes (FP16_b format: 32x32 * 2 bytes)
     constexpr uint32_t single_tile_size = 2 * 1024;
 
-    // Create DRAM interfaces
     const InterleavedAddrGenFast<true> s0 = {
         .bank_base_address = src0_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
 
     const InterleavedAddrGenFast<true> s1 = {
         .bank_base_address = src1_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
 
-    // Read tiles sequentially: reserve, read, barrier, push for each tile
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
-        // Read tile from source 0 (input A)
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
         noc_async_read_tile(tile_idx, s0, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, 1);
 
-        // Read corresponding tile from source 1 (input B)
         cb_reserve_back(cb_id_in1, 1);
         uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
         noc_async_read_tile(tile_idx, s1, l1_write_addr_in1);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    // Runtime arguments - matching test_mul_reduce_scalar.cpp:100-105
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);     // src0_dram_buffer->address()
+    uint32_t src0_bank_id = get_arg_val<uint32_t>(1);  // 0
+    uint32_t src1_addr = get_arg_val<uint32_t>(2);     // src1_dram_buffer->address()
+    uint32_t src1_bank_id = get_arg_val<uint32_t>(3);  // 0
+    uint32_t num_tiles = get_arg_val<uint32_t>(4);     // num_tiles
+
+    // Circular buffer indices
+    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
+
+    // Single tile size in bytes (FP16_b format: 32x32 * 2 bytes)
+    constexpr uint32_t single_tile_size = 2 * 1024;
+
+    // Create DRAM interfaces
+    const InterleavedAddrGenFast<true> s0 = {
+        .bank_base_address = src0_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
+
+    const InterleavedAddrGenFast<true> s1 = {
+        .bank_base_address = src1_addr, .page_size = single_tile_size, .data_format = DataFormat::Float16_b};
+
+    // Read tiles sequentially: reserve, read, barrier, push for each tile
+    for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+        // Read tile from source 0 (input A)
+        cb_reserve_back(cb_id_in0, 1);
+        uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(tile_idx, s0, l1_write_addr_in0);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, 1);
+
+        // Read corresponding tile from source 1 (input B)
+        cb_reserve_back(cb_id_in1, 1);
+        uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+        noc_async_read_tile(tile_idx, s1, l1_write_addr_in1);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in1, 1);
+    }
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -16,7 +16,7 @@ template <
     BroadcastType src_b_bcast_type,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_mul_reduce_scalar_eltwise_init(
+inline void llk_math_eltwise_mul_reduce_scalar_init(
     const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
@@ -31,7 +31,7 @@ template <
     bool is_fp32_dest_acc_en,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_mul_reduce_scalar_eltwise(uint dst_index, const bool clear_fp32_dst_acc = true) {
+inline void llk_math_eltwise_mul_reduce_scalar(uint dst_index, const bool clear_fp32_dst_acc = true) {
     const std::uint32_t num_faces = 4;
 
     _llk_math_eltwise_binary_<

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -11,7 +11,7 @@
  * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
  *************************************************************************/
 
-template <int NUM_FIDELITY_PHASES = 0, EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+template <int NUM_FIDELITY_PHASES = 0>
 inline void llk_math_eltwise_mul_reduce_scalar_init(
     const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);
@@ -21,15 +21,14 @@ inline void llk_math_eltwise_mul_reduce_scalar_init(
         EltwiseBinaryType::ELWMUL,
         BroadcastType::NONE,
         NUM_FIDELITY_PHASES,
-        binary_reuse_dest>(num_faces, acc_to_dest);
+        EltwiseBinaryReuseDestType::NONE>(num_faces, acc_to_dest);
 }
 
-template <
-    bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_eltwise_mul_reduce_scalar(uint dst_index, const bool clear_fp32_dst_acc = true) {
-    const std::uint32_t num_faces = 4;
+template <bool is_fp32_dest_acc_en, int NUM_FIDELITY_PHASES = 0>
+inline void llk_math_eltwise_mul_reduce_scalar(
+    uint dst_index, const std::uint32_t icb0, const bool clear_fp32_dst_acc = true) {
+    const std::uint32_t operand_id = get_operand_id(icb0);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
     _llk_math_eltwise_binary_<
         EltwiseBinaryType::ELWMUL,
@@ -37,7 +36,7 @@ inline void llk_math_eltwise_mul_reduce_scalar(uint dst_index, const bool clear_
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
         NUM_FIDELITY_PHASES,
-        binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
+        EltwiseBinaryReuseDestType::NONE>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
 template <bool is_fp32_dest_acc_en, int num_fidelity_phases = 0, bool enforce_fp32_accumulation = false>
@@ -46,7 +45,9 @@ inline void llk_math_mul_reduce_scalar_reduce_init() {
 }
 
 template <int num_fidelity_phases = 0>
-inline void llk_math_mul_reduce_column(const uint dst_index, const uint num_faces = 4) {
+inline void llk_math_mul_reduce_column(const uint dst_index, const std::uint32_t icb0) {
+    const std::uint32_t operand_id = get_operand_id(icb0);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     _llk_math_mul_reduce_column_<num_fidelity_phases>(dst_index, false, num_faces);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -11,23 +11,20 @@
  * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
  *************************************************************************/
 
-template <
-    EltwiseBinaryType eltwise_binary_type,
-    BroadcastType src_b_bcast_type,
-    int NUM_FIDELITY_PHASES = 0,
-    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+template <int NUM_FIDELITY_PHASES = 0, EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_mul_reduce_scalar_init(
     const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
-        num_faces, acc_to_dest);
+    _llk_math_eltwise_binary_init_<
+        EltwiseBinaryType::ELWMUL,
+        BroadcastType::NONE,
+        NUM_FIDELITY_PHASES,
+        binary_reuse_dest>(num_faces, acc_to_dest);
 }
 
 template <
-    EltwiseBinaryType eltwise_binary_type,
-    BroadcastType src_b_bcast_type,
     bool is_fp32_dest_acc_en,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
@@ -35,8 +32,8 @@ inline void llk_math_eltwise_mul_reduce_scalar(uint dst_index, const bool clear_
     const std::uint32_t num_faces = 4;
 
     _llk_math_eltwise_binary_<
-        eltwise_binary_type,
-        src_b_bcast_type,
+        EltwiseBinaryType::ELWMUL,
+        BroadcastType::NONE,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
         NUM_FIDELITY_PHASES,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_mul_reduce_scalar_api.h
@@ -5,7 +5,7 @@
 #pragma once
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary.h"
-#include "llk_math_mul_reduce_scalar.h"
+#include "experimental/llk_math_mul_reduce_scalar.h"
 
 /*************************************************************************
  * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
@@ -43,50 +43,19 @@ inline void llk_math_mul_reduce_scalar_eltwise(uint dst_index, const bool clear_
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
-    bool enforce_fp32_accumulation = false>
+template <bool is_fp32_dest_acc_en, int num_fidelity_phases = 0, bool enforce_fp32_accumulation = false>
 inline void llk_math_mul_reduce_scalar_reduce_init() {
-    _llk_math_mul_reduce_scalar_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
+    _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
 }
 
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
-    bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
-inline void llk_math_mul_reduce_scalar_column(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_mul_reduce_scalar_column_<
-        type,
-        dim,
-        is_fp32_dest_acc_en,
-        num_fidelity_phases,
-        is_int_fpu_en,
-        enforce_fp32_accumulation,
-        false>(dst_index, false, num_faces);
+template <int num_fidelity_phases = 0>
+inline void llk_math_mul_reduce_column(const uint dst_index, const uint num_faces = 4) {
+    _llk_math_mul_reduce_column_<num_fidelity_phases>(dst_index, false, num_faces);
 }
 
-template <
-    PoolType type,
-    ReduceDim dim,
-    bool is_fp32_dest_acc_en,
-    int num_fidelity_phases = 0,
-    bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
-inline void llk_math_mul_reduce_scalar_final(const uint dst_index, const uint num_faces = 4) {
-    _llk_math_mul_reduce_scalar_final_<
-        type,
-        dim,
-        is_fp32_dest_acc_en,
-        num_fidelity_phases,
-        is_int_fpu_en,
-        enforce_fp32_accumulation,
-        false>(dst_index, false, num_faces);
+template <int num_fidelity_phases = 0>
+inline void llk_math_mul_reduce_scalar() {
+    _llk_math_mul_reduce_scalar_<num_fidelity_phases>();
 }
 
 inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_mul_reduce_scalar_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "llk_unpack_common_api.h"
-#include "llk_unpack_mul_reduce_scalar.h"
+#include "experimental/llk_unpack_mul_reduce_scalar.h"
 
 /*************************************************************************
  * LLK UNPACK MUL REDUCE SCALAR

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_mul_reduce_scalar_api.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "llk_math_eltwise_binary.h"
+#include "llk_math_mul_reduce_scalar.h"
+
+/*************************************************************************
+ * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
+ *************************************************************************/
+
+// Initialize eltwise multiply for mul_reduce_scalar
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    int NUM_FIDELITY_PHASES = 0,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_mul_reduce_scalar_eltwise_init(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, NUM_FIDELITY_PHASES, binary_reuse_dest>(
+        num_faces, acc_to_dest);
+}
+
+// Perform eltwise multiply for mul_reduce_scalar
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    bool is_fp32_dest_acc_en,
+    int NUM_FIDELITY_PHASES = 0,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_mul_reduce_scalar_eltwise(uint dst_index, const bool clear_fp32_dst_acc = true) {
+    const std::uint32_t num_faces = 4;
+
+    _llk_math_eltwise_binary_<
+        eltwise_binary_type,
+        src_b_bcast_type,
+        DstSync::SyncHalf,
+        is_fp32_dest_acc_en,
+        NUM_FIDELITY_PHASES,
+        binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
+}
+
+// Initialize reduce for mul_reduce_scalar
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int num_fidelity_phases = 0,
+    bool enforce_fp32_accumulation = false>
+inline void llk_math_mul_reduce_scalar_reduce_init() {
+    _llk_math_mul_reduce_scalar_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
+}
+
+// Perform column reduction for mul_reduce_scalar (accumulates across tiles)
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int num_fidelity_phases = 0,
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false,
+    bool scalar = false>
+inline void llk_math_mul_reduce_scalar_column(const uint dst_index, const uint num_faces = 4) {
+    _llk_math_mul_reduce_scalar_column_<
+        type,
+        dim,
+        is_fp32_dest_acc_en,
+        num_fidelity_phases,
+        is_int_fpu_en,
+        enforce_fp32_accumulation,
+        scalar>(dst_index, false, num_faces);
+}
+
+// Perform final scalar reduction for mul_reduce_scalar
+template <
+    PoolType type,
+    ReduceDim dim,
+    bool is_fp32_dest_acc_en,
+    int num_fidelity_phases = 0,
+    bool is_int_fpu_en = false,
+    bool enforce_fp32_accumulation = false>
+inline void llk_math_mul_reduce_scalar_final(const uint dst_index, const uint num_faces = 4) {
+    _llk_math_mul_reduce_scalar_final_<
+        type,
+        dim,
+        is_fp32_dest_acc_en,
+        num_fidelity_phases,
+        is_int_fpu_en,
+        enforce_fp32_accumulation,
+        false>(dst_index, false, num_faces);
+}
+
+// Clear data valid flags after mul_reduce_scalar
+inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }
+
+// Move destination to source registers for mul_reduce_scalar
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<binary_reuse_dest>(idst);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_mul_reduce_scalar_api.h
@@ -11,14 +11,13 @@
  * LLK MUL REDUCE SCALAR - Fused multiply and scalar reduction
  *************************************************************************/
 
-// Initialize eltwise multiply for mul_reduce_scalar
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_mul_reduce_scalar_eltwise_init(
-    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_A, const std::uint32_t acc_to_dest = 0) {
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
 
@@ -26,7 +25,6 @@ inline void llk_math_mul_reduce_scalar_eltwise_init(
         num_faces, acc_to_dest);
 }
 
-// Perform eltwise multiply for mul_reduce_scalar
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
@@ -39,13 +37,12 @@ inline void llk_math_mul_reduce_scalar_eltwise(uint dst_index, const bool clear_
     _llk_math_eltwise_binary_<
         eltwise_binary_type,
         src_b_bcast_type,
-        DstSync::SyncHalf,
+        DST_SYNC_MODE,
         is_fp32_dest_acc_en,
         NUM_FIDELITY_PHASES,
         binary_reuse_dest>(num_faces, dst_index, clear_fp32_dst_acc);
 }
 
-// Initialize reduce for mul_reduce_scalar
 template <
     PoolType type,
     ReduceDim dim,
@@ -56,15 +53,13 @@ inline void llk_math_mul_reduce_scalar_reduce_init() {
     _llk_math_mul_reduce_scalar_init_<type, dim, is_fp32_dest_acc_en, num_fidelity_phases, enforce_fp32_accumulation>();
 }
 
-// Perform column reduction for mul_reduce_scalar (accumulates across tiles)
 template <
     PoolType type,
     ReduceDim dim,
     bool is_fp32_dest_acc_en,
     int num_fidelity_phases = 0,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false,
-    bool scalar = false>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_mul_reduce_scalar_column(const uint dst_index, const uint num_faces = 4) {
     _llk_math_mul_reduce_scalar_column_<
         type,
@@ -73,10 +68,9 @@ inline void llk_math_mul_reduce_scalar_column(const uint dst_index, const uint n
         num_fidelity_phases,
         is_int_fpu_en,
         enforce_fp32_accumulation,
-        scalar>(dst_index, false, num_faces);
+        false>(dst_index, false, num_faces);
 }
 
-// Perform final scalar reduction for mul_reduce_scalar
 template <
     PoolType type,
     ReduceDim dim,
@@ -95,10 +89,8 @@ inline void llk_math_mul_reduce_scalar_final(const uint dst_index, const uint nu
         false>(dst_index, false, num_faces);
 }
 
-// Clear data valid flags after mul_reduce_scalar
 inline void llk_math_mul_reduce_scalar_clear_dvalid() { _llk_math_mul_reduce_scalar_clear_dvalid_(); }
 
-// Move destination to source registers for mul_reduce_scalar
 template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
     _llk_math_mul_reduce_scalar_move_dest_to_src_<binary_reuse_dest>(idst);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_mul_reduce_scalar_api.h
@@ -7,14 +7,7 @@
 #include "llk_unpack_mul_reduce_scalar.h"
 
 /*************************************************************************
- * LLK UNPACK MUL REDUCE SCALAR - Unpacker API for fused mul+reduce
+ * LLK UNPACK MUL REDUCE SCALAR
  *************************************************************************/
 
-/**
- * @brief Switch UNPACK state for mul_reduce_scalar reduce phase
- *
- * Prepares the unpacker to transition from multiply phase to reduce phase.
- * Resets counters and sets DVALID flags so the math thread can reuse
- * destination registers as source operands.
- */
 inline void llk_unpack_mul_reduce_scalar_switch_to_reduce() { _llk_unpack_mul_reduce_scalar_switch_to_reduce_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_mul_reduce_scalar_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_mul_reduce_scalar_api.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_unpack_common_api.h"
+#include "llk_unpack_mul_reduce_scalar.h"
+
+/*************************************************************************
+ * LLK UNPACK MUL REDUCE SCALAR - Unpacker API for fused mul+reduce
+ *************************************************************************/
+
+/**
+ * @brief Switch UNPACK state for mul_reduce_scalar reduce phase
+ *
+ * Prepares the unpacker to transition from multiply phase to reduce phase.
+ * Resets counters and sets DVALID flags so the math thread can reuse
+ * destination registers as source operands.
+ */
+inline void llk_unpack_mul_reduce_scalar_switch_to_reduce() { _llk_unpack_mul_reduce_scalar_switch_to_reduce_(); }

--- a/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
+++ b/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "compute_kernel_api/eltwise_binary.h"
-#include "llk_math_eltwise_unary_sfpu_macros.h"
 #ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_macros.h"
 #include "experimental/llk_math_mul_reduce_scalar_api.h"
 #endif
 #ifdef TRISC_UNPACK

--- a/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
+++ b/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
@@ -36,7 +36,7 @@ namespace ckernel {
 ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1) {
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
     MATH((llk_math_mul_reduce_scalar_eltwise_init<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, MATH_FIDELITY>(
-        icb0, icb1, false /*acc_to_dest*/)));
+        icb0, false /*acc_to_dest*/)));
 }
 
 // clang-format off
@@ -105,7 +105,6 @@ ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tile
               ReduceDim::REDUCE_COL,
               DST_ACCUM_MODE,
               MATH_FIDELITY,
-              false,
               false,
               false>(0)));
     }

--- a/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
+++ b/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/fill.h"
+
+#ifdef TRISC_MATH
+#include "llk_math_mul_reduce_scalar_api.h"
+#include "ckernel_sfpu.h"
+#include "sfpu/ckernel_sfpu_mul_reduce_scalar.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "llk_unpack_mul_reduce_scalar_api.h"
+#endif
+
+namespace ckernel {
+
+// Helper function: Move destination to source registers
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+ALWI void mul_reduce_scalar_move_dest_to_src(uint32_t idst = 0) {
+    MATH((llk_math_mul_reduce_scalar_move_dest_to_src<binary_reuse_dest>(idst)));
+}
+
+// clang-format off
+/**
+ * Initializes the fused multiply-reduce-scalar operation.
+ *
+ * This function initializes all necessary components (UNPACK, MATH, PACK) for the fused
+ * multiply + reduce scalar operation. The operation computes: scalar = sum(A * B) where
+ * A and B are input tensors (single tile each) and the result is a single scalar value.
+ *
+ * Must be called before mul_reduce_scalar_tile().
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb0           | Input circular buffer 0 (tensor A)                            | uint32_t | 0 to 31     | True     |
+ * | icb1           | Input circular buffer 1 (tensor B)                            | uint32_t | 0 to 31     | True     |
+ * | ocb            | Output circular buffer (scalar result)                        | uint32_t | 0 to 31     | True     |
+ *
+ * Return value: None
+ */
+// clang-format on
+template <PoolType reduce_type = PoolType::SUM>
+ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1, uint32_t ocb) {
+    // UNPACK initialization
+    UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
+
+    // MATH initialization - eltwise multiply
+    MATH((llk_math_mul_reduce_scalar_eltwise_init<EltwiseBinaryType::ELWMUL, NONE, MATH_FIDELITY>(
+        icb0, icb1, false /*acc_to_dest*/)));
+}
+
+// clang-format off
+/**
+ * Performs a fused multiply-reduce-scalar operation on tiles.
+ *
+ * This function performs:
+ * 1. Element-wise multiplication: C = A * B
+ * 2. Scalar reduction: result = sum(all elements of C)
+ *
+ * The final scalar result is stored in dest[0] at element position [0].
+ *
+ * The scalar result will be at element [0] of the output tile.
+ *
+ * | Argument       | Description                                                   | Type     | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|----------|-------------|----------|
+ * | icb0           | Input circular buffer 0 (tensor A)                            | uint32_t | 0 to 31     | True     |
+ * | icb1           | Input circular buffer 1 (tensor B)                            | uint32_t | 0 to 31     | True     |
+ * | itile0         | Input tile index for tensor A (usually 0)                     | uint32_t | 0+          | True     |
+ * | itile1         | Input tile index for tensor B (usually 0)                     | uint32_t | 0+          | True     |
+ * | num_tiles      | Number of tiles to process                                    | uint32_t | 1+          | True     |
+ *
+ * Return value: None
+ */
+// clang-format on
+template <PoolType reduce_type = PoolType::SUM>
+ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t num_tiles) {
+    // Step 1: Unpack input tiles from both circular buffers and perform multiplication
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        UNPACK((llk_unpack_AB(icb0, icb1, i, i)));
+        // Perform element-wise multiplication into dest[i]
+        MATH((llk_math_mul_reduce_scalar_eltwise<
+              EltwiseBinaryType::ELWMUL,
+              NONE,
+              DST_ACCUM_MODE,
+              MATH_FIDELITY,
+              EltwiseBinaryReuseDestType::NONE>(i)));
+    }
+
+    // Step 2: Switch UNPACK state for reduce phase (reset counters, set DVALID)
+    UNPACK((llk_unpack_mul_reduce_scalar_switch_to_reduce()));
+
+    // Step 3: Initialize reduce operation
+    MATH((llk_math_mul_reduce_scalar_reduce_init<reduce_type, ReduceDim::REDUCE_COL, DST_ACCUM_MODE, MATH_FIDELITY>()));
+
+    // Step 4: Prepare data for first tile's scalar reduction
+    // Move dest[0] (first multiply result) to srcA
+    mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0);
+
+    // Populate srcB with ones for the scaler
+    // Fill row 0 of Dest[0] with 1.0 (0x3F80 in bfloat16)
+    MATH((ckernel::sfpu::populate_dest0_row_with_value_(0, 0x3F80)));
+    mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0);
+
+    // Clear dest[0] - this will accumulate scalar reduction results from all tiles
+    MATH((ckernel::sfpu::populate_dest0_row_with_value_(0, 0x0000)));
+
+    // Step 5: Configure packer for scalar reduction
+    PACK((llk_pack_reduce_mask_config<false /*untilize*/, ReduceDim::REDUCE_SCALAR>()));
+
+    // Step 6: Perform column reduction for each tile, accumulating into dest[0]
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        if (i != 0) {
+            // Move dest[i] to srcA for next iteration
+            mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
+        }
+        // Perform column reduction, accumulating into dest[0]
+        MATH((llk_math_mul_reduce_scalar_column<
+              reduce_type,
+              ReduceDim::REDUCE_COL,
+              DST_ACCUM_MODE,
+              MATH_FIDELITY,
+              false,
+              false,
+              false>(0)));
+    }
+
+    // Step 7: Perform final scalar reduction
+    MATH((llk_math_mul_reduce_scalar_final<
+          reduce_type,
+          ReduceDim::REDUCE_SCALAR,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          false,
+          false>(0)));
+    MATH((llk_math_mul_reduce_scalar_clear_dvalid()));
+}
+
+// clang-format off
+/**
+ * NOTE: Should possibly be removed in the future.
+ * Clears data valid flags after reduce operation.
+ *
+ *
+ * Call sequence:
+ * 1. mul_reduce_scalar_tile()
+ * 2. pack_tile(0, ocb)
+ * 3. mul_reduce_scalar_clear_dvalid()  <- MUST be here
+ * 4. mul_reduce_scalar_uninit()
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void mul_reduce_scalar_clear_dvalid() { MATH((llk_math_mul_reduce_scalar_clear_dvalid())); }
+
+// clang-format off
+/**
+ * Uninitializes the fused multiply-reduce-scalar operation.
+ *
+ * This function cleans up the reduce operation and should be called after
+ * mul_reduce_scalar_tile() operations are complete.
+ *
+ * Return value: None
+ */
+// clang-format on
+ALWI void mul_reduce_scalar_uninit() { PACK((llk_pack_reduce_mask_clear())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
+++ b/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
@@ -53,19 +53,17 @@ ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1) {
  * | icb0           | Input circular buffer 0 (tensor A)                            | uint32_t | 0 to 31     | True     |
  * | icb1           | Input circular buffer 1 (tensor B)                            | uint32_t | 0 to 31     | True     |
  * | num_tiles      | Number of tiles to process                                    | uint32_t | 1 to 8      | True     |
- * | num_faces      | Number of faces per tile (default: 4)                         | uint32_t | 1, 2 or 4   | False    |
  * | scalar         | Scalar multiplier for reduction (default: 1.0)                | float    | Any float   | False    |
  *
  * Return value: None
  */
 // clang-format on
 template <PoolType reduce_type = PoolType::SUM>
-ALWI void mul_reduce_scalar_tile(
-    uint32_t icb0, uint32_t icb1, uint32_t num_tiles, uint32_t num_faces = 4, float scaler = 1.0f) {
+ALWI void mul_reduce_scalar_tile(uint32_t icb0, uint32_t icb1, uint32_t num_tiles, float scaler = 1.0f) {
     // Step 1: Unpack input tiles from both circular buffers and perform multiplication
     for (uint32_t i = 0; i < num_tiles; i++) {
         UNPACK((llk_unpack_AB(icb0, icb1, i, i)));
-        MATH((llk_math_eltwise_mul_reduce_scalar<DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(i)));
+        MATH((llk_math_eltwise_mul_reduce_scalar<DST_ACCUM_MODE, MATH_FIDELITY>(i, icb0)));
     }
 
     // Step 2: Switch UNPACK state for reduce phase (reset counters, set DVALID)
@@ -80,12 +78,12 @@ ALWI void mul_reduce_scalar_tile(
 
     // Populate srcB with the scaler value
     MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(
-        _calculate_fill_, RC, APPROX, 2 /*ITERATIONS*/, 0 /*dst_index*/, scaler));
+        _calculate_fill_, RC_custom, APPROX, 2 /*ITERATIONS*/, 0 /*dst_index*/, scaler));
     MATH((llk_math_mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0)));
 
     // Clear dest[0] - this will accumulate scalar reduction results from all tiles
-    MATH(
-        SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(_calculate_fill_, RC, APPROX, 2 /*ITERATIONS*/, 0 /*dst_index*/, 0.0f));
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(
+        _calculate_fill_, RC_custom, APPROX, 2 /*ITERATIONS*/, 0 /*dst_index*/, 0.0f));
 
     // Step 5: Configure packer for scalar reduction
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, ReduceDim::REDUCE_SCALAR>()));
@@ -97,7 +95,7 @@ ALWI void mul_reduce_scalar_tile(
             MATH((llk_math_mul_reduce_scalar_move_dest_to_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i)));
         }
         // Perform column reduction, accumulating into dest[0]
-        MATH((llk_math_mul_reduce_column<MATH_FIDELITY>(0, num_faces)));
+        MATH((llk_math_mul_reduce_column<MATH_FIDELITY>(0, icb0)));
     }
 
     // Step 7: Perform final scalar reduction

--- a/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
+++ b/tt_metal/include/compute_kernel_api/experimental/mul_reduce_scalar.h
@@ -34,8 +34,7 @@ namespace ckernel {
 // clang-format on
 ALWI void mul_reduce_scalar_init(uint32_t icb0, uint32_t icb1) {
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
-    MATH((llk_math_eltwise_mul_reduce_scalar_init<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, MATH_FIDELITY>(
-        icb0, false /*acc_to_dest*/)));
+    MATH((llk_math_eltwise_mul_reduce_scalar_init<MATH_FIDELITY>(icb0, false /*acc_to_dest*/)));
 }
 
 // clang-format off
@@ -66,12 +65,7 @@ ALWI void mul_reduce_scalar_tile(
     // Step 1: Unpack input tiles from both circular buffers and perform multiplication
     for (uint32_t i = 0; i < num_tiles; i++) {
         UNPACK((llk_unpack_AB(icb0, icb1, i, i)));
-        MATH((llk_math_eltwise_mul_reduce_scalar<
-              EltwiseBinaryType::ELWMUL,
-              BroadcastType::NONE,
-              DST_ACCUM_MODE,
-              MATH_FIDELITY,
-              EltwiseBinaryReuseDestType::NONE>(i)));
+        MATH((llk_math_eltwise_mul_reduce_scalar<DST_ACCUM_MODE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(i)));
     }
 
     // Step 2: Switch UNPACK state for reduce phase (reset counters, set DVALID)


### PR DESCRIPTION
### Ticket
#33339 

### Problem description
RMSNorm would greatly benefit from a fused compute API that would perform eltwise_mul and reduce_scalar operation in one L1-L1 trip. 


### What's changed
This PR covers the tt-metal portion of the code:

- new experimental Compute API;
- new experimental LLK API (BH only);
- LLK unit tests testing the functionality for 32x32 tiles (BH only). 

This PR covers BH code only. 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/fused_mul_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/fused_mul_reduce)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/fused_mul_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/fused_mul_reduce)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/fused_mul_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/fused_mul_reduce)
- [ ] New/Existing tests provide coverage for changes
