### PR TITLE
Switch from SFPCAST to SFPABS per tt-isa-documentation guidance

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -35,14 +35,14 @@ sfpi_inline void calculate_unary_max_min_float_body() {
 // Load value param to lreg2 and cast 2's complement to sign + magnitude format
 sfpi_inline void load_value_param_int(uint value) {
     _sfpu_load_imm32_(p_sfpu::LREG2, value);
-    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG3, 2);
+    TTI_SFPABS(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
     TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
 }
 template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_int32_body() {
     // Load input to lreg0
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
-    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG3, 2);
+    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
     TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
 
     // Copy value param to lreg1

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -35,7 +35,7 @@ sfpi_inline void calculate_unary_max_min_float_body() {
 // Load value param to lreg2 and cast 2's complement to sign + magnitude format
 sfpi_inline void load_value_param_int(uint value) {
     _sfpu_load_imm32_(p_sfpu::LREG2, value);
-    TTI_SFPABS(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+    TTI_SFPABS(0, p_sfpu::LREG2, p_sfpu::LREG3, sfpi::SFPABS_MOD1_INT);
     TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG2, 0);
 }
 template <bool IS_MAX_OP>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -42,7 +42,7 @@ template <bool IS_MAX_OP>
 sfpi_inline void calculate_unary_max_min_int32_body() {
     // Load input to lreg0
     TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
-    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPABS_MOD1_INT);
     TTI_SFPSETSGN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);
 
     // Copy value param to lreg1


### PR DESCRIPTION
### Ticket
/

### Problem description
Per tt-isa-documentation, "software is strongly encouraged to use SFPABS rather than this encoding of SFPCAST".

### What's changed
Switch from SFPCAST to exactly equivalent SFPABS, no change in behavior.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mcraighead/sfpcast-sfpabs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/sfpcast-sfpabs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/sfpcast-sfpabs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/sfpcast-sfpabs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/sfpcast-sfpabs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/sfpcast-sfpabs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/sfpcast-sfpabs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
