### PR TITLE
[skip ci] Suppress all warnings from third-party dependencies

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_CLANG_TIDY "")
 set(CMAKE_VERIFY_INTERFACE_HEADER_SETS FALSE)
 set(DEFAULT_COMPONENT_NAME ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
 
-add_compile_options($<$<COMPILE_LANG_AND_ID:C,CXX,GNU,Clang>:-w>)
+add_compile_options(-w)
 
 ############################################################################################################################
 # NUMA

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_CLANG_TIDY "")
 set(CMAKE_VERIFY_INTERFACE_HEADER_SETS FALSE)
 set(DEFAULT_COMPONENT_NAME ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
 
-add_compile_options(-Wno-unused-variable)
+add_compile_options($<$<COMPILE_LANG_AND_ID:C,CXX,GNU,Clang>:-w>)
 
 ############################################################################################################################
 # NUMA
@@ -105,12 +105,7 @@ set_target_properties(
 # Setting link and compile flags to avoid symbol conflicts with other protobuf libraries when tt-metal package is used.
 # Ensures that tt-metal package only uses its own protobuf library and not the one from the system.
 target_link_options(libprotobuf PRIVATE -Wl,-Bsymbolic)
-target_compile_options(
-    libprotobuf
-    PRIVATE
-        -fno-semantic-interposition
-        -Wno-deprecated-declarations
-)
+target_compile_options(libprotobuf PRIVATE -fno-semantic-interposition)
 
 ############################################################################################################################
 # yaml-cpp
@@ -141,10 +136,6 @@ CPMAddPackage(
         "INSTALL_GTEST OFF"
         "BUILD_SHARED_LIBS OFF"
 )
-
-if(googletest_ADDED)
-    target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)
-endif()
 
 ############################################################################################################################
 # boost-ext reflect : https://github.com/boost-ext/reflect
@@ -328,21 +319,6 @@ CPMAddPackage(
         "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
         "FLATBUFFERS_STRICT_MODE OFF"
 )
-
-if(flatbuffers_ADDED)
-    target_compile_options(
-        flatc
-        PRIVATE
-            -Wno-restrict
-            -Wno-deprecated-declarations
-    )
-    target_compile_options(
-        flatbuffers
-        PRIVATE
-            -Wno-restrict
-            -Wno-deprecated-declarations
-    )
-endif()
 
 ############################################################################################################################
 # simd-everywhere/simde : https://github.com/simd-everywhere/simde


### PR DESCRIPTION
### Ticket
N/A - Build system improvement

### Problem description
Third-party dependencies generate compiler warnings that clutter the build output and make it harder to spot warnings from our own code. Currently, we're suppressing warnings on a per-target, per-warning basis which requires maintenance as new warnings appear.

### What's changed
- Added a global  compile flag for disabling warnings
- Removed per-target warning suppressions:
  - `-Wno-deprecated-declarations` from libprotobuf
  - `-Wno-implicit-int-float-conversion` from gtest
  - `-Wno-restrict` and `-Wno-deprecated-declarations` from flatc and flatbuffers
- Net reduction: 24 lines removed from third_party/CMakeLists.txt

**Impact:** Cleaner build output, easier maintenance, no warnings from third-party code

**Testing:** Verified with `./build_metal.sh --build-all` - build completes successfully with no warnings emitted

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=suppress-third-party-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:suppress-third-party-warnings)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=suppress-third-party-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:suppress-third-party-warnings)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=suppress-third-party-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:suppress-third-party-warnings)
- [x] New/Existing tests provide coverage for changes - Build system change only, no functional changes


#### Model tests
N/A - Build system change only, does not affect model behavior