### PR TITLE
Fix incorrect sigmoid calls after cleanup

### DIFF
--- a/models/experimental/efficientdetd0/tt/bifpn.py
+++ b/models/experimental/efficientdetd0/tt/bifpn.py
@@ -310,7 +310,7 @@ class TtBiFPN:
 
     def _swish(self, x: ttnn.Tensor) -> ttnn.Tensor:
         """Swish activation: x * sigmoid(x)"""
-        return x * ttnn.sigmoid(x, True)
+        return x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
 
     def __call__(self, inputs: Tuple[ttnn.Tensor, ...]) -> Tuple[ttnn.Tensor, ...]:
         """

--- a/models/experimental/efficientdetd0/tt/efficientnetb0.py
+++ b/models/experimental/efficientdetd0/tt/efficientnetb0.py
@@ -104,10 +104,10 @@ class TtMBConvBlock:
 
         if not self.is_depthwise_first:
             x = self._expand_conv(x)
-            x = x * ttnn.sigmoid(x, True)
+            x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
 
         x = self._depthwise_conv(x)
-        x = x * ttnn.sigmoid(x, True)
+        x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
 
         if x.is_sharded():
             x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
@@ -116,13 +116,13 @@ class TtMBConvBlock:
 
         x_squeezed = ttnn.global_avg_pool2d(x)
         x_squeezed = self._se_reduce(x_squeezed)
-        x_squeezed = x_squeezed * ttnn.sigmoid(x_squeezed, True)
+        x_squeezed = x_squeezed * ttnn.sigmoid(x_squeezed, fast_and_approximate_mode=True)
         x_squeezed = self._se_expand(x_squeezed)
 
         if x_squeezed.is_sharded():
             x_squeezed = ttnn.sharded_to_interleaved(x_squeezed, ttnn.L1_MEMORY_CONFIG)
 
-        x = ttnn.sigmoid(x_squeezed, True) * x
+        x = ttnn.sigmoid(x_squeezed, fast_and_approximate_mode=True) * x
         ttnn.deallocate(x_squeezed)
 
         x = self._project_conv(x)

--- a/models/experimental/efficientdetd0/tt/utils.py
+++ b/models/experimental/efficientdetd0/tt/utils.py
@@ -196,6 +196,6 @@ class TtSeparableConvBlock:
         x = self.pointwise_conv(x)
 
         if self.activation:
-            x = x * ttnn.sigmoid(x, True)
+            x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
 
         return x

--- a/models/experimental/efficientnetb0/tt/efficientnetb0.py
+++ b/models/experimental/efficientnetb0/tt/efficientnetb0.py
@@ -216,9 +216,9 @@ class MBConvBlock:
     def __call__(self, x):
         if not self.is_depthwise_first:
             x = self._expand_conv(x)
-            x = x * ttnn.sigmoid(x, True)
+            x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
         x = self._depthwise_conv(x)
-        x = x * ttnn.sigmoid(x, True)
+        x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
         mul1 = x
 
         if x.is_sharded():
@@ -229,10 +229,10 @@ class MBConvBlock:
 
         x = self._se_reduce(x)
 
-        x = x * ttnn.sigmoid(x, True)
+        x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
         x = self._se_expand(x)
 
-        x = ttnn.sigmoid(x, True)
+        x = ttnn.sigmoid(x, fast_and_approximate_mode=True)
         mul1_interleaved = mul1
         if mul1.is_sharded():
             mul1_interleaved = ttnn.sharded_to_interleaved(mul1, ttnn.L1_MEMORY_CONFIG)
@@ -477,7 +477,7 @@ class Efficientnetb0:
 
         x = self._conv_head(x)
 
-        x = x * ttnn.sigmoid(x, True)
+        x = x * ttnn.sigmoid(x, fast_and_approximate_mode=True)
 
         x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
         x = ttnn.global_avg_pool2d(x)


### PR DESCRIPTION
### Ticket
#26946 

### Problem description
Missed change of parameters in sigmoid vs sigmoid_accurate

### What's changed
Add keyword argument to adjust to the change.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/26946_fix_model_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/26946_fix_model_issue)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
