### PR TITLE
Delete rank suffix from cache_path in ttrun.

### DIFF
--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -118,7 +118,7 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         # Use default pattern when TT_METAL_CACHE is not set
         base_path = f"{Path.home()}/.cache"
 
-    # Apply consistent rank suffix pattern to both user-provided and default paths
+    # Apply consistent suffix pattern to both user-provided and default paths
     cache_path = f"{base_path}_{hostname}"
 
     env = {

--- a/ttnn/ttnn/distributed/ttrun.py
+++ b/ttnn/ttnn/distributed/ttrun.py
@@ -19,7 +19,6 @@ from loguru import logger
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 TT_RUN_PREFIX = "[tt-run]"
-DEFAULT_CACHE_DIR_PATTERN = "{home}/.cache/{hostname}_rank{rank}"
 DEFAULT_LD_LIBRARY_PATH = "{home}/build/lib"
 INTERRUPTED_EXIT_CODE = 130  # 128 + SIGINT
 PRETTY_PRINT_THRESHOLD = 10  # Minimum args to trigger multi-line formatting
@@ -120,7 +119,7 @@ def get_rank_environment(binding: RankBinding, config: TTRunConfig) -> Dict[str,
         base_path = f"{Path.home()}/.cache"
 
     # Apply consistent rank suffix pattern to both user-provided and default paths
-    cache_path = f"{base_path}_{hostname}_rank{binding.rank}"
+    cache_path = f"{base_path}_{hostname}"
 
     env = {
         "TT_METAL_CACHE": cache_path,


### PR DESCRIPTION
### Problem description
Since #29164 is closed, we can allow multiple processes to share the same tt-metal-cache dir.

### What's changed
Deleted rank suffix from cache_path.

### Checklist

- [t3000-unit-tests / t3k_tt_metal_multiprocess_tests](https://github.com/tenstorrent/tt-metal/actions/runs/21451412312/job/61782061745#logs) passed (rest of the test suite is on par with main).