### PR TITLE
Revert "Cleanup sigmoid implementation"

### DIFF
--- a/models/demos/vision/segmentation/vgg_unet/common/ttnn/ttnn_vgg_unet.py
+++ b/models/demos/vision/segmentation/vgg_unet/common/ttnn/ttnn_vgg_unet.py
@@ -6,8 +6,7 @@ import ttnn
 
 
 # shard concat function
-# expected input tensors to be in fp16, RM, same (h*w)
-def sharded_concat(input_tensors, num_cores=64, dim=3):
+def sharded_concat(input_tensors, num_cores=64, dim=3):  # expected input tensors to be in fp16, RM, same (h*w)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
     in_shard_width = input_tensors[0].shape[-1]
     shard_height = ((input_tensors[0].shape[2]) + num_cores - 1) // num_cores
@@ -361,6 +360,6 @@ class Tt_vgg_unet:
             use_height_and_width_as_shard_shape=True,
         )
 
-        x = ttnn.sigmoid(x, memory_config=sharded_memory_config)
+        x = ttnn.sigmoid_accurate(x, memory_config=sharded_memory_config)
 
         return x

--- a/models/experimental/efficientdetd0/tt/bifpn.py
+++ b/models/experimental/efficientdetd0/tt/bifpn.py
@@ -310,7 +310,7 @@ class TtBiFPN:
 
     def _swish(self, x: ttnn.Tensor) -> ttnn.Tensor:
         """Swish activation: x * sigmoid(x)"""
-        return x * ttnn.sigmoid(x, True)
+        return x * ttnn.sigmoid_accurate(x, True)
 
     def __call__(self, inputs: Tuple[ttnn.Tensor, ...]) -> Tuple[ttnn.Tensor, ...]:
         """

--- a/models/experimental/efficientdetd0/tt/classifier.py
+++ b/models/experimental/efficientdetd0/tt/classifier.py
@@ -51,7 +51,7 @@ class TtClassifier:
         for feat, conv_list, header in zip(inputs, self.conv_list, self.header_list):
             for conv in conv_list:
                 feat = conv(feat)
-                feat = feat * ttnn.sigmoid(feat)
+                feat = feat * ttnn.sigmoid_accurate(feat)
             feat = header(feat)
             feat = ttnn.to_memory_config(feat, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.float32)
             feat = ttnn.reshape(feat, (feat.shape[0], -1, self.num_classes))
@@ -59,4 +59,4 @@ class TtClassifier:
         concated_feats = ttnn.concat(feats, dim=1)
         for t in feats:
             ttnn.deallocate(t)
-        return ttnn.sigmoid(concated_feats)
+        return ttnn.sigmoid_accurate(concated_feats)

--- a/models/experimental/efficientdetd0/tt/efficientnetb0.py
+++ b/models/experimental/efficientdetd0/tt/efficientnetb0.py
@@ -104,10 +104,10 @@ class TtMBConvBlock:
 
         if not self.is_depthwise_first:
             x = self._expand_conv(x)
-            x = x * ttnn.sigmoid(x, True)
+            x = x * ttnn.sigmoid_accurate(x, True)
 
         x = self._depthwise_conv(x)
-        x = x * ttnn.sigmoid(x, True)
+        x = x * ttnn.sigmoid_accurate(x, True)
 
         if x.is_sharded():
             x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
@@ -116,13 +116,13 @@ class TtMBConvBlock:
 
         x_squeezed = ttnn.global_avg_pool2d(x)
         x_squeezed = self._se_reduce(x_squeezed)
-        x_squeezed = x_squeezed * ttnn.sigmoid(x_squeezed, True)
+        x_squeezed = x_squeezed * ttnn.sigmoid_accurate(x_squeezed, True)
         x_squeezed = self._se_expand(x_squeezed)
 
         if x_squeezed.is_sharded():
             x_squeezed = ttnn.sharded_to_interleaved(x_squeezed, ttnn.L1_MEMORY_CONFIG)
 
-        x = ttnn.sigmoid(x_squeezed, True) * x
+        x = ttnn.sigmoid_accurate(x_squeezed, True) * x
         ttnn.deallocate(x_squeezed)
 
         x = self._project_conv(x)

--- a/models/experimental/efficientdetd0/tt/regressor.py
+++ b/models/experimental/efficientdetd0/tt/regressor.py
@@ -47,7 +47,7 @@ class TtRegressor:
         for feat, conv_list, header in zip(inputs, self.conv_list, self.header_list):
             for conv in conv_list:
                 feat = conv(feat)
-                feat = feat * ttnn.sigmoid(feat)
+                feat = feat * ttnn.sigmoid_accurate(feat)
             feat = header(feat)
             feat = ttnn.to_memory_config(feat, ttnn.DRAM_MEMORY_CONFIG)
             feat = ttnn.reshape(feat, (feat.shape[0], -1, 4))

--- a/models/experimental/efficientdetd0/tt/utils.py
+++ b/models/experimental/efficientdetd0/tt/utils.py
@@ -73,8 +73,7 @@ def _get_dynamic_padding(configuration: Union[MaxPool2dConfiguration, Conv2dConf
     kh, kw = configuration.kernel_size
     sh, sw = configuration.stride
     dh, dw = configuration.dilation
-    # change the output size according to stride ! ! !
-    oh, ow = math.ceil(ih / sh), math.ceil(iw / sw)
+    oh, ow = math.ceil(ih / sh), math.ceil(iw / sw)  # change the output size according to stride ! ! !
     pad_h = max((oh - 1) * sh + (kh - 1) * dh + 1 - ih, 0)
     pad_w = max((ow - 1) * sw + (kw - 1) * dw + 1 - iw, 0)
 
@@ -196,6 +195,6 @@ class TtSeparableConvBlock:
         x = self.pointwise_conv(x)
 
         if self.activation:
-            x = x * ttnn.sigmoid(x, True)
+            x = x * ttnn.sigmoid_accurate(x, True)
 
         return x

--- a/models/experimental/tt_dit/layers/linear.py
+++ b/models/experimental/tt_dit/layers/linear.py
@@ -304,7 +304,7 @@ def _apply_activation_fn(t: ttnn.Tensor, activation_fn: str | None) -> ttnn.Tens
     if activation_fn == "decomposed_gelu":
         return gelu_decomposed(t)
     if activation_fn == "quick_gelu":
-        return t * ttnn.sigmoid(1.702 * t)  # quick approx gelu
+        return t * ttnn.sigmoid_accurate(1.702 * t)  # quick approx gelu
     if activation_fn == "swiglu":
         t, gate = ttnn.chunk(t, 2, -1)
         return t * ttnn.silu(gate)

--- a/models/experimental/uniad/tt/ttnn_resnet.py
+++ b/models/experimental/uniad/tt/ttnn_resnet.py
@@ -139,7 +139,7 @@ class TtModulatedDeformConv2dPack:
         offset = ttnn.concat((o1, o2), dim=3)
         ttnn.deallocate(o1)
         ttnn.deallocate(o2)
-        mask = ttnn.sigmoid(mask)  # low pcc if we use ttnn sigmoid for mask
+        mask = ttnn.sigmoid_accurate(mask)  # low pcc if we use ttnn sigmoid for mask
         mask = ttnn.permute(mask, (0, 3, 1, 2))
 
         mask = ttnn.to_torch(mask).to(dtype=torch.float)

--- a/models/experimental/vadv2/tt/tt_head.py
+++ b/models/experimental/vadv2/tt/tt_head.py
@@ -345,9 +345,7 @@ class TtVADHead:
             z = updated_z * (self.pc_range[5] - self.pc_range[2]) + self.pc_range[2]
 
             tmp_out = ttnn.concat(
-                # 0  # 1  # 2:4 untouched  # 4  # 5:10 untouched
-                [x, y, tmp[..., 2:4], z, tmp[..., 5:]],
-                dim=-1,
+                [x, y, tmp[..., 2:4], z, tmp[..., 5:]], dim=-1  # 0  # 1  # 2:4 untouched  # 4  # 5:10 untouched
             )
 
             #     # TODO: check if using sigmoid
@@ -445,8 +443,7 @@ class TtVADHead:
             if self.motion_det_score is not None:
                 motion_score = outputs_classes[-1]
                 max_motion_score = ttnn.max(max_motion_score, dim=-1)[0]
-                # [B, A]
-                invalid_motion_idx = max_motion_score < self.motion_det_score
+                invalid_motion_idx = max_motion_score < self.motion_det_score  # [B, A]
                 invalid_motion_idx = ttnn.unsqueeze(invalid_motion_idx, 2)
                 invalid_motion_idx = ttnn.repeat(invalid_motion_idx, (1, 1, self.fut_mode))
                 invalid_motion_idx = ttnn.reshape(
@@ -478,8 +475,7 @@ class TtVADHead:
                     (motion_coords.shape[0], motion_coords.shape[1] * motion_coords.shape[2], motion_coords.shape[3]),
                 )
                 map_query = ttnn.reshape(map_hs[-1], (batch_size, self.map_num_vec, self.map_num_pts_per_vec, -1))
-                # [B, P, pts, D] -> [B, P, D]
-                map_query = self.lane_encoder(map_query)
+                map_query = self.lane_encoder(map_query)  # [B, P, pts, D] -> [B, P, D]
                 map_score = map_outputs_classes[-1]
                 map_pos = map_outputs_coords_bev[-1]
 
@@ -533,8 +529,7 @@ class TtVADHead:
             motion_hs = ttnn.reshape(motion_hs, (B, num_agent, self.fut_mode, D))  # [B, A, T, D]
             ca_motion_query = ttnn.reshape(ca_motion_query, (batch_size, num_agent, self.fut_mode, -1))  # [B, A, T, D]
 
-            # [B, A, fut_mode, 2D]  #0.99
-            motion_hs = ttnn.concat([motion_hs, ca_motion_query], dim=-1)
+            motion_hs = ttnn.concat([motion_hs, ca_motion_query], dim=-1)  # [B, A, fut_mode, 2D]  #0.99
         else:
             raise NotImplementedError("Not implement yet")
 
@@ -835,7 +830,7 @@ class TtVADHead:
         min_map_pos = ttnn.reshape(min_map_pos, (batch, num_map, 2))  # [B, P, 2]
         min_map_pos = ttnn.to_layout(min_map_pos, layout=ttnn.TILE_LAYOUT)
 
-        map_score = ttnn.sigmoid(map_score)
+        map_score = ttnn.sigmoid_accurate(map_score)
         map_max_score = ttnn.max(map_score, dim=-1)[0]
         map_max_score = ttnn.unsqueeze(map_max_score, 0)
         map_idx = map_max_score > map_thresh
@@ -934,7 +929,7 @@ class TtVADHead:
     def select_and_pad_query(self, query, query_pos, query_score, score_thresh=0.5, use_fix_pad=True):
         # select & pad query for different batch using score_thresh
         query_score = ttnn.to_layout(query_score, layout=ttnn.TILE_LAYOUT)
-        query_score = ttnn.sigmoid(query_score)
+        query_score = ttnn.sigmoid_accurate(query_score)
         query_score = ttnn.to_layout(query_score, layout=ttnn.ROW_MAJOR_LAYOUT)
         query_score = ttnn.add(query_score, 0.0, dtype=ttnn.float32)
         query_score = ttnn.max(query_score, dim=-1)[0]

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -38,13 +38,31 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     return result;
 }
 
+// sigmoid is anti-symmetric and offset by 1
+// sigmoid[-x] = 1 - sigmoid[x]
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vFloat x = sfpi::abs(val);
+
+    // Polynomial approximation of sigmoid on [0; +inf]
+    result = _sigmoid_piecewise_linear_positive_(x);
+
+    // Sigmoid is anti-symmetric and offset by 1.
+    // If input was negative then subtract result from 1.0f to get the correct result
+    v_if(val < sfpi::vConst0) { result = sfpi::vConst1 - result; }
+    v_endif;
+
+    return result;
+}
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
-#pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
             sfpi::vFloat result = _sfpu_sigmoid_<is_fp32_dest_acc_en>(val);
+
             if constexpr (!is_fp32_dest_acc_en) {
                 result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
             }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -38,10 +38,27 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     return result;
 }
 
+// sigmoid is anti-symmetric and offset by 1
+// sigmoid[-x] = 1 - sigmoid[x]
+sfpi_inline sfpi::vFloat _sfpu_sigmoid_legacy_(sfpi::vFloat val) {
+    sfpi::vFloat result = sfpi::vConst0;
+
+    sfpi::vFloat x = sfpi::abs(val);
+
+    // Polynomial approximation of sigmoid on [0; +inf]
+    result = _sigmoid_piecewise_linear_positive_(x);
+
+    // Sigmoid is anti-symmetric and offset by 1.
+    // If input was negative then subtract result from 1.0f to get the correct result
+    v_if(val < sfpi::vConst0) { result = sfpi::vConst1 - result; }
+    v_endif;
+
+    return result;
+}
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
     if constexpr (!APPROXIMATION_MODE) {
-#pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -243,8 +243,10 @@ Tensor Sigmoid_accurate::invoke(
     const std::optional<Tensor>& optional_output_tensor) {
     return detail::unary_impl(
         input,
-        {UnaryWithParam(
-            UnaryOpType::SIGMOID, {static_cast<float>(VecMode::RC), fast_and_approximate_mode ? 1.0f : 0.0f})},
+        {UnaryWithParam(UnaryOpType::NEG),
+         UnaryWithParam(UnaryOpType::EXP, fast_and_approximate_mode ? 1.0f : 0.0f),
+         UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
+         UnaryWithParam(UnaryOpType::RECIP)},
         memory_config,
         optional_output_tensor);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1202,8 +1202,6 @@ template <typename unary_operation_t>
 void bind_sigmoid_accurate(nb::module_& mod) {
     auto doc = fmt::format(
         R"doc(
-        DEPRECATED in favor of ttnn.sigmoid, which now has exactly the same behavior.
-
         Applies {0} to :attr:`input_tensor` element-wise.
 
         .. math::


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#36308 - too aggressive cleanup fails some models, need to redo the change.

APC: https://github.com/tenstorrent/tt-metal/actions/runs/21457581587