### PR TITLE
Add vLLM DummyNoOpModel for testing vLLM host overhead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -365,7 +365,7 @@ models/experimental/tt_transformers_v2 @gwangTT @yieldthought @uaydonat @tenstor
 models/experimental/retinanet @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 models/experimental/efficientdetd0 @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 models/**/requirements*.txt @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
-models/vllm_test_utils/ @skhorasganiTT @uaydonat @tenstorrent/codeowner-bypass
+models/vllm_test_utils/ @skhorasganiTT @viktorpusTT @uaydonat @tenstorrent/codeowner-bypass
 models/experimental/pi0 @sdawle-TT @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 
 # tracy

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -348,6 +348,21 @@ jobs:
               "use-vllm-v1": true,
               "multimodal": false,
               "co-owner-1-id": "U08CEGF78ET"
+            },
+            {
+              "name": "[WH-N300][v1] NoOp test model (vLLM overhead)",
+              "model": "models/vllm_test_utils/no_op_test",
+              "server-timeout": 2,
+              "benchmark-timeout": 2,
+              "runner-label": "N300",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "N300",
+              "override-tt-config": "{\"register_test_models\": true, \"sample_on_device_mode\": \"all\"}",
+              "additional-server-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --input-queue-batching-delay 0",
+              "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct",
+              "use-vllm-v1": true,
+              "multimodal": false,
+              "owner_id": "U08CEGF78ET"
             }
           ]'
 

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -20,6 +20,7 @@ on:
           - google/gemma-3-27b-it
           - openai/gpt-oss-120b
           - models/vllm_test_utils/t3000_multiproc_test
+          - models/vllm_test_utils/no_op_test
       platform:
         required: false
         type: choice

--- a/models/vllm_test_utils/no_op_test/config.json
+++ b/models/vllm_test_utils/no_op_test/config.json
@@ -1,0 +1,5 @@
+{
+    "architectures": ["DummyNoOpModel"],
+    "model_type": "llama",
+    "vocab_size": 128256
+}

--- a/models/vllm_test_utils/no_op_test/test_model.py
+++ b/models/vllm_test_utils/no_op_test/test_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/vllm_test_utils/no_op_test/test_model.py
+++ b/models/vllm_test_utils/no_op_test/test_model.py
@@ -15,6 +15,7 @@ class DummyNoOpModel:
         self.mesh_device = mesh_device
         self.max_batch_size = max_batch_size
         self.vocab_size = vocab_size
+        self.decode_out = torch.ones(max_batch_size, 1, dtype=torch.int32)
 
     @classmethod
     def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size, **kwargs):
@@ -28,7 +29,9 @@ class DummyNoOpModel:
 
     def decode_forward(self, *args, **kwargs):
         # Run nothing for decode forward in this dummy model
-        return torch.ones(self.max_batch_size, 1, 1, dtype=torch.int32)
+        tokens = kwargs.get("tokens")
+        assert tokens.shape[0] == self.max_batch_size, "Batch size mismatch"
+        return self.decode_out
 
     def allocate_kv_cache(self, *args, **kwargs):
         return None

--- a/models/vllm_test_utils/no_op_test/test_model.py
+++ b/models/vllm_test_utils/no_op_test/test_model.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+
+class DummyNoOpModel:
+    """
+    Dummy model class which does nothing for prefill and decode forward.
+    Assumes sampling on device. Used to measure the host overheads from vLLM.
+    """
+
+    def __init__(self, mesh_device, max_batch_size, vocab_size):
+        self.mesh_device = mesh_device
+        self.max_batch_size = max_batch_size
+        self.vocab_size = vocab_size
+
+    @classmethod
+    def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size, **kwargs):
+        vocab_size = hf_config.vocab_size
+        return cls(mesh_device, max_batch_size, vocab_size)
+
+    def prefill_forward(self, *args, **kwargs):
+        tokens = kwargs.get("tokens")
+        # Run nothing for prefill forward in this dummy model
+        return torch.ones(tokens.shape[0], 1, 1, dtype=torch.int32)
+
+    def decode_forward(self, *args, **kwargs):
+        # Run nothing for decode forward in this dummy model
+        return torch.ones(self.max_batch_size, 1, 1, dtype=torch.int32)
+
+    def allocate_kv_cache(self, *args, **kwargs):
+        return None
+
+    def warmup_model_prefill(self, *args, **kwargs):
+        pass

--- a/models/vllm_test_utils/t3000_multiproc_test/test_model.py
+++ b/models/vllm_test_utils/t3000_multiproc_test/test_model.py
@@ -2,11 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Dummy/test models for vLLM integration testing.
-These models are not production models but are used for testing infrastructure.
-"""
-
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -75,5 +70,5 @@ class DummyT3000MultiProcessModel:
     def allocate_kv_cache(self, *args, **kwargs):
         return None
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params):
+    def warmup_model_prefill(self, *args, **kwargs):
         pass


### PR DESCRIPTION
### Ticket
#36363

### Problem description
- Needed a way to test E2E vLLM host overhead excluding model contribution

### What's changed
- Added DummyNoOpModel test model for vLLM which does no computation, only returns output torch token tensors.
- Added test to vLLM nightly for running DummyNoOpModel and measuring E2E perf
- Corresponding vLLM PR which registers the new test model: https://github.com/tenstorrent/vllm/pull/305

### Checklist
- [ ] vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/21459313092
