### PR TITLE
Wrap max_runtime_args under API

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -525,16 +525,17 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // Set 100 unique args, then try to set max_runtime_args + 1 common args and fail.
+        // Set 100 unique args, then try to set get_max_runtime_args() + 1 common args and fail.
+        const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
-        std::vector<uint32_t> common_runtime_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> common_runtime_args(max_runtime_args + 1);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
-        // Set 100 common args, then try to set another tt::tt_metal::max_runtime_args + 1 unique args and fail.
+        // Set 100 common args, then try to set another get_max_runtime_args() + 1 unique args and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
-        std::vector<uint32_t> more_unique_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> more_unique_args(max_runtime_args + 1);
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -616,9 +616,8 @@ TEST_F(MeshDeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
 
 // Test that active ethernet cores correctly validate max runtime args
 TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     uint32_t active_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        tt::tt_metal::get_max_runtime_args_for_ethernet(HalProgrammableCoreType::ACTIVE_ETH);
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];
@@ -697,9 +696,8 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
 
 // Test that idle ethernet cores correctly validate max runtime args using IDLE_ETH kernel config size
 TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     uint32_t idle_eth_max_runtime_args =
-        hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t);
+        tt::tt_metal::get_max_runtime_args_for_ethernet(HalProgrammableCoreType::IDLE_ETH);
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -525,14 +525,16 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
-        // Set 100 unique args, then try to set get_max_runtime_args() + 1 common args and fail.
-        const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
+        // Set 100 unique args, then try to set get_max_runtime_args() + 1 common args
+        // and fail.
+        const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args(HalProgrammableCoreType::TENSIX);
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
         std::vector<uint32_t> common_runtime_args(max_runtime_args + 1);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
-        // Set 100 common args, then try to set another get_max_runtime_args() + 1 unique args and fail.
+        // Set 100 common args, then try to set another get_max_runtime_args() + 1 unique
+        // args and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
         std::vector<uint32_t> more_unique_args(max_runtime_args + 1);
@@ -616,8 +618,7 @@ TEST_F(MeshDeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
 
 // Test that active ethernet cores correctly validate max runtime args
 TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
-    uint32_t active_eth_max_runtime_args =
-        tt::tt_metal::get_max_runtime_args_for_ethernet(HalProgrammableCoreType::ACTIVE_ETH);
+    uint32_t active_eth_max_runtime_args = tt::tt_metal::get_max_runtime_args(HalProgrammableCoreType::ACTIVE_ETH);
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];
@@ -696,8 +697,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
 
 // Test that idle ethernet cores correctly validate max runtime args using IDLE_ETH kernel config size
 TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
-    uint32_t idle_eth_max_runtime_args =
-        tt::tt_metal::get_max_runtime_args_for_ethernet(HalProgrammableCoreType::IDLE_ETH);
+    uint32_t idle_eth_max_runtime_args = tt::tt_metal::get_max_runtime_args(HalProgrammableCoreType::IDLE_ETH);
     for (unsigned int id = 0; id < num_devices_; id++) {
         auto mesh_device = this->devices_.at(id);
         auto* device = mesh_device->get_devices()[0];

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -19,7 +19,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/kernel_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
 

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/kernel_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
 
@@ -31,6 +32,7 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices();
         init_max_cbs();
     }
@@ -107,6 +109,7 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices();
         init_max_cbs();
     }
@@ -176,6 +179,7 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices(90000000);
         init_max_cbs();
     }

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -32,9 +32,9 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices();
         init_max_cbs();
+        init_max_args();
     }
 
     void TearDown() override {
@@ -109,9 +109,9 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices();
         init_max_cbs();
+        init_max_args();
     }
 
     void TearDown() override {
@@ -179,9 +179,9 @@ protected:
             GTEST_SKIP();
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        this->max_runtime_args_ = get_max_runtime_args();
         this->create_devices(90000000);
         init_max_cbs();
+        init_max_args();
     }
 };
 

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -64,6 +64,7 @@ protected:
     const size_t l1_small_size_{DEFAULT_L1_SMALL_SIZE};
     const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
     uint32_t max_cbs_{};
+    uint32_t max_runtime_args_{};
 
     MeshDispatchFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -18,6 +18,7 @@
 #include "llrt.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
+#include <tt-metalium/kernel_types.hpp>
 
 namespace tt::tt_metal {
 
@@ -65,6 +66,7 @@ protected:
     const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
     uint32_t max_cbs_{};
     uint32_t max_runtime_args_{};
+    uint32_t max_runtime_args_eth_{};
 
     MeshDispatchFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
@@ -75,6 +77,7 @@ protected:
         // Must set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         init_max_cbs();
+        init_max_args();
 
         std::vector<ChipId> ids;
         for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
@@ -124,6 +127,11 @@ protected:
     }
 
     void init_max_cbs() { max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers(); }
+
+    void init_max_args() {
+        max_runtime_args_ = get_max_runtime_args();
+        max_runtime_args_eth_ = get_max_runtime_args_for_ethernet(HalProgrammableCoreType::ACTIVE_ETH);
+    }
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -66,7 +66,6 @@ protected:
     const size_t trace_region_size_{DEFAULT_TRACE_REGION_SIZE};
     uint32_t max_cbs_{};
     uint32_t max_runtime_args_{};
-    uint32_t max_runtime_args_eth_{};
 
     MeshDispatchFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
@@ -128,10 +127,7 @@ protected:
 
     void init_max_cbs() { max_cbs_ = tt::tt_metal::MetalContext::instance().hal().get_arch_num_circular_buffers(); }
 
-    void init_max_args() {
-        max_runtime_args_ = get_max_runtime_args();
-        max_runtime_args_eth_ = get_max_runtime_args_for_ethernet(HalProgrammableCoreType::ACTIVE_ETH);
-    }
+    void init_max_args() { max_runtime_args_ = get_max_runtime_args(HalProgrammableCoreType::TENSIX); }
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1680,7 +1680,7 @@ TEST_F(UnitMeshCQFixture, TensixTestAllRuntimeArgsCorrectlySentMultiCore_MaxRunt
         CoreRangeSet cr_set(cr);
 
         DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-        auto n_rt = tt::tt_metal::max_runtime_args;
+        auto n_rt = max_runtime_args_;
         local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(
             device, device->mesh_command_queue(), dummy_program_config, n_rt, n_rt, n_rt, 1);
     }
@@ -1755,7 +1755,7 @@ TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_MaxRu
         EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
             device,
             dummy_program_config,
-            tt::tt_metal::max_runtime_args,
+            max_runtime_args_,
             0,
             {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
     }
@@ -1772,7 +1772,7 @@ TEST_F(UnitMeshCQFixture, TensixIncrementRuntimeArgsSanityMultiCoreCompute_MaxRu
             device,
             dummy_program_config,
             0,
-            tt::tt_metal::max_runtime_args,
+            max_runtime_args_,
             {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0}));
     }
 }
@@ -2464,7 +2464,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program_, CoreType::ETH, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
     }
@@ -2495,7 +2495,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program_, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -2464,7 +2464,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program_, CoreType::ETH, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
     }
@@ -2495,7 +2495,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program_, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -2464,7 +2464,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
         this->create_kernel(program_, CoreType::ETH, true);
         distributed::EnqueueMeshWorkload(device_->mesh_command_queue(), workload, false);
     }
@@ -2495,7 +2495,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program_, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -56,7 +56,7 @@ inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_ar
     const uint32_t num_common_rt_args,
     const uint32_t unique_base,
     const uint32_t common_base) {
-    const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
+    const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args(HalProgrammableCoreType::TENSIX);
     TT_FATAL(
         num_unique_rt_args + num_common_rt_args <= max_runtime_args,
         "Number of unique runtime args and common runtime args exceeds the maximum limit of {} runtime args",
@@ -81,7 +81,7 @@ inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_ar
 // Optionally force the max size for one of the vectors.
 inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_args(
     const bool force_max_size = false, const uint32_t unique_base = 0, const uint32_t common_base = 100) {
-    uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
+    uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args(HalProgrammableCoreType::TENSIX);
     uint32_t num_rt_args_unique = rand() % (max_runtime_args + 1);
     uint32_t num_rt_args_common =
         num_rt_args_unique < max_runtime_args ? rand() % (max_runtime_args - num_rt_args_unique + 1) : 0;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -56,10 +56,11 @@ inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_ar
     const uint32_t num_common_rt_args,
     const uint32_t unique_base,
     const uint32_t common_base) {
+    const uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
     TT_FATAL(
-        num_unique_rt_args + num_common_rt_args <= tt::tt_metal::max_runtime_args,
+        num_unique_rt_args + num_common_rt_args <= max_runtime_args,
         "Number of unique runtime args and common runtime args exceeds the maximum limit of {} runtime args",
-        tt::tt_metal::max_runtime_args);
+        max_runtime_args);
 
     std::vector<uint32_t> common_rt_args;
     common_rt_args.reserve(num_common_rt_args);
@@ -80,17 +81,17 @@ inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_ar
 // Optionally force the max size for one of the vectors.
 inline std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_args(
     const bool force_max_size = false, const uint32_t unique_base = 0, const uint32_t common_base = 100) {
-    uint32_t num_rt_args_unique = rand() % (tt::tt_metal::max_runtime_args + 1);
-    uint32_t num_rt_args_common = num_rt_args_unique < tt::tt_metal::max_runtime_args
-                                      ? rand() % (tt::tt_metal::max_runtime_args - num_rt_args_unique + 1)
-                                      : 0;
+    uint32_t max_runtime_args = tt::tt_metal::get_max_runtime_args();
+    uint32_t num_rt_args_unique = rand() % (max_runtime_args + 1);
+    uint32_t num_rt_args_common =
+        num_rt_args_unique < max_runtime_args ? rand() % (max_runtime_args - num_rt_args_unique + 1) : 0;
 
     if (force_max_size) {
         if (rand() % 2) {
-            num_rt_args_unique = tt::tt_metal::max_runtime_args;
+            num_rt_args_unique = max_runtime_args;
             num_rt_args_common = 0;
         } else {
-            num_rt_args_common = tt::tt_metal::max_runtime_args;
+            num_rt_args_common = max_runtime_args;
             num_rt_args_unique = 0;
         }
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -748,7 +748,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
@@ -780,7 +780,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;
@@ -946,7 +946,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
@@ -1004,7 +1004,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoT
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -748,7 +748,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
@@ -780,7 +780,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;
@@ -946,7 +946,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
@@ -1004,7 +1004,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoT
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
+            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -748,7 +748,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         distributed::EnqueueMeshWorkload(mesh_command_queue, this->workloads[i], false);
@@ -780,7 +780,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;
@@ -946,7 +946,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
         // and the max kernel size to ensure that the kernel can fit in the ring buffer
         KernelProperties kernel_properties;
         kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-        kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+        kernel_properties.max_num_rt_args = max_runtime_args_eth_;
         this->create_kernel(program, CoreType::ETH, false, kernel_properties);
         this->workloads[i].add_program(device_range_, std::move(program));
         tt::tt_metal::distributed::MeshWorkload& workload = this->workloads[i];
@@ -1004,7 +1004,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoT
             // and the max kernel size to ensure that the kernel can fit in the ring buffer
             KernelProperties kernel_properties;
             kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES / 2;
-            kernel_properties.max_num_rt_args = max_runtime_args_ / 4;
+            kernel_properties.max_num_rt_args = max_runtime_args_eth_;
             kernel_properties.max_num_sems = MAX_NUM_SEMS / 2;
             this->create_kernel(program, CoreType::ETH, false, kernel_properties);
             eth_kernel_added_to_program = true;

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -29,7 +29,6 @@ protected:
     static const uint32_t MAX_KERNEL_RUNTIME_MICROSECONDS = 20000;
 
     static const uint32_t MIN_NUM_RUNTIME_ARGS = 0;
-    static const uint32_t MAX_NUM_RUNTIME_ARGS = max_runtime_args;
     static const uint32_t UNIQUE_RUNTIME_ARGS_VAL_OFFSET = 50;
     static const uint32_t COMMON_RUNTIME_ARGS_VAL_OFFSET = 100;
 
@@ -49,7 +48,7 @@ protected:
         uint32_t min_kernel_runtime_microseconds;
         uint32_t max_kernel_runtime_microseconds;
         uint32_t min_num_rt_args;
-        uint32_t max_num_rt_args;
+        uint32_t max_num_rt_args{};
         uint32_t min_num_sems;
         uint32_t max_num_sems;
         uint32_t min_num_cbs;
@@ -60,7 +59,6 @@ protected:
             min_kernel_runtime_microseconds(MIN_KERNEL_RUNTIME_MICROSECONDS),
             max_kernel_runtime_microseconds(MAX_KERNEL_RUNTIME_MICROSECONDS),
             min_num_rt_args(MIN_NUM_RUNTIME_ARGS),
-            max_num_rt_args(MAX_NUM_RUNTIME_ARGS),
             min_num_sems(MIN_NUM_SEMS),
             max_num_sems(MAX_NUM_SEMS),
             min_num_cbs(MIN_NUM_CBS) {}
@@ -91,6 +89,10 @@ protected:
         KernelProperties kernel_properties = KernelProperties()) {
         if (kernel_properties.max_num_cbs == 0) {
             kernel_properties.max_num_cbs = max_cbs_;
+        }
+
+        if (kernel_properties.max_num_rt_args == 0) {
+            kernel_properties.max_num_rt_args = max_runtime_args_;
         }
 
         CoreRangeSet cores = this->get_cores(kernel_core_type);
@@ -164,8 +166,8 @@ protected:
     std::pair<std::vector<uint32_t>, std::vector<uint32_t>> generate_runtime_args(
         const std::vector<uint32_t>& sem_ids,
         const std::vector<uint32_t>& cb_page_sizes,
-        const uint32_t min = MIN_NUM_RUNTIME_ARGS,
-        const uint32_t max = MAX_NUM_RUNTIME_ARGS) {
+        const uint32_t min,
+        const uint32_t max) {
         const uint32_t num_sems = sem_ids.size();
         const uint32_t num_cbs = cb_page_sizes.size();
         TT_FATAL(
@@ -196,7 +198,7 @@ protected:
         small_kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES * (2.0 / 10);
         small_kernel_properties.min_kernel_runtime_microseconds = MIN_KERNEL_RUNTIME_MICROSECONDS;
         small_kernel_properties.max_kernel_runtime_microseconds = MAX_KERNEL_RUNTIME_MICROSECONDS * (2.0 / 10);
-        small_kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS * (3.0 / 10);
+        small_kernel_properties.max_num_rt_args = max_runtime_args_ * (3.0 / 10);
         small_kernel_properties.min_num_sems = MIN_NUM_SEMS;
         small_kernel_properties.max_num_sems = MAX_NUM_SEMS * (3.0 / 10);
         small_kernel_properties.min_num_cbs = MIN_NUM_CBS;
@@ -212,8 +214,8 @@ protected:
         large_kernel_properties.max_kernel_size_bytes = MAX_KERNEL_SIZE_BYTES;
         large_kernel_properties.min_kernel_runtime_microseconds = MAX_KERNEL_RUNTIME_MICROSECONDS * (9.0 / 10);
         large_kernel_properties.max_kernel_runtime_microseconds = MAX_KERNEL_RUNTIME_MICROSECONDS;
-        large_kernel_properties.min_num_rt_args = MAX_NUM_RUNTIME_ARGS * (9.0 / 10);
-        large_kernel_properties.max_num_rt_args = MAX_NUM_RUNTIME_ARGS;
+        large_kernel_properties.min_num_rt_args = max_runtime_args_ * (9.0 / 10);
+        large_kernel_properties.max_num_rt_args = max_runtime_args_;
         large_kernel_properties.min_num_sems = MAX_NUM_SEMS * (8.0 / 10);
         large_kernel_properties.max_num_sems = MAX_NUM_SEMS;
         large_kernel_properties.min_num_cbs = max_cbs_ * (8.0 / 10);

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -18,10 +18,9 @@
 
 namespace tt::tt_metal {
 
-// 341 = (4096/(3 * sizeof(uint32_t)), where
-// - 4096 - packet size in dispatch
-// - 3 - number of kernels per tensix
-constexpr uint32_t max_runtime_args = 341;
+// Returns max user runtime args (unique + common combined).
+// Accounts for watcher overhead when enabled.
+uint32_t get_max_runtime_args();
 
 using KernelHandle = std::uint32_t;
 

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -22,6 +22,10 @@ namespace tt::tt_metal {
 // Accounts for watcher overhead when enabled.
 uint32_t get_max_runtime_args();
 
+// Returns max user runtime args for ethernet cores (unique + common combined).
+// Accounts for watcher overhead when enabled.
+uint32_t get_max_runtime_args_for_ethernet(HalProgrammableCoreType eth_core_type);
+
 using KernelHandle = std::uint32_t;
 
 // Option that controls build optimization level

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -18,13 +18,9 @@
 
 namespace tt::tt_metal {
 
-// Returns max user runtime args (unique + common combined).
+// Returns max user runtime args (unique + common combined) for the given core type.
 // Accounts for watcher overhead when enabled.
-uint32_t get_max_runtime_args();
-
-// Returns max user runtime args for ethernet cores (unique + common combined).
-// Accounts for watcher overhead when enabled.
-uint32_t get_max_runtime_args_for_ethernet(HalProgrammableCoreType eth_core_type);
+uint32_t get_max_runtime_args(HalProgrammableCoreType core_type);
 
 using KernelHandle = std::uint32_t;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -38,6 +38,21 @@
 
 namespace tt::tt_metal {
 
+namespace {
+// 341 = (4096/(3 * sizeof(uint32_t)), where
+// - 4096 - packet size in dispatch
+// - 3 - number of kernels per tensix
+// Internal constant - use get_max_runtime_args() for user-facing limit
+constexpr uint32_t max_runtime_args = 341;
+}  // namespace
+
+uint32_t get_max_runtime_args() {
+    bool watcher_assert_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
+                                  !tt::tt_metal::MetalContext::instance().rtoptions().watcher_assert_disabled();
+    const uint32_t watcher_reserved_words = watcher_assert_enabled ? 2 : 0;  // 1 for RTA count, 1 for CRTA count
+    return (max_runtime_args - watcher_reserved_words);
+}
+
 namespace fs = std::filesystem;
 
 namespace {
@@ -415,7 +430,7 @@ void Kernel::validate_runtime_args_size(
     uint32_t expected_max_rt_args = 0;
 
     switch (this->get_kernel_programmable_core_type()) {
-        case HalProgrammableCoreType::TENSIX: expected_max_rt_args = max_runtime_args; break;
+        case HalProgrammableCoreType::TENSIX: expected_max_rt_args = get_max_runtime_args(); break;
         case HalProgrammableCoreType::ACTIVE_ETH:
         case HalProgrammableCoreType::IDLE_ETH:
             expected_max_rt_args = MetalContext::instance().hal().get_dev_size(
@@ -451,22 +466,20 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
     auto& set_rt_args = this->core_to_runtime_args_[logical_core.x][logical_core.y];
     // TODO: Only allow setting once
     if (set_rt_args.empty()) {
-        // When watcher assert is enabled, we store [arg count | args]
-        size_t effective_limit = runtime_args.size() + watcher_count_word_offset_;
+        // Validate user-facing sizes against max (accounts for watcher overhead)
+        size_t user_crta_count =
+            common_runtime_args_.empty() ? 0 : (common_runtime_args_.size() - watcher_count_word_offset_);
+        this->validate_runtime_args_size(runtime_args.size(), user_crta_count, logical_core);
 
-        // Validate against hardware limit (341 words)
-        this->validate_runtime_args_size(effective_limit, this->common_runtime_args_.size(), logical_core);
-
-        // Track maximum dispatch size for CRTA validation
-        // Note: max_runtime_args_per_core_ stores effective size (includes count word if watcher enabled)
-        if (effective_limit > max_runtime_args_per_core_) {
-            max_runtime_args_per_core_ = effective_limit;
+        // Track max user RTA count for CRTA validation later
+        if (runtime_args.size() > max_runtime_args_per_core_) {
+            max_runtime_args_per_core_ = runtime_args.size();
             core_with_max_runtime_args_ = logical_core;
         }
 
         // Prepend count when watcher enabled for device-side bounds checking
         if (watcher_assert_enabled_) {
-            set_rt_args.reserve(effective_limit);
+            set_rt_args.reserve(runtime_args.size() + watcher_count_word_offset_);
             set_rt_args.push_back(static_cast<uint32_t>(runtime_args.size()));
             set_rt_args.insert(set_rt_args.end(), runtime_args.begin(), runtime_args.end());
         } else {
@@ -499,15 +512,13 @@ void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_ar
         set_rt_args.empty(),
         "Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.");
 
-    size_t effective_crta_limit = common_runtime_args.size() + watcher_count_word_offset_;
-
-    // Validate combined RTA + CRTA size doesn't exceed hardware limit (341 words)
-    // max_runtime_args_per_core_ already includes count word if watcher enabled
-    this->validate_runtime_args_size(max_runtime_args_per_core_, effective_crta_limit, core_with_max_runtime_args_);
+    // Validate user-facing sizes against max (accounts for watcher overhead)
+    this->validate_runtime_args_size(
+        max_runtime_args_per_core_, common_runtime_args.size(), core_with_max_runtime_args_);
 
     // Prepend count when watcher enabled for device-side bounds checking
     if (watcher_assert_enabled_) {
-        set_rt_args.reserve(effective_crta_limit);
+        set_rt_args.reserve(common_runtime_args.size() + watcher_count_word_offset_);
         set_rt_args.push_back(static_cast<uint32_t>(common_runtime_args.size()));
         set_rt_args.insert(set_rt_args.end(), common_runtime_args.begin(), common_runtime_args.end());
     } else {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -193,6 +193,7 @@ protected:
         defines_;  // preprocessor defines. this is to be able to generate generic instances.
     const bool watcher_assert_enabled_;
     const uint32_t watcher_count_word_offset_;
+    const uint32_t max_runtime_args_;  // Cached max user runtime args for this kernel's core type
     std::set<CoreCoord> logical_cores_;
 
     // Build key -> binaries (moved from KernelImpl)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36689

### Problem description
When watcher asserts are enabled, additional words are reserved in the RTA dispatch payload for count headers (1 for RTA, 1 for CRTA). The compile-time constant `max_runtime_args` doesn't account for this  
overhead, causing tests to fail when watcher is enabled because the effective user limit is lower than the actual maximum. 

### What's changed
- Replaced constant `max_runtime_args` with runtime API `get_max_runtime_args(HalProgrammableCoreType core_type)` that accounts for watcher overhead when enabled. Unified API handles `TENSIX`, `ACTIVE_ETH`, and `IDLE_ETH` core types via internal switch                                                      
- Moved internal constant to `kernel.cpp`
- Updated all test fixtures/files to use `init_max_args()` instead of the compile-time constant   

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/36689_account_watcher_count)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/36689_account_watcher_count)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/36689_account_watcher_count)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/36689_account_watcher_count)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/36689_account_watcher_count)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/36689_account_watcher_count)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/36689_account_watcher_count)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
