### PR TITLE
TTNN-25940: add conv3d dilation support

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -104,6 +104,30 @@ def test_conv3d_sweep_padding(device, B, C_in, C_out, T, H, W, kernel_size, stri
 
 
 @pytest.mark.parametrize(
+    "dilation", [(1, 1, 1), (2, 2, 2), (1, 2, 3)], ids=["dilation_111", "dilation_222", "dilation_123"]
+)
+@pytest.mark.parametrize("padding_mode", ["zeros", "replicate"])
+def test_conv3d_dilation(device, dilation, padding_mode):
+    input_shape = (1, 16, 5, 8, 9)
+    out_channels = 32
+    kernel_size = (3, 3, 3)
+    stride = (1, 1, 1)
+    padding = (0, 1, 1)
+    grid_size = device.compute_with_storage_grid_size()
+    run_conv3d_test(
+        device,
+        input_shape,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+        padding_mode,
+        grid_size=grid_size,
+        dilation=dilation,
+    )
+
+
+@pytest.mark.parametrize(
     "input_shape, out_channels, kernel_size, stride, padding, padding_mode",
     [
         [(1, 128, 16, 16, 16), 128, (3, 3, 3), (1, 1, 1), (1, 1, 1), "replicate"],

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -62,25 +62,34 @@ void bind_conv3d(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none());
 
-    auto py_conv3d_config =
-        nb::class_<ttnn::experimental::prim::Conv3dConfig>(
-            mod,
-            "Conv3dConfig",
-            R"doc(
+    auto py_conv3d_config = nb::class_<ttnn::experimental::prim::Conv3dConfig>(
+                                mod,
+                                "Conv3dConfig",
+                                R"doc(
                             Configuration for the Conv3D operation.
                             )doc")
-            .def(nb::init<>())
-            .def(
-                nb::init<DataType, Layout, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, CoreCoord>(),
-                nb::kw_only(),
-                nb::arg("weights_dtype") = DataType::BFLOAT16,
-                nb::arg("output_layout") = Layout::ROW_MAJOR,
-                nb::arg("T_out_block") = 1,
-                nb::arg("W_out_block") = 1,
-                nb::arg("H_out_block") = 1,
-                nb::arg("C_out_block") = 0,
-                nb::arg("C_in_block") = 0,
-                nb::arg("compute_with_storage_grid_size") = nb::cast(CoreCoord{1, 1}));
+                                .def(nb::init<>())
+                                .def(
+                                    nb::init<
+                                        DataType,
+                                        Layout,
+                                        uint32_t,
+                                        uint32_t,
+                                        uint32_t,
+                                        uint32_t,
+                                        uint32_t,
+                                        std::array<uint32_t, 3>,
+                                        CoreCoord>(),
+                                    nb::kw_only(),
+                                    nb::arg("weights_dtype") = DataType::BFLOAT16,
+                                    nb::arg("output_layout") = Layout::ROW_MAJOR,
+                                    nb::arg("T_out_block") = 1,
+                                    nb::arg("W_out_block") = 1,
+                                    nb::arg("H_out_block") = 1,
+                                    nb::arg("C_out_block") = 0,
+                                    nb::arg("C_in_block") = 0,
+                                    nb::arg("dilation") = std::array<uint32_t, 3>{1, 1, 1},
+                                    nb::arg("compute_with_storage_grid_size") = nb::cast(CoreCoord{1, 1}));
 
     py_conv3d_config.def_rw("weights_dtype", &ttnn::experimental::prim::Conv3dConfig::weights_dtype, "");
     py_conv3d_config.def_rw("output_layout", &ttnn::experimental::prim::Conv3dConfig::output_layout, "");
@@ -89,6 +98,7 @@ void bind_conv3d(nb::module_& mod) {
     py_conv3d_config.def_rw("H_out_block", &ttnn::experimental::prim::Conv3dConfig::H_out_block, "");
     py_conv3d_config.def_rw("C_out_block", &ttnn::experimental::prim::Conv3dConfig::C_out_block, "");
     py_conv3d_config.def_rw("C_in_block", &ttnn::experimental::prim::Conv3dConfig::C_in_block, "");
+    py_conv3d_config.def_rw("dilation", &ttnn::experimental::prim::Conv3dConfig::dilation, "");
     py_conv3d_config.def_rw(
         "compute_with_storage_grid_size", &ttnn::experimental::prim::Conv3dConfig::compute_with_storage_grid_size, "");
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -244,6 +244,8 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
     auto kernel_config_val = init_device_compute_kernel_config(
         input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
 
+    const std::array<uint32_t, 3> default_dilation = {1, 1, 1};
+
     auto operation_attributes = OperationType::operation_attributes_t{
         .config = config,
         .output_mem_config = memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
@@ -254,14 +256,11 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
         .stride = stride_,
         .padding = padding_,
         .dilation =
-            (config.dilation != std::array<uint32_t, 3>({1, 1, 1}) && dilation_ == std::array<uint32_t, 3>({1, 1, 1}))
-                ? config.dilation
-                : dilation_,
+            (config.dilation != default_dilation && dilation_ == default_dilation) ? config.dilation : dilation_,
         .padding_mode = padding_mode_,
         .groups = groups_};
     TT_FATAL(
-        config.dilation == std::array<uint32_t, 3>({1, 1, 1}) || dilation_ == std::array<uint32_t, 3>({1, 1, 1}) ||
-            config.dilation == dilation_,
+        config.dilation == default_dilation || dilation_ == default_dilation || config.dilation == dilation_,
         "dilation in Conv3dConfig and op args must match when both are set. config=({}, {}, {}), args=({}, {}, {})",
         config.dilation[0],
         config.dilation[1],

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -26,10 +26,11 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
     uint32_t W_in,
     const std::array<uint32_t, 3>& padding,
     const std::array<uint32_t, 3>& stride,
-    const std::array<uint32_t, 3>& kernel_size) {
-    uint32_t T_out = ((T_in + 2 * padding[0] - kernel_size[0]) / stride[0]) + 1;
-    uint32_t H_out = ((H_in + 2 * padding[1] - kernel_size[1]) / stride[1]) + 1;
-    uint32_t W_out = ((W_in + 2 * padding[2] - kernel_size[2]) / stride[2]) + 1;
+    const std::array<uint32_t, 3>& kernel_size,
+    const std::array<uint32_t, 3>& dilation) {
+    uint32_t T_out = ((T_in + 2 * padding[0] - (dilation[0] * (kernel_size[0] - 1)) - 1) / stride[0]) + 1;
+    uint32_t H_out = ((H_in + 2 * padding[1] - (dilation[1] * (kernel_size[1] - 1)) - 1) / stride[1]) + 1;
+    uint32_t W_out = ((W_in + 2 * padding[2] - (dilation[2] * (kernel_size[2] - 1)) - 1) / stride[2]) + 1;
     return {T_out, H_out, W_out};
 }
 }  // namespace detail
@@ -37,6 +38,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
 void Conv3dDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor;
+    const auto& input_shape = input_tensor_a.logical_shape();
 
     TT_FATAL(
         input_tensor_a.logical_shape().size() == 5,
@@ -72,6 +74,40 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
         args.padding_mode == "zeros" || args.padding_mode == "replicate",
         "Padding mode must be zeros or replicate. got {}",
         args.padding_mode);
+    TT_FATAL(
+        args.dilation[0] >= 1 && args.dilation[1] >= 1 && args.dilation[2] >= 1,
+        "Dilation must be >= 1 for all dimensions. got ({}, {}, {})",
+        args.dilation[0],
+        args.dilation[1],
+        args.dilation[2]);
+    auto effective_kernel = [](uint32_t k, uint32_t d) -> uint64_t { return static_cast<uint64_t>(d) * (k - 1) + 1; };
+    const uint64_t T_in = input_shape[1];
+    const uint64_t H_in = input_shape[2];
+    const uint64_t W_in = input_shape[3];
+    const uint64_t effective_k_t = effective_kernel(args.kernel_size[0], args.dilation[0]);
+    const uint64_t effective_k_h = effective_kernel(args.kernel_size[1], args.dilation[1]);
+    const uint64_t effective_k_w = effective_kernel(args.kernel_size[2], args.dilation[2]);
+    TT_FATAL(
+        T_in + 2 * static_cast<uint64_t>(args.padding[0]) >= effective_k_t,
+        "Effective kernel size exceeds padded T dimension (T_in={}, pad_t={}, k_t={}, d_t={})",
+        T_in,
+        args.padding[0],
+        args.kernel_size[0],
+        args.dilation[0]);
+    TT_FATAL(
+        H_in + 2 * static_cast<uint64_t>(args.padding[1]) >= effective_k_h,
+        "Effective kernel size exceeds padded H dimension (H_in={}, pad_h={}, k_h={}, d_h={})",
+        H_in,
+        args.padding[1],
+        args.kernel_size[1],
+        args.dilation[1]);
+    TT_FATAL(
+        W_in + 2 * static_cast<uint64_t>(args.padding[2]) >= effective_k_w,
+        "Effective kernel size exceeds padded W dimension (W_in={}, pad_w={}, k_w={}, d_w={})",
+        W_in,
+        args.padding[2],
+        args.kernel_size[2],
+        args.dilation[2]);
 
     if (args.config.C_out_block > 0) {
         TT_FATAL(
@@ -159,7 +195,7 @@ TensorSpec Conv3dDeviceOperation::compute_output_specs(
     uint32_t C_out = args.output_channels;
 
     auto [T_out, H_out, W_out] =
-        detail::compute_output_dims(T_in, H_in, W_in, args.padding, args.stride, args.kernel_size);
+        detail::compute_output_dims(T_in, H_in, W_in, args.padding, args.stride, args.kernel_size, args.dilation);
 
     ttnn::Shape output_shape({N, T_out, H_out, W_out, C_out});
 
@@ -217,9 +253,22 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
         .kernel_size = kernel_size_,
         .stride = stride_,
         .padding = padding_,
-        .dilation = dilation_,
+        .dilation =
+            (config.dilation != std::array<uint32_t, 3>{1, 1, 1} && dilation_ == std::array<uint32_t, 3>{1, 1, 1})
+                ? config.dilation
+                : dilation_,
         .padding_mode = padding_mode_,
         .groups = groups_};
+    TT_FATAL(
+        config.dilation == std::array<uint32_t, 3>{1, 1, 1} || dilation_ == std::array<uint32_t, 3>{1, 1, 1} ||
+            config.dilation == dilation_,
+        "dilation in Conv3dConfig and op args must match when both are set. config=({}, {}, {}), args=({}, {}, {})",
+        config.dilation[0],
+        config.dilation[1],
+        config.dilation[2],
+        dilation_[0],
+        dilation_[1],
+        dilation_[2]);
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .weight_tensor = weight_tensor, .bias_tensor = bias_tensor};
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -254,13 +254,13 @@ ttnn::experimental::prim::Conv3dDeviceOperation::tensor_return_value_t conv3d(
         .stride = stride_,
         .padding = padding_,
         .dilation =
-            (config.dilation != std::array<uint32_t, 3>{1, 1, 1} && dilation_ == std::array<uint32_t, 3>{1, 1, 1})
+            (config.dilation != std::array<uint32_t, 3>({1, 1, 1}) && dilation_ == std::array<uint32_t, 3>({1, 1, 1}))
                 ? config.dilation
                 : dilation_,
         .padding_mode = padding_mode_,
         .groups = groups_};
     TT_FATAL(
-        config.dilation == std::array<uint32_t, 3>{1, 1, 1} || dilation_ == std::array<uint32_t, 3>{1, 1, 1} ||
+        config.dilation == std::array<uint32_t, 3>({1, 1, 1}) || dilation_ == std::array<uint32_t, 3>({1, 1, 1}) ||
             config.dilation == dilation_,
         "dilation in Conv3dConfig and op args must match when both are set. config=({}, {}, {}), args=({}, {}, {})",
         config.dilation[0],

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -80,7 +80,7 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
         args.dilation[0],
         args.dilation[1],
         args.dilation[2]);
-    auto effective_kernel = [](uint32_t k, uint32_t d) -> uint64_t { return static_cast<uint64_t>(d) * (k - 1) + 1; };
+    auto effective_kernel = [](uint32_t k, uint32_t d) -> uint64_t { return (static_cast<uint64_t>(d) * (k - 1)) + 1; };
     const uint64_t T_in = input_shape[1];
     const uint64_t H_in = input_shape[2];
     const uint64_t W_in = input_shape[3];

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <optional>
 #include <string>
 
@@ -21,6 +22,7 @@ struct Conv3dConfig {
         uint32_t H_out_block_ = 1,
         uint32_t C_out_block_ = 0,
         uint32_t C_in_block_ = 0,
+        std::array<uint32_t, 3> dilation_ = {1, 1, 1},
         CoreCoord compute_with_storage_grid_size_ = {1, 1}) :
         weights_dtype(weights_dtype_),
         output_layout(output_layout_),
@@ -29,6 +31,7 @@ struct Conv3dConfig {
         H_out_block(H_out_block_),
         C_out_block(C_out_block_),
         C_in_block(C_in_block_),
+        dilation(dilation_),
         compute_with_storage_grid_size(compute_with_storage_grid_size_) {}
 
     tt::tt_metal::DataType weights_dtype;
@@ -38,6 +41,7 @@ struct Conv3dConfig {
     uint32_t H_out_block;
     uint32_t C_out_block;
     uint32_t C_in_block;
+    std::array<uint32_t, 3> dilation;
     CoreCoord compute_with_storage_grid_size;
 
     static constexpr auto attribute_names = std::make_tuple(
@@ -48,6 +52,7 @@ struct Conv3dConfig {
         "H_out_block",
         "C_out_block",
         "C_in_block",
+        "dilation",
         "compute_with_storage_grid_size");
 
     auto attribute_values() const {
@@ -59,6 +64,7 @@ struct Conv3dConfig {
             this->H_out_block,
             this->C_out_block,
             this->C_in_block,
+            this->dilation,
             this->compute_with_storage_grid_size);
     }
 };
@@ -90,7 +96,8 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_output_dims(
     uint32_t W_in,
     const std::array<uint32_t, 3>& padding,
     const std::array<uint32_t, 3>& stride,
-    const std::array<uint32_t, 3>& kernel_size);
+    const std::array<uint32_t, 3>& kernel_size,
+    const std::array<uint32_t, 3>& dilation);
 }  // namespace detail
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_program_factory.cpp
@@ -39,7 +39,13 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
     uint32_t W_in = input_tensor_shape[3];
     uint32_t C_in = input_tensor_shape[4];
     auto [T_out, H_out, W_out] = detail::compute_output_dims(
-        T_in, H_in, W_in, operation_attributes.padding, operation_attributes.stride, operation_attributes.kernel_size);
+        T_in,
+        H_in,
+        W_in,
+        operation_attributes.padding,
+        operation_attributes.stride,
+        operation_attributes.kernel_size,
+        operation_attributes.dilation);
     uint32_t C_out = operation_attributes.output_channels;
 
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
@@ -188,6 +194,12 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         operation_attributes.stride[2]);
     log_debug(
         tt::LogOp,
+        "Dilation: {}x{}x{}",
+        operation_attributes.dilation[0],
+        operation_attributes.dilation[1],
+        operation_attributes.dilation[2]);
+    log_debug(
+        tt::LogOp,
         "Padding: {}x{}x{}",
         operation_attributes.padding[0],
         operation_attributes.padding[1],
@@ -231,7 +243,10 @@ Conv3dProgramFactory::cached_program_t Conv3dProgramFactory::create(
         semaphore_id,
         operation_attributes.stride[0],
         operation_attributes.stride[1],
-        operation_attributes.stride[2]};
+        operation_attributes.stride[2],
+        operation_attributes.dilation[0],
+        operation_attributes.dilation[1],
+        operation_attributes.dilation[2]};
     tt::tt_metal::TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
 
     auto reader_kernels_id = CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/reader_vol2col.cpp
@@ -32,6 +32,29 @@ inline void zeroPad(uint32_t cb_write_addr) {
     }
 }
 
+template <bool is_sharded, typename Reader>
+FORCE_INLINE void compute_page_id_and_offset_for_c_in_block(
+    const Reader& reader,
+    uint32_t in_page_idx,
+    uint32_t c_in_offset_bytes,
+    uint32_t in_row_size_bytes,
+    uint32_t& in_page_id,
+    uint32_t& in_offset_bytes) {
+    if constexpr (is_sharded) {
+        // For width/block sharded RowMajor tensors, a "row" is split into multiple pages of size in_row_size_bytes.
+        // TensorAccessor expects page_id to be flattened over (row_idx, col_page_idx).
+        //
+        // For height sharded layouts, col_page_idx is always 0 and the channel selection is done via offset.
+        const uint32_t col_page_idx = c_in_offset_bytes / in_row_size_bytes;
+        in_offset_bytes = c_in_offset_bytes - (col_page_idx * in_row_size_bytes);
+        const uint32_t width_in_pages = reader.dspec().tensor_shape()[1];
+        in_page_id = in_page_idx * width_in_pages + col_page_idx;
+    } else {
+        in_page_id = in_page_idx;
+        in_offset_bytes = c_in_offset_bytes;
+    }
+}
+
 void kernel_main() {
     constexpr uint32_t cb_vol2col = get_compile_time_arg_val(0);
     constexpr uint32_t N = get_compile_time_arg_val(1);
@@ -151,21 +174,15 @@ void kernel_main() {
                                                         static_cast<uint32_t>(t_idx) * H_in_W_in +
                                                         static_cast<uint32_t>(h_idx) * W_in +
                                                         static_cast<uint32_t>(w_idx);
-                                                    // For width/block sharded RowMajor tensors, a "row" is split into
-                                                    // multiple pages of size in_row_size_bytes. TensorAccessor expects
-                                                    // page_id to be flattened over (row_idx, col_page_idx).
-                                                    //
-                                                    // For interleaved/height-sharded layouts, col_page_idx is always 0
-                                                    // and the channel selection is done via offset.
                                                     uint32_t in_page_id = in_page_idx;
                                                     uint32_t in_offset_bytes = c_in_offset_bytes;
-                                                    if constexpr (in_args.is_sharded) {
-                                                        // Compute which column-page this C_in_block lives in.
-                                                        const uint32_t col_page_idx = c_in_offset_bytes / in_row_size_bytes;
-                                                        in_offset_bytes = c_in_offset_bytes - (col_page_idx * in_row_size_bytes);
-                                                        const uint32_t width_in_pages = in_reader.dspec().tensor_shape()[1];
-                                                        in_page_id = in_page_idx * width_in_pages + col_page_idx;
-                                                    }
+                                                    compute_page_id_and_offset_for_c_in_block<in_args.is_sharded>(
+                                                        in_reader,
+                                                        in_page_idx,
+                                                        c_in_offset_bytes,
+                                                        in_row_size_bytes,
+                                                        in_page_id,
+                                                        in_offset_bytes);
                                                     const uint64_t in_noc_addr = in_reader.get_noc_addr(in_page_id, in_offset_bytes);
                                                     noc_async_read(in_noc_addr, cb_write_addr, C_in_block_bytes);
 


### PR DESCRIPTION
Ticket
Closes #25940

Problem description
ttnn.experimental.conv3d did not support dilation, which is a standard Conv3d parameter used to expand receptive field. This blocked parity with PyTorch torch.nn.Conv3d and limited model coverage.

What's changed
Added 3D dilation support end‑to‑end (config, bindings, shape calc, device kernel indexing).
Output shape computation now uses effective kernel size.
Added validation to prevent invalid effective kernel sizes and guard against config/arg mismatches.
Added unit and nightly tests for multiple dilation tuples and PyTorch parity.

Checklist
- [X] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/22393473874)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [conv tests pass](https://github.com/tenstorrent/tt-metal/actions/runs/22175593279)
- [X] [(T3K) T3000 integration tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-integration-tests.yaml) CI [same as main](https://github.com/tenstorrent/tt-metal/actions/runs/22298404139) 