### PR TITLE
Fix runtime args validation to account for watcher count words

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -289,6 +289,14 @@ void verify_results(
 
 namespace tt::tt_metal {
 
+// Returns the maximum number of user runtime arguments allowed, accounting for watcher overhead if enabled.
+inline uint32_t get_max_runtime_args_user() {
+    bool watcher_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
+                           !tt::tt_metal::MetalContext::instance().rtoptions().watcher_assert_disabled();
+    uint32_t watcher_overhead = watcher_enabled ? 1 : 0;
+    return tt::tt_metal::get_effective_max_runtime_args() - watcher_overhead;
+}
+
 // Write unique and common runtime args to device and readback to verify written correctly.
 TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
     for (unsigned int id = 0; id < num_devices_; id++) {
@@ -525,16 +533,18 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
             mesh_device, core_range_set, 0, 0);  // Kernel isn't run here.
         auto& program = workload.get_programs().at(device_range);
 
+        uint32_t max_rt_args = get_max_runtime_args_user();
+
         // Set 100 unique args, then try to set max_runtime_args + 1 common args and fail.
         std::vector<uint32_t> initial_runtime_args(100);
         SetRuntimeArgs(program, kernel, core_range_set, initial_runtime_args);
-        std::vector<uint32_t> common_runtime_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> common_runtime_args(max_rt_args + 1);
         EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
 
         // Set 100 common args, then try to set another tt::tt_metal::max_runtime_args + 1 unique args and fail.
         std::vector<uint32_t> more_common_runtime_args(100);
         SetCommonRuntimeArgs(program, kernel, more_common_runtime_args);
-        std::vector<uint32_t> more_unique_args(tt::tt_metal::max_runtime_args + 1);
+        std::vector<uint32_t> more_unique_args(max_rt_args + 1);
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -18,10 +18,17 @@
 
 namespace tt::tt_metal {
 
-// 341 = (4096/(3 * sizeof(uint32_t)), where
-// - 4096 - packet size in dispatch
-// - 3 - number of kernels per tensix
-constexpr uint32_t max_runtime_args = 341;
+
+// Returns the effective maximum number of runtime arguments, including any watcher count words.
+// Implemented in the runtime; forward declaration here keeps this header self-contained.
+std::uint32_t get_effective_max_runtime_args() noexcept;
+
+// Deprecated compatibility alias for legacy code that used tt::tt_metal::max_runtime_args.
+// Prefer tt::tt_metal::get_effective_max_runtime_args() instead.
+[[deprecated("Use tt::tt_metal::get_effective_max_runtime_args() instead.")]]
+inline std::uint32_t max_runtime_args() noexcept {
+    return get_effective_max_runtime_args();
+}
 
 using KernelHandle = std::uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -197,8 +197,12 @@ using namespace tt::constants;
 // Calculate maximum tensors per concat based on runtime args limit
 uint32_t calculate_max_tensors_per_concat(const std::vector<Tensor>& input_tensors, const std::int64_t dim) {
     // Runtime args are limited by available L1 kernel config memory.
-    // The general limit is 341 uint32_t args (from kernel_types.hpp:max_runtime_args),
-    // but concat kernels are compiled with NUM_RUNTIME_ARGS=256.
+    // There is a physical dispatch-word limit of 341 uint32_t entries (internal limit in kernel.cpp),
+    // but this is not a general user-arg limit: when watcher asserts are enabled, count-word prefixes
+    // and internal bookkeeping consume part of this budget and reduce the number of user-supplied args.
+    // Concat kernels are compiled with NUM_RUNTIME_ARGS=256, which is the intended upper bound for the
+    // user-visible runtime-arg payload for these kernels (the effective usable count may be lower when
+    // watcher asserts are enabled).
     //
     // NOTE: The limit applies to the COMBINED total of compile-time + runtime args.
     //


### PR DESCRIPTION
Fixes #36689. Moved max_runtime_args constant to implementation file to enforce validation logic. Updated tests to define the constant locally. Verified validation logic accounts for watcher count word offset.