### PR TITLE
Reduce Qwen2.5-VL unit test checkpoint load

### DIFF
--- a/models/demos/qwen25_vl/tt/model_config.py
+++ b/models/demos/qwen25_vl/tt/model_config.py
@@ -8,8 +8,8 @@ from loguru import logger
 
 import ttnn
 from models.demos.qwen25_vl.tt.common import nearest_multiple
-from models.tt_transformers.tt.model_config import ModelArgs
 from models.tt_transformers.tt.load_checkpoints import load_hf_state_dict_filtered
+from models.tt_transformers.tt.model_config import ModelArgs
 
 
 class ModelOptimizations:
@@ -103,9 +103,9 @@ class VisionModelArgs(ModelArgs):
 
     def reference_vision_model(self, depth=None):
         # Workaround until Qwen2.5-VL is fully integrated into a HF release
+        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VisionTransformerPretrainedModel
         from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
             Qwen2_5_VLForConditionalGeneration as AutoModelForCausalLM,
-            Qwen2_5_VisionTransformerPretrainedModel,
         )
 
         print("Loading Qwen2.5-VL model: ", AutoModelForCausalLM)

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -67,9 +67,7 @@ def load_hf_state_dict_filtered(ckpt_dir, key_prefixes, local_files_only=None):
             from huggingface_hub import hf_hub_download
             from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
         except ImportError as exc:
-            raise ImportError(
-                "huggingface_hub is required to resolve HF repo IDs for safetensors loading."
-            ) from exc
+            raise ImportError("huggingface_hub is required to resolve HF repo IDs for safetensors loading.") from exc
 
     def resolve_file(filename, allow_missing=False):
         if is_local_dir:

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -43,19 +43,56 @@ def load_hf_state_dict(ckpt_dir):
     return loaded_weights
 
 
-def load_hf_state_dict_filtered(ckpt_dir, key_prefixes):
+def load_hf_state_dict_filtered(ckpt_dir, key_prefixes, local_files_only=None):
     """
     Load only the subset of HF checkpoint weights that match the given key prefixes.
     Uses safetensors safe_open to avoid loading unrelated tensors into memory.
+    Supports local checkpoint directories or HF repo IDs.
     """
     prefixes = tuple(key_prefixes)
     if not prefixes:
         return {}
 
-    index_path = os.path.join(ckpt_dir, "model.safetensors.index.json")
+    if local_files_only is None:
+        local_files_only = os.getenv("CI") == "true"
+
+    ckpt_dir = str(ckpt_dir)
+    is_local_dir = os.path.isdir(ckpt_dir)
+
+    hf_hub_download = None
+    EntryNotFoundError = None
+    LocalEntryNotFoundError = None
+    if not is_local_dir:
+        try:
+            from huggingface_hub import hf_hub_download
+            from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub is required to resolve HF repo IDs for safetensors loading."
+            ) from exc
+
+    def resolve_file(filename, allow_missing=False):
+        if is_local_dir:
+            path = os.path.join(ckpt_dir, filename)
+            if os.path.exists(path):
+                return path
+            if allow_missing:
+                return None
+            raise FileNotFoundError(f"Missing safetensors file {path}")
+
+        try:
+            return hf_hub_download(ckpt_dir, filename=filename, local_files_only=local_files_only)
+        except (EntryNotFoundError, LocalEntryNotFoundError) as exc:
+            if allow_missing:
+                return None
+            raise FileNotFoundError(
+                f"Missing safetensors file {filename} for repo {ckpt_dir} (local_files_only={local_files_only})"
+            ) from exc
+
     loaded_weights = {}
 
-    if os.path.exists(index_path):
+    index_path = resolve_file("model.safetensors.index.json", allow_missing=True)
+    if index_path is not None:
         with open(index_path, "r") as f:
             index_data = json.load(f)
 
@@ -66,16 +103,12 @@ def load_hf_state_dict_filtered(ckpt_dir, key_prefixes):
                 file_to_keys.setdefault(file, []).append(key)
 
         for file, keys in file_to_keys.items():
-            safetensor_path = os.path.join(ckpt_dir, file)
-            if not os.path.exists(safetensor_path):
-                raise FileNotFoundError(f"Missing safetensors shard {safetensor_path}")
+            safetensor_path = resolve_file(file)
             with safetensors_safe_open(safetensor_path, framework="pt", device="cpu") as f:
                 for key in keys:
                     loaded_weights[key] = f.get_tensor(key)
     else:
-        safetensor_path = os.path.join(ckpt_dir, "model.safetensors")
-        if not os.path.exists(safetensor_path):
-            raise FileNotFoundError(f"Neither model.safetensors.index.json nor model.safetensors found in {ckpt_dir}")
+        safetensor_path = resolve_file("model.safetensors")
         with safetensors_safe_open(safetensor_path, framework="pt", device="cpu") as f:
             for key in f.keys():
                 if key.startswith(prefixes):


### PR DESCRIPTION
Summary
- Load only Qwen2.5-VL vision weights for reference models to reduce host RAM usage in unit tests.
- Skip checkpoint weight loading entirely when dummy_weights is set.

Testing
- Triggered (T3K) T3000 unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/21478407023
- [x] T3K demo tests on Qwen2.5-VL: https://github.com/tenstorrent/tt-metal/actions/runs/21482030595

Refs #36639

✅ [![T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=fix/qwen25-vl-vision-only-load)](https://github.com/tenstorrent/tt-metal/actions/runs/21478407023) (only dit test fails)
✅ [![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=fix%2Fqwen25-vl-vision-only-load)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml)