### PR TITLE
DeepSeek Op Unit tests

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      enable-tracy:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether Tracy profiling is enabled in the build"
 
 jobs:
   generate-matrix:
@@ -45,6 +50,7 @@ jobs:
           all_tests=$(jq -n '[
             { "name": "(Galaxy) DeepSeek unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "unit", "timeout": 15, "owner_id": "U03HY7MK4BT" },
             { "name": "(Galaxy) DeepSeek module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "module", "timeout": 150, "owner_id": "U03HY7MK4BT" },
+            { "name": "(Galaxy) DeepSeek final-op-unit tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "final-op-unit", "timeout": 150, "owner_id": "U03HY7MK4BT" },
             { "name": "(Galaxy) DeepSeek long-seq module tests", "arch": "wormhole_b0", "model": "deepseek", "test-type": "long-seq-module", "timeout": 115, "owner_id": "U0896VBAKFC" }
           ]')
 
@@ -86,6 +92,11 @@ jobs:
         DEEPSEEK_V3_HF_MODEL: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
         DEEPSEEK_V3_CACHE: /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
         MESH_DEVICE: TG
+        # Required for BenchmarkData to save to Superset
+        CI: true
+        GITHUB_ACTIONS: true
+        # Indicate if Tracy profiling is available in this build
+        TT_METAL_TRACY_BUILD: ${{ inputs.enable-tracy && '1' || '0' }}
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -147,7 +158,7 @@ jobs:
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
       - name: Validate weight cache
-        if: ${{ matrix.test-group.test-type == 'module' }}
+        if: ${{ matrix.test-group.test-type == 'module' || matrix.test-group.test-type == 'final-op-unit' }}
         timeout-minutes: 10
         run: |
           python3 models/demos/deepseek_v3/scripts/validate_weight_cache.py --root "$DEEPSEEK_V3_CACHE/tests_cache" || true
@@ -156,7 +167,51 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --timeout 600  --durations=0
+          pytest models/demos/deepseek_v3/tests --ignore=models/demos/deepseek_v3/tests/unit --ignore=models/demos/deepseek_v3/tests/fused_op_unit_tests --timeout 600  --durations=0
+      - name: Run DeepSeek op unit tests
+        if: ${{ matrix.test-group.test-type == 'final-op-unit' }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          echo "Skipping separate functional fused-op run for final-op-unit."
+          echo "final-op-unit now uses Tracy-backed device perf tests as the single execution path."
+      - name: Check device performance test availability
+        if: ${{ matrix.test-group.test-type == 'final-op-unit' }}
+        run: |
+          if [ "${{ inputs.enable-tracy }}" != "true" ]; then
+            echo "ERROR: final-op-unit requires Tracy-enabled execution for fused-op device perf tests."
+            echo "Set enable-tracy: true in workflow dispatch/caller."
+            exit 1
+          fi
+          echo "✓ Tracy profiling ENABLED - final-op-unit device perf tests will run"
+      - name: Run DeepSeek op unit tests (Device Performance)
+        if: ${{ matrix.test-group.test-type == 'final-op-unit' }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+
+          echo "=============================================="
+          echo "Device Performance Tests"
+          echo "=============================================="
+          echo "DeepSeek fused-op device perf tests (CI-curated selection)"
+          CI_FUSED_OP_DEVICE_PERF_K_EXPR='
+          (
+            (test_ds_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_all_gather_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_lm_head_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_rms_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_distributed_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_ff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+            (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128)))
+          )'
+          CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
+          pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0
+
+          echo "=============================================="
+          echo "All device perf tests completed!"
+          echo "=============================================="
       - name: Run DeepSeek long seq len module tests
         if: ${{ matrix.test-group.test-type == 'long-seq-module' }}
         timeout-minutes: ${{ matrix.test-group.timeout }}

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -12,6 +12,7 @@ on:
           - unit
           - module
           - long-seq-module
+          - final-op-unit
         default: 'all'
       platform:
         required: false
@@ -37,6 +38,7 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+<<<<<<< HEAD
       recreate_weights_cache:
         description: 'Recreate weights cache in a new directory'
         required: false
@@ -50,6 +52,13 @@ on:
         required: false
         type: string
         default: ''
+=======
+      enable-tracy:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable Tracy-based device perf for final-op-unit tests"
+>>>>>>> e4310102ba0 (refactor DeepSeek fused-op CI/perf workflow and local runners)
   schedule:
     - cron: "0 3 * * *" # Run at 3:00 AM UTC (11:00 PM EST) every day
 
@@ -64,6 +73,7 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+      tracy: ${{ inputs.enable-tracy || false }}
   Galaxy-DeepSeek-tests:
     needs: build-artifact
     secrets: inherit
@@ -76,3 +86,4 @@ jobs:
       test-type: ${{ inputs.test-type || 'all' }}
       recreate_weights_cache: ${{ inputs.recreate_weights_cache || 'No' }}
       new_cache_dir: ${{ inputs.new_cache_dir || '' }}
+      enable-tracy: ${{ inputs.enable-tracy || false }}

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -38,7 +38,6 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-<<<<<<< HEAD
       recreate_weights_cache:
         description: 'Recreate weights cache in a new directory'
         required: false
@@ -52,13 +51,11 @@ on:
         required: false
         type: string
         default: ''
-=======
       enable-tracy:
         required: false
         type: boolean
         default: false
         description: "Enable Tracy-based device perf for final-op-unit tests"
->>>>>>> e4310102ba0 (refactor DeepSeek fused-op CI/perf workflow and local runners)
   schedule:
     - cron: "0 3 * * *" # Run at 3:00 AM UTC (11:00 PM EST) every day
 

--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -299,6 +299,10 @@ def pytest_configure(config):
         "device_types can be a single string or list of strings from: N150, N300, T3K, TG, DUAL, QUAD. "
         "Example: @pytest.mark.requires_device(['T3K', 'TG'])",
     )
+    config.addinivalue_line(
+        "markers",
+        "ci_fused_op: mark curated DeepSeek fused-op functional tests used by CI folder-based execution",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/AGENTS_GUIDE_ADD_TEST.md
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/AGENTS_GUIDE_ADD_TEST.md
@@ -1,0 +1,74 @@
+# Guide for adding op unit tests for new fused ops based on an existing model/module
+
+The following should be provided by the user in order to complete this task successfully:
+- The name of the new fused op
+- The sequence of ops that comprise the new fused op
+- The test command for the containing module of the sequence of ops
+
+Before you start, please read the example test in models/demos/deepseek_v3/tests/fused_op_unit_tests/mla/test_ds_fused_wqkva.py carefully. The new test should be similar to the example test, just for a different fused op.
+Example test command for test_mla.py:
+```
+source ../setup_metal.sh
+export DEEPSEEK_V3_HF_MODEL="/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528/" && export DEEPSEEK_V3_CACHE="/proj_sw/user_dev/deepseek-v3-cache2" && export TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/jrock/tt-metal && export MESH_DEVICE=TG && pytest /proj_sw/user_dev/jrock/tt-metal/models/demos/deepseek_v3/tests/test_mla.py::test_forward_pass -k "decode" 2>&1 | tee /proj_sw/user_dev/jrock/tt-metal/logs/ds_mla_$(date +%Y%m%d_%H%M%S).log
+```
+
+Follow these steps to add a new fused op unit test:
+1. Run the provided module test command to capture the baseline accuracy and verify that the test is working.
+2. Identify the ttnn operations that will be fused into a new operation, this should be provided by the user;
+    1. Finde the sequence of ops in the module for decode; if it's unclear which ones should be fused, let the user know immediately.
+    2. Find the sequence of ops in the module for prefill; if the same sequence of ops does not exist for prefill, then ignore all prefill instructions and inform the user in the final summary that this was a decode only fused op sequence.
+3. Create a new file for the new fused op unit test under MODEL_FOLDER/tests/fused_op_unit_tests/test_NEW_FUSED_OP_NAME.py
+4. In the fused op unit test file, create a PyTorch reference for the newly fused op based on the sequence of ttnn ops.
+	- Make sure to use the PyTorch reference as a basis here. To figure out what reference code is used, look at the containing module's test, e.g. test_mla.py for a fused op that's contained in the MLA module. Then figure out which exact portion of the reference model's code corresponds to our new fused op. It might be necessary to modify the reference code slightly to get the correct reference implementation since the exact operations used in the ttnn model and in the reference model my differer.
+	- In the fused op unit test file, create a new reference function "NEW_FUSED_OP_reference". Inputs/outputs to the function should be PyTorch tensors and function parameters of that sequence of ops; make sure to parameterize everything that's parameterized in the module as well, no hardcoding unless it is hardcoded in the model too.
+5. In the fused op unit test file, create a function "NEW_FUSED_OP_ttnn" containing the sequence of ttnn ops that correspond to the new fused op. Inputs and outputs correspond to the inputs/output of the sequence of ops for the new fused op; inputs/outputs should be ttnn tensors and function parameters.
+6. *Verify NEW_FUSED_OP_ttnn* by replacing the identified sequence of ops within the module code with a *function call to NEW_FUSED_OP_ttnn of the newly created test file*, and run the module test to verify that the code is running as expected and producing good outputs (no change to the baseline!). If it's not passing, debug NEW_FUSED_OP_ttnn to make it work. Add the result of this including a log file in the final summary of work. Do not proceed further in the TODOs unless this passes. If it passes, revert those changes in the module and continue.
+7. In the fused op unit test file, implement a pytest that:
+	1. Creates all input tensors and function parameters (based on the actual use in the module code)
+      - Parameters to the ops should be variables in an easily readable section in the code
+      - Use pytest parameters for expected_pcc, expected_perf, mode+seqlen(add decode with seqlen 1, prefill with seqlen 128/1024/8k/128k)
+    2. Add a pytest parameter option to use real model weights/random weights
+	3. Tests the NEW_FUSED_OP_ttnn using the reference code in NEW_FUSED_OP_reference
+    4. Contains a performance measurement wrapper, so that we measure device performance. See following notes on performance measurements.
+    5. Supports trace mode; add a pytest parameter to turn tracing on/off
+      - If it fails due to trace_region_size being too small, set the trace_region_size pytest parameter (see example test) based on the required size as printed in the log.
+    6. Contains a pytet parameter to turn program_caching on/off, this is only done when trace if off, with trace mode program_cache must be enabled too; use device.disable_and_clear_program_cache() for disabling, it's enabled by default
+	7. Compares PCC, ATOL, performance
+8. *Verify NEW_FUSED_OP_reference* and the test code itself by running the unit test and comparing pcc to NEW_FUSED_OP_ttnn. The PCC should typically by > 0.99, otherwise there's likely something wrong. Add the result of this including a log file in the final summary of work. Do not proceed further in the TODOs unless this passes.
+	1. Update the expected_pcc with the pcc value from the test (if it's > 0.99 otherwise, debug the test to fix it!)
+	2. Use the current perf as expected_perf but add a TODO comment to add the actual target (based on theoretical numbers)
+9. *Verify* that the fused op unit test as well as the sequence of ops within the module *use the exact same configuration including input shapes, dtype, memory_config, and buffer type*. Add the result of this including a log file in the final summary of work. Update the test configurations if there are any mismatches, do not change the sequence in the module, consider this the ground truth.
+    1. Run the device perf test of the fused op unit test for prefill (shortest seqlen in fused op unit test) and decode, copy the generated csv files into a newly created folder.
+    2. Run the module test with 1 iteration, both for prefill (same seqlen as in fused op unit test csv) and decode, copy the generated csv files into the same folder as in the last step.
+    3. Compare for each op that all properties are identical, i.e. fused op unit test and module test match in terms of op input/output properties both for prefill and for decode. Take a look at example_compare_fused_wqkva_configs.py to see how that was done for an example fused op unit test.
+10. Add a single device test
+    1. Create a new pytest in the file with the same name + "_single_device"
+    2. If the sequence of ops contains a CCL, skip the single device test with an appropriate skip message. The following points only affect tests that can be executed on single device
+    3. The test takes the first device from the mesh_device fixture and runs the ops only on that device
+    4. The input shape to the single device test is the chunk of the input from the multi device test that resides on the first device, hence the chunk that is processed but the first device. In order to find the correct shape, run the device perf test (multi device) and extract the input shape to the first op from the generated ops_perf_report, this is already the per device shape. Do the same for all matmul input_tensor_b shapes.
+    5. Restructure the existing code to maintain a clean test that re-uses common parts of the code. Be very careful not to change any functionality in the existing test.
+    6. Run the single device test and verify that both the PCC and the perf are the same as for the multi device test.
+11. Add a single device test for device performance, see step 10 for how to do that.
+12. If single device tests are not skipped, *verify* the single device tests by running the single device, device perf test that generated the csv file and compare it to the multi device perf csv. All shapes must match, create a helper script to verify that.
+13. Print the summary for all verification steps clearly representing the results and the links to logs for all successful verification steps.
+14. List anything that was unexpected and/or any workarouds you needed to make the fused op unit test work.
+
+Notes on performance measurements:
+- Performance measurements use three metrics: e2e_duration, kernel_duration, op_to_op_latency
+- e2e_duration: average duration of the whole fused op (sequence of ops), end to end. This is measured using profiler.start and profiler.end calls, use 10 warumup iterations and 100 measurement iterations.
+- Device performance metrics: kernel_duration, op_to_op_latency
+    - Both device performance metrics require tracy profiler to run device performance and post processing of the resulting performance table; uses run_device_profiler helper to run the test function with profiler and subsequent post processing of the results; averages each op's metrics over all iterations
+    - Warumup and measurement iterations
+        - Use 10 warumup iteration and 10 measurement iterations
+        - Signposts are used to ignore the warumup iterations in the post processing step and use the following iterations for perf measurement averages
+        - Per iteration, use the max over devices for all ops except for CCLs (AllGather, ReduceScatter, AllReduce, AllToAll) where to use the average over all devices
+        - Then average over all measurement iterations to compute the average duration per op per iteration
+    - total_kernel_duration/total_op_to_op_latency: the sum of all op's average durations per op per iteration
+    - Both total_kernel_duration and total_op_to_op_latency are printed, asserted and uploaded via benchmark_data.add_measurement
+- Decode uses trace mode for perf measurements, prefill uses non_trace mode for perf measurements
+
+Notes on using TT hardware:
+- If running tests, set a timeout of 15 minutes.
+- If there's a machine issue, you'll need to reset the machine using "tt-smi -glx_reset"
+- Important: Running the test may take a few minutes, if you kill it the device might need a reset. In general, if there is no log output for more than 5 minutes the test likely hangs and needs to be killed + device reset, but if there's log output keep it running.
+- Run each job with piping the output to a log file, i.e. add " 2>&1 | tee $TT_METAL_HOME/logs/ds_mla_$(date +%Y%m%d_%H%M%S).log" to each command

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/ci_ops_test.sh
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/ci_ops_test.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CI Test Script for DeepSeek V3 Op Unit Tests
+
+set -uo pipefail
+
+# Environment setup
+export ARCH_NAME=${ARCH_NAME:-wormhole_b0}
+export TT_METAL_HOME=${TT_METAL_HOME:-$(pwd)}
+export DEEPSEEK_V3_HF_MODEL=${DEEPSEEK_V3_HF_MODEL:-/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528}
+export DEEPSEEK_V3_CACHE=${DEEPSEEK_V3_CACHE:-/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache}
+export MESH_DEVICE=${MESH_DEVICE:-TG}
+export TT_METAL_RUNTIME_ROOT=${TT_METAL_RUNTIME_ROOT:-${TT_METAL_HOME}}
+
+# Enable long sequence tests
+export DEEPSEEK_V3_LONG_SEQ_TESTS=1
+
+# Activate Python virtual environment (check both common locations)
+if [ -f "${TT_METAL_HOME}/python_env/bin/activate" ]; then
+    echo "Activating Python virtual environment from ${TT_METAL_HOME}/python_env..."
+    source "${TT_METAL_HOME}/python_env/bin/activate"
+elif [ -f "${TT_METAL_HOME}/build/python_env/bin/activate" ]; then
+    echo "Activating Python virtual environment from ${TT_METAL_HOME}/build/python_env..."
+    source "${TT_METAL_HOME}/build/python_env/bin/activate"
+else
+    echo "ERROR: Python virtual environment not found."
+    echo "Checked: ${TT_METAL_HOME}/python_env and ${TT_METAL_HOME}/build/python_env"
+    echo "Please activate the environment before running this script."
+    exit 1
+fi
+
+# Set PYTHONPATH after venv activation to ensure ttnn is found
+export PYTHONPATH="${TT_METAL_HOME}:${PYTHONPATH:-}"
+
+# Debug: Show environment
+echo "TT_METAL_HOME: ${TT_METAL_HOME}"
+echo "PYTHONPATH: ${PYTHONPATH}"
+echo "Python: $(which python)"
+
+# Test configuration
+BASE_PATH="models/demos/deepseek_v3/tests/fused_op_unit_tests"
+LOG_DIR="${TT_METAL_HOME}/logs/ci_ops_$(date +%Y%m%d_%H%M%S)"
+TIMEOUT=${TIMEOUT:-1800}  # 30 minutes per test
+
+# Create log directory
+mkdir -p "$LOG_DIR"
+
+# Track results
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+echo "=============================================="
+echo "DeepSeek V3 Op CI Tests"
+echo "=============================================="
+echo "Log directory: $LOG_DIR"
+echo ""
+
+# Function to run a single test and track result
+run_test() {
+    local test_name=$1
+    local test_path=$2
+    local test_func=$3
+    local test_filter=$4
+    local log_file="${LOG_DIR}/${test_name}.log"
+
+    echo "----------------------------------------"
+    echo "Running: $test_name"
+    echo "Path: $test_path::$test_func"
+    echo "Filter: $test_filter"
+    echo "Log: $log_file"
+    echo "----------------------------------------"
+
+    if timeout $TIMEOUT python -m pytest "$test_path::$test_func" -k "$test_filter" -v 2>&1 | tee "$log_file"; then
+        if grep -q "PASSED" "$log_file"; then
+            echo "✓ $test_name: PASSED"
+            PASSED=$((PASSED + 1))
+        elif grep -q "SKIPPED" "$log_file"; then
+            echo "- $test_name: SKIPPED"
+            SKIPPED=$((SKIPPED + 1))
+        else
+            echo "? $test_name: UNKNOWN"
+        fi
+    else
+        if grep -q "SKIPPED" "$log_file"; then
+            echo "- $test_name: SKIPPED"
+            SKIPPED=$((SKIPPED + 1))
+        else
+            echo "✗ $test_name: FAILED"
+            FAILED=$((FAILED + 1))
+        fi
+    fi
+    echo ""
+}
+
+# ============================================
+# EMBEDDING TESTS
+# ============================================
+echo "=========================================="
+echo "EMBEDDING Tests"
+echo "=========================================="
+
+EMBEDDING_PATH="${BASE_PATH}/embedding/test_ds_embedding.py"
+
+run_test "embedding_decode_seq1_trace" \
+    "$EMBEDDING_PATH" \
+    "test_ds_embedding" \
+    "decode and 1 and trace and program_cache and not no_program_cache"
+
+run_test "embedding_prefill_seq128_eager" \
+    "$EMBEDDING_PATH" \
+    "test_ds_embedding" \
+    "prefill and 128 and eager and program_cache and not no_program_cache"
+
+# ============================================
+# EMBEDDING ALL GATHER TESTS
+# ============================================
+echo "=========================================="
+echo "EMBEDDING ALL GATHER Tests"
+echo "=========================================="
+
+EMBEDDING_AG_PATH="${BASE_PATH}/embedding/test_ds_all_gather_embedding.py"
+
+run_test "embedding_all_gather_decode_seq1_trace" \
+    "$EMBEDDING_AG_PATH" \
+    "test_ds_all_gather_embedding" \
+    "decode and 1 and trace and program_cache and not no_program_cache"
+
+run_test "embedding_all_gather_prefill_seq128_eager" \
+    "$EMBEDDING_AG_PATH" \
+    "test_ds_all_gather_embedding" \
+    "prefill and 128 and eager and program_cache and not no_program_cache"
+
+# ============================================
+# LM HEAD TESTS
+# ============================================
+echo "=========================================="
+echo "LM HEAD Tests"
+echo "=========================================="
+
+LM_HEAD_PATH="${BASE_PATH}/lm_head/test_ds_lm_head.py"
+
+run_test "lm_head_decode_seq1_trace" \
+    "$LM_HEAD_PATH" \
+    "test_ds_lm_head" \
+    "decode and 1 and trace and program_cache and not no_program_cache and real_weights"
+
+run_test "lm_head_prefill_seq128_eager" \
+    "$LM_HEAD_PATH" \
+    "test_ds_lm_head" \
+    "prefill and 128 and eager and program_cache and not no_program_cache and real_weights"
+
+# ============================================
+# RMS NORM TESTS
+# ============================================
+echo "=========================================="
+echo "RMS NORM Tests"
+echo "=========================================="
+
+RMS_NORM_PATH="${BASE_PATH}/rms_norm/test_ds_rms_norm.py"
+
+run_test "rms_norm_decode_seq1_trace" \
+    "$RMS_NORM_PATH" \
+    "test_ds_rms_norm" \
+    "decode and 1 and kv_lora_rank_512 and trace and program_cache and not no_program_cache and real_weights"
+
+run_test "rms_norm_prefill_seq128_eager" \
+    "$RMS_NORM_PATH" \
+    "test_ds_rms_norm" \
+    "prefill and 128 and kv_lora_rank_512 and eager and program_cache and not no_program_cache and real_weights"
+
+# ============================================
+# DISTRIBUTED NORM TESTS
+# ============================================
+echo "=========================================="
+echo "DISTRIBUTED NORM Tests"
+echo "=========================================="
+
+DIST_NORM_PATH="${BASE_PATH}/rms_norm/test_ds_distributed_norm.py"
+
+run_test "distributed_norm_decode_seq1_trace" \
+    "$DIST_NORM_PATH" \
+    "test_ds_distributed_norm" \
+    "decode and 1 and trace and program_cache and not no_program_cache and real_weights"
+
+run_test "distributed_norm_prefill_seq128_eager" \
+    "$DIST_NORM_PATH" \
+    "test_ds_distributed_norm" \
+    "prefill and 128 and eager and program_cache and not no_program_cache and real_weights"
+
+# ============================================
+# MLP FF1/3 TESTS
+# ============================================
+echo "=========================================="
+echo "MLP FF1/3 Tests"
+echo "=========================================="
+
+FF1_3_PATH="${BASE_PATH}/mlp/test_ds_ff1_3.py"
+
+run_test "ff1_3_decode_seq1_trace" \
+    "$FF1_3_PATH" \
+    "test_ds_ff1_3" \
+    "decode and 1 and trace and program_cache and not no_program_cache and real_weights"
+
+run_test "ff1_3_prefill_seq128_eager" \
+    "$FF1_3_PATH" \
+    "test_ds_ff1_3" \
+    "prefill and 128 and eager and program_cache and not no_program_cache and real_weights"
+
+# ============================================
+# MLP FF2 TESTS
+# ============================================
+echo "=========================================="
+echo "MLP FF2 Tests"
+echo "=========================================="
+
+FF2_PATH="${BASE_PATH}/mlp/test_ds_ff2.py"
+
+run_test "ff2_decode_seq1_trace" \
+    "$FF2_PATH" \
+    "test_ds_ff2" \
+    "decode and 1 and trace and program_cache and not no_program_cache and real_weights"
+
+run_test "ff2_prefill_seq128_eager" \
+    "$FF2_PATH" \
+    "test_ds_ff2" \
+    "prefill and 128 and eager and program_cache and not no_program_cache and real_weights"
+
+# ============================================
+# MLP MUL TESTS
+# ============================================
+echo "=========================================="
+echo "MLP MUL Tests"
+echo "=========================================="
+
+MUL_PATH="${BASE_PATH}/mlp/test_ds_mul.py"
+
+run_test "mul_decode_seq1_trace" \
+    "$MUL_PATH" \
+    "test_ds_mul" \
+    "decode and 1 and trace and program_cache and not no_program_cache"
+
+run_test "mul_prefill_seq128_eager" \
+    "$MUL_PATH" \
+    "test_ds_mul" \
+    "prefill and 128 and eager and program_cache and not no_program_cache"
+
+# ============================================
+# MLP REDUCE SCATTER TESTS
+# ============================================
+echo "=========================================="
+echo "MLP REDUCE SCATTER Tests"
+echo "=========================================="
+
+RS_PATH="${BASE_PATH}/mlp/test_ds_reduce_scatter_post_ff2.py"
+
+run_test "reduce_scatter_decode_seq1_trace" \
+    "$RS_PATH" \
+    "test_ds_reduce_scatter_post_ff2" \
+    "decode and 1 and trace and program_cache and not no_program_cache"
+
+run_test "reduce_scatter_prefill_seq128_eager" \
+    "$RS_PATH" \
+    "test_ds_reduce_scatter_post_ff2" \
+    "prefill and 128 and eager and program_cache and not no_program_cache"
+
+# ============================================
+# MLP ALL GATHER TESTS
+# ============================================
+echo "=========================================="
+echo "MLP ALL GATHER Tests"
+echo "=========================================="
+
+AG_PATH="${BASE_PATH}/mlp/test_ds_all_gather_preff1_3.py"
+
+run_test "all_gather_decode_seq1_trace" \
+    "$AG_PATH" \
+    "test_ds_all_gather_preff1_3" \
+    "decode and 1 and trace and program_cache and not no_program_cache"
+
+run_test "all_gather_prefill_seq128_eager" \
+    "$AG_PATH" \
+    "test_ds_all_gather_preff1_3" \
+    "prefill and 128 and eager and program_cache and not no_program_cache"
+
+# ============================================
+# SUMMARY
+# ============================================
+echo "=========================================="
+echo "CI Test Summary"
+echo "=========================================="
+echo "Total Passed:  $PASSED"
+echo "Total Failed:  $FAILED"
+echo "Total Skipped: $SKIPPED"
+echo ""
+echo "Logs saved to: $LOG_DIR"
+echo ""
+
+# Exit with error code if any tests failed
+if [ $FAILED -gt 0 ]; then
+    echo "CI FAILED: $FAILED test(s) failed"
+    exit 1
+else
+    echo "CI PASSED: All tests passed or skipped"
+    exit 0
+fi

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/collect_device_perf_baselines.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/collect_device_perf_baselines.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Collect device performance baselines for all DeepSeek V3 fused ops.
+Runs each test twice:
+  - Prefill seq_len=128 with program cache (eager)
+  - Decode seq_len=1 with program cache (trace)
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Map of op names to their test paths
+OPS_MAP = {
+    "embedding": "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding_device_perf",
+    "all_gather_embedding": "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding_device_perf",
+    "lm_head": "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head_device_perf",
+    "rms_norm": "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm_device_perf",
+    "distributed_norm": "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm_device_perf",
+    "ff1_3": "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3_device_perf",
+    "all_gather_preff1_3": "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3_device_perf",
+    "mul": "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul_device_perf",
+    "ff2": "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2_device_perf",
+    "reduce_scatter": "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2_device_perf",
+}
+
+
+def extract_perf_metrics(output: str) -> tuple[float, float]:
+    """Extract kernel and op_to_op times from test output."""
+    match = re.search(r"Device perf totals: kernel=([0-9.]+) us, op_to_op=([0-9.]+) us", output)
+    if match:
+        return float(match.group(1)), float(match.group(2))
+    return None, None
+
+
+def run_device_perf_test(test_path: str, k_filter: str, op_name: str, config_name: str) -> tuple[float, float]:
+    """Run a single device perf test and extract metrics."""
+    print(f"\n{'='*60}")
+    print(f"Running: {op_name} - {config_name}")
+    print(f"{'='*60}")
+
+    # Clean profiler output
+    profiler_dir = Path("generated/profiler/deepseek_v3_fused_ops_device_perf")
+    if profiler_dir.exists():
+        subprocess.run(["rm", "-rf", str(profiler_dir)], check=True)
+
+    # Run test
+    cmd = ["pytest", test_path, "-k", k_filter, "--timeout", "600", "-v", "-s"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    # Extract metrics
+    kernel_us, op_to_op_us = extract_perf_metrics(result.stdout + result.stderr)
+
+    if kernel_us is not None:
+        print(f"✓ {config_name}: kernel={kernel_us:.3f}us, op_to_op={op_to_op_us:.3f}us")
+        return kernel_us, op_to_op_us
+    else:
+        print(f"✗ Failed to extract metrics from output")
+        print(f"Return code: {result.returncode}")
+        # Print last 50 lines of output for debugging
+        lines = (result.stdout + result.stderr).split("\n")
+        print("\n".join(lines[-50:]))
+        return None, None
+
+
+def main():
+    baselines = {}
+
+    for op_name, test_path in OPS_MAP.items():
+        print(f"\n{'#'*60}")
+        print(f"# OP: {op_name}")
+        print(f"{'#'*60}")
+
+        op_baselines = {}
+
+        # Prefill seq_len=128 (eager + program_cache)
+        kernel, op_to_op = run_device_perf_test(test_path, "prefill and 128", op_name, "prefill_128_eager_pcache")
+        if kernel is not None:
+            op_baselines["prefill_128"] = {"kernel_us": kernel, "op_to_op_us": op_to_op}
+
+        # Decode seq_len=1 (trace + program_cache)
+        kernel, op_to_op = run_device_perf_test(test_path, "decode and 1", op_name, "decode_1_trace_pcache")
+        if kernel is not None:
+            op_baselines["decode_1"] = {"kernel_us": kernel, "op_to_op_us": op_to_op}
+
+        baselines[op_name] = op_baselines
+
+    # Save baselines to JSON
+    output_file = "device_perf_baselines.json"
+    with open(output_file, "w") as f:
+        json.dump(baselines, f, indent=2)
+
+    print(f"\n{'='*60}")
+    print(f"All Device Perf Tests Complete!")
+    print(f"Baselines saved to: {output_file}")
+    print(f"{'='*60}\n")
+
+    # Print summary
+    print(json.dumps(baselines, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/collect_device_perf_baselines.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/collect_device_perf_baselines.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
 """
 Collect device performance baselines for all DeepSeek V3 fused ops.
 Runs each test twice:

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py
@@ -1,0 +1,514 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+from tracy import signpost
+
+import ttnn
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.embedding.embedding1d import Embedding1D
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_ALL_GATHER_EMBEDDING_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 25.133, "op_to_op": None},
+    ("prefill", 128): {"kernel": 30.205, "op_to_op": None},
+}
+
+
+def ds_all_gather_embedding_reference(
+    x: torch.Tensor,
+    num_rows: int,
+) -> torch.Tensor:
+    """
+    Reference implementation for AllGather in embedding module.
+
+    The all_gather in embedding gathers across cluster_axis=0 (mesh rows) on dim=-1.
+    Input per device: [1, 1, batch, per_device_hidden] where per_device_hidden = hidden_size/32
+    Output per device: [1, 1, batch, per_row_hidden] where per_row_hidden = per_device_hidden * num_rows
+
+    In the reference model (without tensor parallelism), this simulates gathering
+    data from all rows by concatenating along the last dimension.
+
+    Args:
+        x: Input tensor of shape [1, 1, batch, per_device_hidden * num_rows]
+           representing the full data that would be gathered from all rows
+        num_rows: Number of mesh rows (4 for TG)
+
+    Returns:
+        Output tensor (same as input in reference model since we simulate full data)
+    """
+    # In reference, input already contains the full gathered data
+    return x
+
+
+def ds_all_gather_embedding_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+    ccl,
+    persistent_output_buffer: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for AllGather in embedding module.
+
+    This performs an all-gather operation across mesh rows (cluster_axis=0)
+    to collect embedding data from all rows after the embedding lookup.
+
+    Input per device: [1, 1, batch, 224] (224 = hidden_size/32)
+    Output per device: [1, 1, batch, 896] (896 = 224 * 4 rows)
+
+    Args:
+        x: Input tensor sharded across devices
+        cfg: Configuration dictionary containing all_gather config
+        ccl: CCL runtime object
+        persistent_output_buffer: Optional persistent output for trace mode (ignored, kept for backward compatibility)
+
+    Returns:
+        Output tensor after all-gather
+    """
+    return Embedding1D._fwd_all_gather_embedding(x, cfg, ccl)
+
+
+def _run_ds_all_gather_embedding_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    ccl,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    # Log config for verification
+    logger.info(f"=== ALL_GATHER EMBEDDING OP CONFIG VERIFICATION ===")
+    logger.info(f"Input shape: {tt_input.shape}")
+    logger.info(f"Input memory_config: {tt_input.memory_config()}")
+    logger.info(f"AllGather config: {run_config['all_gather']}")
+    logger.info(f"=== END CONFIG VERIFICATION ===")
+
+    tt_output = ds_all_gather_embedding_ttnn(tt_input, run_config, ccl)
+
+    # After all_gather on cluster_axis=0, data is gathered across rows
+    # Each device now has [1, 1, batch, 896] (896 = 224 * 4)
+    # Take output from first device for comparison
+    tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])
+
+    logger.info(f"tt_output_torch shape: {tt_output_torch.shape}")
+    logger.info(f"ref_output shape: {ref_output.shape}")
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol, convert_to_float=True
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_ALLGATHER_EMBEDDING_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_ALLGATHER_EMBEDDING_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_all_gather_embedding_ttnn(
+                tt_input, run_config, ccl, persistent_output_buffer=persistent_output_buffer
+            )
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_all_gather_embedding_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_all_gather_embedding_ttnn(
+                tt_input, run_config, ccl, persistent_output_buffer=persistent_output_buffer
+            )
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            # Trace mode: use a persistent output buffer
+            persistent_output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            _ = op_fn(persistent_output_buffer=persistent_output)
+            ttnn.synchronize_device(mesh_device)
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            op_fn(persistent_output_buffer=persistent_output)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(persistent_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_all_gather_embedding_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    mode: str,
+    seq_len: int,
+):
+    from models.demos.deepseek_v3.tt.embedding.embedding1d import Embedding1D
+
+    # Generate random embedding state dict for weight config
+    embedding_state_dict = {"weight": torch.randn(hf_config.vocab_size, hf_config.hidden_size, dtype=torch.float32)}
+
+    weight_config = get_test_weight_config(
+        Embedding1D,
+        hf_config,
+        (embedding_state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(Embedding1D, mode, hf_config, mesh_device)
+    model_state = Embedding1D.create_state(hf_config, mesh_device, ccl)
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_rows, num_cols = mesh_device.shape
+    num_devices = mesh_device.get_num_devices()
+
+    # Per-device hidden dimension
+    # hidden_size is split across all 32 devices
+    per_device_hidden = even_int_div(hf_config.hidden_size, num_devices)  # 224 = 7168/32
+
+    # After all_gather on cluster_axis=0, the hidden dimension is gathered across rows
+    # So output per device has: per_device_hidden * num_rows = 224 * 4 = 896
+    per_row_hidden = per_device_hidden * num_rows  # 896
+
+    input_seq_len = seq_len
+
+    torch_full_output = torch.randn(1, 1, input_seq_len, per_row_hidden, dtype=torch.bfloat16)
+
+    # Reference output is the full gathered data
+    ref_output = torch_full_output
+
+    torch_input_per_row = torch.zeros(num_rows, 1, input_seq_len, per_device_hidden, dtype=torch.bfloat16)
+    for r in range(num_rows):
+        torch_input_per_row[r] = torch_full_output[:, :, :, r * per_device_hidden : (r + 1) * per_device_hidden]
+
+    tt_input = ttnn.from_torch(
+        torch_input_per_row,
+        device=mesh_device,
+        # Shard dim 0 across rows (4 rows), replicate across columns (8 cols)
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    return run_config, tt_input, ref_output, batch_size, input_seq_len
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # batch_size=32 for all modes
+        ("decode", 1, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 128, 0.9999, 0.2, 0.2, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "program_cache_enabled",
+    [True, pytest.param(False, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"))],
+    ids=["program_cache", "no_program_cache"],
+)
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_all_gather_embedding(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 2048
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size, original_seq_len = _build_all_gather_embedding_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        mode,
+        seq_len,
+    )
+    _run_ds_all_gather_embedding_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        ccl,
+        f"ds_all_gather_embedding_{mode}_seq{seq_len}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_all_gather_embedding_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR, threshold=2048)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_all_gather_embedding_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    # Use substring matching in-k filter to select the right test variant
+    # This matches test IDs like: test_name[prefill-128-...-program_cache-eager]
+    command = f'pytest {test_path}::test_ds_all_gather_embedding -k "{mode}-{seq_len}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py
@@ -1,0 +1,781 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.embedding.embedding1d import Embedding1D
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_EMBEDDING_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 6.061, "op_to_op": None},
+    ("prefill", 128): {"kernel": 5.577, "op_to_op": None},
+}
+
+
+def ds_embedding_reference(
+    input_ids: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reference implementation for the embedding fused op.
+
+    This uses torch.nn.functional.embedding to look up embeddings.
+
+    Args:
+        input_ids: Input token IDs tensor [1, 1, seq_len] or [1, 1, batch_size]
+        weight: Embedding weight tensor [vocab_size, hidden_size]
+
+    Returns:
+        Output tensor: [1, 1, seq_len, hidden_size] or [1, 1, batch_size, hidden_size]
+    """
+    # input_ids is [1, 1, seq_len], flatten to get [seq_len]
+    # Note: Don't use squeeze() as it removes ALL singleton dims including seq_len=1
+    ids = input_ids.flatten()
+    # Embedding lookup: [seq_len] -> [seq_len, hidden_size]
+    embeddings = torch.nn.functional.embedding(ids, weight)
+    # Reshape to match TTNN output: [1, 1, seq_len, hidden_size]
+    return embeddings.unsqueeze(0).unsqueeze(0)
+
+
+def ds_embedding_ttnn(
+    input_ids: ttnn.Tensor,
+    cfg: dict,
+    original_seq_len: int,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for the embedding fused op.
+
+    This performs: ttnn.embedding(x, **cfg["embedding"]) with optional padding.
+    Matches lines 180-184 of embedding1d.py.
+
+    Args:
+        input_ids: Input token IDs tensor
+        cfg: Configuration dictionary containing embedding config
+        original_seq_len: Original sequence length before padding
+
+    Returns:
+        Output tensor after embedding lookup
+    """
+    return Embedding1D._fwd_embedding(input_ids, cfg, original_seq_len)
+
+
+def _run_ds_embedding_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input_ids: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    step_prefix: str,
+    original_seq_len: int,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    # Log config for verification (Step 9 of AGENTS_GUIDE)
+    logger.info(f"=== EMBEDDING OP CONFIG VERIFICATION ===")
+    logger.info(f"Input input_ids shape: {tt_input_ids.shape}")
+    logger.info(f"Input input_ids memory_config: {tt_input_ids.memory_config()}")
+    logger.info(f"Embedding weight shape: {run_config['embedding']['weight'].shape}")
+    logger.info(f"Embedding config memory_config: {run_config['embedding']['memory_config']}")
+    logger.info(f"Embedding config layout: {run_config['embedding']['layout']}")
+    logger.info(f"=== END CONFIG VERIFICATION ===")
+
+    # Run the embedding op
+    tt_output = ds_embedding_ttnn(tt_input_ids, run_config, original_seq_len)
+
+    # Collect output from all devices and compare
+    # The embedding weight is sharded across ALL 32 devices (4x8 mesh)
+    # Each device has [1, seq_len, hidden_size/32] = [1, seq_len, 224]
+    # ConcatMesh2dToTensor with dims=(0, -1) gives:
+    #   - Concatenate 8 columns on dim -1: [1, seq_len, 224*8=1792] per row
+    #   - Stack 4 rows on dim 0: [4, seq_len, 1792]
+    # To get full hidden_size, we need to reshape and concatenate rows
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+    # Log output shape for debugging
+    logger.info(f"tt_output_torch shape after mesh concat: {tt_output_torch.shape}")
+    # Shape is [num_rows, seq_len, hidden_per_row] = [4, seq_len, 1792]
+
+    # Trim to original seq_len first
+    tt_output_torch = tt_output_torch[:, :original_seq_len, :]
+
+    # Reconstruct full hidden dimension with correct ordering
+    # The embedding weight was reshaped from [vocab_size, hidden_size] to [vocab_size, cols, rows, per_device]
+    # and sharded with dims=(2, 1), meaning:
+    #   - device(r, c) gets weight[:, c, r, :]
+    #   - tt[r, seq, c*per_device:(c+1)*per_device] = device(r, c) output
+    # To reconstruct original hidden order:
+    #   - original h = c*(rows*per_device) + r*per_device + local_h
+    num_rows, seq_dim, hidden_per_row = tt_output_torch.shape
+    num_cols = mesh_device.shape[1]  # 8 columns
+    per_device_hidden = hidden_per_row // num_cols  # 224 typically
+
+    # [4, seq, 1792] -> [4, seq, 8, 224]
+    tt_output_torch = tt_output_torch.reshape(num_rows, seq_dim, num_cols, per_device_hidden)
+    # [4, seq, 8, 224] -> [seq, 8, 4, 224] to match original reshape order
+    tt_output_torch = tt_output_torch.permute(1, 2, 0, 3)
+    # [seq, 8, 4, 224] -> [seq, 7168]
+    tt_output_torch = tt_output_torch.reshape(seq_dim, -1)
+    # [seq, 7168] -> [1, seq, 7168]
+    tt_output_torch = tt_output_torch.unsqueeze(0)
+
+    # Unsqueeze to match reference output shape [1, 1, seq_len, hidden_size]
+    tt_output_torch = tt_output_torch.unsqueeze(1)
+    logger.info(f"tt_output_torch final shape: {tt_output_torch.shape}")
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol, convert_to_float=True
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_EMBEDDING_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_EMBEDDING_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn():
+            return ds_embedding_ttnn(tt_input_ids, run_config, original_seq_len)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_embedding_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_embedding_ttnn(tt_input_ids, run_config, original_seq_len)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_embedding_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    mode: str,
+    seq_len: int,
+    use_real_weights: bool,
+    state_dict: dict = None,
+):
+    from models.demos.deepseek_v3.tt.embedding.embedding1d import Embedding1D
+
+    # For real weights, we need the state dict
+    # For random weights, we generate a random embedding weight tensor
+    if use_real_weights:
+        assert state_dict is not None, "state_dict required for real weights"
+        embedding_state_dict = state_dict
+    else:
+        # Generate random embedding weights matching the expected shape
+        embedding_state_dict = {"weight": torch.randn(hf_config.vocab_size, hf_config.hidden_size, dtype=torch.float32)}
+    state_dicts = (embedding_state_dict,)
+
+    weight_config = get_test_weight_config(
+        Embedding1D,
+        hf_config,
+        state_dicts,
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(Embedding1D, mode, hf_config, mesh_device)
+    model_state = Embedding1D.create_state(hf_config, mesh_device, ccl)
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+
+    # Get dimensions from config
+    vocab_size = hf_config.vocab_size
+
+    # Input shape: [1, batch_size, seq_len] for token IDs
+    # Total tokens = batch_size * seq_len
+    input_seq_len = seq_len
+
+    # Generate random token IDs
+    torch_input_ids = torch.randint(0, vocab_size, (1, 1, input_seq_len), dtype=torch.int64)
+
+    # For reference, use the same weight that was passed to the module
+    torch_weight = embedding_state_dict["weight"].float()
+
+    # Compute reference output
+    ref_output = ds_embedding_reference(torch_input_ids, torch_weight)
+
+    # Convert input IDs to TTNN tensor - replicate across all devices
+    tt_input_ids = ttnn.from_torch(
+        torch_input_ids,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.uint32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    return run_config, tt_input_ids, ref_output, batch_size, input_seq_len
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # PCC ~0.99 is acceptable for embedding with bfloat16
+        # batch_size=32 for all modes
+        ("decode", 1, 0.99, 0.1, 0.1, 0.0),
+        ("prefill", 128, 0.99, 0.1, 0.1, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.99,
+            0.1,
+            0.1,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.99,
+            0.1,
+            0.1,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.99,
+            0.1,
+            0.1,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.99,
+            0.1,
+            0.1,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [True, pytest.param(False, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"))],
+    ids=["real_weights", "random_weights"],
+)
+@pytest.mark.parametrize(
+    "program_cache_enabled",
+    [True, pytest.param(False, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"))],
+    ids=["program_cache", "no_program_cache"],
+)
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_embedding(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    # CI skip logic: only run specific combinations in CI
+    in_ci = os.getenv("CI") == "true"
+    if in_ci:
+        # Only run these combinations in CI:
+        # - decode + seq_len=1 + trace + program_cache + real_weights
+        # - prefill + seq_len=128 + eager + program_cache + real_weights
+        keep_in_ci = (
+            mode == "decode" and seq_len == 1 and trace_mode and program_cache_enabled and use_real_weights
+        ) or (mode == "prefill" and seq_len == 128 and not trace_mode and program_cache_enabled and use_real_weights)
+        if not keep_in_ci:
+            pytest.skip(
+                "Skip in CI - only run decode/1/trace and prefill/128/eager with program_cache and real_weights"
+            )
+
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        # For decode mode, seq_len represents batch_size (32 for USERS_PER_ROW)
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 2048
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    # For real weights, get the embedding state dict
+    embedding_state_dict = None
+    if use_real_weights:
+        from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+
+        embedding_state_dict = sub_state_dict(state_dict, "model.embed_tokens.")
+
+    run_config, tt_input_ids, ref_output, batch_size, original_seq_len = _build_embedding_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        mode,
+        seq_len,
+        use_real_weights,
+        embedding_state_dict,
+    )
+    _run_ds_embedding_test(
+        mesh_device,
+        run_config,
+        tt_input_ids,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        f"ds_embedding_{mode}_seq{seq_len}",
+        original_seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # Single device tests - embedding doesn't have CCL so this works
+        # batch_size=32 for all modes
+        ("decode", 1, 0.99, 0.1, 0.1, 0.0),
+        ("prefill", 128, 0.99, 0.1, 0.1, 0.0),
+        ("prefill", 1024, 0.99, 0.1, 0.1, 0.0),
+        ("prefill", 131072, 0.99, 0.1, 0.1, 0.0),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_embedding_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict,
+):
+    """
+    Single device test for the embedding fused op.
+
+    This test runs on a single device from the mesh. The embedding op itself
+    doesn't use CCL, so we can test just the embedding lookup on a single device.
+    """
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 2048
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    # Get single device from mesh
+    single_device = mesh_device.get_device(0)
+
+    # Get dimensions
+    vocab_size = hf_config.vocab_size
+    hidden_size = hf_config.hidden_size
+    _, mesh_width = mesh_device.shape
+    per_device_hidden_size = even_int_div(hidden_size, mesh_device.get_num_devices())
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    input_seq_len = seq_len
+
+    # Generate random token IDs
+    torch_input_ids = torch.randint(0, vocab_size, (1, 1, input_seq_len), dtype=torch.int64)
+
+    # For reference, use per-device weight slice
+    if use_real_weights:
+        from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
+
+        embedding_state_dict = sub_state_dict(state_dict, "model.embed_tokens.")
+        torch_weight = embedding_state_dict["weight"][:, :per_device_hidden_size].float()
+    else:
+        torch_weight = torch.randn(vocab_size, per_device_hidden_size, dtype=torch.float32)
+
+    # Compute reference output (per-device slice)
+    ref_output = ds_embedding_reference(torch_input_ids, torch_weight)
+
+    # Convert input IDs to TTNN tensor on single device
+    tt_input_ids = ttnn.from_torch(
+        torch_input_ids,
+        device=single_device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    # Convert weight to TTNN tensor on single device
+    # Weight shape should be [1, 1, vocab_size, per_device_hidden_size] to match the module config
+    torch_weight_4d = torch_weight.unsqueeze(0).unsqueeze(0)
+    tt_weight = ttnn.from_torch(
+        torch_weight_4d,
+        device=single_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    # Pad input if necessary
+    if input_seq_len % ttnn.TILE_SIZE == 0:
+        tt_output = ttnn.embedding(
+            tt_input_ids, tt_weight, memory_config=ttnn.DRAM_MEMORY_CONFIG, layout=ttnn.TILE_LAYOUT
+        )
+    else:
+        x_padded = ttnn.pad(tt_input_ids, [(0, 0), (0, 0), (0, ttnn.TILE_SIZE - input_seq_len % ttnn.TILE_SIZE)], 0)
+        tt_output = ttnn.embedding(x_padded, tt_weight, memory_config=ttnn.DRAM_MEMORY_CONFIG, layout=ttnn.TILE_LAYOUT)
+        ttnn.deallocate(x_padded)
+
+    # Convert output to torch
+    tt_output_torch = ttnn.to_torch(tt_output)[:, :input_seq_len, :]
+
+    # Reshape to match reference [1, 1, seq_len, hidden_size]
+    tt_output_torch = tt_output_torch.unsqueeze(0)
+
+    # Compare with reference
+    compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol, convert_to_float=True
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_embedding_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR, threshold=2048)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_embedding_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights"
+    command = f'pytest {test_path}::test_ds_embedding -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_embedding_single_device_device_perf(mode, seq_len):
+    """
+    Single device device performance test for the embedding fused op.
+    """
+    if mode == "decode":
+        assert seq_len == 1, "Decode mode uses seq_len=1, batch=32"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR, threshold=2048)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_embedding_single_device_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights"
+    command = f'pytest {test_path}::test_ds_embedding_single_device -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/example_compare_fused_wqkva_configs.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/example_compare_fused_wqkva_configs.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+# Usage:
+#   python3 compare_fused_wqkva_configs.py --verify-dir /path/to/verify_dir
+# The verify directory must contain:
+#   fused_decode.csv, fused_prefill_128.csv, mla_decode.csv, mla_prefill_128.csv
+
+
+def normalize(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def load_rows(path: Path):
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        fields = reader.fieldnames or []
+    return rows, fields
+
+
+def extract_between_signposts(rows):
+    start_idx = None
+    stop_idx = None
+    for idx, row in enumerate(rows):
+        if row.get("OP TYPE") == "signpost" and row.get("OP CODE") == "start":
+            start_idx = idx
+            break
+    for idx, row in enumerate(rows):
+        if row.get("OP TYPE") == "signpost" and row.get("OP CODE") == "stop":
+            stop_idx = idx
+            break
+    if start_idx is None or stop_idx is None or start_idx >= stop_idx:
+        return rows
+    return rows[start_idx + 1 : stop_idx]
+
+
+def merge_device_rows(rows):
+    block_by_device = defaultdict(list)
+    for row in rows:
+        if row.get("OP TYPE") != "tt_dnn_device":
+            continue
+        op_name = row.get("OP CODE")
+        device_id = int(row.get("DEVICE ID"))
+        block_by_device[device_id].append((op_name, row))
+
+    device_ids = sorted(block_by_device.keys())
+    merged = []
+    while max(len(block_by_device[d]) for d in device_ids) > 0:
+        blocks = []
+        op_name = None
+        for device_id in device_ids:
+            if not block_by_device[device_id]:
+                continue
+            if op_name is None:
+                op_name = block_by_device[device_id][0][0]
+            if op_name != block_by_device[device_id][0][0]:
+                continue
+            blocks.append(block_by_device[device_id].pop(0))
+        if not blocks:
+            break
+
+        is_collective = any(tag in op_name for tag in ("AllGather", "ReduceScatter", "AllReduce", "AllToAll"))
+        if is_collective:
+            device_kernel_durations = []
+            for _, data in blocks:
+                value = data.get("DEVICE KERNEL DURATION [ns]")
+                try:
+                    device_kernel_durations.append(float(value))
+                except (TypeError, ValueError):
+                    continue
+            avg = (
+                sum(device_kernel_durations) / len(device_kernel_durations) if device_kernel_durations else float("nan")
+            )
+            base = dict(blocks[0][1])
+            base["DEVICE KERNEL DURATION [ns]"] = str(avg)
+            merged.append(base)
+        else:
+
+            def duration(row):
+                try:
+                    return float(row.get("DEVICE KERNEL DURATION [ns]", "nan"))
+                except (TypeError, ValueError):
+                    return float("nan")
+
+            max_block = max(blocks, key=lambda x: duration(x[1]))
+            merged.append(dict(max_block[1]))
+    return merged
+
+
+def find_period(op_codes):
+    if not op_codes:
+        return 0
+    first = op_codes[0]
+    repeats = [i for i, code in enumerate(op_codes) if code == first]
+    if len(repeats) < 2:
+        return len(op_codes)
+    return repeats[1]
+
+
+def row_key(row, keys):
+    return {k: normalize(row.get(k, "")) for k in keys}
+
+
+def compare_rows(fused_rows, module_rows, keys):
+    fused_keys = [row_key(r, keys) for r in fused_rows]
+    module_keys = [row_key(r, keys) for r in module_rows]
+
+    matches = []
+    for start in range(0, len(module_keys) - len(fused_keys) + 1):
+        ok = True
+        for offset, fused_key in enumerate(fused_keys):
+            module_key = module_keys[start + offset]
+            for key, value in fused_key.items():
+                if value != module_key.get(key, ""):
+                    ok = False
+                    break
+            if not ok:
+                break
+        if ok:
+            matches.append(start)
+    return matches
+
+
+def report_case(name, fused_csv, module_csv, output_lines):
+    fused_rows, fused_fields = load_rows(fused_csv)
+    module_rows, _ = load_rows(module_csv)
+
+    fused_rows = extract_between_signposts(fused_rows)
+    fused_rows = merge_device_rows(fused_rows)
+    module_rows = merge_device_rows([r for r in module_rows if r.get("OP TYPE") == "tt_dnn_device"])
+
+    fused_codes = [row.get("OP CODE") for row in fused_rows]
+    period = find_period(fused_codes)
+    fused_one_iter = fused_rows[:period]
+
+    key_fields = [f for f in fused_fields if f.startswith("INPUT_") or f.startswith("OUTPUT_")]
+    for extra in ("OP CODE", "ATTRIBUTES"):
+        if extra in fused_fields:
+            key_fields.append(extra)
+
+    output_lines.append(f"Case: {name}")
+    output_lines.append(f"Fused merged rows: {len(fused_rows)}; period: {period}")
+    output_lines.append(f"Module merged rows: {len(module_rows)}")
+    output_lines.append(f"Fused op codes (one iter): {[row.get('OP CODE') for row in fused_one_iter]}")
+
+    matches = compare_rows(fused_one_iter, module_rows, key_fields)
+    if not matches:
+        output_lines.append("Result: NO MATCHING SUBSEQUENCE")
+        return False
+    output_lines.append(f"Result: matched subsequence at start indices: {matches}")
+    if len(matches) > 1:
+        output_lines.append("Result: MULTIPLE MATCHES (ambiguous)")
+        return False
+
+    start = matches[0]
+    ok = True
+    for idx, fused_row in enumerate(fused_one_iter):
+        module_row = module_rows[start + idx]
+        for key in key_fields:
+            fused_value = normalize(fused_row.get(key, ""))
+            module_value = normalize(module_row.get(key, ""))
+            if fused_value != module_value:
+                output_lines.append(
+                    f"MISMATCH row {idx} op {fused_row.get('OP CODE')} key {key}: fused={fused_value} module={module_value}"
+                )
+                ok = False
+    output_lines.append("Result: MATCH" if ok else "Result: MISMATCH")
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare fused op CSVs against MLA module CSVs.")
+    parser.add_argument(
+        "--verify-dir",
+        type=Path,
+        required=True,
+        help="Directory containing fused/module CSVs and where the report will be written.",
+    )
+    args = parser.parse_args()
+    verify_dir = args.verify_dir
+
+    output_lines = []
+    ok_decode = report_case(
+        "decode",
+        verify_dir / "fused_decode.csv",
+        verify_dir / "mla_decode.csv",
+        output_lines,
+    )
+    output_lines.append("")
+    ok_prefill = report_case(
+        "prefill_128",
+        verify_dir / "fused_prefill_128.csv",
+        verify_dir / "mla_prefill_128.csv",
+        output_lines,
+    )
+
+    report_path = verify_dir / "config_compare_report.txt"
+    report_path.write_text("\n".join(output_lines) + "\n")
+    print(report_path)
+    print("\n".join(output_lines))
+    if not (ok_decode and ok_prefill):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/export_device_perf_csv.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/export_device_perf_csv.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Export DeepSeek fused-op device perf artifacts to an Excel-friendly CSV.
+
+This script reads benchmark artifact files (partial_run_*.pkl) and writes a
+flat CSV with one row per fused-op step, including:
+  - step metadata (mode, seq_len)
+  - performance metrics (kernel/op-to-op/total in us)
+  - run metadata (timestamps, commit, device info)
+
+Usage:
+  python3 models/demos/deepseek_v3/tests/fused_op_unit_tests/export_device_perf_csv.py
+  python3 .../export_device_perf_csv.py --input-glob "generated/benchmark_data/partial_run_*.pkl" \
+      --output "generated/benchmark_data/deepseek_device_perf_summary.csv"
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import pickle
+import re
+from pathlib import Path
+from typing import Any
+
+STEP_RE = re.compile(r"(?P<mode>decode|prefill)_seq(?P<seq>\d+)")
+
+
+def _to_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _extract_step_fields(step_name: str) -> tuple[str, str]:
+    match = STEP_RE.search(step_name or "")
+    if not match:
+        return "", ""
+    return match.group("mode"), match.group("seq")
+
+
+def _collect_rows(input_glob: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    files = sorted(glob.glob(input_glob))
+    if not files:
+        raise FileNotFoundError(f"No files found for glob: {input_glob}")
+
+    for path in files:
+        with open(path, "rb") as fp:
+            run = pickle.load(fp)
+
+        per_step: dict[str, dict[str, Any]] = {}
+        measurements = getattr(run, "measurements", [])
+        for m in measurements:
+            step_name = _to_str(getattr(m, "step_name", ""))
+            if not step_name:
+                continue
+
+            entry = per_step.setdefault(
+                step_name,
+                {
+                    "kernel_us": None,
+                    "op_to_op_us": None,
+                },
+            )
+
+            metric_name = _to_str(getattr(m, "name", ""))
+            metric_value = getattr(m, "value", None)
+            if metric_name == "total_kernel_duration_us":
+                entry["kernel_us"] = float(metric_value)
+            elif metric_name == "total_op_to_op_latency_us":
+                entry["op_to_op_us"] = float(metric_value)
+
+        for step_name, metrics in per_step.items():
+            mode, seq_len = _extract_step_fields(step_name)
+            kernel_us = metrics["kernel_us"]
+            op_to_op_us = metrics["op_to_op_us"]
+            total_us = ""
+            if kernel_us is not None and op_to_op_us is not None:
+                total_us = kernel_us + op_to_op_us
+
+            rows.append(
+                {
+                    "artifact_file": path,
+                    "step_name": step_name,
+                    "mode": mode,
+                    "seq_len": seq_len,
+                    "kernel_us": "" if kernel_us is None else kernel_us,
+                    "op_to_op_us": "" if op_to_op_us is None else op_to_op_us,
+                    "total_us": total_us,
+                    "run_start_ts": _to_str(getattr(run, "run_start_ts", "")),
+                    "run_end_ts": _to_str(getattr(run, "run_end_ts", "")),
+                    "git_commit_hash": _to_str(getattr(run, "git_commit_hash", "")),
+                    "git_branch_name": _to_str(getattr(run, "git_branch_name", "")),
+                    "device_info": _to_str(getattr(run, "device_info", "")),
+                    "device_hostname": _to_str(getattr(run, "device_hostname", "")),
+                }
+            )
+
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export DeepSeek device perf artifacts to CSV")
+    parser.add_argument(
+        "--input-glob",
+        default="generated/benchmark_data/partial_run_*.pkl",
+        help="Glob pattern for benchmark artifact files",
+    )
+    parser.add_argument(
+        "--output",
+        default="generated/benchmark_data/deepseek_device_perf_summary.csv",
+        help="Output CSV path",
+    )
+    args = parser.parse_args()
+
+    rows = _collect_rows(args.input_glob)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = [
+        "artifact_file",
+        "step_name",
+        "mode",
+        "seq_len",
+        "kernel_us",
+        "op_to_op_us",
+        "total_us",
+        "run_start_ts",
+        "run_end_ts",
+        "git_commit_hash",
+        "git_branch_name",
+        "device_info",
+        "device_hostname",
+    ]
+
+    # utf-8-sig makes Excel reliably detect UTF-8 encoding.
+    with open(output_path, "w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"Wrote {len(rows)} rows to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/export_device_perf_csv.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/export_device_perf_csv.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
 """
 Export DeepSeek fused-op device perf artifacts to an Excel-friendly CSV.
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py
@@ -1,0 +1,679 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fused op unit test for lm_head (vocabulary projection).
+
+lm_head is the linear projection from hidden_size (7168) to vocab_size (129280).
+The weight is sharded across all 32 devices, with each device holding vocab/32 = 4040
+output features.
+
+Sequence of ops:
+    Decode:  output = ttnn.linear(x, **cfg["linear"])
+    Prefill: output = ttnn.linear(x, program_config=..., **cfg["linear"])
+
+Key characteristics:
+    - Weight dtype: bfloat4_b (quantized)
+    - Weight shape per device: [7168, 4040]
+    - Weight memory: WIDTH_SHARDED DRAM
+    - Decode input: WIDTH_SHARDED L1
+    - Prefill input: DRAM INTERLEAVED
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.lm_head import LMHead
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, pad_or_trim_seq_len
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_LM_HEAD_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 90.564, "op_to_op": None},
+    ("prefill", 128): {"kernel": 255.285, "op_to_op": None},
+}
+
+
+class DeepseekV3LMHead(nn.Module):
+    """PyTorch reference model for LMHead."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states):
+        return self.lm_head(hidden_states)
+
+
+def ds_lm_head_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reference implementation for lm_head linear projection.
+
+    Args:
+        x: Input tensor of shape [1, 1, seq_len, hidden_size] or [1, num_chunks, chunk_size, hidden_size]
+        weight: Weight tensor of shape [vocab_size, hidden_size]
+
+    Returns:
+        Output tensor of shape [1, 1, seq_len, vocab_size] or [1, num_chunks, chunk_size, vocab_size]
+    """
+    return torch.nn.functional.linear(x, weight)
+
+
+def ds_lm_head_ttnn_decode(
+    x: ttnn.Tensor,
+    cfg: dict,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for lm_head linear projection (decode mode).
+
+    Uses DRAM sharded matmul with WIDTH_SHARDED L1 activations.
+
+    Args:
+        x: Input tensor (WIDTH_SHARDED L1)
+        cfg: Configuration dictionary containing linear config
+
+    Returns:
+        Output tensor (WIDTH_SHARDED L1)
+    """
+    output = LMHead._fwd_linear(x, cfg)
+    return output
+
+
+def ds_lm_head_ttnn_prefill(
+    x: ttnn.Tensor,
+    cfg: dict,
+    seq_len: int,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for lm_head linear projection (prefill mode).
+
+    Uses multicore multicast matmul with DRAM INTERLEAVED tensors.
+    For long sequences, handles chunking.
+
+    Args:
+        x: Input tensor (DRAM INTERLEAVED)
+        cfg: Configuration dictionary containing linear and linear_pc_gen configs
+        seq_len: Original sequence length (before any chunking)
+
+    Returns:
+        Output tensor (DRAM INTERLEAVED)
+    """
+    # Use effective sequence length (chunk size) for program config to avoid L1 overflow
+    effective_seq_len = min(seq_len, cfg.get("max_rows", seq_len))
+
+    # Generate program config based on effective sequence length
+    program_config = LMHead._get_prefill_pc(seq_len=effective_seq_len, **cfg["linear_pc_gen"])
+
+    output = LMHead._fwd_linear(x, cfg, program_config=program_config)
+    return output
+
+
+def _run_ds_lm_head_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    step_prefix: str,
+):
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    # Run lm_head
+    if mode == "decode":
+        tt_output = ds_lm_head_ttnn_decode(tt_input, run_config)
+    else:
+        tt_output = ds_lm_head_ttnn_prefill(tt_input, run_config, seq_len)
+
+    # Convert output to torch - concatenate vocab dimension across all 32 devices
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=3))
+
+    # Slice to actual vocab_size if needed (output may be padded)
+    if tt_output_torch.shape[-1] > ref_output.shape[-1]:
+        tt_output_torch = tt_output_torch[..., : ref_output.shape[-1]]
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        convert_to_float=True,
+        strict_assert=False,
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_LM_HEAD_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_LM_HEAD_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        if mode == "decode":
+
+            def op_fn():
+                return ds_lm_head_ttnn_decode(tt_input, run_config)
+
+        else:
+
+            def op_fn():
+                return ds_lm_head_ttnn_prefill(tt_input, run_config, seq_len)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_lm_head_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "lm_head",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "lm_head",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        if mode == "decode":
+
+            def op_fn():
+                return ds_lm_head_ttnn_decode(tt_input, run_config)
+
+        else:
+
+            def op_fn():
+                return ds_lm_head_ttnn_prefill(tt_input, run_config, seq_len)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            traced_output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(traced_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+    # Clean up output
+    ttnn.deallocate(tt_output)
+
+
+def _build_lm_head_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config: Any,
+    cache_path: Path,
+    force_recalculate_weight_config: bool,
+    use_real_weights: bool,
+    mode: str,
+    seq_len: int,
+    state_dict: dict[str, torch.Tensor] | None,
+):
+    """Build inputs for lm_head test.
+
+    Args:
+        mesh_device: The mesh device
+        hf_config: HuggingFace config
+        cache_path: Path for weight caching
+        force_recalculate_weight_config: Whether to force recalculate weights
+        use_real_weights: Whether to use real model weights
+        mode: "decode" or "prefill"
+        seq_len: Sequence length
+        state_dict: Model state dict (needed if use_real_weights=True)
+
+    LMHead shape convention (from original test_lm_head.py):
+    - Decode: height = 32 (USERS_PER_ROW users × 1 token each)
+    - Prefill: height = seq_len (1 user × seq_len tokens)
+    """
+    hidden_size = hf_config.hidden_size
+
+    # LMHead uses different batch conventions:
+    # - Decode: batch_size=32 (USERS_PER_ROW), seq_len=1 → height=32
+    # - Prefill: batch_size=1, seq_len=N → height=N
+    if mode == "decode":
+        batch_size = USERS_PER_ROW
+        effective_height = batch_size * seq_len  # 32 × 1 = 32
+    else:
+        batch_size = 1
+        effective_height = seq_len  # 1 × seq_len = seq_len
+
+    # Create reference model
+    reference_model = DeepseekV3LMHead(hf_config).eval()
+
+    if use_real_weights and state_dict is not None:
+        # Use provided real weights
+        lm_head_state_dict = sub_state_dict(state_dict, "lm_head.")
+        reference_model.load_state_dict(lm_head_state_dict, strict=False)
+    else:
+        # Use random weights (already initialized by nn.Linear)
+        pass
+
+    # Get state dict for TTNN weight conversion
+    lm_head_state_dict = sub_state_dict(reference_model.state_dict(), "lm_head.")
+
+    # Generate reference output
+    # Shape: [1, 1, effective_height, hidden_size]
+    torch_input = torch.randn(1, 1, effective_height, hidden_size)
+    reference_output = reference_model(torch_input)
+
+    # Pad input to SEQ_LEN_CHUNK_SIZE if necessary for TTNN
+    torch_input_padded = pad_or_trim_seq_len(torch_input, mode, effective_height)
+
+    # Generate TTNN configs
+    # input_row_idx=3 matches the default in LMHead module test
+    input_row_idx = 3
+    weight_config = get_test_weight_config(
+        LMHead, hf_config, (lm_head_state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+    )
+    # Note: LMHead doesn't take seq_len in model_config - it computes program config dynamically
+    model_config = get_model_config(LMHead, mode, hf_config, mesh_device, input_row_idx)
+    model_state = LMHead.create_state(hf_config, mesh_device, None)  # CCL not needed for linear only
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Convert input to TTNN - replicate to all devices
+    tt_input = ttnn.from_torch(
+        torch_input_padded,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        dtype=ttnn.bfloat16,
+        memory_config=run_config["input_memory_config"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    return run_config, tt_input, reference_output, batch_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        ("decode", 1, 0.97, 1.0, 1.0, 0.0),  # batch=32, seq=1 → 32 tokens
+        ("prefill", 128, 0.97, 1.0, 1.0, 0.0),  # batch=32, seq=128 → 4096 tokens
+        pytest.param(
+            "prefill",
+            1024,
+            0.97,
+            1.0,
+            1.0,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),  # batch=32, seq=1024 → 32768 tokens
+        pytest.param(
+            "prefill",
+            8192,
+            0.97,
+            1.0,
+            1.0,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.97,
+            1.0,
+            1.0,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.97,
+            1.0,
+            1.0,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),  # batch=32, seq=128k
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [True, pytest.param(False, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"))],
+    ids=["real_weights", "random_weights"],
+)
+@pytest.mark.parametrize(
+    "program_cache_enabled",
+    [True, pytest.param(False, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"))],
+    ids=["program_cache", "no_program_cache"],
+)
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 23740416,  # Large trace region for vocab projection
+        }
+    ],
+    indirect=True,
+)
+def test_ds_lm_head(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+):
+    """Test lm_head fused op (vocabulary projection).
+
+    This tests the linear projection from hidden_size (7168) to vocab_size (129280).
+    The weight is sharded across all 32 devices with bfloat4_b quantization.
+    """
+    # CI skip logic: only run specific combinations in CI
+    in_ci = os.getenv("CI") == "true"
+    if in_ci:
+        # Only run these combinations in CI:
+        # - decode + seq_len=1 + trace + program_cache + real_weights
+        # - prefill + seq_len=128 + eager + program_cache + real_weights
+        keep_in_ci = (
+            mode == "decode" and seq_len == 1 and trace_mode and program_cache_enabled and use_real_weights
+        ) or (mode == "prefill" and seq_len == 128 and not trace_mode and program_cache_enabled and use_real_weights)
+        if not keep_in_ci:
+            pytest.skip(
+                "Skip in CI - only run decode/1/trace and prefill/128/eager with program_cache and real_weights"
+            )
+
+    # Trace capture requires program cache enabled
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size = _build_lm_head_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        force_recalculate_weight_config,
+        use_real_weights,
+        mode,
+        seq_len,
+        state_dict if use_real_weights else None,
+    )
+
+    _run_ds_lm_head_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        f"ds_lm_head_{mode}_seq{seq_len}",
+    )
+
+    # Cleanup
+    ttnn.deallocate(tt_input)
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        ("decode", 1, 0.97, 1.0, 1.0, 0.0),
+        ("prefill", 128, 0.97, 1.0, 1.0, 0.0),
+        ("prefill", 1024, 0.97, 1.0, 1.0, 0.0),
+        ("prefill", 131072, 0.97, 1.0, 1.0, 0.0),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 23740416,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_lm_head_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+):
+    """Single device test for lm_head.
+
+    The lm_head linear projection can run on a single device with per-device
+    weight shard (vocab/32). However, the output would only be 1/32 of the full vocab.
+    For simplicity, we skip this test as the multi-device test is the primary use case.
+    """
+    pytest.skip(
+        "Single-device test skipped: lm_head outputs vocab_size/32 per device. "
+        "Multi-device test with all_gather is the primary use case."
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_lm_head_device_perf(mode, seq_len):
+    maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    # batch_size=32 (USERS_PER_ROW) for all modes
+    batch_size = USERS_PER_ROW
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_lm_head_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights"
+    command = f'pytest {test_path}::test_ds_lm_head -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        ("prefill", 1024),
+    ],
+)
+def test_ds_lm_head_single_device_device_perf(mode, seq_len):
+    pytest.skip(
+        "Single-device device perf test skipped: lm_head outputs vocab_size/32 per device. "
+        "Multi-device test with all_gather is the primary use case."
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_ALL_GATHER_PREFF1_3_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 42.082, "op_to_op": None},
+    ("prefill", 128): {"kernel": 1794.324, "op_to_op": None},
+}
+
+
+def ds_all_gather_preff1_3_reference(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reference implementation for AllGather_preff1/3.
+
+    In the reference model (without tensor parallelism), this is just an identity operation
+    since the input is not sharded across devices.
+
+    Args:
+        x: Input tensor of shape [num_layers, batch_size, seq_len, hidden_size]
+
+    Returns:
+        Output tensor (same as input in reference model)
+    """
+    return x
+
+
+def ds_all_gather_preff1_3_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+    ccl,
+    persistent_output_buffer: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """TTNN implementation for AllGather_preff1/3."""
+    # Note: persistent_output_buffer is only used for perf measurement in tests,
+    # not in production. The wrapper doesn't support it.
+    return MLP._fwd_all_gather_preff1_3(x, cfg, ccl)
+
+
+def _run_ds_all_gather_preff1_3_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    ccl,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    tt_output = ds_all_gather_preff1_3_ttnn(tt_input, run_config, ccl)
+
+    # Output is replicated across devices after all-gather; just take from first device
+    # since all devices have identical copies
+    tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_ALLGATHER_PREFF1_3_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_ALLGATHER_PREFF1_3_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_all_gather_preff1_3_ttnn(
+                tt_input, run_config, ccl, persistent_output_buffer=persistent_output_buffer
+            )
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_all_gather_preff1_3_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "mlp",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "all_gather",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_all_gather_preff1_3_ttnn(
+                tt_input, run_config, ccl, persistent_output_buffer=persistent_output_buffer
+            )
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            # Trace mode: use a persistent output buffer and avoid deallocate inside trace capture.
+            persistent_output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            # Warm up the persistent-buffer variant before capture so we don't do any first-time
+            # program/buffer setup (host↔device reads/writes) while trace capture is active.
+            _ = op_fn(persistent_output_buffer=persistent_output)
+            ttnn.synchronize_device(mesh_device)
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            op_fn(persistent_output_buffer=persistent_output)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(persistent_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_all_gather_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    mode: str,
+    seq_len: int,
+):
+    from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (None,) * mesh_device.shape[0],  # No weights needed for AllGather
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_layers = mesh_device.shape[0]
+
+    # For decode mode, input shape is [seq_len, batch_size, hidden_size]
+    # For prefill mode, input shape is [batch_size, seq_len, hidden_size]
+    if mode == "decode":
+        torch_input = torch.randn(num_layers, seq_len, batch_size, hf_config.hidden_size, dtype=torch.bfloat16)
+    else:
+        torch_input = torch.randn(num_layers, batch_size, seq_len, hf_config.hidden_size, dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Reference output: After AllGather on dim=-1, each device has full hidden_size but still only its shard of layers
+    # Input is sharded as [num_layers, batch, seq_len, hidden_size] with dims=(0, -1)
+    # So each device gets [num_layers/mesh_rows, batch, seq_len, hidden_size/mesh_cols]
+    # After AllGather on dim=-1, each device has [num_layers/mesh_rows, batch, seq_len, hidden_size]
+    # For the first device (row=0, col=0), this is the first num_layers/mesh_rows layers
+    ref_output = torch_input[:1]  # First layer only (each device has 1 layer after sharding on dim 0)
+
+    return run_config, tt_input, ref_output, batch_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # batch_size=32 for all modes
+        ("decode", 1, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 128, 0.9999, 0.2, 0.2, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_all_gather_preff1_3(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 8192
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size = _build_all_gather_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        mode,
+        seq_len,
+    )
+    _run_ds_all_gather_preff1_3_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        ccl,
+        f"ds_all_gather_preff1_3_{mode}_seq{seq_len}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_all_gather_preff1_3_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_all_gather_preff1_3_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_all_gather_preff1_3 -k "{expr}"'
+
+    profiler.start("run")
+    profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    profiler.end(step_name)
+    profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py
@@ -1,0 +1,629 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MLP
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    deallocate_outputs,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+    skip_single_device_sharded,
+)
+from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_FF1_3_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 64.825, "op_to_op": None},
+    ("prefill", 128): {"kernel": 3907.177, "op_to_op": None},
+}
+
+
+@dataclass
+class FusedWeights:
+    w1: torch.Tensor
+    w3: torch.Tensor
+
+
+def ds_ff1_3_reference(
+    x: torch.Tensor, weights: FusedWeights, mode: Literal["decode", "prefill"]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference implementation for FF1/3 fused op (gate + up projections only).
+
+    Args:
+        x: Input tensor shaped like the module input after all-gather. Shape is
+           [num_layers, seq_len, batch, hidden] for decode and
+           [num_layers, batch, seq_len, hidden] for prefill (chunked if needed).
+        weights: W1 (gate_proj) and W3 (up_proj) weights from the reference model.
+        mode: "decode" or "prefill" (unused, kept for API consistency).
+
+    Returns:
+        Tuple of (w1_out, w3_out) tensors.
+    """
+    w1_out = torch.nn.functional.linear(x, weights.w1)
+    w3_out = torch.nn.functional.linear(x, weights.w3)
+    return w1_out, w3_out
+
+
+def ds_ff1_3_ttnn(
+    x: ttnn.Tensor, cfg: dict, mode: Literal["decode", "prefill"], seq_len: int
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """TTNN implementation for FF1/3 op (gate + up projections)."""
+    # Compute program config for prefill if needed
+    program_config = None
+    if mode == "prefill":
+        program_config = MLP._get_prefill_pc(seq_len=seq_len, is_w2=False, **cfg["linear_pc_gen"])
+
+    return MLP._fwd_ff1_3(x, cfg["w1"], cfg["w3"], program_config=program_config)
+
+
+def _run_ds_ff1_3_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_outputs: tuple[torch.Tensor, torch.Tensor],
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    step_prefix: str,
+    use_real_weights: bool,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len, use_real_weights=use_real_weights)
+
+    ref_w1_out, ref_w3_out = ref_outputs
+    tt_w1_out, tt_w3_out = ds_ff1_3_ttnn(tt_input, run_config, mode, seq_len)
+
+    tt_w1_out_torch = ttnn.to_torch(
+        tt_w1_out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+    tt_w3_out_torch = ttnn.to_torch(
+        tt_w3_out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+    logger.info("Comparing w1_out (gate projection):")
+    w1_pcc, w1_max_abs_error = compare_with_reference(
+        tt_w1_out_torch, ref_w1_out, expected_pcc, expected_atol, expected_rtol, strict_assert=False
+    )
+    logger.info("Comparing w3_out (up projection):")
+    w3_pcc, w3_max_abs_error = compare_with_reference(
+        tt_w3_out_torch, ref_w3_out, expected_pcc, expected_atol, expected_rtol, strict_assert=False
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_FF1_3_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_FF1_3_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_ff1_3_ttnn(tt_input, run_config, mode, seq_len)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_ff1_3_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-w1_pcc", w1_pcc)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-w1_max_abs_error", w1_max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-w3_pcc", w3_pcc)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-w3_max_abs_error", w3_max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "mlp",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "ff1_3",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_ff1_3_ttnn(tt_input, run_config, mode, seq_len)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            outputs = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            deallocate_outputs(outputs)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            traced_outputs = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            deallocate_outputs(traced_outputs)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                outputs = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                deallocate_outputs(outputs)
+            signpost("stop")
+
+
+def _build_ff1_3_weights(hf_config, use_real_weights: bool) -> FusedWeights:
+    if use_real_weights:
+        ref_model = DeepseekV3MLP(hf_config).eval().to(torch.bfloat16)
+        state_dict = ref_model.state_dict()
+    else:
+        hidden = hf_config.hidden_size
+        intermediate = hf_config.intermediate_size
+        state_dict = {
+            "gate_proj.weight": torch.randn(intermediate, hidden, dtype=torch.bfloat16),
+            "up_proj.weight": torch.randn(intermediate, hidden, dtype=torch.bfloat16),
+            "down_proj.weight": torch.randn(hidden, intermediate, dtype=torch.bfloat16),
+        }
+    return FusedWeights(w1=state_dict["gate_proj.weight"], w3=state_dict["up_proj.weight"])
+
+
+def _build_ff1_3_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    use_real_weights: bool,
+    mode: str,
+    seq_len: int,
+):
+    weights = _build_ff1_3_weights(hf_config, use_real_weights)
+
+    state_dict = {
+        "gate_proj.weight": weights.w1,
+        "up_proj.weight": weights.w3,
+        "down_proj.weight": torch.randn(hf_config.hidden_size, hf_config.intermediate_size, dtype=torch.bfloat16),
+    }
+
+    from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (state_dict,) * mesh_device.shape[0],
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_layers = mesh_device.shape[0]
+    if mode == "decode":
+        torch_input = torch.randn(num_layers, seq_len, batch_size, hf_config.hidden_size, dtype=torch.bfloat16)
+    else:
+        torch_input = torch.randn(num_layers, batch_size, seq_len, hf_config.hidden_size, dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    x = ttnn.experimental.all_gather_async(tt_input, **ccl.populate_all_gather_runtime_args(run_config["all_gather"]))
+    # After sharding with dims=(0, -1), each device has num_layers/mesh_rows layers
+    # The reshape must use the per-device layer count, not the total
+    num_layers_per_device = x.shape[0]
+
+    effective_seq_len = seq_len
+    ref_input = torch_input
+    if mode == "prefill" and seq_len > run_config["max_rows"]:
+        num_chunks = math.ceil(seq_len / run_config["max_rows"])
+        x = ttnn.reshape(x, [num_layers_per_device, num_chunks, run_config["max_rows"], -1])
+        # Reference uses full num_layers since we'll concat all device outputs
+        ref_input = torch_input.reshape(num_layers, num_chunks, run_config["max_rows"], -1)
+        effective_seq_len = run_config["max_rows"]
+
+    ref_outputs = ds_ff1_3_reference(ref_input, weights, mode)
+    return run_config, x, ref_outputs, batch_size, effective_seq_len
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # PCC ~0.97 is acceptable for bfloat4_b quantized weights
+        # batch_size=32 for all modes
+        ("decode", 1, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 128, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 1024, 0.97, 0.5, 0.5, 0.0),
+        pytest.param(
+            "prefill",
+            8192,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_ff1_3(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    is_ci_env,
+):
+    # CI skip logic: keep only decode/1/trace and prefill/128/eager in CI with program_cache and real_weights
+    if is_ci_env:
+        ci_keep = (mode == "decode" and seq_len == 1 and trace_mode and program_cache_enabled and use_real_weights) or (
+            mode == "prefill" and seq_len == 128 and not trace_mode and program_cache_enabled and use_real_weights
+        )
+        if not ci_keep:
+            pytest.skip("CI test only runs decode/1/trace and prefill/128/eager with program_cache and real_weights")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_outputs, batch_size, effective_seq_len = _build_ff1_3_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        use_real_weights,
+        mode,
+        seq_len,
+    )
+    _run_ds_ff1_3_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_outputs,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        effective_seq_len,
+        batch_size,
+        f"ds_ff1_3_{mode}_seq{seq_len}",
+        use_real_weights,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        ("decode", 1, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 128, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 1024, 0.97, 0.5, 0.5, 0.0),
+        pytest.param(
+            "prefill",
+            8192,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(
+                os.getenv("DEEPSEEK_V3_LONG_SEQ_TESTS") is None,
+                reason="Set DEEPSEEK_V3_LONG_SEQ_TESTS=1 to enable long seq tests",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_ff1_3_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    skip_single_device_sharded("ds_ff1_3")
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_ff1_3_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_ff1_3_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_ff1_3 -k "{expr}"'
+
+    profiler.start("run")
+    profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    profiler.end(step_name)
+    profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_ff1_3_single_device_device_perf(mode, seq_len):
+    skip_single_device_sharded("ds_ff1_3")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MLP
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    deallocate_outputs,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+    skip_single_device_sharded,
+)
+from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_FF2_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 105.901, "op_to_op": None},
+    ("prefill", 128): {"kernel": 126.340, "op_to_op": None},
+}
+
+
+@dataclass
+class FusedWeights:
+    w2: torch.Tensor  # down_proj weight
+
+
+def ds_ff2_reference(x: torch.Tensor, weights: FusedWeights, mode: Literal["decode", "prefill"]) -> torch.Tensor:
+    """
+    Reference implementation for FF2 fused op (down projection).
+
+    This is the down projection operation in the MLP that projects
+    from intermediate_size back to hidden_size.
+
+    Args:
+        x: Input tensor from the mul operation (activated).
+           Shape is [num_layers, 1, batch_size, intermediate_size] for decode
+           and [num_layers, 1, seq_len, intermediate_size] for prefill.
+        weights: W2 (down_proj) weight from the reference model.
+        mode: "decode" or "prefill" (unused, kept for API consistency).
+
+    Returns:
+        w2_out tensor with shape [num_layers, 1, batch_size, hidden_size] for decode
+        or [num_layers, 1, seq_len, hidden_size] for prefill.
+    """
+    w2_out = torch.nn.functional.linear(x, weights.w2)
+    return w2_out
+
+
+def ds_ff2_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+    mode: Literal["decode", "prefill"],
+    seq_len: int,
+    output_mem_config: ttnn.MemoryConfig | None = None,
+    dram_interleaved_weight: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """TTNN implementation for FF2 op (down projection).
+
+    Note: output_mem_config and dram_interleaved_weight kept for backward compatibility but ignored.
+    """
+    # Compute program config for prefill if needed
+    program_config = None
+    if mode == "prefill":
+        program_config = MLP._get_prefill_pc(seq_len=seq_len, is_w2=True, **cfg["linear_pc_gen"])
+
+    return MLP._fwd_ff2(x, cfg["w2"], program_config=program_config)
+
+
+def _run_ds_ff2_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    step_prefix: str,
+    dram_interleaved_weight: ttnn.Tensor,
+    use_real_weights: bool,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len, use_real_weights=use_real_weights)
+
+    # Log config for verification (Step 9 of AGENTS_GUIDE)
+    logger.info("=== FF2 OP CONFIG VERIFICATION ===")
+    logger.info(f"Input shape: {tt_input.shape}")
+    logger.info(f"Input memory_config: {tt_input.memory_config()}")
+    logger.info(f"W2 config keys: {run_config['w2'].keys()}")
+    logger.info(f"W2 input_tensor_b shape: {run_config['w2']['input_tensor_b'].shape}")
+    logger.info(f"W2 memory_config: {run_config['w2']['memory_config']}")
+    logger.info(f"DRAM-interleaved weight shape: {dram_interleaved_weight.shape}")
+    logger.info("=== END CONFIG VERIFICATION ===")
+
+    # Run the fused op
+    # Use dram_interleaved_weight for unit testing with DRAM interleaved inputs.
+    # In the actual MLP, inputs come from the mul op which is L1 WIDTH_SHARDED
+    # and uses the DRAM-sharded weights from cfg["w2"].
+    tt_w2_out = ds_ff2_ttnn(tt_input, run_config, mode, seq_len, dram_interleaved_weight=dram_interleaved_weight)
+
+    # Convert to torch for comparison
+    # For ff2 (down projection), the input is width-sharded on intermediate_size.
+    # Each column device computes a PARTIAL product that needs to be SUMMED (reduce),
+    # not concatenated. The output hidden_size is the same on all column devices.
+    #
+    # Mesh shape is (rows, cols) = (num_layers, 8)
+    # - Rows (dim 0): different layers → concat
+    # - Cols (dim -1): partial products → sum
+    mesh_rows, mesh_cols = mesh_device.shape
+
+    # Get per-device tensors and convert to torch
+    device_tensors = ttnn.get_device_tensors(tt_w2_out)
+    torch_tensors = [ttnn.to_torch(t, mesh_composer=None) for t in device_tensors]
+
+    # torch_tensors is a flat list of 32 tensors (4 rows × 8 cols)
+    # Reshape into [rows][cols] and sum across columns, concat across rows
+    layer_outputs = []
+    for row_idx in range(mesh_rows):
+        # Sum partial products from all columns for this layer
+        col_tensors = [torch_tensors[row_idx * mesh_cols + col_idx] for col_idx in range(mesh_cols)]
+        layer_sum = col_tensors[0].clone()
+        for t in col_tensors[1:]:
+            layer_sum = layer_sum + t
+        layer_outputs.append(layer_sum)
+
+    # Stack layers on dim 0
+    tt_w2_out_torch = torch.cat(layer_outputs, dim=0)
+
+    logger.info("Comparing w2_out (down projection):")
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_w2_out_torch, ref_output, expected_pcc, expected_atol, expected_rtol, strict_assert=False
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_FF2_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_FF2_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn():
+            return ds_ff2_ttnn(tt_input, run_config, mode, seq_len, dram_interleaved_weight=dram_interleaved_weight)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_ff2_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "mlp",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "ff2",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_ff2_ttnn(tt_input, run_config, mode, seq_len)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            outputs = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            deallocate_outputs(outputs)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            # Trace mode: capture trace and avoid any IO during trace execution
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            traced_output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            deallocate_outputs(traced_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                outputs = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                deallocate_outputs(outputs)
+            signpost("stop")
+
+
+def _build_ff2_weights(hf_config, use_real_weights: bool) -> FusedWeights:
+    if use_real_weights:
+        ref_model = DeepseekV3MLP(hf_config).eval().to(torch.bfloat16)
+        state_dict = ref_model.state_dict()
+    else:
+        hidden = hf_config.hidden_size
+        intermediate = hf_config.intermediate_size
+        state_dict = {
+            "gate_proj.weight": torch.randn(intermediate, hidden, dtype=torch.bfloat16),
+            "up_proj.weight": torch.randn(intermediate, hidden, dtype=torch.bfloat16),
+            "down_proj.weight": torch.randn(hidden, intermediate, dtype=torch.bfloat16),
+        }
+    return FusedWeights(w2=state_dict["down_proj.weight"])
+
+
+def _build_ff2_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    use_real_weights: bool,
+    mode: str,
+    seq_len: int,
+):
+    """
+    Build inputs for FF2 test.
+
+    The FF2 operation (down projection) takes the output of the mul operation as input.
+    The input tensor `activated` has shape:
+    - Decode: [num_layers, 1, batch_size, intermediate_size] - full tensor before sharding
+    - Prefill: [num_layers, 1, seq_len, intermediate_size] - full tensor before sharding
+
+    The input is sharded across the mesh on dimension (0, -1) meaning:
+    - First dimension (layers) is split across mesh rows
+    - Last dimension (intermediate_size) is split across mesh columns
+
+    For decode mode with batch_size=32, per device shape is:
+    - [1, 1, 32, intermediate_size/mesh_width] = [1, 1, 32, 2304] for mesh_width=8
+    """
+    weights = _build_ff2_weights(hf_config, use_real_weights)
+
+    state_dict = {
+        "gate_proj.weight": torch.randn(hf_config.intermediate_size, hf_config.hidden_size, dtype=torch.bfloat16),
+        "up_proj.weight": torch.randn(hf_config.intermediate_size, hf_config.hidden_size, dtype=torch.bfloat16),
+        "down_proj.weight": weights.w2,
+    }
+
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (state_dict,) * mesh_device.shape[0],
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_layers = mesh_device.shape[0]
+    _, mesh_width = mesh_device.shape
+
+    # The input to w2 is the output of the mul operation (activated)
+    # This tensor is width-sharded with per_device_intermediate = intermediate_size / mesh_width
+    # Full shape: [num_layers, 1, batch_size, intermediate_size]
+    intermediate_size = hf_config.intermediate_size
+
+    if mode == "decode":
+        # Input shape for decode: [num_layers, 1, batch_size, intermediate_size]
+        torch_input = torch.randn(num_layers, 1, batch_size, intermediate_size, dtype=torch.bfloat16)
+    else:
+        # Input shape for prefill: [num_layers, 1, seq_len, intermediate_size]
+        torch_input = torch.randn(num_layers, 1, seq_len, intermediate_size, dtype=torch.bfloat16)
+
+    # Convert to TTNN tensor - sharded across mesh on dims (0, -1)
+    # Match production: mul output is L1 WIDTH_SHARDED for decode (cfg["mul"]["memory_config"])
+    # For prefill, use DRAM INTERLEAVED (production uses DRAM for prefill)
+    if mode == "decode":
+        from models.demos.deepseek_v3.utils.config_helpers import get_activation_sharding_core_counts_for_dram_matmul
+
+        max_num_cores = mesh_device.core_grid.x * mesh_device.core_grid.y
+        inner_num_cores = max(
+            get_activation_sharding_core_counts_for_dram_matmul(intermediate_size // mesh_width, max_num_cores)
+        )
+
+        # Create L1 WIDTH_SHARDED memory config matching production mul output
+        activation_mem_config = ttnn.create_sharded_memory_config_(
+            shape=(
+                32,  # USERS_PER_ROW (batch_size for decode)
+                intermediate_size // mesh_width // inner_num_cores,
+            ),
+            core_grid=ttnn.num_cores_to_corerangeset(
+                inner_num_cores,
+                ttnn.CoreCoord(mesh_device.core_grid.x, mesh_device.core_grid.y),
+                row_wise=True,
+            ),
+            strategy=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            tile_layout=True,
+            use_height_and_width_as_shard_shape=True,
+        )
+    else:
+        # Prefill uses DRAM_MEMORY_CONFIG (cfg["mul"]["memory_config"] = DRAM for prefill)
+        activation_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=activation_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Production w2 weight shape per device: [1, 2304, 7168] (3D)
+    # Full shape before sharding: [num_layers, intermediate_size, hidden_size]
+    # - dim 0 (num_layers) sharded across mesh rows
+    # - dim 1 (intermediate_size) sharded across mesh cols
+    # Per device: [1, 2304, 7168]
+    w2_weight_transposed = weights.w2.t()  # [intermediate_size, hidden_size]
+    w2_weight_3d = w2_weight_transposed.reshape(1, intermediate_size, hf_config.hidden_size)
+    w2_weight_3d = w2_weight_3d.expand(num_layers, intermediate_size, hf_config.hidden_size).contiguous()
+    tt_w2_weight_interleaved = ttnn.from_torch(
+        w2_weight_3d,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat4_b,  # Match production weight dtype
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # For prefill, handle chunking if needed
+    effective_seq_len = seq_len
+    ref_input = torch_input
+    num_layers_per_device = tt_input.shape[0]
+
+    if mode == "prefill" and seq_len > run_config["max_rows"]:
+        num_chunks = math.ceil(seq_len / run_config["max_rows"])
+        tt_input = ttnn.reshape(tt_input, [num_layers_per_device, num_chunks, run_config["max_rows"], -1])
+        # Reference uses full num_layers since we'll concat all device outputs
+        ref_input = torch_input.reshape(num_layers, num_chunks, run_config["max_rows"], -1)
+        effective_seq_len = run_config["max_rows"]
+
+    # Compute reference output
+    ref_output = ds_ff2_reference(ref_input, weights, mode)
+
+    return run_config, tt_input, ref_output, batch_size, effective_seq_len, tt_w2_weight_interleaved
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # PCC ~0.97 is acceptable for bfloat4_b quantized weights
+        # batch_size=32 for all modes
+        ("decode", 1, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 128, 0.97, 0.5, 0.5, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_ff2(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size, effective_seq_len, tt_w2_weight = _build_ff2_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        use_real_weights,
+        mode,
+        seq_len,
+    )
+    _run_ds_ff2_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        effective_seq_len,
+        batch_size,
+        f"ds_ff2_{mode}_seq{seq_len}",
+        tt_w2_weight,
+        use_real_weights,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # PCC ~0.97 is acceptable for bfloat4_b quantized weights
+        # batch_size=32 for all modes
+        ("decode", 1, 0.97, 0.5, 0.5, 0.0),
+        ("prefill", 128, 0.97, 0.5, 0.5, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.97,
+            0.5,
+            0.5,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_ff2_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    skip_single_device_sharded("ds_ff2")
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_ff2_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_ff2_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_ff2 -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_ff2_single_device_device_perf(mode, seq_len):
+    skip_single_device_sharded("ds_ff2")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py
@@ -1,0 +1,755 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_MUL_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 8.210, "op_to_op": None},
+    ("prefill", 128): {"kernel": 27.984, "op_to_op": None},
+}
+
+
+def ds_mul_reference(
+    w1_out: torch.Tensor,
+    w3_out: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reference implementation for the mul fused op with SILU activation.
+
+    The ttnn.mul operation includes a built-in SILU activation applied to input_tensor_a
+    before multiplication.
+
+    Args:
+        w1_out: Input tensor that will have SILU applied (corresponds to w1_out_activated before fusing)
+        w3_out: Input tensor to multiply with
+
+    Returns:
+        Output tensor: silu(w1_out) * w3_out
+    """
+    # Apply SILU activation to w1_out, then multiply with w3_out
+    w1_activated = torch.nn.functional.silu(w1_out.float()).to(w1_out.dtype)
+    return w1_activated * w3_out
+
+
+def ds_mul_ttnn(
+    w1_out: ttnn.Tensor,
+    w3_out: ttnn.Tensor,
+    cfg: dict,
+    mode: str,
+    output_mem_config: ttnn.MemoryConfig = None,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for the mul fused op with SILU activation.
+
+    This performs: silu(w1_out) * w3_out
+    - For prefill: Uses fused activation in ttnn.mul
+    - For decode: Applies MLP._silu_workaround before calling the wrapper
+
+    Args:
+        w1_out: Input tensor that will have SILU applied
+        w3_out: Input tensor to multiply with
+        cfg: Configuration dictionary containing mul config
+        mode: "decode" or "prefill"
+        output_mem_config: Optional override for output memory config (useful for unit tests)
+
+    Returns:
+        Output tensor after silu+mul
+    """
+    mul_cfg = dict(cfg["mul"])
+
+    # Allow test to override memory_config if needed (e.g., when inputs are in DRAM)
+    if output_mem_config is not None:
+        mul_cfg["memory_config"] = output_mem_config
+        # When using DRAM output, we need to apply SILU separately
+        if output_mem_config == ttnn.DRAM_MEMORY_CONFIG:
+            mul_cfg.pop("input_tensor_a_activations", None)
+            # Apply SILU before mul for DRAM output
+            if mode == "decode":
+                w1_out = MLP._silu_workaround(w1_out)
+            else:  # prefill
+                w1_out = ttnn.silu(w1_out, memory_config=output_mem_config)
+    else:
+        # For non-DRAM output in decode mode, apply the workaround before calling the wrapper
+        if mode == "decode":
+            w1_out = MLP._silu_workaround(w1_out)
+
+    # Call the MLP wrapper
+    return MLP._fwd_mul(w1_out, w3_out, mul_cfg)
+
+
+def _run_ds_mul_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_w1_out: ttnn.Tensor,
+    tt_w3_out: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    # Log config for verification (Step 9 of AGENTS_GUIDE)
+    logger.info(f"=== MUL OP CONFIG VERIFICATION ===")
+    logger.info(f"Input w1_out shape: {tt_w1_out.shape}")
+    logger.info(f"Input w3_out shape: {tt_w3_out.shape}")
+    logger.info(f"Input w1_out memory_config: {tt_w1_out.memory_config()}")
+    logger.info(f"Mul config from run_config: {run_config['mul']}")
+    logger.info(f"=== END CONFIG VERIFICATION ===")
+
+    # Use DRAM output since inputs are in DRAM (unit test simplification)
+    # In actual MLP forward, inputs would be L1_WIDTH_SHARDED from linear ops
+    tt_output = ds_mul_ttnn(tt_w1_out, tt_w3_out, run_config, mode, output_mem_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    # Collect output from all devices and compare
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_MUL_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_MUL_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn():
+            return ds_mul_ttnn(tt_w1_out, tt_w3_out, run_config, mode, output_mem_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_mul_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "mlp",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "mul",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_mul_ttnn(tt_w1_out, tt_w3_out, run_config, mode, output_mem_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_mul_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    mode: str,
+    seq_len: int,
+):
+    from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (None,) * mesh_device.shape[0],  # No weights needed for mul op
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_layers = mesh_device.shape[0]
+
+    # Get dimensions from config
+    hidden_dim = hf_config.intermediate_size
+    _, mesh_width = mesh_device.shape
+
+    # Input shape for decode: [num_layers, 1, batch_size, hidden_dim]
+    # Input shape for prefill: [num_layers, 1, seq_len, hidden_dim]
+    if mode == "decode":
+        # Input tensors come from w1/w3 linear outputs in decode mode
+        # Shape: [1, 1, batch_size, hidden_dim] per device before sharding
+        torch_w1_out = torch.randn(num_layers, 1, batch_size, hidden_dim, dtype=torch.bfloat16)
+        torch_w3_out = torch.randn(num_layers, 1, batch_size, hidden_dim, dtype=torch.bfloat16)
+    else:
+        torch_w1_out = torch.randn(num_layers, 1, seq_len, hidden_dim, dtype=torch.bfloat16)
+        torch_w3_out = torch.randn(num_layers, 1, seq_len, hidden_dim, dtype=torch.bfloat16)
+
+    # Compute reference output before sharding
+    ref_output = ds_mul_reference(torch_w1_out, torch_w3_out)
+
+    # Convert to TTNN tensors - always start in DRAM, then reshard if needed
+    # This matches how the MLP module receives inputs (from previous ops in DRAM or already sharded)
+    tt_w1_out = ttnn.from_torch(
+        torch_w1_out,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    tt_w3_out = ttnn.from_torch(
+        torch_w3_out,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    return run_config, tt_w1_out, tt_w3_out, ref_output, batch_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # batch_size=32 for all modes
+        ("decode", 1, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 128, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 1024, 0.9999, 0.2, 0.2, 0.0),
+        pytest.param(
+            "prefill",
+            131072,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_mul(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 8192
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_w1_out, tt_w3_out, ref_output, batch_size = _build_mul_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        mode,
+        seq_len,
+    )
+    _run_ds_mul_test(
+        mesh_device,
+        run_config,
+        tt_w1_out,
+        tt_w3_out,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        f"ds_mul_{mode}_seq{seq_len}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # batch_size=32 for all modes
+        ("decode", 1, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 128, 0.9999, 0.2, 0.2, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_mul_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    """
+    Single device test for the mul fused op.
+
+    This test runs on a single device from the mesh. Since mul doesn't use CCL ops,
+    we can run a proper single-device test.
+    """
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        # Skip removed: now handled by pytest.param marks for seq_len > 8192
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    # For single device test, we need to extract single device shapes
+    # The per-device shape is the full tensor shape divided by the mesh dims
+    from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (None,) * mesh_device.shape[0],
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+
+    # Get dimensions from config
+    hidden_dim = hf_config.intermediate_size
+    _, mesh_width = mesh_device.shape
+
+    # Per-device hidden_dim (sharded on last dimension)
+    per_device_hidden_dim = even_int_div(hidden_dim, mesh_width)
+
+    # Single device input shape
+    if mode == "decode":
+        torch_w1_out = torch.randn(1, 1, batch_size, per_device_hidden_dim, dtype=torch.bfloat16)
+        torch_w3_out = torch.randn(1, 1, batch_size, per_device_hidden_dim, dtype=torch.bfloat16)
+    else:
+        torch_w1_out = torch.randn(1, 1, seq_len, per_device_hidden_dim, dtype=torch.bfloat16)
+        torch_w3_out = torch.randn(1, 1, seq_len, per_device_hidden_dim, dtype=torch.bfloat16)
+
+    # Compute reference output
+    ref_output = ds_mul_reference(torch_w1_out, torch_w3_out)
+
+    # Get single device from mesh
+    single_device = mesh_device.get_device(0)
+
+    # Get the memory config for the mul op inputs
+    if mode == "decode":
+        input_memory_config = run_config["w1"]["memory_config"]
+    else:
+        input_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+    # Convert to TTNN tensors on single device
+    tt_w1_out = ttnn.from_torch(
+        torch_w1_out,
+        device=single_device,
+        dtype=ttnn.bfloat16,
+        memory_config=input_memory_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    tt_w3_out = ttnn.from_torch(
+        torch_w3_out,
+        device=single_device,
+        dtype=ttnn.bfloat16,
+        memory_config=input_memory_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Run the mul op
+    tt_output = ttnn.mul(tt_w1_out, tt_w3_out, **run_config["mul"])
+
+    # Convert output to torch
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    # Compare with reference
+    compare_with_reference(tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol)
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_mul_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_mul_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_mul -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_mul_single_device_device_perf(mode, seq_len):
+    """
+    Single device device performance test for the mul fused op.
+    """
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_mul_single_device_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_mul_single_device -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from typing import Literal
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import profiler
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+)
+from models.demos.deepseek_v3.tt.mlp.mlp import MLP
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_REDUCE_SCATTER_POST_FF2_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 75.485, "op_to_op": None},
+    ("prefill", 128): {"kernel": 971.716, "op_to_op": None},
+}
+
+
+def ds_reduce_scatter_post_ff2_reference(
+    x: torch.Tensor, mesh_width: int, mode: Literal["decode", "prefill"]
+) -> torch.Tensor:
+    """
+    Reference implementation for ReduceScatter_post_ff2.
+
+    In the distributed model, reduce_scatter:
+    1. Takes input from each device which is a partial product from w2 linear
+    2. Performs a reduction (sum) across the mesh_width devices
+    3. Scatters the result so each device gets 1/mesh_width of the output
+
+    For the test, the input tensor `x` represents partial products from each device
+    that are concatenated along the last dimension (simulating what all devices have).
+    Each device originally has [..., dim], and there are mesh_width devices.
+    So x has shape [..., dim * mesh_width].
+
+    The reduce_scatter operation:
+    1. Sums all partial products element-wise (each is [..., dim])
+    2. Scatters the result: each device gets [..., dim / mesh_width]
+
+    For the reference, we need to match the first device's output:
+    - Sum: x[..., :dim] + x[..., dim:2*dim] + ... = summed_result [..., dim]
+    - First device gets: summed_result[..., :dim/mesh_width]
+
+    Args:
+        x: Input tensor of shape [num_layers, seq_len, batch, dim * mesh_width] for decode
+           or [num_layers, batch, seq_len, dim * mesh_width] for prefill.
+           This represents the concatenated partial products from all mesh_width devices.
+        mesh_width: Number of devices in the mesh width (typically 8 for TG).
+        mode: "decode" or "prefill" (unused but kept for API consistency).
+
+    Returns:
+        Output tensor representing what the first device has after reduce_scatter.
+        Shape is [num_layers, seq_len, batch, dim / mesh_width] for decode
+        or [num_layers, batch, seq_len, dim / mesh_width] for prefill.
+    """
+    # Get the dimensions
+    last_dim = x.shape[-1]
+    per_device_input_dim = last_dim // mesh_width  # dim - what each device has as input
+    per_device_output_dim = per_device_input_dim // mesh_width  # dim / mesh_width - output per device
+
+    # Reshape to separate device contributions: [..., mesh_width, per_device_input_dim]
+    shape_prefix = x.shape[:-1]
+    x_reshaped = x.reshape(*shape_prefix, mesh_width, per_device_input_dim)
+
+    # Sum across devices (dim=-2) to get the reduced result: [..., per_device_input_dim]
+    x_reduced = x_reshaped.sum(dim=-2)
+
+    # Scatter: each device gets 1/mesh_width of the reduced result
+    # First device gets the first chunk: [..., per_device_output_dim]
+    x_scattered = x_reduced[..., :per_device_output_dim]
+
+    return x_scattered
+
+
+def ds_reduce_scatter_post_ff2_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+    ccl,
+    mode: Literal["decode", "prefill"],
+    persistent_output_buffer: ttnn.Tensor | None = None,
+) -> ttnn.Tensor:
+    """TTNN implementation for ReduceScatter_post_ff2.
+
+    Note: persistent_output_buffer kept for backward compatibility but ignored.
+          The wrapper matches forward_decode which doesn't do DRAM conversion.
+    """
+    return MLP._fwd_reduce_scatter_post_ff2(x, cfg, ccl)
+
+
+def _measure_perf_us(
+    mesh_device: ttnn.MeshDevice, op_fn, warmup_iters: int, measure_iters: int, trace_mode: bool = False
+) -> float:
+    ttnn.synchronize_device(mesh_device)
+    if trace_mode:
+        # Trace mode: use a persistent output buffer and avoid deallocate inside trace capture.
+        persistent_output = op_fn()
+        ttnn.synchronize_device(mesh_device)
+        # Warm up the persistent-buffer variant before capture
+        _ = op_fn(persistent_output_buffer=persistent_output)
+        ttnn.synchronize_device(mesh_device)
+
+        logger.info("Capturing trace for perf…")
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        op_fn(persistent_output_buffer=persistent_output)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        logger.info("Trace captured. Replaying warmup…")
+
+        for _ in range(warmup_iters):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+
+        logger.info("Warmup done. Replaying measured iterations…")
+        profiler.clear()
+        profiler.start("ds_reduce_scatter_post_ff2_perf")
+        for _ in range(measure_iters):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+        profiler.end("ds_reduce_scatter_post_ff2_perf", PERF_CNT=measure_iters)
+        logger.info("Measured iterations done. Releasing trace…")
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(persistent_output)
+        return profiler.get("ds_reduce_scatter_post_ff2_perf") * 1e6
+
+    for _ in range(warmup_iters):
+        output = op_fn()
+        ttnn.synchronize_device(mesh_device)
+        ttnn.deallocate(output)
+
+    profiler.clear()
+    profiler.start("ds_reduce_scatter_post_ff2_perf")
+    for _ in range(measure_iters):
+        output = op_fn()
+        ttnn.synchronize_device(mesh_device)
+        ttnn.deallocate(output)
+    profiler.end("ds_reduce_scatter_post_ff2_perf", PERF_CNT=measure_iters)
+    return profiler.get("ds_reduce_scatter_post_ff2_perf") * 1e6
+
+
+def _run_ds_reduce_scatter_post_ff2_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    ccl,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    tt_output = ds_reduce_scatter_post_ff2_ttnn(tt_input, run_config, ccl, mode)
+
+    # Get output from the first device only for comparison with reference
+    # (similar to how all_gather test does it)
+    tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch, ref_output, expected_pcc, expected_atol, expected_rtol, strict_assert=False
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_REDUCE_SCATTER_POST_FF2_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_REDUCE_SCATTER_POST_FF2_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_reduce_scatter_post_ff2_ttnn(
+                tt_input, run_config, ccl, mode, persistent_output_buffer=persistent_output_buffer
+            )
+
+        perf_us = _measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "mlp",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "reduce_scatter",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn(*, persistent_output_buffer=None):
+            return ds_reduce_scatter_post_ff2_ttnn(
+                tt_input, run_config, ccl, mode, persistent_output_buffer=persistent_output_buffer
+            )
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            persistent_output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            _ = op_fn(persistent_output_buffer=persistent_output)
+            ttnn.synchronize_device(mesh_device)
+
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            op_fn(persistent_output_buffer=persistent_output)
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(persistent_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_reduce_scatter_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    mode: str,
+    seq_len: int,
+):
+    """Build inputs for reduce_scatter_post_ff2 test.
+
+    The input to reduce_scatter is the output of the w2 linear layer (down projection).
+    In the MLP, reduce_scatter takes partial products from each device and:
+    1. Reduces (sums) across mesh columns
+    2. Scatters the result across mesh columns
+
+    For this test:
+    - Create input tensor that will be sharded across the mesh
+    - Each device gets a portion of the input
+    - reduce_scatter sums contributions from all devices and scatters
+    """
+    # Get MLP config to get the reduce_scatter configuration
+    weight_config = get_test_weight_config(
+        MLP,
+        hf_config,
+        (None,) * mesh_device.shape[0],  # No actual weights needed for this test
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(MLP, mode, hf_config, mesh_device)
+    model_state = {
+        "mesh_device": mesh_device,
+        "mesh_shape": mesh_device.shape,
+        "ccl": ccl,
+    }
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    batch_size = USERS_PER_ROW  # Always 32 for all modes
+    num_layers = mesh_device.shape[0]
+    mesh_width = mesh_device.shape[1]
+    dim = hf_config.hidden_size
+
+    # Create input tensor with shape [num_layers, ..., dim]
+    # This will be sharded: each device gets [1, ..., dim/mesh_width] after sharding on dims=(0, -1)
+    if mode == "decode":
+        torch_input = torch.randn(num_layers, seq_len, batch_size, dim, dtype=torch.bfloat16)
+    else:
+        torch_input = torch.randn(num_layers, batch_size, seq_len, dim, dtype=torch.bfloat16)
+
+    # Shard across mesh devices with dims=(0, -1)
+    # Each device (row=r, col=c) gets portion:
+    # - Layer: layers[r]
+    # - Dim: dim[c * dim/mesh_width : (c+1) * dim/mesh_width]
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    per_device_dim = dim // mesh_width
+    per_device_output_dim = per_device_dim // mesh_width
+
+    # Get first layer and reshape to separate device contributions
+    first_layer = torch_input[:1]  # [1, seq, batch, dim]
+    shape_prefix = first_layer.shape[:-1]  # [1, seq, batch]
+    first_layer_reshaped = first_layer.reshape(*shape_prefix, mesh_width, per_device_dim)
+
+    # Sum across devices (simulate reduce)
+    reduced = first_layer_reshaped.sum(dim=-2)  # [1, seq, batch, per_device_dim]
+
+    # Scatter: first device gets first chunk
+    ref_output = reduced[..., :per_device_output_dim]  # [1, seq, batch, per_device_output_dim]
+
+    return run_config, tt_input, ref_output, batch_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # TODO: Replace expected_perf_us baselines with theoretical targets.
+        # batch_size=32 for all modes
+        ("decode", 1, 0.9999, 0.2, 0.2, 0.0),
+        ("prefill", 128, 0.9999, 0.2, 0.2, 0.0),
+        pytest.param(
+            "prefill",
+            1024,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            8192,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            32768,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+        pytest.param(
+            "prefill",
+            131072,
+            0.9999,
+            0.2,
+            0.2,
+            0.0,
+            marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_reduce_scatter_post_ff2(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+):
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size = _build_reduce_scatter_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        mode,
+        seq_len,
+    )
+    _run_ds_reduce_scatter_post_ff2_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        ccl,
+        f"ds_reduce_scatter_post_ff2_{mode}_seq{seq_len}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_reduce_scatter_post_ff2_device_perf(mode, seq_len):
+    if mode == "decode":
+        assert seq_len == 1, "Decode only supports seq_len=1"
+    else:
+        assert mode == "prefill", "Unsupported mode"
+        maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_reduce_scatter_post_ff2_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len}"
+    command = f'pytest {test_path}::test_ds_reduce_scatter_post_ff2 -k "{expr}"'
+
+    profiler.start("run")
+    profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    profiler.end(step_name)
+    profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py
@@ -1,0 +1,530 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fused op unit test for Distributed RMSNorm.
+
+This tests the distributed RMSNorm sequence:
+1. ttnn.rms_norm_pre_all_gather - compute local statistics
+2. ttnn.experimental.all_gather_async - gather stats across devices
+3. ttnn.rms_norm_post_all_gather - apply normalization with gathered stats
+"""
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3RMSNorm
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.rms_norm.distributed_rms_norm import DistributedRMSNorm
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_DISTRIBUTED_NORM_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1): {"kernel": 26.311, "op_to_op": None},
+    ("prefill", 128): {"kernel": 92.016, "op_to_op": None},
+}
+
+
+def ds_distributed_norm_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> torch.Tensor:
+    """
+    Reference implementation for Distributed RMSNorm.
+
+    In the reference model (without tensor parallelism), this is standard RMSNorm.
+    The distributed version gathers statistics across devices, but the math is the same.
+
+    Args:
+        x: Input tensor of shape [num_layers, batch_size, seq_len, hidden_size]
+        weight: RMSNorm weight tensor of shape [hidden_size]
+        epsilon: Small constant for numerical stability
+
+    Returns:
+        Normalized output tensor of same shape as input
+    """
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + epsilon)
+    return (weight.to(torch.float32) * x).to(input_dtype)
+
+
+def ds_distributed_norm_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+    ccl,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for Distributed RMSNorm.
+
+    This performs the distributed RMSNorm in three steps:
+    1. Compute local statistics (partial sum of squares)
+    2. AllGather statistics across devices
+    3. Apply normalization using gathered statistics
+
+    Args:
+        x: Input tensor sharded across devices (WIDTH_SHARDED)
+        cfg: Configuration dictionary containing all op configs
+        ccl: CCL runtime object for all-gather
+
+    Returns:
+        Normalized output tensor (same shape and sharding as input)
+    """
+    program_config = DistributedRMSNorm._get_pc(x.memory_config())
+
+    # Step 1: Compute local statistics
+    tt_stats = DistributedRMSNorm._fwd_rms_norm_pre_all_gather(x, cfg, program_config)
+
+    # Step 2: AllGather stats across devices
+    tt_gathered_stats = DistributedRMSNorm._fwd_all_gather_stats(tt_stats, cfg, ccl)
+    ttnn.deallocate(tt_stats)
+
+    # Step 3: Apply normalization with gathered stats
+    tt_out = DistributedRMSNorm._fwd_rms_norm_post_all_gather(x, tt_gathered_stats, cfg, program_config)
+    ttnn.deallocate(tt_gathered_stats)
+
+    return tt_out
+
+
+def _run_ds_distributed_norm_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    ccl,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len)
+
+    tt_output = ds_distributed_norm_ttnn(tt_input, run_config, ccl)
+
+    # Convert output back to torch - concat across mesh
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
+    )
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        convert_to_float=True,
+        strict_assert=False,
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_DISTRIBUTED_NORM_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_DISTRIBUTED_NORM_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn():
+            return ds_distributed_norm_ttnn(tt_input, run_config, ccl)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_distributed_norm_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "rms_norm",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "distributed_norm",
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_distributed_norm_ttnn(tt_input, run_config, ccl)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            traced_output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(traced_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_distributed_norm_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    ccl,
+    force_recalculate_weight_config: bool,
+    use_real_weights: bool,
+    mode: str,
+    seq_len: int,
+    state_dict: dict[str, torch.Tensor] | None,
+    reference_layernorm_path: str | None,
+):
+    """Build inputs for distributed norm test.
+
+    Args:
+        mesh_device: The mesh device
+        hf_config: HuggingFace config
+        cache_path: Path for weight caching
+        ccl: CCL object for all-gather
+        force_recalculate_weight_config: Whether to force recalculate weights
+        use_real_weights: Whether to use real model weights
+        mode: "decode" or "prefill"
+        seq_len: Sequence length (batch size for decode mode)
+        state_dict: Model state dict (needed if use_real_weights=True)
+        reference_layernorm_path: Path to layernorm in state dict
+    """
+    num_module_layers = mesh_device.shape[0]
+    hidden_size = hf_config.hidden_size
+    epsilon = hf_config.rms_norm_eps
+
+    # Get reference weights
+    reference_model = DeepseekV3RMSNorm(
+        hidden_size=hidden_size,
+        eps=epsilon,
+    ).eval()
+
+    if use_real_weights and state_dict is not None and reference_layernorm_path is not None:
+        # Use real weights from the model
+        norm_state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
+        reference_model.load_state_dict({k: v.to(torch.float32) for k, v in norm_state_dict.items()})
+        norm_state_dict = {k: v.to(torch.bfloat16) for k, v in norm_state_dict.items()}
+    else:
+        norm_state_dict = reference_model.to(torch.bfloat16).state_dict()
+
+    weight = norm_state_dict["weight"]
+
+    # Generate TTNN configs
+    weight_config = get_test_weight_config(
+        DistributedRMSNorm,
+        hf_config,
+        [norm_state_dict] * num_module_layers,
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(DistributedRMSNorm, mode, hf_config, mesh_device)
+    model_state = DistributedRMSNorm.create_state(hf_config, mesh_device, ccl)
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Input shape: [num_layers, 1, height, hidden_size]
+    # RMSNorm convention (from original test_rms_norm.py):
+    # - Decode: height = 32 (USERS_PER_ROW users × 1 token each)
+    # - Prefill: height = seq_len (1 user × seq_len tokens)
+    if mode == "decode":
+        batch_size = USERS_PER_ROW
+        effective_height = batch_size * seq_len  # 32 × 1 = 32
+    else:
+        batch_size = 1
+        effective_height = seq_len  # 1 × seq_len = seq_len
+    torch_input = torch.randn(num_module_layers, 1, effective_height, hidden_size, dtype=torch.bfloat16)
+
+    # Convert to TTNN with WIDTH_SHARDED memory config
+    # Shard across mesh rows (dim 0) and mesh cols (dim -1 = hidden_size)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=(0, -1)),
+        dtype=ttnn.bfloat16,
+        memory_config=run_config["input_memory_config"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Compute reference output using PyTorch
+    ref_output = ds_distributed_norm_reference(torch_input, weight, epsilon)
+
+    return run_config, tt_input, ref_output, batch_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # For decode mode, seq_len=1 with batch_size=32 (USERS_PER_ROW)
+        # PCC ~0.98 is typical for RMSNorm
+        ("decode", 1, 0.98, 0.5, 0.5, 0.0),  # TODO: set real perf targets
+        ("prefill", 128, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 1024, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 8192, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 32768, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 131072, 0.98, 0.5, 0.5, 0.0),  # 128k
+    ],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_distributed_norm(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    ccl,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+    is_ci_env,
+):
+    # CI skip logic: keep only decode/1/trace and prefill/128/eager in CI with program_cache and real_weights
+    if is_ci_env:
+        ci_keep = (mode == "decode" and seq_len == 1 and trace_mode and program_cache_enabled and use_real_weights) or (
+            mode == "prefill" and seq_len == 128 and not trace_mode and program_cache_enabled and use_real_weights
+        )
+        if not ci_keep:
+            pytest.skip("CI test only runs decode/1/trace and prefill/128/eager with program_cache and real_weights")
+
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    # Use input_layernorm path for real weights
+    reference_layernorm_path = "model.layers.0.input_layernorm" if use_real_weights else None
+
+    run_config, tt_input, ref_output, batch_size = _build_distributed_norm_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        ccl,
+        force_recalculate_weight_config,
+        use_real_weights,
+        mode,
+        seq_len,
+        state_dict if use_real_weights else None,
+        reference_layernorm_path,
+    )
+    _run_ds_distributed_norm_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        ccl,
+        f"ds_distributed_norm_{mode}_seq{seq_len}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len",
+    [
+        ("decode", 1),
+        ("prefill", 128),
+        pytest.param("prefill", 1024, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 8192, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 32768, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+        pytest.param("prefill", 131072, marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")),
+    ],
+)
+def test_ds_distributed_norm_device_perf(mode, seq_len):
+    maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    batch_size = USERS_PER_ROW * mesh_shape[0]
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_distributed_norm_device_perf_{mode}_seq{seq_len}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights"
+    command = f'pytest {test_path}::test_ds_distributed_norm -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py
@@ -1,0 +1,656 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fused op unit test for RMSNorm (non-distributed).
+
+This tests the single-op RMSNorm used for smaller dimensions in DeepSeek:
+- kv_lora_rank (512) - for kv_a_layernorm in MLA
+- q_lora_rank (1536) - for q_a_layernorm in MLA
+
+Unlike DistributedRMSNorm, this version does NOT shard the hidden dimension
+across devices, so no all-gather is needed.
+"""
+
+import json
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3RMSNorm
+from models.demos.deepseek_v3.tests.fused_op_unit_tests.test_utils import (
+    collect_device_perf,
+    compare_with_reference,
+    get_int_env,
+    log_run_mode,
+    maybe_skip_long_seq,
+    measure_perf_us,
+)
+from models.demos.deepseek_v3.tt.rms_norm.rms_norm import RMSNorm
+from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
+from models.demos.deepseek_v3.utils.run_config import create_run_config
+from models.demos.deepseek_v3.utils.test_utils import (
+    get_model_config,
+    get_test_weight_config,
+    system_name_to_mesh_shape,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+LONG_SEQ_ENV_VAR = "DEEPSEEK_V3_LONG_SEQ_TESTS"
+DEVICE_PERF_ENV_VAR = "DS_RMS_NORM_DEVICE_PERF"
+PERF_WARMUP_ITERS = 10
+PERF_MEASURE_ITERS = 100
+DEVICE_PERF_ITERS = 10
+DEVICE_PERF_MARGIN = 1.0
+DEVICE_PERF_TARGETS_US = {
+    ("decode", 1, "kv_lora_rank"): {"kernel": 11.448, "op_to_op": None},
+    ("decode", 1, "q_lora_rank"): {"kernel": 27.317, "op_to_op": None},
+    ("prefill", 128, "kv_lora_rank"): {"kernel": 11.710, "op_to_op": None},
+    ("prefill", 128, "q_lora_rank"): {"kernel": 27.997, "op_to_op": None},
+    ("prefill", 1024, "kv_lora_rank"): {
+        "kernel": 45.244,
+        "op_to_op": None,
+    },  # Measured: kernel=41.131, op_to_op=34021.424
+    ("prefill", 1024, "q_lora_rank"): {
+        "kernel": 111.938,
+        "op_to_op": None,
+    },  # Measured: kernel=101.76, op_to_op=96449.43
+}
+
+
+def ds_rms_norm_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> torch.Tensor:
+    """
+    Reference implementation for RMSNorm (non-distributed).
+
+    This is standard RMSNorm without any tensor parallelism.
+
+    Args:
+        x: Input tensor of shape [num_layers, batch_size, seq_len, hidden_size]
+           where hidden_size is kv_lora_rank (512) or q_lora_rank (1536)
+        weight: RMSNorm weight tensor of shape [hidden_size]
+        epsilon: Small constant for numerical stability
+
+    Returns:
+        Normalized output tensor of same shape as input
+    """
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + epsilon)
+    return (weight.to(torch.float32) * x).to(input_dtype)
+
+
+def ds_rms_norm_ttnn(
+    x: ttnn.Tensor,
+    cfg: dict,
+) -> ttnn.Tensor:
+    """
+    TTNN implementation for RMSNorm (non-distributed).
+
+    This is a single ttnn.rms_norm op, no all-gather needed since the
+    hidden dimension is NOT sharded across devices.
+
+    Args:
+        x: Input tensor (INTERLEAVED DRAM)
+        cfg: Configuration dictionary containing epsilon, weight, compute_kernel_config
+
+    Returns:
+        Normalized output tensor (same shape as input)
+    """
+    program_config = RMSNorm._get_pc(x.memory_config())
+    return RMSNorm._fwd_rms_norm(x, cfg, program_config)
+
+
+def _run_ds_rms_norm_test(
+    mesh_device: ttnn.MeshDevice,
+    run_config: dict,
+    tt_input: ttnn.Tensor,
+    ref_output: torch.Tensor,
+    hidden_size: int,
+    expected_pcc: float,
+    expected_atol: float,
+    expected_rtol: float,
+    expected_perf_us: float,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    mode: str,
+    seq_len: int,
+    batch_size: int,
+    hf_config_size_attr: str,
+    step_prefix: str,
+):
+    # Log run configuration for superset
+    log_run_mode(mode, trace_mode, program_cache_enabled, seq_len, hf_config_size_attr=hf_config_size_attr)
+
+    tt_output = ds_rms_norm_ttnn(tt_input, run_config)
+
+    # Convert output back to torch - concat across mesh rows (dim 0 only, not dim -1)
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
+    )
+    # Slice to actual hidden_size (output may be padded to tile width)
+    tt_output_torch = tt_output_torch[..., :hidden_size]
+
+    pcc_value, max_abs_error = compare_with_reference(
+        tt_output_torch,
+        ref_output,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        convert_to_float=True,
+        strict_assert=False,
+    )
+
+    if os.getenv(DEVICE_PERF_ENV_VAR) is None:
+        perf_profiler = BenchmarkProfiler()
+        benchmark_data = BenchmarkData()
+        trace_suffix = "trace" if trace_mode else "no_trace"
+        cache_suffix = "pcache" if program_cache_enabled else "no_pcache"
+        step_name = f"{step_prefix}_{trace_suffix}_{cache_suffix}"
+
+        warmup_iters = get_int_env("DS_RMS_NORM_PERF_WARMUP_ITERS", PERF_WARMUP_ITERS)
+        measure_iters = get_int_env("DS_RMS_NORM_PERF_MEASURE_ITERS", PERF_MEASURE_ITERS)
+        logger.info(
+            f"Starting e2e perf measurement: trace_mode={trace_mode}, program_cache={program_cache_enabled}, "
+            f"warmup_iters={warmup_iters}, measure_iters={measure_iters}"
+        )
+
+        perf_profiler.start("run")
+        perf_profiler.start(step_name)
+
+        def op_fn():
+            return ds_rms_norm_ttnn(tt_input, run_config)
+
+        perf_us = measure_perf_us(
+            mesh_device,
+            op_fn,
+            warmup_iters,
+            measure_iters,
+            trace_mode=trace_mode,
+            profiler_name="ds_rms_norm_perf",
+        )
+        logger.info(f"Perf avg: {perf_us:.3f} us over {measure_iters} iters (warmup {warmup_iters})")
+        perf_profiler.end(step_name)
+        perf_profiler.end("run")
+
+        benchmark_data.add_measurement(
+            perf_profiler,
+            0,
+            step_name,
+            f"{step_name}-avg_us",
+            perf_us,
+            step_warm_up_num_iterations=PERF_WARMUP_ITERS,
+            target=expected_perf_us if expected_perf_us > 0 and not trace_mode and program_cache_enabled else None,
+        )
+        # Log PCC and ATOL metrics to superset
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-pcc", pcc_value)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-max_abs_error", max_abs_error)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_atol", expected_atol)
+        benchmark_data.add_measurement(perf_profiler, 0, step_name, f"{step_name}-expected_rtol", expected_rtol)
+        benchmark_data.save_partial_run_json(
+            perf_profiler,
+            run_type="deepseek_v3_fused_ops",
+            ml_model_name="deepseek-v3",
+            batch_size=batch_size,
+            input_sequence_length=seq_len,
+            config_params={
+                "mode": mode,
+                "trace": trace_mode,
+                "program_cache_enabled": program_cache_enabled,
+                "module": "rms_norm",
+                "mesh_device": os.getenv("MESH_DEVICE", "TG"),
+                "op_type": "rms_norm",
+                "hf_config_size_attr": hf_config_size_attr,
+            },
+        )
+        if expected_perf_us > 0 and not trace_mode and program_cache_enabled:
+            perf_margin = 0.2
+            assert perf_us <= expected_perf_us * (
+                1 + perf_margin
+            ), f"Perf regression: {perf_us:.3f}us exceeds expected {expected_perf_us:.3f}us"
+        elif expected_perf_us == 0 and not trace_mode and program_cache_enabled:
+            logger.warning("TODO: Set expected_perf_us using a measured baseline.")
+    else:
+        logger.info("Skipping e2e perf measurement during device-perf profiling.")
+        from tracy import signpost
+
+        def op_fn():
+            return ds_rms_norm_ttnn(tt_input, run_config)
+
+        for _ in range(PERF_WARMUP_ITERS):
+            output = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            ttnn.deallocate(output)
+
+        ttnn.synchronize_device(mesh_device)
+        if trace_mode:
+            trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+            traced_output = op_fn()
+            ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            ttnn.synchronize_device(mesh_device)
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+                ttnn.synchronize_device(mesh_device)
+            signpost("stop")
+            ttnn.release_trace(mesh_device, trace_id)
+            ttnn.deallocate(traced_output)
+        else:
+            signpost("start")
+            for _ in range(DEVICE_PERF_ITERS):
+                output = op_fn()
+                ttnn.synchronize_device(mesh_device)
+                ttnn.deallocate(output)
+            signpost("stop")
+
+
+def _build_rms_norm_inputs(
+    mesh_device: ttnn.MeshDevice,
+    hf_config,
+    cache_path: str,
+    force_recalculate_weight_config: bool,
+    use_real_weights: bool,
+    mode: str,
+    seq_len: int,
+    hf_config_size_attr: str,
+    state_dict: dict[str, torch.Tensor] | None,
+):
+    """Build inputs for RMSNorm test.
+
+    Args:
+        mesh_device: The mesh device
+        hf_config: HuggingFace config
+        cache_path: Path for weight caching
+        force_recalculate_weight_config: Whether to force recalculate weights
+        use_real_weights: Whether to use real model weights
+        mode: "decode" or "prefill"
+        seq_len: Sequence length (batch size for decode mode)
+        hf_config_size_attr: "kv_lora_rank" (512) or "q_lora_rank" (1536)
+        state_dict: Model state dict (needed if use_real_weights=True)
+    """
+    num_module_layers = mesh_device.shape[0]
+
+    # Get hidden_size based on hf_config_size_attr
+    hidden_size = getattr(hf_config, hf_config_size_attr)
+    epsilon = hf_config.rms_norm_eps
+
+    # Get reference weights
+    reference_model = DeepseekV3RMSNorm(
+        hidden_size=hidden_size,
+        eps=epsilon,
+    ).eval()
+
+    # Determine the reference path based on hf_config_size_attr
+    if hf_config_size_attr == "kv_lora_rank":
+        reference_layernorm_path = "model.layers.0.self_attn.kv_a_layernorm"
+    else:  # q_lora_rank
+        reference_layernorm_path = "model.layers.0.self_attn.q_a_layernorm"
+
+    if use_real_weights and state_dict is not None:
+        # Use real weights from the model
+        norm_state_dict = sub_state_dict(state_dict, reference_layernorm_path + ".")
+        reference_model.load_state_dict({k: v.to(torch.float32) for k, v in norm_state_dict.items()})
+        norm_state_dict = {k: v.to(torch.bfloat16) for k, v in norm_state_dict.items()}
+    else:
+        norm_state_dict = reference_model.to(torch.bfloat16).state_dict()
+
+    weight = norm_state_dict["weight"]
+
+    # Generate TTNN configs
+    weight_config = get_test_weight_config(
+        RMSNorm,
+        hf_config,
+        [norm_state_dict] * num_module_layers,
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+    )
+    model_config = get_model_config(RMSNorm, mode, hf_config, mesh_device)
+    model_state = RMSNorm.create_state(hf_config, mesh_device)  # No CCL needed for non-distributed
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Input shape: [num_layers, 1, height, hidden_size]
+    # RMSNorm convention (from original test_rms_norm.py):
+    # - Decode: height = 32 (USERS_PER_ROW users × 1 token each)
+    # - Prefill: height = seq_len (1 user × seq_len tokens)
+    if mode == "decode":
+        batch_size = USERS_PER_ROW
+        effective_height = batch_size * seq_len  # 32 × 1 = 32
+    else:
+        batch_size = 1
+        effective_height = seq_len  # 1 × seq_len = seq_len
+    torch_input = torch.randn(num_module_layers, 1, effective_height, hidden_size, dtype=torch.bfloat16)
+
+    # Convert to TTNN with INTERLEAVED DRAM memory config
+    # Shard only across mesh rows (dim 0 for layers), NOT across mesh cols (dim -1)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=(0, None)),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    # Compute reference output using PyTorch
+    ref_output = ds_rms_norm_reference(torch_input, weight, epsilon)
+
+    return run_config, tt_input, ref_output, batch_size, hidden_size
+
+
+@pytest.mark.ci_fused_op
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        # PCC ~0.98 is typical for RMSNorm
+        # Decode with seq_len=1, batch_size=32 (USERS_PER_ROW)
+        ("decode", 1, 0.98, 0.5, 0.5, 0.0),  # TODO: set real perf targets
+        ("prefill", 128, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 1024, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 8192, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 32768, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 131072, 0.98, 0.5, 0.5, 0.0),  # 128k
+    ],
+)
+@pytest.mark.parametrize(
+    "hf_config_size_attr",
+    ["kv_lora_rank", "q_lora_rank"],
+    ids=["kv_lora_rank_512", "q_lora_rank_1536"],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_rms_norm(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    hf_config_size_attr,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+    is_ci_env,
+):
+    # CI skip logic: keep only decode/1/trace and prefill/128/eager in CI with program_cache and real_weights
+    if is_ci_env:
+        ci_keep = (mode == "decode" and seq_len == 1 and trace_mode and program_cache_enabled and use_real_weights) or (
+            mode == "prefill" and seq_len == 128 and not trace_mode and program_cache_enabled and use_real_weights
+        )
+        if not ci_keep:
+            pytest.skip("CI test only runs decode/1/trace and prefill/128/eager with program_cache and real_weights")
+
+    # Trace capture replays pre-compiled binaries. When program cache is disabled, ops may
+    # trigger compilation/program writes during capture, which is forbidden and can TT_FATAL.
+    if trace_mode and not program_cache_enabled:
+        pytest.skip("Trace mode requires program cache enabled (skip trace + no_program_cache).")
+
+    if not program_cache_enabled:
+        mesh_device.disable_and_clear_program_cache()
+
+    run_config, tt_input, ref_output, batch_size, hidden_size = _build_rms_norm_inputs(
+        mesh_device,
+        hf_config,
+        cache_path,
+        force_recalculate_weight_config,
+        use_real_weights,
+        mode,
+        seq_len,
+        hf_config_size_attr,
+        state_dict if use_real_weights else None,
+    )
+    _run_ds_rms_norm_test(
+        mesh_device,
+        run_config,
+        tt_input,
+        ref_output,
+        hidden_size,
+        expected_pcc,
+        expected_atol,
+        expected_rtol,
+        expected_perf_us,
+        trace_mode,
+        program_cache_enabled,
+        mode,
+        seq_len,
+        batch_size,
+        hf_config_size_attr,
+        f"ds_rms_norm_{mode}_seq{seq_len}_{hf_config_size_attr}",
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, expected_pcc, expected_atol, expected_rtol, expected_perf_us",
+    [
+        ("decode", 1, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 128, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 1024, 0.98, 0.5, 0.5, 0.0),
+        ("prefill", 131072, 0.98, 0.5, 0.5, 0.0),
+    ],
+)
+@pytest.mark.parametrize(
+    "hf_config_size_attr",
+    ["kv_lora_rank", "q_lora_rank"],
+    ids=["kv_lora_rank_512", "q_lora_rank_1536"],
+)
+@pytest.mark.parametrize("use_real_weights", [True, False], ids=["real_weights", "random_weights"])
+@pytest.mark.parametrize("program_cache_enabled", [True, False], ids=["program_cache", "no_program_cache"])
+@pytest.mark.parametrize("trace_mode", [False, True], ids=["eager", "trace"])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 2967552,
+        }
+    ],
+    indirect=True,
+)
+def test_ds_rms_norm_single_device(
+    mode,
+    seq_len,
+    expected_pcc,
+    expected_atol,
+    expected_rtol,
+    expected_perf_us,
+    hf_config_size_attr,
+    use_real_weights,
+    program_cache_enabled,
+    trace_mode,
+    hf_config,
+    cache_path,
+    mesh_device,
+    force_recalculate_weight_config,
+    set_deterministic_env,
+    state_dict: dict[str, torch.Tensor],
+):
+    """Single device test for RMSNorm.
+
+    Unlike DistributedRMSNorm, the non-distributed RMSNorm does NOT have CCL ops,
+    so single device test is applicable. However, since this test uses the same
+    code path and the op runs independently on each device (no sharding on hidden dim),
+    the multi-device test already exercises the single-device behavior.
+    """
+    # For now, skip with a note that the multi-device test already covers this
+    pytest.skip(
+        "Single-device test skipped: RMSNorm runs identically on each device "
+        "(hidden dim not sharded). Multi-device test already validates correctness."
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, hf_config_size_attr",
+    [
+        ("decode", 1, "kv_lora_rank"),
+        ("decode", 1, "q_lora_rank"),
+        ("prefill", 128, "kv_lora_rank"),
+        ("prefill", 128, "q_lora_rank"),
+        pytest.param(
+            "prefill", 1024, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 1024, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 8192, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 8192, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 32768, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 32768, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 131072, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 131072, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+    ],
+)
+def test_ds_rms_norm_device_perf(mode, seq_len, hf_config_size_attr):
+    maybe_skip_long_seq(seq_len, LONG_SEQ_ENV_VAR)
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to T3K, DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    # batch_size=32 (USERS_PER_ROW) for all modes
+    batch_size = USERS_PER_ROW
+
+    perf_profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"ds_rms_norm_device_perf_{mode}_seq{seq_len}_{hf_config_size_attr}"
+    test_path = "models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py"
+    trace_filter = "trace" if mode == "decode" else "eager"
+    size_filter = "kv_lora_rank_512" if hf_config_size_attr == "kv_lora_rank" else "q_lora_rank_1536"
+    expr = f"program_cache and not no_program_cache and {trace_filter} and {mode} and {seq_len} and real_weights and {size_filter}"
+    command = f'pytest {test_path}::test_ds_rms_norm -k "{expr}"'
+
+    perf_profiler.start("run")
+    perf_profiler.start(step_name)
+    os.environ[DEVICE_PERF_ENV_VAR] = "1"
+    op_stats, total_kernel_ns, total_op_to_op_ns = collect_device_perf(
+        command,
+        subdir="deepseek_v3_fused_ops_device_perf",
+        warmup_iters=0,
+        use_signposts=True,
+    )
+    os.environ.pop(DEVICE_PERF_ENV_VAR, None)
+    perf_profiler.end(step_name)
+    perf_profiler.end("run")
+
+    assert op_stats, "No device perf stats captured."
+    total_kernel_us = total_kernel_ns / 1000.0
+    total_op_to_op_us = total_op_to_op_ns / 1000.0
+    logger.info(f"Device perf per-op averages (ns): {json.dumps(op_stats, indent=2)}")
+    logger.info(f"Device perf totals: kernel={total_kernel_us:.3f} us, op_to_op={total_op_to_op_us:.3f} us")
+    assert total_kernel_ns > 0, "Total kernel duration must be positive."
+    assert total_op_to_op_ns >= 0, "Total op-to-op latency must be non-negative."
+    targets = DEVICE_PERF_TARGETS_US.get((mode, seq_len, hf_config_size_attr))
+    if targets is None or targets["kernel"] == 0.0:
+        logger.warning("No device perf targets configured; skipping perf assertions.")
+    else:
+        kernel_target_us = targets["kernel"]
+        kernel_limit_us = kernel_target_us * (1 + DEVICE_PERF_MARGIN)
+        assert (
+            total_kernel_us <= kernel_limit_us
+        ), f"Kernel perf regression: {total_kernel_us:.3f}us exceeds {kernel_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+        op_to_op_target_us = targets.get("op_to_op")
+        if op_to_op_target_us is None:
+            logger.info("Op-to-op perf target is unset; skipping op-to-op perf assertion.")
+        else:
+            op_to_op_limit_us = op_to_op_target_us * (1 + DEVICE_PERF_MARGIN)
+            assert (
+                total_op_to_op_us <= op_to_op_limit_us
+            ), f"Op-to-op perf regression: {total_op_to_op_us:.3f}us exceeds {op_to_op_target_us:.3f}us (+{DEVICE_PERF_MARGIN:.0%})"
+
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_kernel_duration_us",
+        total_kernel_us,
+    )
+    benchmark_data.add_measurement(
+        perf_profiler,
+        0,
+        step_name,
+        "total_op_to_op_latency_us",
+        total_op_to_op_us,
+    )
+    benchmark_data.save_partial_run_json(
+        perf_profiler,
+        run_type="deepseek_v3_fused_ops_device_perf",
+        ml_model_name="deepseek-v3",
+        batch_size=batch_size,
+        input_sequence_length=seq_len,
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, seq_len, hf_config_size_attr",
+    [
+        ("decode", 1, "kv_lora_rank"),
+        ("decode", 1, "q_lora_rank"),
+        ("prefill", 128, "kv_lora_rank"),
+        ("prefill", 128, "q_lora_rank"),
+        pytest.param(
+            "prefill", 1024, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 1024, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 8192, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 8192, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 32768, "kv_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+        pytest.param(
+            "prefill", 32768, "q_lora_rank", marks=pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip in CI")
+        ),
+    ],
+)
+def test_ds_rms_norm_single_device_device_perf(mode, seq_len, hf_config_size_attr):
+    pytest.skip(
+        "Single-device device perf test skipped: RMSNorm runs identically on each device "
+        "(hidden dim not sharded). Multi-device test already validates performance."
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_op_tests_locally.sh
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/run_ci_op_tests_locally.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Run fused-op device perf tests locally (CI-aligned scenarios)
+#
+# Usage:
+#   ./run_ci_op_tests_locally.sh
+
+set -euo pipefail
+
+cd /home/models-team/hzhou/tt-metal
+source python_env/bin/activate
+
+RUN_DEVICE_PERF=true
+
+# Set environment variables to match CI
+export ARCH_NAME=wormhole_b0
+export TT_METAL_HOME=$(pwd)
+export PYTHONPATH=$(pwd)
+export LD_LIBRARY_PATH=$(pwd)/build/lib
+export LOGURU_LEVEL=INFO
+export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
+export MESH_DEVICE=TG
+export CI=true
+export GITHUB_ACTIONS=true
+export TT_METAL_RUNTIME_ROOT=/home/models-team/hzhou/tt-metal
+
+echo "=============================================="
+echo "DeepSeek V3 Fused Op Tests - Local Execution"
+echo "=============================================="
+echo "Environment Setup:"
+echo "  DEEPSEEK_V3_HF_MODEL: $DEEPSEEK_V3_HF_MODEL"
+echo "  DEEPSEEK_V3_CACHE: $DEEPSEEK_V3_CACHE"
+echo "  MESH_DEVICE: $MESH_DEVICE"
+echo "  Run Device Perf: $RUN_DEVICE_PERF"
+echo "=============================================="
+
+# ============================================
+# DeepSeek Op Unit Tests - Device Performance
+# ============================================
+if [ "$RUN_DEVICE_PERF" = true ]; then
+    echo ""
+    echo "=============================================="
+    echo "Starting Device Performance Tests"
+    echo "=============================================="
+    echo "Collecting kernel and op-to-op latency metrics"
+    echo "Configuration: prefill 128 (eager+pcache) + decode 1 (trace+pcache)"
+    echo ""
+
+    echo "=============================================="
+    echo "DeepSeek fused-op device perf tests (CI-style selection)"
+    echo "=============================================="
+    CI_FUSED_OP_DEVICE_PERF_K_EXPR='
+    (
+      (test_ds_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_all_gather_embedding_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_lm_head_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_rms_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_distributed_norm_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_ff1_3_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_mul_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_reduce_scatter_post_ff2_device_perf and ((decode and 1) or (prefill and 128))) or
+      (test_ds_all_gather_preff1_3_device_perf and ((decode and 1) or (prefill and 128)))
+    )'
+    # Keep expression formatting readable in source but parser-safe for pytest -k.
+    CI_FUSED_OP_DEVICE_PERF_K_EXPR="$(printf '%s' "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" | tr '\n' ' ' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
+    pytest models/demos/deepseek_v3/tests/fused_op_unit_tests -k "$CI_FUSED_OP_DEVICE_PERF_K_EXPR" --timeout 600 --durations=0
+
+    echo "=============================================="
+    echo "All device perf tests completed!"
+    echo "=============================================="
+fi
+
+echo ""
+echo "=============================================="
+echo "Test Execution Complete!"
+echo "=============================================="
+if [ "$RUN_DEVICE_PERF" = true ]; then
+    echo "✓ Device perf tests completed:"
+    echo "  - Kernel duration metrics collected"
+    echo "  - Op-to-op latency metrics collected"
+    echo "  - Benchmark data saved to: generated/benchmark_data/"
+fi
+echo ""
+echo "=============================================="

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_all_device_perf.sh
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_all_device_perf.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Test all device perf tests to ensure they work and collect baselines
+set -uo pipefail
+
+cd /home/models-team/hzhou/tt-metal
+source python_env/bin/activate
+
+# Set environment variables
+export ARCH_NAME=wormhole_b0
+export TT_METAL_HOME=$(pwd)
+export PYTHONPATH=$(pwd)
+export LD_LIBRARY_PATH=$(pwd)/build/lib
+export LOGURU_LEVEL=INFO
+export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
+export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
+export MESH_DEVICE=TG
+export CI=true
+export GITHUB_ACTIONS=true
+export TT_METAL_RUNTIME_ROOT=/home/models-team/hzhou/tt-metal
+
+# Output file for collected baselines
+BASELINE_FILE="device_perf_baselines.json"
+echo "{" > "$BASELINE_FILE"
+
+# Array of all fused ops with their test paths
+declare -A OPS_MAP
+OPS_MAP["embedding"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_embedding.py::test_ds_embedding_device_perf"
+OPS_MAP["all_gather_embedding"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/embedding/test_ds_all_gather_embedding.py::test_ds_all_gather_embedding_device_perf"
+OPS_MAP["lm_head"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/lm_head/test_ds_lm_head.py::test_ds_lm_head_device_perf"
+OPS_MAP["rms_norm"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_rms_norm.py::test_ds_rms_norm_device_perf"
+OPS_MAP["distributed_norm"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/rms_norm/test_ds_distributed_norm.py::test_ds_distributed_norm_device_perf"
+OPS_MAP["ff1_3"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff1_3.py::test_ds_ff1_3_device_perf"
+OPS_MAP["all_gather_preff1_3"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_all_gather_preff1_3.py::test_ds_all_gather_preff1_3_device_perf"
+OPS_MAP["mul"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_mul.py::test_ds_mul_device_perf"
+OPS_MAP["ff2"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_ff2.py::test_ds_ff2_device_perf"
+OPS_MAP["reduce_scatter"]="models/demos/deepseek_v3/tests/fused_op_unit_tests/mlp/test_ds_reduce_scatter_post_ff2.py::test_ds_reduce_scatter_post_ff2_device_perf"
+
+first_op=true
+
+for op_name in "${!OPS_MAP[@]}"; do
+    test_path="${OPS_MAP[$op_name]}"
+
+    echo "=============================================="
+    echo "Testing: $op_name"
+    echo "=============================================="
+
+    if [ "$first_op" = false ]; then
+        echo "," >> "$BASELINE_FILE"
+    fi
+    first_op=false
+
+    echo "  \"$op_name\": {" >> "$BASELINE_FILE"
+
+    # Test prefill seq_len=128 (eager + program_cache)
+    echo ""
+    echo "Running $op_name prefill seq_len=128 (eager + program_cache)..."
+    rm -rf generated/profiler/deepseek_v3_fused_ops_device_perf
+
+    OUTPUT=$(pytest "$test_path" -k "prefill and 128" --timeout 600 -v -s 2>&1)
+    PREFILL_KERNEL=$(echo "$OUTPUT" | grep "Device perf totals:" | grep -oP "kernel=\K[0-9.]+")
+    PREFILL_OP_TO_OP=$(echo "$OUTPUT" | grep "Device perf totals:" | grep -oP "op_to_op=\K[0-9.]+")
+
+    echo "  Prefill 128: kernel=${PREFILL_KERNEL}us, op_to_op=${PREFILL_OP_TO_OP}us"
+
+    # Test decode seq_len=1 (trace + program_cache)
+    echo ""
+    echo "Running $op_name decode seq_len=1 (trace + program_cache)..."
+    rm -rf generated/profiler/deepseek_v3_fused_ops_device_perf
+
+    OUTPUT=$(pytest "$test_path" -k "decode and 1" --timeout 600 -v -s 2>&1)
+    DECODE_KERNEL=$(echo "$OUTPUT" | grep "Device perf totals:" | grep -oP "kernel=\K[0-9.]+")
+    DECODE_OP_TO_OP=$(echo "$OUTPUT" | grep "Device perf totals:" | grep -oP "op_to_op=\K[0-9.]+")
+
+    echo "  Decode 1: kernel=${DECODE_KERNEL}us, op_to_op=${DECODE_OP_TO_OP}us"
+
+    # Write to baseline file
+    echo "    \"prefill_128\": {" >> "$BASELINE_FILE"
+    echo "      \"kernel_us\": $PREFILL_KERNEL," >> "$BASELINE_FILE"
+    echo "      \"op_to_op_us\": $PREFILL_OP_TO_OP" >> "$BASELINE_FILE"
+    echo "    }," >> "$BASELINE_FILE"
+    echo "    \"decode_1\": {" >> "$BASELINE_FILE"
+    echo "      \"kernel_us\": $DECODE_KERNEL," >> "$BASELINE_FILE"
+    echo "      \"op_to_op_us\": $DECODE_OP_TO_OP" >> "$BASELINE_FILE"
+    echo "    }" >> "$BASELINE_FILE"
+    echo "  }" >> "$BASELINE_FILE"
+
+    echo ""
+done
+
+echo "}" >> "$BASELINE_FILE"
+
+echo "=============================================="
+echo "All Device Perf Tests Complete!"
+echo "Baselines saved to: $BASELINE_FILE"
+echo "=============================================="
+
+cat "$BASELINE_FILE"

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_utils.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_utils.py
@@ -1,0 +1,869 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared utility functions for DeepSeek V3 fused op unit tests.
+
+This module contains common helper functions used across all fused op unit tests
+to reduce code duplication and ensure consistent behavior.
+"""
+
+import math
+import os
+import re
+import shlex
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc, profiler
+from tools.tracy.process_model_log import get_profiler_folder
+
+TIMESTAMP_DIR_RE = re.compile(r"^\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}$")
+
+
+def _get_latest_timestamped_ops_report(subdir: str) -> tuple[Path, str]:
+    """Return latest Tracy ops report from timestamped report directories only."""
+    profiler_dir = Path(get_profiler_folder(subdir))
+    reports_dir = profiler_dir / "reports"
+    if not reports_dir.exists():
+        raise FileNotFoundError(f"Profiler reports directory not found: {reports_dir}")
+
+    run_dirs = sorted(
+        [p for p in reports_dir.iterdir() if p.is_dir() and TIMESTAMP_DIR_RE.match(p.name)],
+        key=lambda p: p.name,
+    )
+    if not run_dirs:
+        raise FileNotFoundError(f"No timestamped profiler report directories found in: {reports_dir}")
+
+    latest_dir = run_dirs[-1]
+    expected_name = latest_dir / f"ops_perf_results_{latest_dir.name}.csv"
+    if expected_name.exists():
+        return expected_name, latest_dir.name
+
+    # Defensive fallback in case Tracy changes exact filename pattern.
+    matches = sorted(latest_dir.glob("ops_perf_results_*.csv"))
+    if not matches:
+        raise FileNotFoundError(f"No ops_perf_results_*.csv found in latest report directory: {latest_dir}")
+    return matches[-1], latest_dir.name
+
+
+def _build_report_tag_from_command(command: str) -> str:
+    """Create a stable per-test tag from pytest command and -k expression."""
+    normalized_command = command.strip()
+    if (
+        len(normalized_command) >= 2
+        and normalized_command[0] == normalized_command[-1]
+        and normalized_command[0] in {"'", '"'}
+    ):
+        normalized_command = normalized_command[1:-1]
+
+    try:
+        tokens = shlex.split(normalized_command)
+    except ValueError:
+        tokens = normalized_command.split()
+
+    test_spec = next((t for t in tokens if "::" in t and t.endswith(".py") is False), None)
+    if test_spec is None:
+        # Try recovering from separate path + ::test style
+        for i, token in enumerate(tokens[:-1]):
+            if token.endswith(".py") and tokens[i + 1].startswith("::"):
+                test_spec = f"{token}{tokens[i + 1]}"
+                break
+
+    op_part = "unknown_test"
+    if test_spec:
+        test_path = test_spec.split("::")[0]
+        op_part = Path(test_path).stem
+
+    expr = ""
+    if "-k" in tokens:
+        k_idx = tokens.index("-k")
+        if k_idx + 1 < len(tokens):
+            expr = tokens[k_idx + 1]
+
+    expr_tokens = [t.strip() for t in re.split(r"\s+", expr) if t.strip()]
+    mode = "decode" if "decode" in expr_tokens else ("prefill" if "prefill" in expr_tokens else "mode")
+    runtime = "trace" if "trace" in expr_tokens else ("eager" if "eager" in expr_tokens else "runtime")
+    seq = next((t for t in expr_tokens if t.isdigit()), "seq")
+    program_cache = "pcache" if "program_cache" in expr_tokens else "nopcache"
+
+    extras = []
+    for token in expr_tokens:
+        if token in {"and", "or", "not", "decode", "prefill", "trace", "eager", "program_cache", "no_program_cache"}:
+            continue
+        if token.isdigit():
+            continue
+        extras.append(token)
+    extras = extras[:3]
+
+    parts = [op_part, f"{mode}_seq{seq}", runtime, program_cache]
+    if extras:
+        parts.extend(extras)
+
+    tag = "__".join(parts)
+    # Keep the directory/file names portable.
+    tag = re.sub(r"[^a-zA-Z0-9_.-]+", "_", tag).strip("._-")
+    return tag or "unknown_test"
+
+
+def _copy_ops_report_to_test_folder(subdir: str, report_tag: str, ops_report_path: Path, run_timestamp: str) -> None:
+    """Copy ops report to reports/<test-tag>/<timestamp>_ops_perf_results_*.csv."""
+    import shutil
+
+    profiler_dir = Path(get_profiler_folder(subdir))
+    destination_dir = profiler_dir / "reports" / report_tag
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    destination_name = f"{run_timestamp}_{ops_report_path.name}"
+    destination_path = destination_dir / destination_name
+    shutil.copy2(ops_report_path, destination_path)
+    logger.info(f"Saved test-specific ops report copy: {destination_path}")
+
+
+def get_int_env(name: str, default: int) -> int:
+    """Get an integer environment variable with a default value.
+
+    Args:
+        name: Name of the environment variable.
+        default: Default value if the environment variable is not set.
+
+    Returns:
+        The integer value of the environment variable, or the default.
+
+    Raises:
+        ValueError: If the environment variable is set but cannot be parsed as an integer.
+    """
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError as e:
+        raise ValueError(f"Env var {name} must be an int, got {val!r}") from e
+
+
+def maybe_skip_long_seq(seq_len: int, long_seq_env_var: str, threshold: int = 8192):
+    """Skip test if sequence length exceeds threshold and env var is not set.
+
+    Args:
+        seq_len: The sequence length being tested.
+        long_seq_env_var: Name of the environment variable that enables long sequence tests.
+        threshold: Maximum sequence length before requiring the env var (default: 8192).
+    """
+    if seq_len <= threshold:
+        return
+    if os.getenv(long_seq_env_var) is None:
+        pytest.skip(f"Set {long_seq_env_var}=1 to enable seq_len={seq_len} coverage.")
+
+
+def compare_with_reference(
+    tt_output: torch.Tensor,
+    ref_output: torch.Tensor,
+    expected_pcc: float,
+    atol: float,
+    rtol: float,
+    convert_to_float: bool = False,
+    strict_assert: bool = True,
+) -> tuple[float, float]:
+    """Compare TTNN output with reference and return metrics.
+
+    Args:
+        tt_output: Output tensor from TTNN operation.
+        ref_output: Reference output tensor.
+        expected_pcc: Minimum expected Pearson correlation coefficient.
+        atol: Absolute tolerance for torch.testing.assert_close.
+        rtol: Relative tolerance for torch.testing.assert_close.
+        convert_to_float: If True, convert tensors to float before comparison.
+        strict_assert: If True, raise AssertionError on assert_close failure.
+                      If False, log a warning instead.
+
+    Returns:
+        Tuple of (pcc_value, max_abs_error) for logging to superset.
+    """
+    if convert_to_float:
+        tt_for_compare = tt_output.float()
+        ref_for_compare = ref_output.float()
+    else:
+        tt_for_compare = tt_output
+        ref_for_compare = ref_output
+
+    passing, pcc = comp_pcc(ref_for_compare, tt_for_compare, expected_pcc)
+    max_abs_error = (tt_for_compare - ref_for_compare).abs().max().item()
+    logger.info(f"PCC: {pcc}")
+    logger.info(f"Max absolute error: {max_abs_error}")
+    assert passing, f"PCC {pcc} is below required {expected_pcc}"
+
+    if strict_assert:
+        torch.testing.assert_close(tt_for_compare, ref_for_compare, rtol=rtol, atol=atol)
+    else:
+        try:
+            torch.testing.assert_close(tt_for_compare, ref_for_compare, rtol=rtol, atol=atol)
+        except AssertionError as e:
+            logger.warning(f"assert_close failed but PCC passed: {e}")
+
+    return pcc, max_abs_error
+
+
+def log_run_mode(
+    mode: str,
+    trace_mode: bool,
+    program_cache_enabled: bool,
+    seq_len: int,
+    **extra_fields,
+):
+    """Log the test run configuration.
+
+    Args:
+        mode: Test mode ("decode" or "prefill").
+        trace_mode: Whether trace mode is enabled.
+        program_cache_enabled: Whether program cache is enabled.
+        seq_len: Sequence length being tested.
+        **extra_fields: Additional fields to log (e.g., use_real_weights, hf_config_size_attr).
+    """
+    logger.info("=== TEST RUN CONFIGURATION ===")
+    logger.info(f"Mode: {mode}")
+    logger.info(f"Sequence length: {seq_len}")
+    for key, value in extra_fields.items():
+        # Convert snake_case to readable format
+        readable_key = key.replace("_", " ").title()
+        logger.info(f"{readable_key}: {value}")
+    logger.info(f"Trace mode: {trace_mode}")
+    logger.info(f"Program cache enabled: {program_cache_enabled}")
+    logger.info("===============================")
+
+
+def deallocate_outputs(outputs):
+    """Deallocate outputs which can be a single tensor or tuple of tensors.
+
+    Args:
+        outputs: A single ttnn.Tensor or a tuple of ttnn.Tensor objects.
+    """
+    if isinstance(outputs, tuple):
+        for out in outputs:
+            ttnn.deallocate(out)
+    else:
+        ttnn.deallocate(outputs)
+
+
+def measure_perf_us(
+    mesh_device: ttnn.MeshDevice,
+    op_fn: Callable,
+    warmup_iters: int,
+    measure_iters: int,
+    trace_mode: bool = False,
+    profiler_name: str = "perf_measurement",
+) -> float:
+    """Measure operation performance in microseconds.
+
+    Args:
+        mesh_device: The mesh device to run operations on.
+        op_fn: Function that executes the operation. Should return output tensor(s).
+               For trace mode with persistent buffers, should accept optional
+               `persistent_output_buffer` kwarg.
+        warmup_iters: Number of warmup iterations before measurement.
+        measure_iters: Number of iterations to measure.
+        trace_mode: If True, use trace capture and replay for measurement.
+        profiler_name: Name for the profiler measurement (default: "perf_measurement").
+
+    Returns:
+        Average operation time in microseconds.
+    """
+    ttnn.synchronize_device(mesh_device)
+
+    if trace_mode:
+        # Warmup in eager mode first
+        for _ in range(warmup_iters):
+            outputs = op_fn()
+            ttnn.synchronize_device(mesh_device)
+            deallocate_outputs(outputs)
+
+        # Capture trace
+        ttnn.synchronize_device(mesh_device)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        traced_outputs = op_fn()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        deallocate_outputs(traced_outputs)
+
+        # Additional warmup with trace execution
+        for _ in range(warmup_iters):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+
+        # Measure with trace
+        profiler.clear()
+        profiler.start(profiler_name)
+        for _ in range(measure_iters):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+        profiler.end(profiler_name, PERF_CNT=measure_iters)
+        ttnn.release_trace(mesh_device, trace_id)
+        return profiler.get(profiler_name) * 1e6
+
+    # Eager mode
+    for _ in range(warmup_iters):
+        outputs = op_fn()
+        ttnn.synchronize_device(mesh_device)
+        deallocate_outputs(outputs)
+
+    profiler.clear()
+    profiler.start(profiler_name)
+    for _ in range(measure_iters):
+        outputs = op_fn()
+        ttnn.synchronize_device(mesh_device)
+        deallocate_outputs(outputs)
+    profiler.end(profiler_name, PERF_CNT=measure_iters)
+    return profiler.get(profiler_name) * 1e6
+
+
+def merge_device_rows_for_perf(df: pd.DataFrame) -> pd.DataFrame:
+    """Merge device performance rows across devices for collective operations.
+
+    For collective operations (AllGather, ReduceScatter, etc.), computes average
+    kernel duration across devices. For other operations, takes the maximum
+    kernel duration.
+
+    Args:
+        df: DataFrame containing device performance data with columns:
+            - "OP CODE": Operation name
+            - "OP TYPE": Operation type (e.g., "tt_dnn_device")
+            - "DEVICE ID": Device identifier
+            - "DEVICE KERNEL DURATION [ns]": Kernel duration in nanoseconds
+
+    Returns:
+        DataFrame with merged performance rows.
+    """
+    block_by_device = defaultdict(list)
+
+    # Device profiling CSV uses "OP NAME" instead of "OP CODE" and has no "OP TYPE"
+    op_col = "OP NAME" if "OP NAME" in df.columns else "OP CODE"
+
+    for _, row in df.iterrows():
+        op_name = row[op_col]
+        # Skip rows with NaN op names
+        if pd.isna(op_name):
+            continue
+        op_name = str(op_name)  # Ensure it's a string
+        device_id = int(row["DEVICE ID"])
+        block_by_device[device_id].append((op_name, row.to_dict()))
+
+    device_ids = sorted(block_by_device.keys())
+    merged_blocks = []
+    global_index = 0
+    while max(len(block_by_device[device_id]) for device_id in device_ids) > 0:
+        blocks = []
+        op_name = None
+        missing_devices = []
+        for device_id in device_ids:
+            if not len(block_by_device[device_id]):
+                logger.warning(f"Warning: Device {device_id} is missing operation {op_name} at index {global_index}")
+                continue
+            if op_name is None:
+                op_name = block_by_device[device_id][0][0]
+            elif op_name != block_by_device[device_id][0][0]:
+                missing_devices.append(device_id)
+                continue
+
+            blocks.append(block_by_device[device_id].pop(0))
+
+        if missing_devices:
+            logger.warning(
+                f"Warning: {op_name} at index {global_index} not present in CSV for {len(missing_devices)} devices "
+                f"{missing_devices} - do not trust data for this op or directly subsequent ops with the same name"
+            )
+
+        if not blocks:
+            break
+
+        is_collective = any(tag in op_name for tag in ("AllGather", "ReduceScatter", "AllReduce", "AllToAll"))
+        if is_collective:
+            device_kernel_durations = [
+                d["DEVICE KERNEL DURATION [ns]"]
+                for _, d in blocks
+                if "DEVICE KERNEL DURATION [ns]" in d and not math.isnan(d["DEVICE KERNEL DURATION [ns]"])
+            ]
+            average_duration = (
+                sum(device_kernel_durations) / len(device_kernel_durations) if device_kernel_durations else float("nan")
+            )
+            base_block = blocks[0][1].copy()
+            base_block["DEVICE KERNEL DURATION [ns]"] = average_duration
+            merged_blocks.append(base_block)
+        else:
+            max_duration_block = max(blocks, key=lambda x: x[1]["DEVICE KERNEL DURATION [ns]"])
+            merged_blocks.append(max_duration_block[1])
+
+        global_index += 1
+
+    return pd.DataFrame(merged_blocks)
+
+
+def run_device_profiler_local(
+    command: str,
+    subdir: str,
+    device_analysis_types: list[str],
+    op_support_count: int = 10000,
+) -> None:
+    """Run device profiler with robust fallback behavior.
+
+    Prefer Tracy post-processing mode (-r) for op-level reports. Some environments
+    do not generate host capture artifacts reliably; in those cases, retry in
+    device-only mode (-p) so perf collection still proceeds.
+
+    Args:
+        command: The pytest command to profile.
+        subdir: Subdirectory for profiler output.
+        device_analysis_types: List of analysis types (e.g., ["device_kernel_duration"]).
+        op_support_count: Maximum number of ops to profile.
+    """
+    import shlex
+    import subprocess
+    from pathlib import Path
+
+    profiler_dir = Path(get_profiler_folder(subdir))
+
+    # Set environment variables for device profiling.
+    env = os.environ.copy()
+    env["TT_METAL_DEVICE_PROFILER"] = "1"
+    env["TTNN_OP_PROFILER"] = "1"
+    env["TT_METAL_PROFILER_TRACE_TRACKING"] = "1"
+
+    normalized_command = command.strip()
+    if (
+        len(normalized_command) >= 2
+        and normalized_command[0] == normalized_command[-1]
+        and normalized_command[0] in {"'", '"'}
+    ):
+        # Guard against accidentally wrapping the full command in a single quote pair.
+        normalized_command = normalized_command[1:-1]
+
+    def run_tracy(python_post_process: bool):
+        if python_post_process:
+            tracy_args = [
+                "python3",
+                "-m",
+                "tracy",
+                "-p",
+                "-r",
+                "-o",
+                str(profiler_dir),
+                "--check-exit-code",
+                "--op-support-count",
+                str(op_support_count),
+                "-t",
+                "5000",
+            ]
+            for analysis in device_analysis_types:
+                tracy_args.extend(["-a", analysis])
+            tracy_args.append("-m")
+            # Tracy expects a single command string after -m; tokenizing here
+            # causes quoted pytest -k expressions to be split and misparsed.
+            tracy_args.append(normalized_command)
+            profiler_cmd = " ".join(shlex.quote(arg) for arg in tracy_args)
+            logger.info(f"Running device profiler: {profiler_cmd}")
+            result = subprocess.run(tracy_args, check=False, capture_output=True, text=True, env=env)
+            return profiler_cmd, result
+
+        # For -p fallback, pass argv tokens to avoid treating full command as a module name.
+        tracy_args = [
+            "python3",
+            "-m",
+            "tracy",
+            "-p",
+            "-o",
+            str(profiler_dir),
+            "--check-exit-code",
+            "--op-support-count",
+            str(op_support_count),
+            "-t",
+            "5000",
+        ]
+        for analysis in device_analysis_types:
+            tracy_args.extend(["-a", analysis])
+        tracy_args.append("-m")
+        # Keep command as one string so pytest -k expressions remain intact.
+        tracy_args.append(normalized_command)
+
+        profiler_cmd = " ".join(shlex.quote(arg) for arg in tracy_args)
+        logger.info(f"Running device profiler: {profiler_cmd}")
+        result = subprocess.run(tracy_args, check=False, capture_output=True, text=True, env=env)
+        return profiler_cmd, result
+
+    # Attempt 1: -r mode for post-processed ops report
+    profiler_cmd, result = run_tracy(python_post_process=True)
+    if result.returncode == 0:
+        return
+
+    stderr = result.stderr or ""
+    host_capture_missing = (
+        "tracy_profile_log_host.tracy was not generated" in stderr or "tracy capture out not found" in stderr
+    )
+
+    if host_capture_missing:
+        logger.error(
+            "Tracy -r failed due to missing host capture artifact. "
+            "Device perf collection requires reports/ops_perf_results_*.csv; "
+            "-p fallback is disabled by policy."
+        )
+        logger.error(f"STDOUT: {result.stdout}")
+        logger.error(f"STDERR: {result.stderr}")
+        raise subprocess.CalledProcessError(result.returncode, profiler_cmd, result.stdout, result.stderr)
+
+    logger.error(f"Tracy profiler failed with return code {result.returncode}")
+    logger.error(f"STDOUT: {result.stdout}")
+    logger.error(f"STDERR: {result.stderr}")
+    raise subprocess.CalledProcessError(result.returncode, profiler_cmd, result.stdout, result.stderr)
+
+
+def collect_device_perf(
+    command: str,
+    subdir: str,
+    warmup_iters: int,
+    use_signposts: bool = False,
+) -> tuple[dict[str, dict[str, float]], float, float]:
+    """Collect device performance statistics by running a profiled command.
+
+    Args:
+        command: The pytest command to run with device profiling.
+        subdir: Subdirectory for profiler output files.
+        warmup_iters: Number of warmup iterations to exclude from statistics.
+        use_signposts: If True, only analyze ops between "start" and "stop" signposts.
+
+    Returns:
+        Tuple of:
+            - op_stats: Dict mapping op names to their avg kernel duration and op-to-op latency.
+            - total_kernel_ns: Total kernel duration in nanoseconds.
+            - total_op_to_op_ns: Total op-to-op latency in nanoseconds.
+    """
+    # Use local device profiler with environment fix
+    device_analysis_types = ["device_kernel_duration"]
+    run_device_profiler_local(
+        command,
+        subdir,
+        device_analysis_types=device_analysis_types,
+        op_support_count=10000,
+    )
+
+    # Require Tracy post-processed ops report (tt-perf-report semantics).
+    # We intentionally do not accept .logs/cpp_device_perf_report.csv as the source
+    # for fused-op perf targets.
+    try:
+        # Use timestamped-run lookup so reports/<test-name>/ folders don't break discovery.
+        ops_filename, run_timestamp = _get_latest_timestamped_ops_report(subdir)
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "Required Tracy ops report directory was not generated. "
+            "Perf collection requires reports/ops_perf_results_*.csv output."
+        ) from e
+
+    if not ops_filename.exists():
+        raise RuntimeError(
+            f"Required Tracy ops report was not generated: {ops_filename}. "
+            "Perf collection requires reports/ops_perf_results_*.csv output."
+        )
+
+    logger.info(f"Using post-processed ops report: {ops_filename}")
+    ops_df = pd.read_csv(ops_filename)
+    report_tag = _build_report_tag_from_command(command)
+    _copy_ops_report_to_test_folder(subdir, report_tag, ops_filename, run_timestamp)
+
+    required_ops_cols = ["OP TYPE", "OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    missing_ops_cols = [col for col in required_ops_cols if col not in ops_df.columns]
+    if missing_ops_cols:
+        raise RuntimeError(f"Ops report missing required columns: {missing_ops_cols}. " f"Report file: {ops_filename}")
+
+    ops_df["DEVICE KERNEL DURATION [ns]"] = pd.to_numeric(
+        ops_df["DEVICE KERNEL DURATION [ns]"], errors="coerce"
+    ).fillna(0.0)
+    ops_df["OP TO OP LATENCY [ns]"] = pd.to_numeric(ops_df["OP TO OP LATENCY [ns]"], errors="coerce").fillna(0.0)
+
+    if use_signposts:
+        signposts = ops_df[ops_df["OP TYPE"] == "signpost"]
+        starts = signposts[signposts["OP CODE"] == "start"].index.tolist()
+        stops = signposts[signposts["OP CODE"] == "stop"].index.tolist()
+        if starts and stops:
+            start_idx = starts[0]
+            stop_idx = next((idx for idx in stops if idx > start_idx), None)
+            if stop_idx is not None:
+                ops_df = ops_df.iloc[start_idx + 1 : stop_idx]
+                logger.info(
+                    "Filtered ops report to signpost window: "
+                    f"rows={len(ops_df)} between start={start_idx} and stop={stop_idx}"
+                )
+
+    ops_df = ops_df[ops_df["OP TYPE"] != "signpost"]
+
+    if warmup_iters > 0 and not use_signposts and len(ops_df) > warmup_iters:
+        ops_df = ops_df.iloc[warmup_iters:]
+
+    if len(ops_df) == 0:
+        raise RuntimeError(
+            f"Ops report is empty after filtering for command: {command}. "
+            "Cannot compute fused-op perf from empty reports/ops_perf_results_*.csv."
+        )
+
+    op_stats = {}
+    for op_name, group in ops_df.groupby("OP CODE"):
+        if pd.isna(op_name):
+            continue
+        op_name = str(op_name)
+        op_stats[op_name] = {
+            "avg_kernel_duration_ns": float(group["DEVICE KERNEL DURATION [ns]"].mean()),
+            "avg_op_to_op_latency_ns": float(group["OP TO OP LATENCY [ns]"].mean()),
+        }
+
+    total_kernel_ns = float(sum(v["avg_kernel_duration_ns"] for v in op_stats.values()))
+    total_op_to_op_ns = float(sum(v["avg_op_to_op_latency_ns"] for v in op_stats.values()))
+    logger.info(
+        f"Computed totals from ops report: kernel={total_kernel_ns/1e3:.2f} us, "
+        f"op-to-op={total_op_to_op_ns/1e3:.2f} us"
+    )
+    return op_stats, total_kernel_ns, total_op_to_op_ns
+
+    # Fallback: cpp_device_perf_report.csv in .logs
+    from pathlib import Path
+
+    profiler_dir = Path(get_profiler_folder(subdir))
+    filename = profiler_dir / ".logs" / "cpp_device_perf_report.csv"
+
+    if not filename.exists():
+        raise FileNotFoundError(f"Device perf CSV not found at {filename}")
+
+    logger.info(f"Using CSV from .logs/: {filename}")
+    df = pd.read_csv(filename)
+
+    # Check if we have OP NAME populated (from -r mode) or if it's empty (from -p only mode)
+    required_cols = ["DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    assert not missing_cols, f"Missing device perf columns: {missing_cols}"
+
+    df["DEVICE KERNEL DURATION [ns]"] = pd.to_numeric(df["DEVICE KERNEL DURATION [ns]"], errors="coerce").fillna(0.0)
+    df["OP TO OP LATENCY [ns]"] = pd.to_numeric(df["OP TO OP LATENCY [ns]"], errors="coerce").fillna(0.0)
+
+    # Check if OP NAME has any valid (non-NaN) values
+    has_op_names = False
+    if "OP NAME" in df.columns:
+        has_op_names = df["OP NAME"].notna().any()
+
+    op_stats: dict[str, dict[str, float]] = {}
+
+    if has_op_names:
+        # We have operation names - provide per-op breakdown
+        logger.info("Device perf CSV contains operation names - providing per-op breakdown")
+        df = merge_device_rows_for_perf(df)
+
+        for op_name, group in df.groupby("OP NAME"):
+            if pd.isna(op_name):
+                continue
+            op_name = str(op_name)
+            kernel_vals = group["DEVICE KERNEL DURATION [ns]"].tolist()
+            op_to_op_vals = group["OP TO OP LATENCY [ns]"].tolist()
+            if warmup_iters > 0:
+                kernel_vals = kernel_vals[warmup_iters:]
+                op_to_op_vals = op_to_op_vals[warmup_iters:]
+            if kernel_vals and op_to_op_vals:
+                op_stats[op_name] = {
+                    "avg_kernel_duration_ns": sum(kernel_vals) / len(kernel_vals),
+                    "avg_op_to_op_latency_ns": sum(op_to_op_vals) / len(op_to_op_vals),
+                }
+
+        total_kernel_ns = sum(entry["avg_kernel_duration_ns"] for entry in op_stats.values())
+        total_op_to_op_ns = sum(entry["avg_op_to_op_latency_ns"] for entry in op_stats.values())
+    else:
+        # No operation names - can only provide aggregate totals
+        logger.warning("Device perf CSV does not contain operation names - providing aggregate totals only")
+
+        # CRITICAL FIX: Filter to ONLY traced operations to exclude compile/eager ops
+        # Check if we have trace replay session IDs to filter by
+        if "METAL TRACE REPLAY SESSION ID" in df.columns:
+            # Filter to only rows with trace replay session ID (excludes compile/eager ops)
+            traced_mask = df["METAL TRACE REPLAY SESSION ID"].notna() & (df["METAL TRACE REPLAY SESSION ID"] != "")
+            traced_df = df[traced_mask].copy()
+
+            if len(traced_df) > 0:
+                # Count unique trace replay sessions (iterations)
+                num_trace_sessions = traced_df["METAL TRACE REPLAY SESSION ID"].nunique()
+                num_traced_ops = len(traced_df)
+                ops_per_iteration = num_traced_ops / num_trace_sessions
+
+                logger.info(
+                    f"Filtered to {num_traced_ops} traced ops across {num_trace_sessions} iterations "
+                    f"({ops_per_iteration:.0f} ops/iter, excluded {len(df) - num_traced_ops} compile/eager ops)"
+                )
+
+                # Group by iteration and device to calculate per-device metrics
+                # Operations run in PARALLEL across devices, so we need max/avg, not sum!
+                device_iter_metrics = []
+                for session_id in traced_df["METAL TRACE REPLAY SESSION ID"].unique():
+                    session_df = traced_df[traced_df["METAL TRACE REPLAY SESSION ID"] == session_id]
+                    # For each device in this iteration
+                    for device_id in session_df["DEVICE ID"].unique():
+                        device_df = session_df[session_df["DEVICE ID"] == device_id]
+                        device_kernel = float(device_df["DEVICE KERNEL DURATION [ns]"].sum())
+                        device_op_to_op = float(device_df["OP TO OP LATENCY [ns]"].sum())
+                        device_iter_metrics.append(
+                            {
+                                "session": session_id,
+                                "device": device_id,
+                                "kernel_ns": device_kernel,
+                                "op_to_op_ns": device_op_to_op,
+                            }
+                        )
+
+                # Calculate per-iteration metrics using MAX across devices (critical path)
+                per_iter_metrics = []
+                for session_id in traced_df["METAL TRACE REPLAY SESSION ID"].unique():
+                    session_metrics = [m for m in device_iter_metrics if m["session"] == session_id]
+                    max_kernel = max(m["kernel_ns"] for m in session_metrics)
+                    max_op_to_op = max(m["op_to_op_ns"] for m in session_metrics)
+                    per_iter_metrics.append({"kernel_ns": max_kernel, "op_to_op_ns": max_op_to_op})
+
+                # Average across iterations
+                per_iter_kernel_ns = sum(m["kernel_ns"] for m in per_iter_metrics) / len(per_iter_metrics)
+                per_iter_op_to_op_ns = sum(m["op_to_op_ns"] for m in per_iter_metrics) / len(per_iter_metrics)
+
+                # Calculate per-op average (for reference)
+                per_op_kernel_ns = per_iter_kernel_ns / ops_per_iteration
+                per_op_op_to_op_ns = per_iter_op_to_op_ns / ops_per_iteration
+
+                logger.info(
+                    f"Per-iteration totals: kernel={per_iter_kernel_ns/1e3:.2f} us, "
+                    f"op-to-op={per_iter_op_to_op_ns/1e3:.2f} us, "
+                    f"total={(per_iter_kernel_ns + per_iter_op_to_op_ns)/1e3:.2f} us"
+                )
+                logger.info(
+                    f"Per-op averages: kernel={per_op_kernel_ns/1e3:.2f} us, "
+                    f"op-to-op={per_op_op_to_op_ns/1e3:.2f} us, "
+                    f"total={(per_op_kernel_ns + per_op_op_to_op_ns)/1e3:.2f} us"
+                )
+
+                # Return per-iteration totals (for comparison with e2e benchmark)
+                total_kernel_ns = per_iter_kernel_ns
+                total_op_to_op_ns = per_iter_op_to_op_ns
+            else:
+                # No traced operations - this is eager mode
+                # Use GLOBAL CALL COUNT to filter out compile operations
+                logger.info("No traced operations - running in eager mode, filtering by GLOBAL CALL COUNT")
+
+                if "GLOBAL CALL COUNT" in df.columns:
+                    # Filter to operations with call count >= 1024 to skip compile phase
+                    # Compile ops typically have lower call counts
+                    eager_mask = df["GLOBAL CALL COUNT"] >= 1024
+                    eager_df = df[eager_mask].copy()
+
+                    if len(eager_df) > 0:
+                        # Guardrail for unreliable fallback data:
+                        # In some environments, fallback CSVs can contain a small number of
+                        # massive op-to-op rows (seconds-scale) that dominate totals and
+                        # produce meaningless fused-op latency.
+                        op_to_op_vals = eager_df["OP TO OP LATENCY [ns]"]
+                        outlier_mask = op_to_op_vals >= 1_000_000  # >= 1 ms per row
+                        if outlier_mask.any():
+                            total_op_to_op_ns_all_rows = float(op_to_op_vals.sum())
+                            outlier_op_to_op_ns = float(op_to_op_vals[outlier_mask].sum())
+                            outlier_contribution = (
+                                outlier_op_to_op_ns / total_op_to_op_ns_all_rows
+                                if total_op_to_op_ns_all_rows > 0
+                                else 0.0
+                            )
+                            if outlier_contribution >= 0.95:
+                                # Fallback robustness: remove pathological rows and continue.
+                                # This prevents a handful of massive artifact rows from dominating
+                                # eager-mode op-to-op totals when -r data is unavailable.
+                                num_outliers = int(outlier_mask.sum())
+                                eager_df = eager_df[~outlier_mask].copy()
+                                if len(eager_df) == 0:
+                                    raise RuntimeError(
+                                        "Unreliable eager fallback device perf: all rows were outliers "
+                                        "(>=1ms op-to-op) after filtering."
+                                    )
+                                logger.warning(
+                                    "Outlier-dominated eager fallback detected: "
+                                    f"{outlier_contribution:.2%} of op-to-op from {num_outliers} rows (>=1ms). "
+                                    f"Dropping outliers and continuing with {len(eager_df)} rows."
+                                )
+
+                        # Group by device and calculate per-device totals
+                        device_metrics = []
+                        for device_id in eager_df["DEVICE ID"].unique():
+                            device_df = eager_df[eager_df["DEVICE ID"] == device_id]
+                            device_kernel = float(device_df["DEVICE KERNEL DURATION [ns]"].sum())
+                            device_op_to_op = float(device_df["OP TO OP LATENCY [ns]"].sum())
+                            device_metrics.append(
+                                {"device": device_id, "kernel_ns": device_kernel, "op_to_op_ns": device_op_to_op}
+                            )
+
+                        # For parallel operations, use MAX across devices (critical path)
+                        total_kernel_ns_all = max(m["kernel_ns"] for m in device_metrics)
+                        total_op_to_op_ns_all = max(m["op_to_op_ns"] for m in device_metrics)
+
+                        # In eager mode, tests run DEVICE_PERF_ITERS (typically 10) iterations
+                        # We need to divide by this to get per-iteration time
+                        DEVICE_PERF_ITERS = 10  # Standard across all device perf tests
+                        total_kernel_ns = total_kernel_ns_all / DEVICE_PERF_ITERS
+                        total_op_to_op_ns = total_op_to_op_ns_all / DEVICE_PERF_ITERS
+
+                        logger.info(
+                            f"Eager mode: Filtered {len(eager_df)} operations (call count >= 1024) "
+                            f"across {len(device_metrics)} devices, {DEVICE_PERF_ITERS} iterations"
+                        )
+                        logger.info(
+                            f"Total (all iterations): kernel={total_kernel_ns_all/1e3:.2f} us, "
+                            f"op-to-op={total_op_to_op_ns_all/1e3:.2f} us, "
+                            f"total={(total_kernel_ns_all + total_op_to_op_ns_all)/1e3:.2f} us"
+                        )
+                        logger.info(
+                            f"Per-iteration average: kernel={total_kernel_ns/1e3:.2f} us, "
+                            f"op-to-op={total_op_to_op_ns/1e3:.2f} us, "
+                            f"total={(total_kernel_ns + total_op_to_op_ns)/1e3:.2f} us"
+                        )
+                    else:
+                        logger.warning("No operations found with call count >= 1024")
+                        total_kernel_ns = float(df["DEVICE KERNEL DURATION [ns]"].sum())
+                        total_op_to_op_ns = float(df["OP TO OP LATENCY [ns]"].sum())
+                else:
+                    logger.warning("GLOBAL CALL COUNT column not found - using all rows (may include compile ops)")
+                    total_kernel_ns = float(df["DEVICE KERNEL DURATION [ns]"].sum())
+                    total_op_to_op_ns = float(df["OP TO OP LATENCY [ns]"].sum())
+        else:
+            # Fallback: No trace session column, use old behavior but warn
+            logger.warning(
+                "METAL TRACE REPLAY SESSION ID column not found - "
+                "metrics may include compile/eager ops (will be inflated)"
+            )
+            total_kernel_ns = float(df["DEVICE KERNEL DURATION [ns]"].sum())
+            total_op_to_op_ns = float(df["OP TO OP LATENCY [ns]"].sum())
+
+        # Create a single aggregate entry (convert to Python float for JSON serialization)
+        op_stats["<all_ops_aggregate>"] = {
+            "avg_kernel_duration_ns": total_kernel_ns,
+            "avg_op_to_op_latency_ns": total_op_to_op_ns,
+        }
+
+    return op_stats, total_kernel_ns, total_op_to_op_ns
+
+
+def skip_single_device_ccl(op_name: str):
+    """Skip test because it includes CCL operations that require multiple devices.
+
+    Args:
+        op_name: Name of the operation being tested.
+    """
+    pytest.skip(f"Single-device test is not applicable because {op_name} includes CCL ops.")
+
+
+def skip_single_device_sharded(op_name: str):
+    """Skip test because it relies on width-sharded matmuls across the mesh.
+
+    Args:
+        op_name: Name of the operation being tested.
+    """
+    pytest.skip(
+        f"Single-device test is not applicable because {op_name} relies on width-sharded matmuls across the mesh."
+    )

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -104,6 +104,7 @@ def test_forward_pass(
 
     # TTNN forward pass
     tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
+
     tt_output = run_module_forward(LMHead, mode, tt_input, run_config)
 
     expected_output_memory_config = run_config["output_memory_config"]

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -206,6 +206,7 @@ def test_forward_pass(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
     )
+<<<<<<< HEAD
 
     # TTNN forward pass - collective operations handled inside forward functions
     # SharedExpert needs handle_tensor_parallel=True for standalone testing to enable CCLs
@@ -214,6 +215,10 @@ def test_forward_pass(
         tt_output = run_module_forward(MLPClass, mode, tt_input, run_config, handle_tensor_parallel=True)
     else:
         tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+=======
+    # TTNN forward pass
+    tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+>>>>>>> 8c4d27d337 (refactor DeepSeek fused-op CI/perf workflow and local runners)
 
     # Verify output memory config matches expected
     expected_output_memory_config = run_config["output_memory_config"]

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -208,7 +208,10 @@ def test_forward_pass(
     )
 
     # TTNN forward pass
-    tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+    if MLPClass.__name__ == "SharedExpert":
+        tt_output = run_module_forward(MLPClass, mode, tt_input, run_config, handle_tensor_parallel=True)
+    else:
+        tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
 
     # Verify output memory config matches expected
     expected_output_memory_config = run_config["output_memory_config"]

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -206,19 +206,9 @@ def test_forward_pass(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
     )
-<<<<<<< HEAD
 
-    # TTNN forward pass - collective operations handled inside forward functions
-    # SharedExpert needs handle_tensor_parallel=True for standalone testing to enable CCLs
-    # NonExpert and MLP don't have this parameter and handle CCLs internally
-    if MLPClass.__name__ == "SharedExpert":
-        tt_output = run_module_forward(MLPClass, mode, tt_input, run_config, handle_tensor_parallel=True)
-    else:
-        tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
-=======
     # TTNN forward pass
     tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
->>>>>>> 8c4d27d337 (refactor DeepSeek fused-op CI/perf workflow and local runners)
 
     # Verify output memory config matches expected
     expected_output_memory_config = run_config["output_memory_config"]

--- a/models/demos/deepseek_v3/tt/lm_head.py
+++ b/models/demos/deepseek_v3/tt/lm_head.py
@@ -257,6 +257,24 @@ class LMHead(AbstractModule):
             "ccl": ccl,
         }
 
+    @staticmethod
+    def _fwd_linear(x: ttnn.Tensor, cfg: dict, program_config: Any = None) -> ttnn.Tensor:
+        """Wrapper for lm_head linear projection.
+        Matches: forward_decode line 267, forward_prefill line 315-316
+
+        Args:
+            x: Input tensor
+            cfg: Config for linear operation (cfg["linear"])
+            program_config: Optional program config (required for prefill, None for decode)
+
+        Returns:
+            Output tensor after linear projection
+        """
+        if program_config is not None:  # prefill
+            return ttnn.linear(x, program_config=program_config, **cfg["linear"])
+        else:  # decode
+            return ttnn.linear(x, **cfg["linear"])
+
     @classmethod
     def forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
         assert x.memory_config() == cfg["input_memory_config"], f"{x.memory_config()} != {cfg['input_memory_config']}"

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -367,9 +367,9 @@ class MLP(AbstractModule):
             "ccl": ccl,
         }
 
-    @classmethod
+    @staticmethod
     def _get_prefill_pc(
-        cls, seq_len: int, dim: int, hidden_dim: int, num_devices: int, core_grid_size: ttnn.CoreCoord, is_w2: bool
+        seq_len: int, dim: int, hidden_dim: int, num_devices: int, core_grid_size: ttnn.CoreCoord, is_w2: bool
     ) -> Any:
         """Get the program config for linear layers in prefill mode based on sequence length."""
         if is_w2:
@@ -396,8 +396,8 @@ class MLP(AbstractModule):
             fuse_batch=False,
         )
 
-    @classmethod
-    def _silu_workaround(cls, x: ttnn.Tensor) -> ttnn.Tensor:  # TODO: remove once ttnn.silu PCC is fixed
+    @staticmethod
+    def _silu_workaround(x: ttnn.Tensor) -> ttnn.Tensor:  # TODO: remove once ttnn.silu PCC is fixed
         """Workaround for the silu PCC issue in ttnn."""
         # -x
         x1 = ttnn.neg(x)
@@ -423,6 +423,73 @@ class MLP(AbstractModule):
         ttnn.deallocate(x5)
 
         return x6
+
+    @staticmethod
+    def _fwd_all_gather_preff1_3(x: ttnn.Tensor, cfg: dict, ccl) -> ttnn.Tensor:
+        """Wrapper for all-gather before FF1/3 projections.
+        Matches: forward_prefill line 439, forward_decode line 491
+        """
+        return ttnn.experimental.all_gather_async(x, **ccl.populate_all_gather_runtime_args(cfg["all_gather"]))
+
+    @staticmethod
+    def _fwd_ff1_3(
+        x: ttnn.Tensor, w1_cfg: dict, w3_cfg: dict, program_config: Any = None
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Wrapper for FF1 (gate) and FF3 (up) projections.
+        Matches: forward_prefill lines 447-452, forward_decode lines 494-495
+
+        Args:
+            x: Input tensor
+            w1_cfg: Config for w1 linear (cfg["w1"])
+            w3_cfg: Config for w3 linear (cfg["w3"])
+            program_config: Optional program config (required for prefill, None for decode)
+        """
+        if program_config is not None:  # prefill
+            w1_out = ttnn.linear(x, program_config=program_config, **w1_cfg)
+            w3_out = ttnn.linear(x, program_config=program_config, **w3_cfg)
+        else:  # decode
+            w1_out = ttnn.linear(x, **w1_cfg)
+            w3_out = ttnn.linear(x, **w3_cfg)
+        return w1_out, w3_out
+
+    @staticmethod
+    def _fwd_mul(w1_out: ttnn.Tensor, w3_out: ttnn.Tensor, mul_cfg: dict) -> ttnn.Tensor:
+        """Wrapper for element-wise multiply.
+        Matches: forward_prefill line 460, forward_decode line 502
+
+        Args:
+            w1_out: First input (for decode: SILU should be applied BEFORE calling this)
+            w3_out: Second input
+            mul_cfg: Config for mul operation (cfg["mul"])
+
+        Note: For prefill, mul_cfg should contain input_tensor_a_activations=[SILU] for fused activation.
+              For decode, caller should apply MLP._silu_workaround(w1_out) before calling this.
+        """
+        return ttnn.mul(w1_out, w3_out, **mul_cfg)
+
+    @staticmethod
+    def _fwd_ff2(x: ttnn.Tensor, w2_cfg: dict, program_config: Any = None) -> ttnn.Tensor:
+        """Wrapper for FF2 (down) projection.
+        Matches: forward_prefill lines 465-469, forward_decode line 507
+
+        Args:
+            x: Input tensor
+            w2_cfg: Config for w2 linear (cfg["w2"])
+            program_config: Optional program config (required for prefill, None for decode)
+        """
+        if program_config is not None:  # prefill
+            return ttnn.linear(x, program_config=program_config, **w2_cfg)
+        else:  # decode
+            return ttnn.linear(x, **w2_cfg)
+
+    @staticmethod
+    def _fwd_reduce_scatter_post_ff2(x: ttnn.Tensor, cfg: dict, ccl) -> ttnn.Tensor:
+        """Wrapper for reduce-scatter after FF2.
+        Matches: forward_prefill lines 473-475, forward_decode lines 511-513
+        """
+        return ttnn.experimental.reduce_scatter_minimal_async(
+            x, **ccl.populate_reduce_scatter_runtime_args(cfg["reduce_scatter_async"])
+        )
 
     @classmethod
     def _forward_compute_only(cls, x: ttnn.Tensor, cfg: RunPrefillConfig | RunDecodeConfig, mode: str) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+from typing import Any
 
 import torch
 from transformers.configuration_utils import PretrainedConfig
@@ -64,6 +65,21 @@ class RMSNorm(RMSNormBase):
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
             compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
         )
+
+    @staticmethod
+    def _fwd_rms_norm(x: ttnn.Tensor, cfg: dict, program_config: Any) -> ttnn.Tensor:
+        """Wrapper for RMS norm (non-distributed).
+        Matches: _rmsnorm_forward line 79
+
+        Args:
+            x: Input tensor
+            cfg: Config for rms_norm operation
+            program_config: Program config (computed externally via _get_pc)
+
+        Returns:
+            Normalized output tensor
+        """
+        return ttnn.rms_norm(x, program_config=program_config, **cfg)
 
     @classmethod
     def _rmsnorm_forward(cls, x: ttnn.Tensor, cfg: RunPrefillConfig | RunDecodeConfig) -> ttnn.Tensor:


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/36347)

### Problem description
We want  an effective  way to  log per op  performance as we begin op  optimization for deepsek

### What's changed
Using netmap, we organize op tests into  groups that corresponds to their fused version. 
We log performance on the following setting:
- seq len: 1, 32, 128, 1024
- batch: 32
- with or without program cache
- with or without trace

Op tests are created  for the following modules:
- LM  head
- RMS Norm
- MLP
- Embedding

These test  are then logged to  supersets dashboard for performance visualizations


#### Model tests
-  [DeepSeek op unit test](https://github.com/tenstorrent/tt-metal/actions/runs/22738067701)
- [DeepSeek module test](https://github.com/tenstorrent/tt-metal/actions/runs/22738080804)