### PR TITLE
matmul only movement

### DIFF
--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -9,7 +9,7 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/compute_kernel_config.hpp"
-#include "ttnn_fixed/matmuls.hpp"
+// #include "ttnn_fixed/matmuls.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 using namespace tt::constants;
@@ -27,13 +27,14 @@ void ttnn_linear_backward(
     auto reshaped_tensor = ttnn::reshape(
         tensor_value, ttnn::Shape({static_cast<uint32_t>(volume_without_features), tensor_value.logical_shape()[-1]}));
 
+    using ttnn::operations::matmul::matmul_full_grid_precise;
     auto reshaped_grad = ttnn::reshape(
         out->get_grad(),
         ttnn::Shape({static_cast<uint32_t>(volume_without_features), out->get_grad().logical_shape()[-1]}));
     auto reshaped_weight_grad =
-        ttnn_fixed::matmul(reshaped_grad, reshaped_tensor, /* transpose_a */ true, /* transpose_b */ false);
+        matmul_full_grid_precise(reshaped_grad, reshaped_tensor, /* transpose_a */ true, /* transpose_b */ false);
     auto reshaped_tensor_grad =
-        ttnn_fixed::matmul(reshaped_grad, weight->get_value(), /* transpose_a */ false, /* transpose_b */ false);
+        matmul_full_grid_precise(reshaped_grad, weight->get_value(), /* transpose_a */ false, /* transpose_b */ false);
     if (bias) {
         auto reshaped_bias_grad = ttnn_fixed::sum_over_dim(reshaped_grad, /* axis */ 0);
         auto bias_grad = ttnn::reshape(reshaped_bias_grad, bias->get_value().logical_shape());

--- a/tt-train/sources/ttml/ops/linear_op.cpp
+++ b/tt-train/sources/ttml/ops/linear_op.cpp
@@ -9,7 +9,6 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "core/compute_kernel_config.hpp"
-// #include "ttnn_fixed/matmuls.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
 using namespace tt::constants;

--- a/tt-train/sources/ttml/ops/matmul_op.cpp
+++ b/tt-train/sources/ttml/ops/matmul_op.cpp
@@ -12,7 +12,8 @@ namespace ttml::ops {
 autograd::TensorPtr matmul_op(
     const autograd::TensorPtr& a, const autograd::TensorPtr& b, bool transpose_a, bool transpose_b) {
     auto out = autograd::create_tensor();
-    auto res = ttnn_fixed::matmul(a->get_value(), b->get_value(), transpose_a, transpose_b);
+    auto res =
+        ttnn::operations::matmul::matmul_full_grid_precise(a->get_value(), b->get_value(), transpose_a, transpose_b);
     out->set_value(res);
 
     autograd::GradFunction grad = [a, b, out, transpose_a, transpose_b]() {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -17,6 +17,7 @@
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::matmul {
 
@@ -319,6 +320,32 @@ Tensor matmul(
         /*bias=*/std::nullopt,
         matmul_params,
         optional_output_tensor);
+}
+
+Tensor matmul_full_grid_precise(
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool transpose_a, bool transpose_b) {
+    const auto grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
+    auto core_grid = std::make_optional<ttnn::CoreGrid>(grid_size.x, grid_size.y);
+
+    const ttnn::WormholeComputeKernelConfig matmul_config{
+        .math_fidelity = MathFidelity::HiFi4,
+        .math_approx_mode = false,
+        .fp32_dest_acc_en = true,
+        .packer_l1_acc = true};
+
+    return matmul(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a,
+        transpose_b,
+        /* memory_config */ std::nullopt,
+        /* dtype */ std::nullopt,
+        /* program_config */ std::nullopt,
+        /* activation */ std::nullopt,
+        /* compute_kernel_config */
+        // like in ttml::core::ComputeKernelConfig::matmul(),
+        std::make_optional<DeviceComputeKernelConfig>(matmul_config),
+        /* core_grid */ core_grid);
 }
 
 Tensor linear(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -17,7 +17,6 @@
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp"
-#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::operations::matmul {
 
@@ -327,6 +326,7 @@ Tensor matmul_full_grid_precise(
     const auto grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
     auto core_grid = std::make_optional<ttnn::CoreGrid>(grid_size.x, grid_size.y);
 
+    // like in ttml::core::ComputeKernelConfig::matmul()
     const ttnn::WormholeComputeKernelConfig matmul_config{
         .math_fidelity = MathFidelity::HiFi4,
         .math_approx_mode = false,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -45,6 +45,9 @@ Tensor matmul(
     const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
 
+Tensor matmul_full_grid_precise(
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, bool transpose_a = false, bool transpose_b = false);
+
 std::vector<Tensor> matmul_batched_weights(
     const Tensor& input_tensor_a,
     const std::vector<Tensor>& input_tensors_b,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/ttnn_fixed/move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/ttnn_fixed/move)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
