### PR TITLE
[skip ci] Bump dev tag from bigger from semver and rc tag

### DIFF
--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -36,20 +36,36 @@ runs:
       run: |
         # Get all tags matching exact semver format v{number}.{number}.{number} excluding any with dashes
         tags=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '-' || true)
+
+        # Get all rc tags matching exact semver-rc format v{number}.{number}.{number}-rc{number} excluding any with dashes
+        rc-tags=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$' || true)
+
         if [ -z "$tags" ]; then
           echo "No semver tags found, using v0.0.0"
           latest_semver="v0.0.0"
         else
           latest_semver=$(echo "$tags" | sort -V | tail -1)
         fi
+
+        if [ -z "$rc-tags" ]; then
+          echo "No semver tags found, using v0.0.0"
+          latest_rc="v0.0.0"
+        else
+          latest_rc=$(echo "$rc-tags" | sort -V | tail -1)
+        fi
+
         echo "Latest semver tag: $latest_semver"
         echo "latest_semver=$latest_semver" >> "$GITHUB_OUTPUT"
+
+        echo "Latest rc tag: $latest_rc"
+        echo "latest_rc=$latest_rc" >> "$GITHUB_OUTPUT"
 
     - name: Analyze commits for version bump
       id: analyze-commits
       shell: bash
       run: |
         latest_tag="${{ steps.get-latest-semver.outputs.latest_semver }}"
+        latest_rc="${{ steps.get-latest-semver.outputs.latest_rc }}"
         force_bump="${{ inputs.force-bump-type }}"
         ignore_commits="${{ inputs.ignore-commits }}"
 
@@ -58,7 +74,7 @@ runs:
           echo "Using forced bump type: $force_bump"
           bump_type="$force_bump"
         else
-          echo "Analyzing commits since $latest_tag"
+          echo "Analyzing commits since $latest_tag and $latest_rc for version bump indicators"
 
           # Get commit messages and SHAs since the latest tag
           if [ "$latest_tag" = "v0.0.0" ]; then
@@ -124,20 +140,46 @@ runs:
       shell: bash
       run: |
         latest_tag="${{ steps.get-latest-semver.outputs.latest_semver }}"
+        latest_rc="${{ steps.get-latest-semver.outputs.latest_rc }}"
         bump_type="${{ steps.analyze-commits.outputs.bump_type }}"
         tag_type="${{ inputs.tag-type }}"
 
         if [ "$tag_type" = "dev" ]; then
           echo "Dev tag type - forcing minor version bump"
-          # Extract version numbers (remove 'v' prefix) for dev minor bump
-          version_no_v=${latest_tag#v}
-          IFS='.' read -r major minor patch <<< "$version_no_v"
+          echo "latest_tag=$latest_tag"
+          echo "latest_rc=$latest_rc"
 
-          # Always increment minor version for dev tags
+          # Parse semver: vX.Y.Z
+          semver_no_v="${latest_tag#v}"
+          IFS='.' read -r s_major s_minor s_patch <<< "$semver_no_v"
+
+          # Parse rc: vX.Y.Z-rcN  (we only care about X.Y.Z for "bigger version" decision)
+          rc_no_v="${latest_rc#v}"
+          rc_core="${rc_no_v%%-*}"   # X.Y.Z
+          IFS='.' read -r r_major r_minor r_patch <<< "$rc_core"
+
+          # Choose the bigger base version by comparing (major, minor, patch)
+          use_rc=0
+          if   [ "$r_major" -gt "$s_major" ]; then use_rc=1
+          elif [ "$r_major" -eq "$s_major" ] && [ "$r_minor" -gt "$s_minor" ]; then use_rc=1
+          elif [ "$r_major" -eq "$s_major" ] && [ "$r_minor" -eq "$s_minor" ] && [ "$r_patch" -gt "$s_patch" ]; then use_rc=1
+          else
+            use_rc=0
+          fi
+
+          if [ "$use_rc" -eq 1 ]; then
+            echo "Using RC base version (bigger core): v${r_major}.${r_minor}.${r_patch}"
+            major="$r_major"; minor="$r_minor"; patch="$r_patch"
+          else
+            echo "Using SemVer base version (>= RC core): v${s_major}.${s_minor}.${s_patch}"
+            major="$s_major"; minor="$s_minor"; patch="$s_patch"
+          fi
+
+          # Always increment minor for dev tags
           minor=$((minor + 1))
           patch=0
 
-          new_version="v$major.$minor.$patch"
+          new_version="v${major}.${minor}.${patch}"
           echo "Dev version calculated: $new_version"
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -38,7 +38,7 @@ runs:
         tags=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '-' || true)
 
         # Get all rc tags matching exact semver-rc format v{number}.{number}.{number}-rc{number} excluding any with dashes
-        rc-tags=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$' || true)
+        rc_tags=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$' || true)
 
         if [ -z "$tags" ]; then
           echo "No semver tags found, using v0.0.0"
@@ -47,11 +47,11 @@ runs:
           latest_semver=$(echo "$tags" | sort -V | tail -1)
         fi
 
-        if [ -z "$rc-tags" ]; then
+        if [ -z "$rc_tags" ]; then
           echo "No semver tags found, using v0.0.0"
           latest_rc="v0.0.0"
         else
-          latest_rc=$(echo "$rc-tags" | sort -V | tail -1)
+          latest_rc=$(echo "$rc_tags" | sort -V | tail -1)
         fi
 
         echo "Latest semver tag: $latest_semver"

--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -48,8 +48,8 @@ runs:
         fi
 
         if [ -z "$rc_tags" ]; then
-          echo "No semver tags found, using v0.0.0"
-          latest_rc="v0.0.0"
+          echo "No rc tags found, using v0.0.0"
+          latest_rc="v0.0.0-rc0"
         else
           latest_rc=$(echo "$rc_tags" | sort -V | tail -1)
         fi

--- a/.github/workflows/test-action-calculate-version.yml
+++ b/.github/workflows/test-action-calculate-version.yml
@@ -902,10 +902,203 @@ jobs:
           echo "  - Force bump type to none"
           echo "  - Ignore commits using short SHA"
 
+  test-dev-tag-rc-comparison:
+    name: Test Dev Tag RC vs Semver Comparison
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup git
+        run: |
+          git config user.name "Test User"
+          git config user.email "test@example.com"
+
+      # Test 1: RC tag is bigger than semver tag
+      - name: Test 1 - RC tag bigger than semver (v1.5.0 vs v1.5.0-rc3)
+        run: |
+          git tag v1.4.0
+          git tag v1.5.0-rc1
+          git tag v1.5.0-rc2
+          git tag v1.5.0-rc3
+          echo "Created tags: v1.4.0 (semver), v1.5.0-rc1, rc2, rc3"
+
+      - name: Dev tag should bump from bigger RC tag
+        id: test-dev-from-bigger-rc
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev bumps from bigger RC
+        run: |
+          echo "Dev tag from bigger RC results:"
+          echo "  Latest semver: ${{ steps.test-dev-from-bigger-rc.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-from-bigger-rc.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-from-bigger-rc.outputs.final_version }}"
+
+          # Should use v1.5.0 (from rc) and bump minor -> v1.6.0
+          if [ "${{ steps.test-dev-from-bigger-rc.outputs.new_version }}" != "v1.6.0" ]; then
+            echo "❌ FAILED: Expected v1.6.0 but got ${{ steps.test-dev-from-bigger-rc.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly bumped from bigger RC tag"
+
+      # Test 2: Semver tag is bigger than RC tag
+      - name: Test 2 - Semver tag bigger than RC (v2.0.0 vs v1.9.0-rc5)
+        run: |
+          git tag -d $(git tag -l) || true
+          git tag v1.9.0-rc1
+          git tag v1.9.0-rc5
+          git tag v2.0.0
+          echo "Created tags: v1.9.0-rc1, rc5 (rc), v2.0.0 (semver)"
+
+      - name: Dev tag should bump from bigger semver
+        id: test-dev-from-bigger-semver
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev bumps from bigger semver
+        run: |
+          echo "Dev tag from bigger semver results:"
+          echo "  Latest semver: ${{ steps.test-dev-from-bigger-semver.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-from-bigger-semver.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-from-bigger-semver.outputs.final_version }}"
+
+          # Should use v2.0.0 (semver, bigger) and bump minor -> v2.1.0
+          if [ "${{ steps.test-dev-from-bigger-semver.outputs.new_version }}" != "v2.1.0" ]; then
+            echo "❌ FAILED: Expected v2.1.0 but got ${{ steps.test-dev-from-bigger-semver.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly bumped from bigger semver tag"
+
+      # Test 3: RC and semver are equal (same major.minor.patch)
+      - name: Test 3 - RC and semver equal version numbers (v3.2.1-rc2 vs v3.2.1)
+        run: |
+          git tag -d $(git tag -l) || true
+          git tag v3.2.0
+          git tag v3.2.1-rc1
+          git tag v3.2.1-rc2
+          git tag v3.2.1
+          echo "Created tags: v3.2.0, v3.2.1-rc1, rc2 (rc equal), v3.2.1 (semver)"
+
+      - name: Dev tag with equal versions should use semver
+        id: test-dev-equal-versions
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev uses semver when versions equal
+        run: |
+          echo "Dev tag with equal versions results:"
+          echo "  Latest semver: ${{ steps.test-dev-equal-versions.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-equal-versions.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-equal-versions.outputs.final_version }}"
+
+          # Should use v3.2.1 (semver, when equal prefer semver) and bump minor -> v3.3.0
+          if [ "${{ steps.test-dev-equal-versions.outputs.new_version }}" != "v3.3.0" ]; then
+            echo "❌ FAILED: Expected v3.3.0 but got ${{ steps.test-dev-equal-versions.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly uses semver when versions equal"
+
+      # Test 4: RC major version bigger
+      - name: Test 4 - RC major version bigger (v1.9.9 vs v2.0.0-rc1)
+        run: |
+          git tag -d $(git tag -l) || true
+          git tag v1.9.9
+          git tag v2.0.0-rc1
+          echo "Created tags: v1.9.9 (semver), v2.0.0-rc1 (rc, bigger major)"
+
+      - name: Dev tag should bump from RC with bigger major
+        id: test-dev-rc-bigger-major
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev bumps from RC with bigger major
+        run: |
+          echo "Dev tag from RC bigger major results:"
+          echo "  Latest semver: ${{ steps.test-dev-rc-bigger-major.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-rc-bigger-major.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-rc-bigger-major.outputs.final_version }}"
+
+          # Should use v2.0.0 (from rc, bigger major) and bump minor -> v2.1.0
+          if [ "${{ steps.test-dev-rc-bigger-major.outputs.new_version }}" != "v2.1.0" ]; then
+            echo "❌ FAILED: Expected v2.1.0 but got ${{ steps.test-dev-rc-bigger-major.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly bumped from RC with bigger major"
+
+      # Test 5: RC minor version bigger (same major)
+      - name: Test 5 - RC minor version bigger (v2.5.0 vs v2.6.0-rc1)
+        run: |
+          git tag -d $(git tag -l) || true
+          git tag v2.5.0
+          git tag v2.6.0-rc1
+          echo "Created tags: v2.5.0 (semver), v2.6.0-rc1 (rc, bigger minor)"
+
+      - name: Dev tag should bump from RC with bigger minor
+        id: test-dev-rc-bigger-minor
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev bumps from RC with bigger minor
+        run: |
+          echo "Dev tag from RC bigger minor results:"
+          echo "  Latest semver: ${{ steps.test-dev-rc-bigger-minor.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-rc-bigger-minor.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-rc-bigger-minor.outputs.final_version }}"
+
+          # Should use v2.6.0 (from rc, bigger minor) and bump minor -> v2.7.0
+          if [ "${{ steps.test-dev-rc-bigger-minor.outputs.new_version }}" != "v2.7.0" ]; then
+            echo "❌ FAILED: Expected v2.7.0 but got ${{ steps.test-dev-rc-bigger-minor.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly bumped from RC with bigger minor"
+
+      # Test 6: RC patch version bigger (same major.minor)
+      - name: Test 6 - RC patch version bigger (v3.1.5 vs v3.1.6-rc1)
+        run: |
+          git tag -d $(git tag -l) || true
+          git tag v3.1.5
+          git tag v3.1.6-rc1
+          echo "Created tags: v3.1.5 (semver), v3.1.6-rc1 (rc, bigger patch)"
+
+      - name: Dev tag should bump from RC with bigger patch
+        id: test-dev-rc-bigger-patch
+        uses: ./.github/actions/calculate-version
+        with:
+          tag-type: "dev"
+
+      - name: Verify dev bumps from RC with bigger patch
+        run: |
+          echo "Dev tag from RC bigger patch results:"
+          echo "  Latest semver: ${{ steps.test-dev-rc-bigger-patch.outputs.latest_semver }}"
+          echo "  New version: ${{ steps.test-dev-rc-bigger-patch.outputs.new_version }}"
+          echo "  Final version: ${{ steps.test-dev-rc-bigger-patch.outputs.final_version }}"
+
+          # Should use v3.1.6 (from rc, bigger patch) and bump minor -> v3.2.0
+          if [ "${{ steps.test-dev-rc-bigger-patch.outputs.new_version }}" != "v3.2.0" ]; then
+            echo "❌ FAILED: Expected v3.2.0 but got ${{ steps.test-dev-rc-bigger-patch.outputs.new_version }}"
+            exit 1
+          fi
+
+          echo "✅ PASS: Dev tag correctly bumped from RC with bigger patch"
+
   final-test-summary:
     name: Final Test Summary
     runs-on: ubuntu-latest
-    needs: [test-calculate-version, test-version-bumping, test-dev-tag-versioning, test-dev-tag-consistency, test-edge-cases, integration-test, test-force-bump-and-ignore-commits]
+    needs: [test-calculate-version, test-version-bumping, test-dev-tag-versioning, test-dev-tag-consistency, test-edge-cases, integration-test, test-force-bump-and-ignore-commits, test-dev-tag-rc-comparison]
     steps:
       - name: Test summary
         run: |

--- a/.github/workflows/test-action-calculate-version.yml
+++ b/.github/workflows/test-action-calculate-version.yml
@@ -918,7 +918,7 @@ jobs:
           git config user.email "test@example.com"
 
       # Test 1: RC tag is bigger than semver tag
-      - name: Test 1 - RC tag bigger than semver (v1.5.0 vs v1.5.0-rc3)
+      - name: Test 1 - RC tag bigger than semver (v1.4.0 vs v1.5.0-rc3)
         run: |
           git tag v1.4.0
           git tag v1.5.0-rc1


### PR DESCRIPTION
### Problem description
Currently dev tag is bump after full release, we want to bump it after first rc

### What's changed
Calculate what is bigger between semver tag and rc tag. Bump bigger one

