### PR TITLE
[#37052] Merge cluster configs and allow overlapping hostnames for intra pod config merge

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -176,6 +176,9 @@ public:
     // Method to emit merged cabling descriptor
     void emit_cabling_descriptor(const std::string& output_path) const;
 
+    // Method to emit deployment descriptor (one host per node in host_id order; use for merged output)
+    void emit_deployment_descriptor(const std::string& output_path) const;
+
 private:
     // Track which node_descriptors were explicitly present in source files (not inferred)
     std::unordered_set<std::string> explicit_node_descriptors_;

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -13,11 +13,14 @@ Usage:
         --deployment1 <path> \
         [--deployment2 <path>] \
         --output-dir <path> \
-        [--temp-dir <path>]
+        [--temp-dir <path>] \
+        [--build-dir <name>]
 
   deployment1 is required (first cluster: cabling + deployment).
   deployment2 is optional; if omitted, the merged deployment is deployment1 only
   (use when merging with a cabling-only second cluster).
+  build-dir optionally specifies which build directory to use (e.g., build_Release,
+  build_Debug). If not specified, searches common build directories automatically.
 
 Generates in output-dir:
     - merged_fsd.textproto

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -11,9 +11,13 @@ Usage:
         --cabling1 <path> \
         --cabling2 <path> \
         --deployment1 <path> \
-        --deployment2 <path> \
+        [--deployment2 <path>] \
         --output-dir <path> \
         [--temp-dir <path>]
+
+  deployment1 is required (first cluster: cabling + deployment).
+  deployment2 is optional; if omitted, the merged deployment is deployment1 only
+  (use when merging with a cabling-only second cluster).
 
 Generates in output-dir:
     - merged_fsd.textproto
@@ -46,8 +50,9 @@ def merge_deployment_descriptors(dep1_path, dep2_path, output_path):
 
 
 def run_cabling_generator(cabling_dir, deployment_path, output_fsd, work_dir):
-    script_dir = Path(__file__).parent
-    repo_root = script_dir.parent.parent
+    script_dir = Path(__file__).resolve().parent
+    # Script lives at tools/scaleout/cabling_generator/merge_cluster_configs.py -> repo root is 3 levels up
+    repo_root = script_dir.parent.parent.parent
 
     cabling_gen = repo_root / "build_Release" / "tools" / "scaleout" / "run_cabling_generator"
     if not cabling_gen.exists():
@@ -67,6 +72,7 @@ def run_cabling_generator(cabling_dir, deployment_path, output_fsd, work_dir):
 
     generated_fsd = repo_root / "out" / "scaleout" / "factory_system_descriptor_merged.textproto"
     generated_cabling = repo_root / "out" / "scaleout" / "cabling_descriptor_merged.textproto"
+    generated_deployment = repo_root / "out" / "scaleout" / "deployment_descriptor_merged.textproto"
 
     if not generated_fsd.exists():
         print(f"Error: Output file not found: {generated_fsd}", file=sys.stderr)
@@ -77,8 +83,10 @@ def run_cabling_generator(cabling_dir, deployment_path, output_fsd, work_dir):
     if generated_cabling.exists():
         cabling_output = Path(str(output_fsd).replace("merged_fsd", "merged_cabling_descriptor"))
         shutil.copy(generated_cabling, cabling_output)
-        return True
-    return False
+
+    # Return path to C++-generated deployment descriptor (one host per node, no duplicates)
+    # or None if not produced (fallback to concatenated temp file)
+    return generated_deployment if generated_deployment.exists() else None
 
 
 def count_nodes(deployment_path):
@@ -90,21 +98,21 @@ def main():
     parser = argparse.ArgumentParser(description="Merge two cluster configurations.")
     parser.add_argument("--cabling1", required=True, help="First cabling_descriptor.textproto")
     parser.add_argument("--cabling2", required=True, help="Second cabling_descriptor.textproto")
-    parser.add_argument("--deployment1", required=True, help="First deployment_descriptor.textproto")
-    parser.add_argument("--deployment2", required=True, help="Second deployment_descriptor.textproto")
+    parser.add_argument("--deployment1", required=True, help="First deployment_descriptor.textproto (required)")
+    parser.add_argument(
+        "--deployment2",
+        default=None,
+        help="Second deployment_descriptor.textproto (optional; if omitted, merged deployment is deployment1 only)",
+    )
     parser.add_argument("--output-dir", "-o", required=True, help="Output directory")
     parser.add_argument("--temp-dir", default=None, help="Temporary directory")
 
     args = parser.parse_args()
 
-    validate_files(
-        {
-            "cabling1": args.cabling1,
-            "cabling2": args.cabling2,
-            "deployment1": args.deployment1,
-            "deployment2": args.deployment2,
-        }
-    )
+    files_to_validate = {"cabling1": args.cabling1, "cabling2": args.cabling2, "deployment1": args.deployment1}
+    if args.deployment2 is not None:
+        files_to_validate["deployment2"] = args.deployment2
+    validate_files(files_to_validate)
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -125,15 +133,24 @@ def main():
         shutil.copy(args.cabling2, cabling_dir / "cluster2_cabling.textproto")
 
         merged_deployment = temp_dir / "merged_deployment_descriptor.textproto"
-        merge_deployment_descriptors(args.deployment1, args.deployment2, merged_deployment)
+        if args.deployment2 is not None:
+            merge_deployment_descriptors(args.deployment1, args.deployment2, merged_deployment)
+        else:
+            shutil.copy(args.deployment1, merged_deployment)
 
         merged_fsd = output_dir / "merged_fsd.textproto"
-        run_cabling_generator(str(cabling_dir), str(merged_deployment), str(merged_fsd), temp_dir)
+        generated_deployment_path = run_cabling_generator(
+            str(cabling_dir), str(merged_deployment), str(merged_fsd), temp_dir
+        )
 
         final_deployment = output_dir / "merged_deployment_descriptor.textproto"
-        shutil.copy(merged_deployment, final_deployment)
+        if generated_deployment_path is not None:
+            # Use C++-generated deployment (one host per node in host_id order, no duplicates)
+            shutil.copy(generated_deployment_path, final_deployment)
+        else:
+            shutil.copy(merged_deployment, final_deployment)
 
-        total_nodes = count_nodes(str(merged_deployment))
+        total_nodes = count_nodes(str(final_deployment))
         print(f"Merged {total_nodes} nodes")
         print(f"Output: {output_dir}")
 

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -161,6 +161,7 @@ int main(int argc, char** argv) {
         std::string factory_output = "out/scaleout/factory_system_descriptor" + config.output_name + ".textproto";
         std::string cabling_output = "out/scaleout/cabling_guide" + config.output_name + ".csv";
         std::string cabling_desc_output = "out/scaleout/cabling_descriptor" + config.output_name + ".textproto";
+        std::string deployment_output = "out/scaleout/deployment_descriptor" + config.output_name + ".textproto";
 
         // Ensure output directory exists
         std::filesystem::create_directories("out/scaleout");
@@ -175,10 +176,14 @@ int main(int argc, char** argv) {
         std::cout << "Generating merged cabling descriptor..." << std::endl;
         cabling_generator.emit_cabling_descriptor(cabling_desc_output);
 
+        std::cout << "Generating deployment descriptor..." << std::endl;
+        cabling_generator.emit_deployment_descriptor(deployment_output);
+
         std::cout << "Successfully generated:" << std::endl;
         std::cout << "  - " << factory_output << std::endl;
         std::cout << "  - " << cabling_output << std::endl;
         std::cout << "  - " << cabling_desc_output << std::endl;
+        std::cout << "  - " << deployment_output << std::endl;
 
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37052

### Problem description

- Merging two clusters with overlapping hostnames created duplicate hosts instead of recognizing them as the same physical machine
- The --deployment2 argument was required even when merging with a cabling-only cluster that has no deployment info
- Path resolution bug prevented the script from finding the run_cabling_generator binary


### What's changed
- Hostname-based deduplication: Same hostname in both clusters now maps to the same host_id, eliminating duplicates in the merged deployment descriptor
- Optional deployment2: Made --deployment2 optional; the C++ generator now emits a clean deployment_descriptor_merged.textproto with correct ordering
- Bug fixes: Fixed path resolution, null check ordering, write validation, build directory detection, and replaced std::function with self-passing lambdas

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jpanasiuk/allow_single_depl_desc_merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jpanasiuk/allow_single_depl_desc_merge)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/allow_single_depl_desc_merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/allow_single_depl_desc_merge)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/allow_single_depl_desc_merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/allow_single_depl_desc_merge)
- [ ] New/Existing tests provide coverage for changes