### PR TITLE
Integrate mul_reduce_scalar into RMSNorm for Deepseek Blitz

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -56,13 +56,9 @@ void kernel_main() {
             "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
     };
 
-    using KV_RMSNormCTArgs =
-        deepseek_b1_ops::RMSNorm::ReaderCTArgs<get_named_compile_time_arg_val("kv_rmsnorm_num_faces")>;
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
     // kv cache rmsnorm reader args
-    deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{
-        get_named_compile_time_arg_val("kv_rmsnorm_scalars_cb"),
-        get_arg_val<uint32_t>(0),  // scalar (1/sqrt(512)) #TODO: fix id when used in pre sdpa
-    };
+    deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{};
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<get_named_compile_time_arg_val("Wt")>;
     constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
@@ -134,11 +130,10 @@ void kernel_main() {
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
         get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_scalars_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_interm_cb"),
         get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
         get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         get_arg_val<uint32_t>(0),  // epsilon
+        get_arg_val<float>(1),     // scalar (1/sqrt(512))
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::ComputeCTArgs<get_named_compile_time_arg_val("Wt")>;

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
@@ -85,6 +85,14 @@ inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(src_index);
     rmsnorm_bcast_scalar_reuse_dest_as_src();
+    if constexpr (clear_dest) {
+        if constexpr (Dst == DstSync::SyncFull) {
+            TT_ZEROACC(p_zeroacc::CLR_ALL, is_fp32_dest_acc_en, 0, ADDR_MOD_1, 0);
+        } else {
+            static_assert(Dst == DstSync::SyncHalf);
+            TT_ZEROACC(p_zeroacc::CLR_HALF, is_fp32_dest_acc_en, 0, ADDR_MOD_1, dest_offset_id);
+        }
+    }
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
     if constexpr ((eltwise_binary_type == ELWADD) || (eltwise_binary_type == ELWSUB)) {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_rmsnorm_bcast_scalar_dest_reuse_api.h
@@ -25,12 +25,14 @@ template <
     EltwiseBinaryType eltwise_binary_type,
     uint32_t num_tiles,
     bool is_fp32_dest_acc_en,
-    int NUM_FIDELITY_PHASES = 0>
+    int NUM_FIDELITY_PHASES = 0,
+    bool clear_dest = false>
 inline void llk_math_rmsnorm_bcast_scalar_dest_reuse(const std::uint32_t src_index, const std::uint32_t dst_index) {
     _llk_math_rmsnorm_bcast_scalar_dest_reuse_<
         eltwise_binary_type,
         num_tiles,
         DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        NUM_FIDELITY_PHASES>(src_index, dst_index);
+        NUM_FIDELITY_PHASES,
+        clear_dest>(src_index, dst_index);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/rmsnorm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/rmsnorm.h
@@ -23,13 +23,17 @@ ALWI void rmsnorm_bcast_scalar_reuse_tiles_init(uint32_t icb0) {
         icb0, icb0, false)));
 }
 
-template <EltwiseBinaryType eltwise_binary_type = ELWADD, uint32_t num_tiles>
+template <EltwiseBinaryType eltwise_binary_type = ELWADD, uint32_t num_tiles, bool clear_dest = false>
 ALWI void rmsnorm_bcast_scalar_reuse_tiles(
     uint32_t in_cb_id, uint32_t in_tile_index, uint32_t src_tile_index, uint32_t dst_tile_index) {
     UNPACK(
         (llk_unpack_A<BroadcastType::SCALAR, true, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(in_cb_id, in_tile_index)));
-    MATH((llk_math_rmsnorm_bcast_scalar_dest_reuse<eltwise_binary_type, num_tiles, DST_ACCUM_MODE, MATH_FIDELITY>(
-        src_tile_index, dst_tile_index)));
+    MATH((llk_math_rmsnorm_bcast_scalar_dest_reuse<
+          eltwise_binary_type,
+          num_tiles,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          clear_dest>(src_tile_index, dst_tile_index)));
 }
 
 template <uint32_t num_tiles>
@@ -37,9 +41,10 @@ ALWI void rmsnorm_mul_bcast_scalar_reuse_tiles_init(uint32_t icb0) {
     rmsnorm_bcast_scalar_reuse_tiles_init<ELWMUL, num_tiles>(icb0);
 }
 
-template <uint32_t num_tiles>
+template <uint32_t num_tiles, bool clear_dest = false>
 ALWI void rmsnorm_mul_bcast_scalar_reuse_tiles(
     uint32_t in_cb_id, uint32_t in_tile_index, uint32_t src_tile_index, uint32_t dst_tile_index) {
-    rmsnorm_bcast_scalar_reuse_tiles<ELWMUL, num_tiles>(in_cb_id, in_tile_index, src_tile_index, dst_tile_index);
+    rmsnorm_bcast_scalar_reuse_tiles<ELWMUL, num_tiles, clear_dest>(
+        in_cb_id, in_tile_index, src_tile_index, dst_tile_index);
 }
 }  // namespace ckernel

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
@@ -23,25 +23,21 @@ void kernel_main() {
 // ============================================================================
 #if defined(COMPILE_FOR_NCRISC)
     // CTArgs type alias (required for Op template)
-    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs<get_named_compile_time_arg_val("rmsnorm_num_faces")>;
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
 
     // Named compile-time args
     constexpr uint32_t input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-    constexpr uint32_t scalars_cb = get_named_compile_time_arg_val("rmsnorm_scalars_cb");
     constexpr uint32_t gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
     constexpr uint32_t num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
 
     // Setup sharded persistent buffers (input and gamma are backed by L1 shards)
     if constexpr (Core::is_active_core) {
-        unified_kernels::setup_sharded_buffer(input_cb, num_tiles);
         unified_kernels::setup_sharded_buffer(gamma_cb, num_tiles);
+        unified_kernels::setup_sharded_buffer(input_cb, num_tiles);
     }
 
-    // Reader args: scalars_cb and scalar (1/sqrt(num_elements))
-    deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{
-        scalars_cb,
-        get_arg_val<uint32_t>(0),  // scalar (1/sqrt(num_elements))
-    };
+    // Reader args: none needed
+    deepseek_b1_ops::RMSNorm::ReaderArgs rmsnorm_args{};
 
 #elif defined(COMPILE_FOR_BRISC)
     // CTArgs type alias (required for Op template)
@@ -59,19 +55,16 @@ void kernel_main() {
 
     // Named compile-time args
     constexpr uint32_t input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-    constexpr uint32_t scalars_cb = get_named_compile_time_arg_val("rmsnorm_scalars_cb");
-    constexpr uint32_t interm_cb = get_named_compile_time_arg_val("rmsnorm_interm_cb");
     constexpr uint32_t gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
     constexpr uint32_t output_cb = get_named_compile_time_arg_val("rmsnorm_output_cb");
 
     // Compute args
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
         .input_cb = input_cb,
-        .scalars_cb = scalars_cb,
-        .interm_cb = interm_cb,
         .gamma_cb = gamma_cb,
         .output_cb = output_cb,
         .epsilon = get_arg_val<uint32_t>(0),  // epsilon
+        .scalar = get_arg_val<float>(1),   // scalar (1/sqrt(num_elements))
     };
 #endif
 

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
@@ -11,7 +11,7 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
-from models.demos.deepseek_v3_b1.utils import float_to_bfloat16_packed, float_to_uint32
+from models.demos.deepseek_v3_b1.utils import float_to_uint32
 
 
 class RMSNormSingleCore:
@@ -96,17 +96,15 @@ class RMSNormSingleCore:
 
         # Compute 1/sqrt(num_elements) for RMS reduction
         inv_sqrt_numel = 1.0 / math.sqrt(float(numel))
-        scalar_packed = float_to_bfloat16_packed(inv_sqrt_numel)
+        scalar_packed = float_to_uint32(inv_sqrt_numel)
 
         # Define circular buffer page size
         cb_page_size = tile_size
 
         # CB indices
         input_cb = 0
-        scalars_cb = 1
-        interm_cb = 2
-        gamma_cb = 3
-        output_cb = 4
+        gamma_cb = 1
+        output_cb = 2
 
         # Create tile descriptor for proper tile dimensions
         tile_descriptor = ttnn.TileDescriptor(interpreted_tile)
@@ -117,32 +115,6 @@ class RMSNormSingleCore:
         # Update the tile descriptor in the format descriptor
         in_cb_descriptor.format_descriptors[0].tile = tile_descriptor
         in_cb_descriptor.format_descriptors[0].page_size = cb_page_size
-
-        # CB 1: Scalars (epsilon and reduction scalar)
-        scalars_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=scalars_cb,
-            data_format=data_format,
-            page_size=cb_page_size,
-            tile=tile_descriptor,
-        )
-        scalars_cb_descriptor = ttnn.CBDescriptor(
-            total_size=cb_page_size,
-            core_ranges=core_grid,
-            format_descriptors=[scalars_cb_format],
-        )
-
-        # CB 2: Intermediate buffer
-        interm_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=interm_cb,
-            data_format=data_format,
-            page_size=cb_page_size,
-            tile=tile_descriptor,
-        )
-        interm_cb_descriptor = ttnn.CBDescriptor(
-            total_size=num_tiles * cb_page_size,
-            core_ranges=core_grid,
-            format_descriptors=[interm_cb_format],
-        )
 
         # CB 3: Gamma (created from sharded tensor)
         gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gamma_cb, gamma_tensor)
@@ -159,7 +131,6 @@ class RMSNormSingleCore:
         # Named compile-time args for NCRISC (reader)
         ncrisc_named_compile_time_args = [
             ("rmsnorm_input_cb", input_cb),
-            ("rmsnorm_scalars_cb", scalars_cb),
             ("rmsnorm_gamma_cb", gamma_cb),
             ("rmsnorm_num_tiles", num_tiles),
             ("rmsnorm_num_faces", num_faces),
@@ -168,8 +139,6 @@ class RMSNormSingleCore:
         # Named compile-time args for TRISC (compute)
         trisc_named_compile_time_args = [
             ("rmsnorm_input_cb", input_cb),
-            ("rmsnorm_scalars_cb", scalars_cb),
-            ("rmsnorm_interm_cb", interm_cb),
             ("rmsnorm_gamma_cb", gamma_cb),
             ("rmsnorm_output_cb", output_cb),
             ("rmsnorm_fp32_acc", 1 if fp32_dest_acc_en else 0),
@@ -184,8 +153,7 @@ class RMSNormSingleCore:
             ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
             brisc_named_compile_time_args=[],
             trisc_named_compile_time_args=trisc_named_compile_time_args,
-            ncrisc_common_runtime_args=[scalar_packed],
-            trisc_common_runtime_args=[epsilon_packed],
+            trisc_common_runtime_args=[epsilon_packed, scalar_packed],
             trisc_compute_config=ttnn.ComputeConfigDescriptor(
                 math_fidelity=ttnn.MathFidelity.LoFi,
                 math_approx_mode=False,
@@ -205,7 +173,7 @@ class RMSNormSingleCore:
         # Create program descriptor
         program_descriptor = ttnn.ProgramDescriptor(
             kernels=unified_kernel.get_kernel_descriptors(),
-            cbs=[in_cb_descriptor, scalars_cb_descriptor, interm_cb_descriptor, gamma_cb_descriptor, out_cb_descriptor],
+            cbs=[in_cb_descriptor, gamma_cb_descriptor, out_cb_descriptor],
         )
 
         # Execute generic op

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -248,13 +248,7 @@ def test_kv_cache_branch(device, epsilon, use_fp32):
     logger.info(f"Done creating TT tensors.")
     logger.info("Running KV cache branch operation...")
     ttnn_result = KVCacheBranch.op(
-        ttnn_input,
-        ttnn_W_dkv_rope,
-        ttnn_gamma,
-        tt_cos,
-        tt_sin,
-        tt_trans_replicated,
-        ttnn_output,
+        ttnn_input, ttnn_W_dkv_rope, ttnn_gamma, tt_cos, tt_sin, tt_trans_replicated, ttnn_output, epsilon, use_fp32
     )
 
     # Convert back to torch for verification

--- a/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
@@ -19,6 +19,7 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/eltwise_binary_sfpu.h"
 #include "compute_kernel_api/eltwise_unary/rsqrt.h"
+#include "compute_kernel_api/experimental/mul_reduce_scalar.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/add_rsqrt.h"
 #include "../kernel_includes/tt_metal/include/compute_kernel_api/rmsnorm.h"
 #endif
@@ -33,16 +34,13 @@ namespace deepseek_b1_ops {
 //
 // CB States:
 //   NCRISC (Reader):
-//     - Reserves: scalars_cb (1 tile: reduction scalar)
-//     - Pushes: scalars_cb (1 tile)
 //     Note: input_cb and gamma_cb setup done externally via setup_sharded_buffer
 //   BRISC: No-op (next op waits on output if needed)
 //   TRISC (Compute):
-//     - Waits: input_cb (num_tiles), scalars_cb (1), gamma_cb (num_tiles)
-//     - Reserves: interm_cb (num_tiles), output_cb (num_tiles)
+//     - Waits: input_cb (num_tiles), gamma_cb (num_tiles)
+//     - Reserves: output_cb (num_tiles)
 //     - Pushes: output_cb (num_tiles)
 //     - Pops: input_cb (num_tiles) if pop_input=true
-//     - Pops: interm_cb (used internally)
 // ============================================================================
 struct RMSNorm {
     // ========================================================================
@@ -50,11 +48,8 @@ struct RMSNorm {
     // (used as template parameters or in constexpr expressions)
     // ========================================================================
 
-    // Reader CTArgs: num_faces (used as template param in generate_reduce_scaler)
-    template <uint32_t NumFaces>
-    struct ReaderCTArgs {
-        static constexpr uint32_t num_faces = NumFaces;
-    };
+    // Reader CTArgs:none needed
+    struct ReaderCTArgs {};
 
     // Writer CTArgs: none needed
     struct WriterCTArgs {};
@@ -70,20 +65,16 @@ struct RMSNorm {
     // ========================================================================
     // Runtime args structs - different layout per RISC
     // ========================================================================
-    // Reader args (NCRISC): only scalars needed (input_cb and gamma_cb setup done externally)
-    struct ReaderArgs {
-        uint32_t scalars_cb;
-        uint32_t scalar;
-    };
+    // Reader args (NCRISC): none needed
+    struct ReaderArgs {};
     // Writer args (BRISC): none (BRISC is no-op)
     struct WriterArgs {};
     struct ComputeArgs {
         uint32_t input_cb;
-        uint32_t scalars_cb;
-        uint32_t interm_cb;
         uint32_t gamma_cb;
         uint32_t output_cb;
         uint32_t epsilon;
+        float scalar;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -102,19 +93,12 @@ struct RMSNorm {
 
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
-#if defined(COMPILE_FOR_NCRISC)
-            // ================================================================
-            // NCRISC (Reader) - ReaderConfigDescriptor compiles as NCRISC
-            // ================================================================
-            // Generate reduction scalar (1/sqrt(num_elements))
-            generate_reduce_scaler<CTArgs::num_faces>(args.scalars_cb, args.scalar);
-#elif defined(COMPILE_FOR_TRISC)
+#if defined(COMPILE_FOR_TRISC)
             // ================================================================
             // TRISC (Compute)
             // ================================================================
             // Init block done only once
             binary_op_init_common(args.input_cb, args.input_cb, args.output_cb);
-            cb_wait_front(args.scalars_cb, 1);
             cb_wait_front(args.gamma_cb, CTArgs::num_tiles);  // we don't pop, only wait once and reuse
 
             compute_rmsnorm(args);
@@ -126,40 +110,20 @@ struct RMSNorm {
             constexpr uint32_t num_tiles = CTArgs::num_tiles;
             {
                 // Square the input
-                mul_tiles_init(args.input_cb, args.input_cb);
+                mul_reduce_scalar_init(args.input_cb, args.input_cb);
                 add_rsqrt_tile_init();
                 cb_wait_front(args.input_cb, num_tiles);
-                cb_reserve_back(args.interm_cb, num_tiles);
                 tile_regs_acquire();
-                for (uint32_t i = 0; i < num_tiles; i++) {
-                    mul_tiles(args.input_cb, args.input_cb, i, i, i);
-                }
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile_block(0, args.interm_cb, num_tiles);
-                cb_push_back(args.interm_cb, num_tiles);
-                tile_regs_release();
-
-                // Calculate the avg of the sum of the squares
-                reduce_init<PoolType::SUM, ReduceDim::REDUCE_SCALAR, CTArgs::fp32_acc>(
-                    args.interm_cb, args.scalars_cb, args.interm_cb);
-                cb_wait_front(args.interm_cb, num_tiles);
-                tile_regs_acquire();
-                for (uint32_t i = 0; i < num_tiles; i++) {
-                    reduce_tile<PoolType::SUM, ReduceDim::REDUCE_SCALAR, CTArgs::fp32_acc>(
-                        args.interm_cb, args.scalars_cb, i, 0, num_tiles);
-                }
-                cb_pop_front(args.interm_cb, num_tiles);
-                cb_pop_front(args.scalars_cb, 1);  // Pop scalar tiles
-                reduce_uninit();
+                mul_reduce_scalar_tile<PoolType::SUM>(args.input_cb, args.input_cb, num_tiles, args.scalar);
+                mul_reduce_scalar_uninit();
             }
             {
-                add_rsqrt_tile<CTArgs::rsqrt_fast_approx, VectorMode::RC_custom, 1>(num_tiles, args.epsilon);
+                add_rsqrt_tile<CTArgs::rsqrt_fast_approx, VectorMode::RC_custom, 1>(0, args.epsilon);
             }
             {
                 // Multiply input by 1/RMS
                 rmsnorm_mul_bcast_scalar_reuse_tiles_init<num_tiles>(args.input_cb);
-                rmsnorm_mul_bcast_scalar_reuse_tiles<num_tiles>(args.input_cb, 0, num_tiles, 0);
+                rmsnorm_mul_bcast_scalar_reuse_tiles<num_tiles, true>(args.input_cb, 0, 0, 0);
                 if constexpr (pop_input) {
                     cb_pop_front(args.input_cb, num_tiles);
                 }

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -16,17 +16,6 @@ def float_to_bfloat16_packed(value):
     return packed
 
 
-def float_to_bfloat16_padded(value):
-    """Convert float to packed bfloat16 (one copy padded with zero in uint32)"""
-    # Convert float32 to bytes
-    float_bytes = struct.pack("f", value)
-    # Extract upper 16 bits (bfloat16 is truncated float32)
-    bf16_bytes = float_bytes[2:4]  # upper 16 bits in little-endian layout
-    # Pack one copy into uint32 (little endian)
-    packed = int.from_bytes(bf16_bytes + b"\x00\x00", byteorder="little")
-    return packed
-
-
 def float_to_uint32(value):
     """Convert float to uint32"""
     return int.from_bytes(struct.pack("f", value), byteorder="little")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
New fused mul reduce scalar api is available. This allows us to compute the Mean Square without having to pack and unpack when going between mul and reduce. This provides several benefits:

- Perf improvement since we are no longer serialized on Mul->Pack->Unpack->Red, we can directly do Mul->Red
- Reduces CB usage. We no longer need an intermediate circular buffer to store the squared values, and this API additionally generates the scaler mask within the API, which means we no longer need a scalar CB as well.

### What's changed
Integrate the new llk api into the RMSNorm kernel, and update pre_sdpa and rmsnorm op/unit tests to no longer create intermediate and scalar CBs.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/rmsnorm-mul-red2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/rmsnorm-mul-red2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/rmsnorm-mul-red2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/rmsnorm-mul-red2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/rmsnorm-mul-red2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/rmsnorm-mul-red2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/rmsnorm-mul-red2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
