### PR TITLE
[Blitz Decode] Changes to setup and teardown FD Manually

### DIFF
--- a/.github/workflows/galaxy-unit-tests-impl.yaml
+++ b/.github/workflows/galaxy-unit-tests-impl.yaml
@@ -174,6 +174,7 @@ jobs:
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
           ./build/test/tt_metal/unit_tests_device --gtest_filter="GalaxyFixture.*:TGFixture.*"
           TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshMultiCQMultiDevice*Fixture.*"
+          TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*DispatchContext*"
 
       - name: Run fabric tests
         if: ${{ matrix.test-group.model == 'fabric' }}

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
         test_mesh_events.cpp
         test_mesh_trace.cpp
         test_thread_pool.cpp
+        test_dispatch_context.cpp
         utils.cpp
 )
 

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/dispatch_context.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "impl/context/metal_context.hpp"
+#include "tests/tt_metal/distributed/utils.hpp"
+
+namespace tt::tt_metal::distributed::test {
+
+TEST(DispatchContext, TestWritesAndWorkloads) {
+    // Test using DispatchContext to turn FD on and off during runtime.
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
+    }
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape(4, 8)));
+    uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+
+    const uint32_t tiles_per_device = 512;
+    const uint32_t bytes_per_device = tiles_per_device * single_tile_size;
+    const uint32_t num_programs = 5;
+
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    std::vector<uint32_t> src_vec(bytes_per_device / sizeof(uint32_t), 0);
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    // Turn on Fast Dispatch for issuing writes.
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+
+    for (std::size_t logical_x = 0; logical_x < mesh_buffer->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < mesh_buffer->device()->num_rows(); logical_y++) {
+            WriteShard(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec, MeshCoordinate(logical_y, logical_x));
+        }
+    }
+    Finish(mesh_device_->mesh_command_queue());
+
+    // Turn off FD for running a workload and issuing reads.
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+
+    auto seed = 0;
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+        num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
+
+    for (uint32_t i = 0; i < num_programs; i++) {
+        auto random_workload = std::make_shared<MeshWorkload>();
+        random_workload->add_program(
+            MeshCoordinateRange(
+                MeshCoordinate{0, 0},
+                MeshCoordinate{mesh_buffer->device()->num_rows() - 1, mesh_buffer->device()->num_cols() - 1}),
+            std::move(*programs[i]));
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *random_workload, true);
+    }
+
+    for (std::size_t logical_x = 0; logical_x < mesh_buffer->device()->num_cols(); logical_x++) {
+        for (std::size_t logical_y = 0; logical_y < mesh_buffer->device()->num_rows(); logical_y++) {
+            std::vector<uint32_t> dst_vec = {};
+            ReadShard(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer, MeshCoordinate(logical_y, logical_x));
+            EXPECT_EQ(dst_vec, src_vec);
+        }
+    }
+}
+
+}  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -32,6 +32,10 @@ TEST(DispatchContext, TestWritesAndWorkloads) {
         GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
     }
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape(4, 8)));
+
+    // Terminating without initializing should throw
+    EXPECT_THROW(experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get()), std::runtime_error);
+
     uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
 
     DeviceLocalBufferConfig per_device_buffer_config{
@@ -81,6 +85,9 @@ TEST(DispatchContext, TestWritesAndWorkloads) {
             EXPECT_EQ(dst_vec, src_vec);
         }
     }
+
+    // Initializing again should throw
+    EXPECT_THROW(experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get()), std::runtime_error);
 }
 
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -52,6 +52,7 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include <tt-metalium/experimental/dispatch_context.hpp>
 
 namespace tt::tt_metal::distributed::test {
 namespace {

--- a/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
@@ -15,6 +15,12 @@ class MeshDevice;
 
 namespace experimental {
 
+// This class provides APIs to dynamically enable and teardown Fast Dispatch during runtime.
+// Functionality is currently limited to Galaxy clusters.
+// Note: The functionality in this class is extremely application specific, and will likely be
+// removed once we implement a proper weight loading solution for Low Latency Decode.
+// As such its exposed as experimental.
+
 class DispatchContext {
 public:
     static DispatchContext& get();

--- a/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dispatch_context.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace tt::tt_metal {
+
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+
+namespace experimental {
+
+class DispatchContext {
+public:
+    static DispatchContext& get();
+    void initialize_fast_dispatch(distributed::MeshDevice* mesh_device);
+    void terminate_fast_dispatch(distributed::MeshDevice* mesh_device);
+
+private:
+    DispatchContext() = default;
+    ~DispatchContext() = default;
+
+    // Custom deleter to allow unique_ptr with private destructor
+    struct Deleter {
+        void operator()(DispatchContext* p) const { delete p; }
+    };
+    friend struct Deleter;
+
+    bool fast_dispatch_enabled_ = false;
+    uint32_t num_fd_inits_ = 0;
+    static std::unique_ptr<DispatchContext, Deleter> dispatch_context_ptr_;
+};
+
+}  // namespace experimental
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -19,6 +19,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/system_mesh_translation_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_host_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multihost/distributed_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_context.cpp
 )
 
 # Include helper functions and generate headers from flatbuffer schemas

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/dispatch_context.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include "mesh_device_impl.hpp"
+#include "mesh_command_queue.hpp"
+#include "fd_mesh_command_queue.hpp"
+#include "sd_mesh_command_queue.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/device/device_manager.hpp"
+#include "impl/device/device_impl.hpp"
+#include "impl/dispatch/topology.hpp"
+#include "impl/dispatch/cq_shared_state.hpp"
+#include "llrt/hal/generated/dev_msgs.hpp"
+#include "llrt/llrt.hpp"
+
+namespace tt::tt_metal {
+
+namespace experimental {
+
+// Define the static member with custom deleter
+std::unique_ptr<DispatchContext, DispatchContext::Deleter> DispatchContext::dispatch_context_ptr_ = nullptr;
+
+DispatchContext& DispatchContext::get() {
+    if (!dispatch_context_ptr_) {
+        dispatch_context_ptr_ = std::unique_ptr<DispatchContext, Deleter>(new DispatchContext());
+    }
+    return *dispatch_context_ptr_;
+}
+
+void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_device) {
+    fast_dispatch_enabled_ = MetalContext::instance().rtoptions().get_fast_dispatch();
+    const auto& cluster = MetalContext::instance().get_cluster();
+    TT_FATAL(
+        !fast_dispatch_enabled_,
+        "Fast Dispatch can only be manually enabled when running the workload with Slow Dispatch mode.");
+    TT_FATAL(num_fd_inits_ == 0, "Fast Dispatch can only be manually initialized and torn down once.");
+    TT_FATAL(
+        cluster.is_ubb_galaxy(),
+        "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy clusters.");
+
+    const auto& device_manager = MetalContext::instance().device_manager();
+    const auto& active_devices = device_manager->get_all_active_devices();
+
+    uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
+    for (const auto& dev : active_devices) {
+        TT_FATAL(dev->num_hw_cqs() == num_hw_cqs, "All devices must have the same number of command queues.");
+        dev->init_command_queue_host();
+    }
+    // Query the number of command queues requested
+    populate_fd_kernels(active_devices, num_hw_cqs);
+
+    for (auto* dev : active_devices) {
+        populate_cq_static_args(dev);
+    }
+
+    for (auto* dev : active_devices) {
+        create_cq_program(dev);
+    }
+    compile_cq_programs();
+
+    std::vector<std::shared_future<void>> events;
+    for (auto* dev : active_devices) {
+        events.emplace_back(detail::async([dev]() {
+            dev->init_command_queue_device();
+            log_info(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+        }));
+    }
+    for (const auto& event : events) {
+        event.get();
+    }
+
+    fast_dispatch_enabled_ = true;
+    num_fd_inits_++;
+    tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
+
+    auto& mesh_device_impl = mesh_device->impl();
+    mesh_device_impl.mesh_command_queues_.clear();
+    mesh_device_impl.mesh_command_queues_.reserve(num_hw_cqs);
+
+    auto cq_shared_state = std::make_shared<CQSharedState>();
+    cq_shared_state->sub_device_cq_owner.resize(1);
+
+    for (std::size_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        mesh_device_impl.mesh_command_queues_.push_back(std::make_unique<distributed::FDMeshCommandQueue>(
+            mesh_device,
+            cq_id,
+            mesh_device_impl.dispatch_thread_pool_,
+            mesh_device_impl.reader_thread_pool_,
+            cq_shared_state,
+            std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl)));
+    }
+}
+
+void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_device) {
+    TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
+    TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch can only be manually terminated and torn down once.");
+
+    const auto& device_manager = MetalContext::instance().device_manager();
+    const auto& active_devices = device_manager->get_all_active_devices();
+
+    uint8_t num_hw_cqs = active_devices[0]->num_hw_cqs();
+    auto& mesh_device_impl = mesh_device->impl();
+    mesh_device_impl.mesh_command_queues_.clear();
+    mesh_device_impl.mesh_command_queues_.reserve(num_hw_cqs);
+    for (std::size_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        mesh_device_impl.mesh_command_queues_.push_back(std::make_unique<distributed::SDMeshCommandQueue>(
+            mesh_device, cq_id, std::bind(&distributed::MeshDeviceImpl::lock_api, &mesh_device_impl)));
+    }
+    for (const auto& dev : active_devices) {
+        for (int cq_id = 0; cq_id < dev->num_hw_cqs(); cq_id++) {
+            dynamic_cast<tt::tt_metal::Device*>(dev)->command_queues_[cq_id].get()->terminate();
+        }
+    }
+
+    for (const auto& dev : active_devices) {
+        auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev->id());
+        tt::llrt::internal_::wait_until_cores_done(dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
+    }
+
+    fast_dispatch_enabled_ = false;
+    tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
+}
+
+}  // namespace experimental
+
+}  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -41,6 +41,10 @@ class CommandQueue;
 class SubDevice;
 class SystemMemoryManager;
 
+namespace experimental {
+class DispatchContext;
+}  // namespace experimental
+
 namespace program_cache::detail {
 struct ProgramCache;
 }  // namespace program_cache::detail
@@ -153,6 +157,8 @@ private:
 
     // Distributed context used to synchronize operations done by all ranks on the given mesh device.
     std::shared_ptr<distributed::multihost::DistributedContext> distributed_context_;
+
+    friend class ::tt::tt_metal::experimental::DispatchContext;
 
 public:
     MeshDeviceImpl(

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -23,6 +23,10 @@ namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 class AllocatorImpl;
 
+namespace experimental {
+class DispatchContext;
+}  // namespace experimental
+
 // A physical PCIexpress Tenstorrent device
 class Device : public IDevice {
 public:
@@ -241,6 +245,8 @@ private:
     // Friend declaration for experimental API
     friend uint32_t experimental::Device::get_worker_noc_hop_distance(
         IDevice* device, const CoreCoord& logical_src, const CoreCoord& logical_dst, NOC noc);
+
+    friend class experimental::DispatchContext;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -12,6 +12,11 @@
 #include "umd/device/types/cluster_descriptor_types.hpp"
 
 namespace tt::tt_metal {
+
+namespace experimental {
+class DispatchContext;
+}  // namespace experimental
+
 class IDevice;
 class DeviceManager {
 public:
@@ -79,6 +84,8 @@ private:
     // Initialize state for activated devices
     void init_fabric(const std::vector<IDevice*>& active_devices) const;
     void initialize_active_devices();
+    void configure_and_load_fast_dispatch_kernels();
+    void compile_and_load_fabric();
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
     void wait_for_fabric_router_sync(uint32_t timeout_ms = 5000) const;
     IDevice* get_device(ChipId id) const;
@@ -87,6 +94,8 @@ private:
 
     // Retrieves the fabric router sync timeout value from configuration or returns a default
     static uint32_t get_fabric_router_sync_timeout_ms();
+
+    friend class experimental::DispatchContext;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -113,7 +113,7 @@ void validate_kernel_placement(bool force_slow_dispatch, std::shared_ptr<Kernel>
     //      - tensix kernels cannot be on dispatch cores
     //  Fast dispatch (ethernet):
     //      - eth kernels cannot be on idle eth cores
-    bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+    bool slow_dispatch = !(MetalContext::instance().rtoptions().get_fast_dispatch());
 
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     tt::CoreType dispatch_core_type = get_core_type_from_config(dispatch_core_config);
@@ -1286,7 +1286,7 @@ const std::vector<SubDeviceId>& detail::ProgramImpl::determine_sub_device_ids(co
     auto& sub_device_ids_map = this->sub_device_ids_[device->id()];
     auto sub_device_ids = sub_device_ids_map.find(sub_device_manager_id);
     if (this->compiled_.empty() || sub_device_ids == sub_device_ids_map.end()) {
-        if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr ||
+        if (!MetalContext::instance().rtoptions().get_fast_dispatch() ||
             sub_device_manager_id == device->get_default_sub_device_manager_id()) {
             // No sub device manager, nothing to validate
             auto [sub_device_ids, _] =
@@ -1689,7 +1689,7 @@ void detail::ProgramImpl::set_program_attrs_across_core_types(IDevice* device) {
     program_config_sizes_[programmable_core_count_ + 1] = runs_on_noc_unicast_only_cores();
     set_launch_msg_sem_offsets();
     // TODO: This check is wrong - it populates dispatch data for dispatch kernels
-    if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
+    if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
         populate_dispatch_data(device);  // TODO: maybe rename
     }
 }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -592,6 +592,8 @@ public:
     }
     bool get_fast_dispatch() const { return fast_dispatch; }
 
+    void set_fast_dispatch(bool enable) { fast_dispatch = enable; }
+
     // Temporary API until all multi-device workloads are ported to run on fabric.
     // It's currently not possible to enable Erisc IRAM by default for all legacy CCL
     // workloads. In those workloads, erisc kernels are loaded every CCL op; the binary


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36533)

### Problem description
- As part of the Blitz Decode effort, we plan on using Slow Dispatch to launch a persistent "Mega-Kernel"
- Since the kernels will be loaded once, host performance during workload execution is not a concern
- Usage of SD is necessary, since the Blitz Decode kernels will be using the dispatch column - cc @abhullar-tt @msudumbrekar-TT 
- The main challenge here is loading weights at the start of the workload with Slow Dispatch. This step can become a significant bottleneck
- The correct way of resolving this is with a custom "Weight-Loading" Kernel that streams data directly from `PinnedMemory` on host to Worker SRAM
- We don't have such a solution yet, so as a contingency we're doing the following:
   - Expose an extremely limited experimental set of APIs, that allow a user to manually setup/teardown FD
   - Usage requires the workload to be run with SD on a Galaxy system
   - The workload will then setup FD, load weights, teardown FD and load the persistent kernels
  
**Note: This work is extremely application specific, and will likely be removed once we implement a proper weight loading solution. As such its exposed as experimental**

### What's changed
- Add the aforementioned functionality and expose the FD setup + teardown APIs through a new class: `DispatchContext`
- When FD is setup, we also call the `rt_options.set_fast_dispatch()` API to ensure that host code uses the correct dispatch path
- Cleanup `program.cpp` to use RT Options instead of manually passing `TT_METAL_SLOW_DISPATCH_MODE`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/fd_init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/fd_init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/fd_init)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/fd_init)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/fd_init)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/fd_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/fd_init)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
