### PR TITLE
Fix watcher assert in multi-core range runtime args test

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -92,23 +92,26 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const CoreRangeSet& core_range_set,
     uint32_t num_unique_rt_args,
-    bool common_rtas = false) {
+    bool common_rtas = false,
+    uint32_t num_common_rt_args = 0) {
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     tt::tt_metal::Program program = tt_metal::CreateProgram();
 
+    // Use unique_address (false) so kernel writes (base, base+4096) align with verify_results reads
     uint32_t rta_base_dm = get_runtime_arg_addr(
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1),
         tt::tt_metal::HalProcessorClassType::DM,
         0,
-        common_rtas);
+        false);
     std::map<std::string, std::string> dm_defines = {
         {"DATA_MOVEMENT", "1"},
         {"NUM_RUNTIME_ARGS", std::to_string(num_unique_rt_args)},
         {"RESULTS_ADDR", std::to_string(rta_base_dm)}};
     if (common_rtas) {
         dm_defines["COMMON_RUNTIME_ARGS"] = "1";
+        dm_defines["NUM_COMMON_RUNTIME_ARGS"] = std::to_string(num_common_rt_args);
     }
 
     tt_metal::CreateKernel(
@@ -250,8 +253,11 @@ void verify_results(
         // Verify Unique RT Args (per core)
         for (const auto& logical_core : kernel->cores_with_runtime_args()) {
             const auto& expected_rt_args = core_to_rt_args.at(logical_core);
-            auto rt_args = kernel->runtime_args(logical_core);
-            EXPECT_EQ(rt_args, expected_rt_args) << "(unique rta)";
+            auto& rt_args_data = kernel->runtime_args_data(logical_core);
+            EXPECT_EQ(rt_args_data.size(), expected_rt_args.size()) << "(unique rta size)";
+            for (size_t i = 0; i < expected_rt_args.size(); i++) {
+                EXPECT_EQ(rt_args_data[i], expected_rt_args[i]) << "(unique rta[" << i << "])";
+            }
 
             verify_core_rt_args(
                 mesh_device, false, logical_core, rt_args_base_addr, expected_rt_args, unique_arg_incr_val);
@@ -259,18 +265,30 @@ void verify_results(
 
         // Verify common RT Args (same for all cores) if they exist.
         if (!common_rt_args.empty()) {
-            auto common_rt_args_base_addr = get_runtime_arg_addr(
-                device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1),
-                kernel->get_kernel_processor_class(),
-                kernel->get_kernel_processor_type(0),
-                true);
+            // DM kernel writes common at base+4096 (fixed offset scheme)
+            // Compute kernel writes common to get_runtime_arg_addr() (separate address)
+            uint32_t common_rt_args_base_addr = 0;
+            if (kernel->get_kernel_processor_class() == tt::tt_metal::HalProcessorClassType::COMPUTE) {
+                // Original behavior for compute kernel - use actual common address
+                common_rt_args_base_addr = get_runtime_arg_addr(
+                    device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1),
+                    kernel->get_kernel_processor_class(),
+                    kernel->get_kernel_processor_type(0),
+                    true);
+            } else {
+                // New fix for DM kernel - use fixed offset
+                common_rt_args_base_addr = rt_args_base_addr + 1024 * sizeof(uint32_t);
+            }
 
             for (auto& core_range : kernel->logical_coreranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         CoreCoord logical_core({x, y});
-                        auto rt_args = kernel->common_runtime_args();
-                        EXPECT_EQ(rt_args, common_rt_args) << "(common rta)";
+                        auto& rt_args_data = kernel->common_runtime_args_data();
+                        EXPECT_EQ(rt_args_data.size(), common_rt_args.size()) << "(common rta size)";
+                        for (size_t i = 0; i < common_rt_args.size(); i++) {
+                            EXPECT_EQ(rt_args_data[i], common_rt_args[i]) << "(common rta[" << i << "])";
+                        }
                         verify_core_rt_args(
                             mesh_device,
                             true,
@@ -334,11 +352,11 @@ TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
         distributed::EnqueueMeshWorkload(cq, workload, false);
         unit_tests::runtime_args::verify_results(false, mesh_device, workload, core_to_rt_args);
 
-        auto workload2 =
-            unit_tests::runtime_args::initialize_program_data_movement_rta(mesh_device, core_range_set, 4, true);
-        auto& program2 = workload2.get_programs().at(device_range);
         // Set common runtime args, automatically sent to all cores used by kernel.
         std::vector<uint32_t> common_runtime_args = {0x30303030, 0x60606060, 0x90909090, 1234};
+        auto workload2 = unit_tests::runtime_args::initialize_program_data_movement_rta(
+            mesh_device, core_range_set, 0, true, common_runtime_args.size());
+        auto& program2 = workload2.get_programs().at(device_range);
         SetCommonRuntimeArgs(program2, 0, common_runtime_args);
         detail::WriteRuntimeArgsToDevice(device, program2);
         distributed::EnqueueMeshWorkload(cq, workload2, false);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -539,7 +539,6 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     // This test creates separate kernels for each core range with different unique RTA counts
     // Common RTAs remain consistent across all kernels
 
-    CoreRangeSet cr_set = program_config.cr_set;
     constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
     constexpr uint32_t num_common_runtime_args = 13;
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -536,264 +536,214 @@ bool test_dummy_EnqueueProgram_with_runtime_args_multi_crs(
     Program program;
     bool pass = true;
 
-    // TODO: this test would be better if it varied args across core ranges and kernel type
+    // This test creates separate kernels for each core range with different unique RTA counts
+    // Common RTAs remain consistent across all kernels
 
     CoreRangeSet cr_set = program_config.cr_set;
     constexpr uint32_t kCommonRTASeparation = 1024 * sizeof(uint32_t);
+    constexpr uint32_t num_common_runtime_args = 13;
 
-    uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    uint32_t rta_base_dm1 = rta_base_dm0 + (2048 * sizeof(uint32_t));
-    uint32_t rta_base_compute = rta_base_dm1 + (4096 * sizeof(uint32_t));
-    // Copy max # runtime args in the kernel for simplicity
-    std::map<std::string, std::string> dm_defines0 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm0)}};
-    std::map<std::string, std::string> dm_defines1 = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"DATA_MOVEMENT", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_dm1)}};
-    std::map<std::string, std::string> compute_defines = {
-        {"COMMON_RUNTIME_ARGS", "1"},
-        {"COMPUTE", "1"},
-        {"NUM_RUNTIME_ARGS", std::to_string(256)},
-        {"RESULTS_ADDR", std::to_string(rta_base_compute)}};
+    TT_FATAL(
+        program_config.cr_set.ranges().size() == 2,
+        "This test requires exactly 2 core ranges, got {}. "
+        "Function only provides RTA counts for cr0 and cr1.",
+        program_config.cr_set.ranges().size());
 
-    auto dummy_kernel0 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = dm_defines0});
-
-    auto dummy_kernel1 = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = dm_defines1});
-
-    auto dummy_compute_kernel = CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
-        cr_set,
-        ComputeConfig{.defines = compute_defines});
-
-    vector<uint32_t> dummy_cr0_args;
-    vector<uint32_t> dummy_cr1_args;
-    vector<uint32_t> dummy_common_args;
-
+    // Extract the two core ranges to create separate kernels for each
     auto it = program_config.cr_set.ranges().begin();
     CoreRange core_range_0 = *it;
     std::advance(it, 1);
     CoreRange core_range_1 = *it;
+    std::vector<CoreRange> ranges = {core_range_0, core_range_1};
+    std::vector<uint32_t> num_rtas_per_range = {num_runtime_args_for_cr0, num_runtime_args_for_cr1};
+
+    uint32_t rta_base_dm0 = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    uint32_t rta_base_dm1 = rta_base_dm0 + (2048 * sizeof(uint32_t));
+    uint32_t rta_base_compute = rta_base_dm1 + (4096 * sizeof(uint32_t));
+
+    auto make_defines = [&](bool dm, uint32_t num_rtas, CoreCoord core, uint32_t rta_base) {
+        std::map<std::string, std::string> defines = {
+            {"COMMON_RUNTIME_ARGS", "1"},
+            {"NUM_RUNTIME_ARGS", std::to_string(num_rtas)},
+            {"NUM_COMMON_RUNTIME_ARGS", std::to_string(num_common_runtime_args)},
+            {"SKIP_CORE_LOG_X", std::to_string(core.x)},
+            {"SKIP_CORE_LOG_Y", std::to_string(core.y)},
+            {"RESULTS_ADDR", std::to_string(rta_base)}};
+        if (dm) {
+            defines["DATA_MOVEMENT"] = "1";
+        } else {
+            defines["COMPUTE"] = "1";
+        }
+        return defines;
+    };
+
+    // Struct to hold kernel group
+    struct RangeKernels {
+        KernelHandle dm0, dm1, compute;
+    };
+    std::vector<RangeKernels> kernel_handles(ranges.size());
+
+    // Create 6 kernels total: 2 ranges x (dm0, dm1, compute)
+    // Each kernel is configured to skip execution on the first core of its range
+    for (uint32_t i = 0; i < ranges.size(); i++) {
+        kernel_handles[i].dm0 = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            ranges[i],
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .defines = make_defines(true, num_rtas_per_range[i], ranges[i].start_coord, rta_base_dm0)});
+        kernel_handles[i].dm1 = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            ranges[i],
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .defines = make_defines(true, num_rtas_per_range[i], ranges[i].start_coord, rta_base_dm1)});
+        kernel_handles[i].compute = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            ranges[i],
+            ComputeConfig{
+                .defines = make_defines(false, num_rtas_per_range[i], ranges[i].start_coord, rta_base_compute)});
+    }
+
+    std::vector<std::vector<uint32_t>> dummy_cr_args(ranges.size());
+    vector<uint32_t> dummy_common_args;
 
     uint32_t idx = 0;
-    constexpr uint32_t num_common_runtime_args = 13;
     workload.add_program(device_range, std::move(program));
 
     for (uint32_t iter = 0; iter < num_iterations; iter++) {
         auto& program_ = workload.get_programs().at(device_range);
         SCOPED_TRACE(iter);
-        dummy_cr0_args.clear();
-        dummy_cr1_args.clear();
-        dummy_common_args.clear();
-
-        for (uint32_t i = 0; i < num_runtime_args_for_cr0; i++) {
-            dummy_cr0_args.push_back(idx++);
+        for (uint32_t range = 0; range < ranges.size(); range++) {
+            dummy_cr_args[range].clear();
         }
 
-        for (uint32_t i = 0; i < num_runtime_args_for_cr1; i++) {
-            dummy_cr1_args.push_back(idx++);
+        dummy_common_args.clear();
+
+        for (uint32_t range = 0; range < ranges.size(); range++) {
+            for (uint32_t i = 0; i < num_rtas_per_range[range]; i++) {
+                dummy_cr_args[range].push_back(idx++);
+            }
         }
 
         for (uint32_t i = 0; i < num_common_runtime_args; i++) {
             dummy_common_args.push_back(idx++);
         }
 
-        bool first = true;
-        for (const CoreCoord& core_coord : core_range_0) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
+        // Set RTAs for all cores except the first in each range
+        // This tests partial RTA coverage - the kernel will check if it's the first core and skip execution
+        for (uint32_t i = 0; i < ranges.size(); i++) {
+            bool first = true;
+            for (const CoreCoord& core_coord : ranges[i]) {
+                if (first) {
+                    first = false;
+                    continue;  // Don't set RTAs on first core
+                }
+
+                SetRuntimeArgs(program_, kernel_handles[i].dm0, core_coord, dummy_cr_args[i]);
+                SetRuntimeArgs(program_, kernel_handles[i].dm1, core_coord, dummy_cr_args[i]);
+                SetRuntimeArgs(program_, kernel_handles[i].compute, core_coord, dummy_cr_args[i]);
             }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr0_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr0_args);
-        }
-
-        first = true;
-        for (const CoreCoord& core_coord : core_range_1) {
-            // Don't set RTAs on all cores
-            if (first) {
-                first = false;
-                continue;
-            }
-
-            SetRuntimeArgs(program_, dummy_kernel0, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_kernel1, core_coord, dummy_cr1_args);
-            SetRuntimeArgs(program_, dummy_compute_kernel, core_coord, dummy_cr1_args);
         }
 
         if (iter == 0) {
-            SetCommonRuntimeArgs(program_, dummy_kernel0, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_kernel1, dummy_common_args);
-            SetCommonRuntimeArgs(program_, dummy_compute_kernel, dummy_common_args);
+            for (uint32_t i = 0; i < ranges.size(); i++) {
+                SetCommonRuntimeArgs(program_, kernel_handles[i].dm0, dummy_common_args);
+                SetCommonRuntimeArgs(program_, kernel_handles[i].dm1, dummy_common_args);
+                SetCommonRuntimeArgs(program_, kernel_handles[i].compute, dummy_common_args);
+            }
         } else {
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel0).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_kernel1).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
-            memcpy(
-                GetCommonRuntimeArgs(program_, dummy_compute_kernel).rt_args_data,
-                dummy_common_args.data(),
-                dummy_common_args.size() * sizeof(uint32_t));
+            for (uint32_t i = 0; i < ranges.size(); i++) {
+                memcpy(
+                    GetCommonRuntimeArgs(program_, kernel_handles[i].dm0).rt_args_data,
+                    dummy_common_args.data(),
+                    dummy_common_args.size() * sizeof(uint32_t));
+                memcpy(
+                    GetCommonRuntimeArgs(program_, kernel_handles[i].dm1).rt_args_data,
+                    dummy_common_args.data(),
+                    dummy_common_args.size() * sizeof(uint32_t));
+                memcpy(
+                    GetCommonRuntimeArgs(program_, kernel_handles[i].compute).rt_args_data,
+                    dummy_common_args.data(),
+                    dummy_common_args.size() * sizeof(uint32_t));
+            }
         }
 
         distributed::EnqueueMeshWorkload(cq, workload, false);
         Finish(cq);
 
-        first = true;
-        for (const CoreCoord& core_coord : core_range_0) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel0_args_readback);
+        for (uint32_t i = 0; i < ranges.size(); i++) {
+            // Verify unique RTAs and common RTAs (skipping first core which has no RTAs set)
+            bool first = true;
+            for (const CoreCoord& core_coord : ranges[i]) {
+                if (first) {
+                    first = false;
+                    continue;  // Skip verification on first core (no RTAs set)
+                }
+                {
+                    vector<uint32_t> dummy_kernel0_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_dm0,
+                        dummy_cr_args[i].size() * sizeof(uint32_t),
+                        dummy_kernel0_args_readback);
+                    pass &= (dummy_cr_args[i] == dummy_kernel0_args_readback);
 
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr0_args == dummy_kernel1_args_readback);
+                    vector<uint32_t> dummy_kernel1_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_dm1,
+                        dummy_cr_args[i].size() * sizeof(uint32_t),
+                        dummy_kernel1_args_readback);
+                    pass &= (dummy_cr_args[i] == dummy_kernel1_args_readback);
 
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr0_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr0_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
+                    vector<uint32_t> dummy_compute_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_compute,
+                        dummy_cr_args[i].size() * sizeof(uint32_t),
+                        dummy_compute_args_readback);
+                    pass &= (dummy_cr_args[i] == dummy_compute_args_readback);
+                }
+                {
+                    vector<uint32_t> dummy_kernel0_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_dm0 + kCommonRTASeparation,
+                        dummy_common_args.size() * sizeof(uint32_t),
+                        dummy_kernel0_args_readback);
+                    EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
+                    pass &= (dummy_common_args == dummy_kernel0_args_readback);
 
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
+                    vector<uint32_t> dummy_kernel1_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_dm1 + kCommonRTASeparation,
+                        dummy_common_args.size() * sizeof(uint32_t),
+                        dummy_kernel1_args_readback);
+                    EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
+                    pass &= (dummy_common_args == dummy_kernel1_args_readback);
 
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
-            }
-        }
-
-        first = true;
-        for (const CoreCoord& core_coord : core_range_1) {
-            // Don't test RTAs on first cores
-            if (first) {
-                first = false;
-                continue;
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                pass &= (dummy_cr1_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute,
-                    dummy_cr1_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                pass &= (dummy_cr1_args == dummy_compute_args_readback);
-            }
-            {
-                vector<uint32_t> dummy_kernel0_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm0 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel0_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel0_args_readback);
-                pass &= (dummy_common_args == dummy_kernel0_args_readback);
-
-                vector<uint32_t> dummy_kernel1_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_dm1 + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_kernel1_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_kernel1_args_readback);
-                pass &= (dummy_common_args == dummy_kernel1_args_readback);
-
-                vector<uint32_t> dummy_compute_args_readback;
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
-                    core_coord,
-                    rta_base_compute + kCommonRTASeparation,
-                    dummy_common_args.size() * sizeof(uint32_t),
-                    dummy_compute_args_readback);
-                EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
-                pass &= (dummy_common_args == dummy_compute_args_readback);
+                    vector<uint32_t> dummy_compute_args_readback;
+                    tt::tt_metal::detail::ReadFromDeviceL1(
+                        device,
+                        core_coord,
+                        rta_base_compute + kCommonRTASeparation,
+                        dummy_common_args.size() * sizeof(uint32_t),
+                        dummy_compute_args_readback);
+                    EXPECT_EQ(dummy_common_args, dummy_compute_args_readback);
+                    pass &= (dummy_common_args == dummy_compute_args_readback);
+                }
             }
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -20,15 +20,27 @@ void kernel_main() {
     namespace NAMESPACE {
     void MAIN {
 #endif
+#if defined(SKIP_CORE_LOG_X) && defined(SKIP_CORE_LOG_Y)
+        // Skip execution on a specific core (by logical coords) to test partial RTA coverage
+        // This core doesn't have RTAs set, so accessing them would trigger watcher assert
+        if (get_relative_logical_x() == SKIP_CORE_LOG_X && get_relative_logical_y() == SKIP_CORE_LOG_Y) {
+            return;
+        }
+#endif
+
         volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
         int i;
+        // Read unique runtime args
         for (i = 0; i < NUM_RUNTIME_ARGS; i++) {
-#ifdef COMMON_RUNTIME_ARGS
-            constexpr uint32_t kCommonRTASeparation = 1024;
-            results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
-#endif
             results[i] = get_arg_val<uint32_t>(i);
         }
+#ifdef COMMON_RUNTIME_ARGS
+        // Read common runtime args
+        constexpr uint32_t kCommonRTASeparation = 1024;
+        for (i = 0; i < NUM_COMMON_RUNTIME_ARGS; i++) {
+            results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+        }
+#endif
 
 #ifdef COORDS_ADDR
 #ifdef DATA_MOVEMENT


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36796

### Problem description
The `test_dummy_EnqueueProgram_with_runtime_args_multi_crs` function in `test_EnqueueProgram.cpp` triggered watcher assertions due to out-of-bounds runtime args access. The test skipped setting RTAs on the first core of each range, but those cores still executed the kernel configured to read 256 RTAs.

### What's changed
`test_EnqueueProgram.cpp`:
- Refactored test to create separate kernels per core range with exact RTA counts
- Added `SKIP_CORE_LOG_X/Y` defines to kernel so cores without RTAs skip execution
- Added `NUM_COMMON_RUNTIME_ARGS` define to properly bound the common args loop

`runtime_args_kernel.cpp`:
- Added skip logic for cores without RTAs (prevents watcher assert)
- Separated unique and common args into separate loops with independent counts

`test_runtime_args.cpp`:
- Changed to `runtime_args_data()` / `common_runtime_args_data()` which return raw args without watcher prefix
- Added conditional for common args address: DM kernel (fixed offset) vs compute kernel (dynamic) 

This also addresses the existing TODO by actually varying args across core ranges.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/36796_fix_rta_bounds_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/36796_fix_rta_bounds_access)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/36796_fix_rta_bounds_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/36796_fix_rta_bounds_access)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/36796_fix_rta_bounds_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/36796_fix_rta_bounds_access)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
