### PR TITLE
ci: parallel execution of workflows during llk dry-run

### DIFF
--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -408,8 +408,8 @@ jobs:
 
   # Job 3: Terminate spawned workflows if parent is cancelled
   cancel-on-failure:
-    needs: [setup, run-tests]
-    if: cancelled()
+    needs: [setup]
+    if: always() && cancelled() && needs.setup.outputs.branch-exists == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Terminate spawned workflows

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -57,9 +57,10 @@ on:
         description: 'Result of Device perf regressions (status:url format)'
         value: ${{ jobs.setup-and-test.outputs.perf-device-models-result }}
 
-concurrency:
-  group: llk-integration-${{ inputs.mirrored_branch }}
-  cancel-in-progress: true
+# NOTE: Concurrency is intentionally NOT set here.
+# When called via workflow_call, the caller (tt-llk) manages concurrency.
+# This workflow's proactive cancellation step handles cleanup of spawned workflows.
+# Setting concurrency here would conflict with the caller's concurrency settings.
 
 env:
   PARENT_BRANCH_NAME: test-llk-${{ inputs.mirrored_branch }}-${{ github.run_id }}
@@ -108,6 +109,62 @@ jobs:
         run: |
           git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Cancel any previous spawned workflows
+        env:
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
+        run: |
+          echo "🔍 Proactively cancelling any previous spawned workflows for this branch..."
+          MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
+          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml")
+          STATUSES=("queued" "in_progress")
+
+          for workflow in "${SPAWNED_WORKFLOWS[@]}"; do
+            for status in "${STATUSES[@]}"; do
+              echo "🔍 Checking for $status instances of $workflow..."
+              # Get all runs and filter by branch pattern (test-llk-<mirrored_branch>-*)
+              run_data=$(gh run list \
+                --workflow "$workflow" \
+                --status "$status" \
+                --limit 100 \
+                --json databaseId,headBranch \
+                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "[]")
+
+              # Filter runs matching our branch pattern and extract IDs
+              run_ids=$(echo "$run_data" | jq -r --arg pattern "test-llk-$MIRRORED_BRANCH-" \
+                '.[] | select(.headBranch | startswith($pattern)) | .databaseId')
+
+              if [ -n "$run_ids" ]; then
+                for run_id in $run_ids; do
+                  echo "🛑 Cancelling previous spawned workflow run $run_id ($workflow)..."
+                  if gh run cancel "$run_id" --repo "${{ env.METAL_REPO }}"; then
+                    echo "✅ Successfully cancelled run $run_id"
+                  else
+                    echo "⚠️ Failed to cancel run $run_id (may have already completed)"
+                  fi
+                done
+              else
+                echo "ℹ️ No $status instances of $workflow found for branch pattern test-llk-$MIRRORED_BRANCH-*"
+              fi
+            done
+          done
+
+          # Also clean up old parent branches from previous runs to avoid git conflicts
+          echo "🧹 Cleaning up old parent branches..."
+          OLD_BRANCHES=$(gh api "repos/${{ env.METAL_REPO }}/branches" --paginate --jq \
+            --arg pattern "test-llk-$MIRRORED_BRANCH-" \
+            '.[] | select(.name | startswith($pattern)) | .name' 2>/dev/null || echo "")
+
+          if [ -n "$OLD_BRANCHES" ]; then
+            for branch in $OLD_BRANCHES; do
+              echo "🗑️ Deleting old parent branch: $branch"
+              gh api --method DELETE "repos/${{ env.METAL_REPO }}/git/refs/heads/$branch" 2>/dev/null || \
+                echo "⚠️ Failed to delete branch $branch (may not exist)"
+            done
+          else
+            echo "ℹ️ No old parent branches found"
+          fi
+
+          echo "✅ Proactive cleanup completed"
       - name: Setup test branch and parent repository
         id: check-branch
         run: |

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -198,7 +198,9 @@ jobs:
             if [ "$BRANCH_VS_MAIN_COMMITS" -gt 0 ]; then
               echo "🔄 Branch is $BRANCH_VS_MAIN_COMMITS commits behind latest main - merging latest changes"
               if ! git merge origin/main --no-edit; then
-                echo "❌ Merge with latest main failed - conflicts need manual resolution"
+                echo "❌ Merge with latest main failed - conflicts need manual resolution."
+                echo "   This usually means your mirrored branch is conflicting with recent changes on origin/main in the LLK submodule."
+                echo "   Please resolve the merge conflicts locally (e.g., checkout '$MIRRORED_BRANCH', merge origin/main, fix conflicts), push the updated branch to origin, and re-run this workflow."
                 exit 1
               fi
               echo "✅ Successfully merged latest submodule main into branch"

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -401,10 +401,16 @@ jobs:
             fi
           done
 
-          # If we somehow exit the retry loop without success (shouldn't happen)
-          echo "❌ $DISPLAY_NAME failed after $max_attempts attempts"
-          echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
-          exit 1
+          # Fallback for unexpected exit from retry loop (shouldn't normally be reached)
+          if [ "$attempt" -gt "$max_attempts" ]; then
+            echo "❌ $DISPLAY_NAME failed after $max_attempts attempts"
+            echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "❌ $DISPLAY_NAME monitoring ended unexpectedly (attempt: $attempt/$max_attempts, should_retry: $should_retry)"
+            echo "$OUTPUT_KEY=unknown:$run_url" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
   # Job 3: Terminate spawned workflows if parent is cancelled
   cancel-on-failure:

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -101,7 +101,6 @@ jobs:
       should-run-blackhole: ${{ inputs.run_blackhole_post_commit }}
       should-run-l2-nightly: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
       should-run-perf: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
-      arch-param: ${{ steps.check-branch.outputs.arch-param }}
     steps:
       - name: Setup
         uses: actions/checkout@v4
@@ -224,15 +223,6 @@ jobs:
 
             echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
             echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
-
-            # Build architecture parameter
-            if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
-              echo 'arch-param=["wormhole_b0", "blackhole"]' >> $GITHUB_OUTPUT
-            elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
-              echo 'arch-param=["wormhole_b0"]' >> $GITHUB_OUTPUT
-            else
-              echo 'arch-param=["blackhole"]' >> $GITHUB_OUTPUT
-            fi
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
@@ -254,18 +244,22 @@ jobs:
             name: "All Post Commit Workflows"
             output-key: "all-post-commit-result"
             should-run: ${{ inputs.run_all_post_commit }}
+            arch: ""  # all-post-commit doesn't use architecture parameter
           - workflow: "blackhole-post-commit.yaml"
             name: "Blackhole Post Commit"
             output-key: "blackhole-result"
             should-run: ${{ inputs.run_blackhole_post_commit }}
+            arch: ""  # blackhole-post-commit doesn't use architecture parameter
           - workflow: "tt-metal-l2-nightly.yaml"
             name: "TT-Metal L2 Nightly APC"
             output-key: "tt-metal-l2-nightly-result"
             should-run: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+            arch: "dynamic"  # architecture determined at runtime based on enabled tests
           - workflow: "perf-device-models.yaml"
             name: "Device Perf Regressions"
             output-key: "perf-device-models-result"
             should-run: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+            arch: "dynamic"  # architecture determined at runtime based on enabled tests
     outputs:
       all-post-commit-result: ${{ steps.monitor.outputs.all-post-commit-result }}
       blackhole-result: ${{ steps.monitor.outputs.blackhole-result }}
@@ -286,13 +280,25 @@ jobs:
           MAX_RETRIES: 3
           POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
           PARENT_BRANCH_NAME: ${{ needs.setup.outputs.parent-branch-name }}
-          ARCH_PARAM: ${{ needs.setup.outputs.arch-param }}
         run: |
           WORKFLOW="${{ matrix.workflow }}"
           DISPLAY_NAME="${{ matrix.name }}"
           OUTPUT_KEY="${{ matrix.output-key }}"
+          ARCH_TYPE="${{ matrix.arch }}"
 
           echo "🚀 Triggering $DISPLAY_NAME ($WORKFLOW)..."
+
+          # Build architecture parameter dynamically if needed
+          if [ "$ARCH_TYPE" = "dynamic" ]; then
+            if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
+              ARCH_PARAM='["wormhole_b0", "blackhole"]'
+            elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
+              ARCH_PARAM='["wormhole_b0"]'
+            else
+              ARCH_PARAM='["blackhole"]'
+            fi
+            echo "📋 Using architecture parameter: $ARCH_PARAM"
+          fi
 
           # Trigger workflow with appropriate inputs
           if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -377,6 +377,11 @@ jobs:
             fi
           done
 
+          # If no workflows were enabled, exit early with a log message
+          if [ ${#pids[@]} -eq 0 ]; then
+            echo "ℹ️ No workflows to monitor"
+            exit 0
+          fi
           # Wait for all background processes to complete and collect exit codes
           echo "⏳ Waiting for all workflows to complete..."
           exit_code=0

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -373,7 +373,7 @@ jobs:
             if [ "$enabled" = "true" ]; then
               # Run monitor_workflow in background
               monitor_workflow "$run_id" "$workflow_file" "$output_var" &
-              pids+=($!)
+              pids+=("$!")
             fi
           done
 

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -363,15 +363,33 @@ jobs:
           workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
           workflow_configs["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$PERF_DEVICE_MODELS_RUN_ID:perf-device-models-result"
           exit_code=0
+
+          echo "📊 Starting parallel monitoring of all triggered workflows..."
+          # Start monitoring all workflows in parallel
+          declare -a pids=()
           for workflow_file in "${!workflow_configs[@]}"; do
             IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"
 
             if [ "$enabled" = "true" ]; then
-              if ! monitor_workflow "$run_id" "$workflow_file" "$output_var"; then
-                exit_code=1
-              fi
+              # Run monitor_workflow in background
+              monitor_workflow "$run_id" "$workflow_file" "$output_var" &
+              pids+=($!)
             fi
           done
+
+          # Wait for all background processes to complete and collect exit codes
+          echo "⏳ Waiting for all workflows to complete..."
+          exit_code=0
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+              exit_code=1
+            fi
+          done
+          if [ $exit_code -eq 0 ]; then
+            echo "✅ All workflows completed successfully"
+          else
+            echo "❌ One or more workflows failed"
+          fi
           exit $exit_code
       - name: Terminate spawned workflows on cancellation
         if: cancelled()

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -337,12 +337,14 @@ jobs:
           echo "✅ $DISPLAY_NAME triggered (run ID: $run_id): $run_url"
 
           # Monitor workflow with retry logic for failed jobs
-          attempt=0
+          attempt=1
           timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
+          max_attempts=$MAX_RETRIES
 
-          while [ $attempt -lt $MAX_RETRIES ]; do
-            echo "📊 Monitoring $DISPLAY_NAME (attempt $((attempt + 1))/$MAX_RETRIES)..."
+          while [ $attempt -le $max_attempts ]; do
+            echo "📊 Monitoring $DISPLAY_NAME (attempt $attempt/$max_attempts)..."
             elapsed=0
+            should_retry=false
 
             while [ $elapsed -lt $timeout_seconds ]; do
               status=$(gh run view "$run_id" --json status,conclusion \
@@ -357,25 +359,24 @@ jobs:
                   echo "$OUTPUT_KEY=success:$run_url" >> $GITHUB_OUTPUT
                   exit 0
                 else
-                  echo "🛑 $DISPLAY_NAME completed with status: $conclusion (attempt $((attempt + 1)))"
+                  echo "🛑 $DISPLAY_NAME completed with status: $conclusion (attempt $attempt/$max_attempts)"
 
-                  # Retry failed jobs only
-                  if [ $attempt -lt $((MAX_RETRIES - 1)) ]; then
-                    attempt=$((attempt + 1))
-                    echo "🔄 Retrying failed jobs only (attempt $((attempt + 1))/$MAX_RETRIES)..."
+                  # Check if we should retry
+                  if [ $attempt -lt $max_attempts ]; then
+                    echo "🔄 Retrying failed jobs only (will be attempt $((attempt + 1))/$max_attempts)..."
 
                     if gh run rerun "$run_id" --failed --repo "${{ env.METAL_REPO }}"; then
                       echo "✅ Rerun triggered for run ID: $run_id"
                       sleep 30  # Wait for rerun to start
-                      elapsed=0  # Reset timeout for retry
-                      break  # Break inner loop to start monitoring again
+                      should_retry=true
+                      break  # Break inner loop to continue outer loop for next attempt
                     else
                       echo "❌ Failed to trigger rerun"
                       echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
                       exit 1
                     fi
                   else
-                    echo "❌ Max retries reached"
+                    echo "❌ Max retries reached ($max_attempts attempts)"
                     echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
                     exit 1
                   fi
@@ -386,7 +387,13 @@ jobs:
               elapsed=$((elapsed + POLL_INTERVAL))
             done
 
-            # Check if we timed out
+            # Check if we broke out to retry or if we timed out
+            if [ "$should_retry" = "true" ]; then
+              attempt=$((attempt + 1))
+              continue  # Continue to next retry attempt
+            fi
+
+            # If we didn't break for retry, we timed out
             if [ $elapsed -ge $timeout_seconds ]; then
               echo "⏰ $DISPLAY_NAME timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
               echo "$OUTPUT_KEY=timeout:$run_url" >> $GITHUB_OUTPUT
@@ -394,8 +401,8 @@ jobs:
             fi
           done
 
-          # If we exit the retry loop without success
-          echo "❌ $DISPLAY_NAME failed after $MAX_RETRIES attempts"
+          # If we somehow exit the retry loop without success (shouldn't happen)
+          echo "❌ $DISPLAY_NAME failed after $max_attempts attempts"
           echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
           exit 1
 

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -78,6 +78,7 @@ env:
   METAL_REPO: tenstorrent/tt-metal
   LLK_REPO: tenstorrent/tt-llk
   GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
+  MAX_RETRIES: 3
   POLL_INTERVAL: 120
 
 permissions:
@@ -277,75 +278,74 @@ jobs:
       - name: Trigger and monitor workflow
         id: monitor
         if: matrix.should-run == true || matrix.should-run == 'true'
-        uses: nick-fields/retry@v3
         env:
           GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
           WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 720 }}
+          MAX_RETRIES: 3
           POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
           PARENT_BRANCH_NAME: ${{ needs.setup.outputs.parent-branch-name }}
           ARCH_PARAM: ${{ needs.setup.outputs.arch-param }}
-        with:
-          timeout_minutes: ${{ inputs.workflow_timeout || 720 }}
-          max_attempts: 3
-          retry_wait_seconds: 60
-          retry_on: error
-          command: |
-            WORKFLOW="${{ matrix.workflow }}"
-            DISPLAY_NAME="${{ matrix.name }}"
-            OUTPUT_KEY="${{ matrix.output-key }}"
+        run: |
+          WORKFLOW="${{ matrix.workflow }}"
+          DISPLAY_NAME="${{ matrix.name }}"
+          OUTPUT_KEY="${{ matrix.output-key }}"
 
-            echo "🚀 Triggering $DISPLAY_NAME ($WORKFLOW)..."
+          echo "🚀 Triggering $DISPLAY_NAME ($WORKFLOW)..."
 
-            # Trigger workflow with appropriate inputs
-            if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
-              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
-                -f architecture="$ARCH_PARAM" \
-                -f run_cpp_tests=true \
-                -f run_metal_iommu_tests=true \
-                -f run_sd_unit_tests=true \
-                -f run_fd_unit_tests=true \
-                -f run_profiler_regression=true \
-                -f run_tt_train_cpp_unit_tests=true \
-                -f run_models_unit_tests=true \
-                -f run_tt_cnn_unit_tests=true
-            elif [ "$WORKFLOW" = "perf-device-models.yaml" ]; then
-              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
-                -f architecture="$ARCH_PARAM"
-            else
-              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
+          # Trigger workflow with appropriate inputs
+          if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
+            gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
+              -f architecture="$ARCH_PARAM" \
+              -f run_cpp_tests=true \
+              -f run_metal_iommu_tests=true \
+              -f run_sd_unit_tests=true \
+              -f run_fd_unit_tests=true \
+              -f run_profiler_regression=true \
+              -f run_tt_train_cpp_unit_tests=true \
+              -f run_models_unit_tests=true \
+              -f run_tt_cnn_unit_tests=true
+          elif [ "$WORKFLOW" = "perf-device-models.yaml" ]; then
+            gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
+              -f architecture="$ARCH_PARAM"
+          else
+            gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
+          fi
+
+          # Poll for run ID
+          run_id=""
+          for i in {1..12}; do
+            sleep 5
+            run_data=$(gh run list --workflow "$WORKFLOW" --branch "$PARENT_BRANCH_NAME" --limit 1 \
+              --json databaseId,url --jq '.[0] | select(.databaseId != null) | "\(.databaseId)|\(.url)"' \
+              --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
+            if [ -n "$run_data" ] && [ "$run_data" != "null" ]; then
+              run_id=$(echo "$run_data" | cut -d'|' -f1)
+              run_url=$(echo "$run_data" | cut -d'|' -f2)
+              break
             fi
+          done
 
-            # Poll for run ID
-            run_id=""
-            for i in {1..12}; do
-              sleep 5
-              run_data=$(gh run list --workflow "$WORKFLOW" --branch "$PARENT_BRANCH_NAME" --limit 1 \
-                --json databaseId,url --jq '.[0] | select(.databaseId != null) | "\(.databaseId)|\(.url)"' \
-                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
-              if [ -n "$run_data" ] && [ "$run_data" != "null" ]; then
-                run_id=$(echo "$run_data" | cut -d'|' -f1)
-                run_url=$(echo "$run_data" | cut -d'|' -f2)
-                break
-              fi
-            done
+          if [ -z "$run_id" ]; then
+            echo "❌ Failed to get run ID for $DISPLAY_NAME"
+            echo "$OUTPUT_KEY=failure:unknown" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
-            if [ -z "$run_id" ]; then
-              echo "❌ Failed to get run ID for $DISPLAY_NAME"
-              echo "$OUTPUT_KEY=failure:unknown" >> $GITHUB_OUTPUT
-              exit 1
-            fi
+          run_url="https://github.com/${{ env.METAL_REPO }}/actions/runs/$run_id"
+          echo "✅ $DISPLAY_NAME triggered (run ID: $run_id): $run_url"
 
-            run_url="https://github.com/${{ env.METAL_REPO }}/actions/runs/$run_id"
-            echo "✅ $DISPLAY_NAME triggered: $run_url"
+          # Monitor workflow with retry logic for failed jobs
+          attempt=0
+          timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
 
-            # Monitor workflow until completion
-            timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
+          while [ $attempt -lt $MAX_RETRIES ]; do
+            echo "📊 Monitoring $DISPLAY_NAME (attempt $((attempt + 1))/$MAX_RETRIES)..."
             elapsed=0
 
             while [ $elapsed -lt $timeout_seconds ]; do
               status=$(gh run view "$run_id" --json status,conclusion \
-                --jq '.status + ":" + (.conclusion // "unknown")' \
-                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "unknown:unknown")
+                --jq '.status + ":" + (.conclusion // "")' \
+                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "unknown:")
               run_status=$(echo "$status" | cut -d: -f1)
               conclusion=$(echo "$status" | cut -d: -f2)
 
@@ -355,9 +355,28 @@ jobs:
                   echo "$OUTPUT_KEY=success:$run_url" >> $GITHUB_OUTPUT
                   exit 0
                 else
-                  echo "🛑 $DISPLAY_NAME failed: $run_url"
-                  echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
-                  exit 1
+                  echo "🛑 $DISPLAY_NAME completed with status: $conclusion (attempt $((attempt + 1)))"
+
+                  # Retry failed jobs only
+                  if [ $attempt -lt $((MAX_RETRIES - 1)) ]; then
+                    attempt=$((attempt + 1))
+                    echo "🔄 Retrying failed jobs only (attempt $((attempt + 1))/$MAX_RETRIES)..."
+
+                    if gh run rerun "$run_id" --failed --repo "${{ env.METAL_REPO }}"; then
+                      echo "✅ Rerun triggered for run ID: $run_id"
+                      sleep 30  # Wait for rerun to start
+                      elapsed=0  # Reset timeout for retry
+                      break  # Break inner loop to start monitoring again
+                    else
+                      echo "❌ Failed to trigger rerun"
+                      echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
+                      exit 1
+                    fi
+                  else
+                    echo "❌ Max retries reached"
+                    echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
+                    exit 1
+                  fi
                 fi
               fi
 
@@ -365,10 +384,18 @@ jobs:
               elapsed=$((elapsed + POLL_INTERVAL))
             done
 
-            # Timeout
-            echo "⏰ $DISPLAY_NAME timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
-            echo "$OUTPUT_KEY=timeout:$run_url" >> $GITHUB_OUTPUT
-            exit 1
+            # Check if we timed out
+            if [ $elapsed -ge $timeout_seconds ]; then
+              echo "⏰ $DISPLAY_NAME timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
+              echo "$OUTPUT_KEY=timeout:$run_url" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          done
+
+          # If we exit the retry loop without success
+          echo "❌ $DISPLAY_NAME failed after $MAX_RETRIES attempts"
+          echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
+          exit 1
 
   # Job 3: Terminate spawned workflows if parent is cancelled
   cancel-on-failure:

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -44,18 +44,27 @@ on:
         type: number
         default: 720
     outputs:
+      run-tests-result:
+        description: 'Overall result of all test workflows (success/failure/cancelled)'
+        value: ${{ jobs.run-tests.result }}
+      branch-exists:
+        description: 'Whether the mirrored branch exists'
+        value: ${{ jobs.setup.outputs.branch-exists }}
+      test-branch-name:
+        description: 'Name of the test branch created'
+        value: ${{ jobs.setup.outputs.test-branch-name }}
       all-post-commit-result:
         description: 'Result of All post-commit tests (status:url format)'
-        value: ${{ jobs.setup-and-test.outputs.all-post-commit-result }}
+        value: ${{ jobs.run-tests.outputs.all-post-commit-result }}
       blackhole-result:
         description: 'Result of Blackhole post-commit tests (status:url format)'
-        value: ${{ jobs.setup-and-test.outputs.blackhole-result }}
+        value: ${{ jobs.run-tests.outputs.blackhole-result }}
       tt-metal-l2-nightly-result:
         description: 'Result of All post-commit C++ tests (status:url format)'
-        value: ${{ jobs.setup-and-test.outputs.tt-metal-l2-nightly-result }}
+        value: ${{ jobs.run-tests.outputs.tt-metal-l2-nightly-result }}
       perf-device-models-result:
         description: 'Result of Device perf regressions (status:url format)'
-        value: ${{ jobs.setup-and-test.outputs.perf-device-models-result }}
+        value: ${{ jobs.run-tests.outputs.perf-device-models-result }}
 
 # NOTE: Concurrency is intentionally NOT set here.
 # When called via workflow_call, the caller (tt-llk) manages concurrency.
@@ -69,7 +78,6 @@ env:
   METAL_REPO: tenstorrent/tt-metal
   LLK_REPO: tenstorrent/tt-llk
   GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
-  MAX_RETRIES: 3
   POLL_INTERVAL: 120
 
 permissions:
@@ -80,21 +88,19 @@ permissions:
   checks: read
 
 jobs:
-  setup-and-test:
+  # Job 1: Setup - Prepare branches and determine which workflows to run
+  setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 720
+    timeout-minutes: 30
     outputs:
       branch-exists: ${{ steps.check-branch.outputs.branch-exists }}
       test-branch-name: ${{ steps.check-branch.outputs.test-branch-name }}
       parent-branch-name: ${{ env.PARENT_BRANCH_NAME }}
-      all-post-commit-run-id: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
-      blackhole-run-id: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
-      tt-metal-l2-nightly-run-id: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
-      perf-device-models-run-id: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
-      all-post-commit-result: ${{ steps.monitor-workflows.outputs.all-post-commit-result }}
-      blackhole-result: ${{ steps.monitor-workflows.outputs.blackhole-result }}
-      tt-metal-l2-nightly-result: ${{ steps.monitor-workflows.outputs.tt-metal-l2-nightly-result }}
-      perf-device-models-result: ${{ steps.monitor-workflows.outputs.perf-device-models-result }}
+      should-run-all-post-commit: ${{ inputs.run_all_post_commit }}
+      should-run-blackhole: ${{ inputs.run_blackhole_post_commit }}
+      should-run-l2-nightly: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+      should-run-perf: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+      arch-param: ${{ steps.check-branch.outputs.arch-param }}
     steps:
       - name: Setup
         uses: actions/checkout@v4
@@ -105,23 +111,24 @@ jobs:
           fetch-depth: 0
           ref: main
           clean: true
+
       - name: Configure git
         run: |
           git config --global user.name "LLK Integration Tester [bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Cancel any previous spawned workflows
         env:
           GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
           echo "🔍 Proactively cancelling any previous spawned workflows for this branch..."
           MIRRORED_BRANCH="${{ inputs.mirrored_branch }}"
-          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml")
+          SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml" "perf-device-models.yaml")
           STATUSES=("queued" "in_progress")
 
           for workflow in "${SPAWNED_WORKFLOWS[@]}"; do
             for status in "${STATUSES[@]}"; do
               echo "🔍 Checking for $status instances of $workflow..."
-              # Get all runs and filter by branch pattern (test-llk-<mirrored_branch>-*)
               run_data=$(gh run list \
                 --workflow "$workflow" \
                 --status "$status" \
@@ -129,7 +136,6 @@ jobs:
                 --json databaseId,headBranch \
                 --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "[]")
 
-              # Filter runs matching our branch pattern and extract IDs
               run_ids=$(echo "$run_data" | jq -r --arg pattern "test-llk-$MIRRORED_BRANCH-" \
                 '.[] | select(.headBranch | startswith($pattern)) | .databaseId')
 
@@ -148,7 +154,7 @@ jobs:
             done
           done
 
-          # Also clean up old parent branches from previous runs to avoid git conflicts
+          # Clean up old parent branches
           echo "🧹 Cleaning up old parent branches..."
           OLD_BRANCHES=$(gh api "repos/${{ env.METAL_REPO }}/branches" --paginate --jq \
             --arg pattern "test-llk-$MIRRORED_BRANCH-" \
@@ -165,6 +171,7 @@ jobs:
           fi
 
           echo "✅ Proactive cleanup completed"
+
       - name: Setup test branch and parent repository
         id: check-branch
         run: |
@@ -179,23 +186,18 @@ jobs:
             echo "branch-exists=true" >> $GITHUB_OUTPUT
             echo "✅ Mirrored branch '$MIRRORED_BRANCH' exists in submodule"
 
-            # Get the commit currently pinned in the parent repo
             cd "${{ github.workspace }}"
             PARENT_PINNED_COMMIT=$(git ls-tree main "$SUBMODULE_PATH" | awk '{print $3}')
             cd "$SUBMODULE_PATH"
 
-            # Checkout mirrored branch
             git checkout -b "$TEST_BRANCH_NAME" "$MIRRORED_BRANCH"
 
-            # Ensure branch is up to date with latest submodule's main
             echo "🔍 Checking if branch needs updates from latest submodule main..."
             BRANCH_VS_MAIN_COMMITS=$(git rev-list --count HEAD..origin/main)
             if [ "$BRANCH_VS_MAIN_COMMITS" -gt 0 ]; then
               echo "🔄 Branch is $BRANCH_VS_MAIN_COMMITS commits behind latest main - merging latest changes"
               if ! git merge origin/main --no-edit; then
                 echo "❌ Merge with latest main failed - conflicts need manual resolution"
-                echo "💡 This suggests genuine conflicts between your changes and recent main updates"
-                echo "💡 Please resolve conflicts locally and push updated branch"
                 exit 1
               fi
               echo "✅ Successfully merged latest submodule main into branch"
@@ -203,15 +205,11 @@ jobs:
               echo "✅ Branch is up to date with latest submodule main"
             fi
 
-            echo "✅ Branch updated with latest submodule changes - ready for testing"
-
-            # Push test branch to origin
             if ! git push origin "$TEST_BRANCH_NAME"; then
               echo "❌ Failed to push test branch to origin"
               exit 1
             fi
 
-            # Update parent repository to reference new submodule commit
             cd "${{ github.workspace }}"
             git checkout -b "${{ env.PARENT_BRANCH_NAME }}"
             git add "$SUBMODULE_PATH"
@@ -223,264 +221,170 @@ jobs:
 
             echo "test-branch-name=$TEST_BRANCH_NAME" >> $GITHUB_OUTPUT
             echo "✅ Created test branch '$TEST_BRANCH_NAME' and updated parent repository"
+
+            # Build architecture parameter
+            if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
+              echo 'arch-param=["wormhole_b0", "blackhole"]' >> $GITHUB_OUTPUT
+            elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
+              echo 'arch-param=["wormhole_b0"]' >> $GITHUB_OUTPUT
+            else
+              echo 'arch-param=["blackhole"]' >> $GITHUB_OUTPUT
+            fi
           else
             echo "branch-exists=false" >> $GITHUB_OUTPUT
             echo "❌ Mirrored branch '$MIRRORED_BRANCH' does not exist in submodule"
           fi
-      - name: Trigger workflows
-        id: trigger-workflows
-        if: |
-          steps.check-branch.outputs.branch-exists == 'true' &&
-          (inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true)
-        env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
-          PARENT_BRANCH_NAME: ${{ env.PARENT_BRANCH_NAME }}
+
+  # Job 2: Run tests using matrix strategy for parallel execution
+  run-tests:
+    needs: setup
+    if: |
+      needs.setup.outputs.branch-exists == 'true' &&
+      (inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.workflow_timeout || 720 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - workflow: "all-post-commit-workflows.yaml"
+            name: "All Post Commit Workflows"
+            output-key: "all-post-commit-result"
+            should-run: ${{ inputs.run_all_post_commit }}
+          - workflow: "blackhole-post-commit.yaml"
+            name: "Blackhole Post Commit"
+            output-key: "blackhole-result"
+            should-run: ${{ inputs.run_blackhole_post_commit }}
+          - workflow: "tt-metal-l2-nightly.yaml"
+            name: "TT-Metal L2 Nightly APC"
+            output-key: "tt-metal-l2-nightly-result"
+            should-run: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+          - workflow: "perf-device-models.yaml"
+            name: "Device Perf Regressions"
+            output-key: "perf-device-models-result"
+            should-run: ${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}
+    outputs:
+      all-post-commit-result: ${{ steps.monitor.outputs.all-post-commit-result }}
+      blackhole-result: ${{ steps.monitor.outputs.blackhole-result }}
+      tt-metal-l2-nightly-result: ${{ steps.monitor.outputs.tt-metal-l2-nightly-result }}
+      perf-device-models-result: ${{ steps.monitor.outputs.perf-device-models-result }}
+    steps:
+      - name: Skip if not enabled
+        if: matrix.should-run != true && matrix.should-run != 'true'
         run: |
-          # Define workflows to trigger
-          declare -A workflows
-          workflows["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}"
-          workflows["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}"
-          workflows["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
-          workflows["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}"
+          echo "⚪ Skipping ${{ matrix.name }} - not enabled for this run"
 
-          declare -A run_ids
+      - name: Trigger and monitor workflow
+        id: monitor
+        if: matrix.should-run == true || matrix.should-run == 'true'
+        uses: nick-fields/retry@v3
+        env:
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
+          WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 720 }}
+          POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
+          PARENT_BRANCH_NAME: ${{ needs.setup.outputs.parent-branch-name }}
+          ARCH_PARAM: ${{ needs.setup.outputs.arch-param }}
+        with:
+          timeout_minutes: ${{ inputs.workflow_timeout || 720 }}
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          command: |
+            WORKFLOW="${{ matrix.workflow }}"
+            DISPLAY_NAME="${{ matrix.name }}"
+            OUTPUT_KEY="${{ matrix.output-key }}"
 
-          # Build architecture parameter based on which post-commit tests are enabled
-          if [ "${{ inputs.run_all_post_commit }}" = "true" ] && [ "${{ inputs.run_blackhole_post_commit }}" = "true" ]; then
-            ARCH_PARAM='["wormhole_b0", "blackhole"]'
-          elif [ "${{ inputs.run_all_post_commit }}" = "true" ]; then
-            ARCH_PARAM='["wormhole_b0"]'
-          else
-            ARCH_PARAM='["blackhole"]'
-          fi
+            echo "🚀 Triggering $DISPLAY_NAME ($WORKFLOW)..."
 
-          # Function to trigger workflow and get run ID and URL
-          trigger_and_get_id() {
-            local workflow_file="$1"
-            local display_name="$2"
-
-            if [ "$workflow_file" = "tt-metal-l2-nightly.yaml" ]; then
-              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
-              -f architecture="$ARCH_PARAM" \
-              -f run_cpp_tests=true \
-              -f run_metal_iommu_tests=true \
-              -f run_sd_unit_tests=true \
-              -f run_fd_unit_tests=true \
-              -f run_profiler_regression=true \
-              -f run_tt_train_cpp_unit_tests=true \
-              -f run_models_unit_tests=true \
-              -f run_tt_cnn_unit_tests=true
-            elif [ "$workflow_file" = "perf-device-models.yaml" ]; then
-              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
-              -f architecture="$ARCH_PARAM"
+            # Trigger workflow with appropriate inputs
+            if [ "$WORKFLOW" = "tt-metal-l2-nightly.yaml" ]; then
+              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
+                -f architecture="$ARCH_PARAM" \
+                -f run_cpp_tests=true \
+                -f run_metal_iommu_tests=true \
+                -f run_sd_unit_tests=true \
+                -f run_fd_unit_tests=true \
+                -f run_profiler_regression=true \
+                -f run_tt_train_cpp_unit_tests=true \
+                -f run_models_unit_tests=true \
+                -f run_tt_cnn_unit_tests=true
+            elif [ "$WORKFLOW" = "perf-device-models.yaml" ]; then
+              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}" \
+                -f architecture="$ARCH_PARAM"
             else
-              gh workflow run "$workflow_file" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
+              gh workflow run "$WORKFLOW" --ref "$PARENT_BRANCH_NAME" --repo "${{ env.METAL_REPO }}"
             fi
 
-            # Poll for run ID and URL
-            local run_data=""
+            # Poll for run ID
+            run_id=""
             for i in {1..12}; do
               sleep 5
-              run_data=$(gh run list --workflow "$workflow_file" --branch "$PARENT_BRANCH_NAME" --limit 1 --json databaseId,url --jq '.[0] | select(.databaseId != null) | "\(.databaseId)|\(.url)"' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
+              run_data=$(gh run list --workflow "$WORKFLOW" --branch "$PARENT_BRANCH_NAME" --limit 1 \
+                --json databaseId,url --jq '.[0] | select(.databaseId != null) | "\(.databaseId)|\(.url)"' \
+                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
               if [ -n "$run_data" ] && [ "$run_data" != "null" ]; then
+                run_id=$(echo "$run_data" | cut -d'|' -f1)
+                run_url=$(echo "$run_data" | cut -d'|' -f2)
                 break
               fi
             done
-            echo "$run_data"
-          }
 
-          # Trigger enabled workflows
-          for workflow in "${!workflows[@]}"; do
-            if [ "${workflows[$workflow]}" = "true" ]; then
-              echo "🚀 Triggering $workflow..."
-              case "$workflow" in
-                "all-post-commit-workflows.yaml")
-                  run_data=$(trigger_and_get_id "$workflow" "All post-commit")
-                  if [ -n "$run_data" ]; then
-                    run_ids["all-post-commit"]=$(echo "$run_data" | cut -d'|' -f1)
-                    run_url=$(echo "$run_data" | cut -d'|' -f2)
-                    echo "✅ All post-commit run: $run_url"
-                  fi
-                  ;;
-                "blackhole-post-commit.yaml")
-                  run_data=$(trigger_and_get_id "$workflow" "Blackhole")
-                  if [ -n "$run_data" ]; then
-                    run_ids["blackhole"]=$(echo "$run_data" | cut -d'|' -f1)
-                    run_url=$(echo "$run_data" | cut -d'|' -f2)
-                    echo "✅ Blackhole post-commit run: $run_url"
-                  fi
-                  ;;
-                "tt-metal-l2-nightly.yaml")
-                  run_data=$(trigger_and_get_id "$workflow" "TT-Metal L2 Nightly APC")
-                  if [ -n "$run_data" ]; then
-                    run_ids["tt-metal-l2-nightly"]=$(echo "$run_data" | cut -d'|' -f1)
-                    run_url=$(echo "$run_data" | cut -d'|' -f2)
-                    echo "✅ All post-commit C++ tests run: $run_url"
-                  fi
-                  ;;
-                "perf-device-models.yaml")
-                  run_data=$(trigger_and_get_id "$workflow" "Device Perf Regressions")
-                  if [ -n "$run_data" ]; then
-                    run_ids["perf-device-models"]=$(echo "$run_data" | cut -d'|' -f1)
-                    run_url=$(echo "$run_data" | cut -d'|' -f2)
-                    echo "✅ Device perf regressions run: $run_url"
-                  fi
-                  ;;
-              esac
-            fi
-          done
-
-          # Output run IDs for monitoring steps
-          echo "all-post-commit-run-id=${run_ids[all-post-commit]}" >> $GITHUB_OUTPUT
-          echo "blackhole-run-id=${run_ids[blackhole]}" >> $GITHUB_OUTPUT
-          echo "tt-metal-l2-nightly-run-id=${run_ids[tt-metal-l2-nightly]}" >> $GITHUB_OUTPUT
-          echo "perf-device-models-run-id=${run_ids[perf-device-models]}" >> $GITHUB_OUTPUT
-      - name: Monitor triggered workflows
-        id: monitor-workflows
-        if: |
-          steps.check-branch.outputs.branch-exists == 'true' &&
-          (inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true)
-        env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
-          WORKFLOW_TIMEOUT: ${{ env.WORKFLOW_TIMEOUT }}
-          MAX_RETRIES: ${{ env.MAX_RETRIES }}
-          POLL_INTERVAL: ${{ env.POLL_INTERVAL }}
-          ALL_POST_COMMIT_RUN_ID: ${{ steps.trigger-workflows.outputs.all-post-commit-run-id }}
-          BLACKHOLE_RUN_ID: ${{ steps.trigger-workflows.outputs.blackhole-run-id }}
-          TT_METAL_L2_NIGHTLY_RUN_ID: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
-          PERF_DEVICE_MODELS_RUN_ID: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
-        run: |
-          # Create temporary directory for workflow results to avoid race conditions
-          # when multiple background processes write outputs simultaneously
-          TEMP_OUTPUT_DIR=$(mktemp -d)
-          trap "rm -rf $TEMP_OUTPUT_DIR" EXIT
-
-          # Helper function for workflow monitoring
-          # Writes results to temp files instead of $GITHUB_OUTPUT to avoid race conditions
-          monitor_workflow() {
-            local run_id="$1"
-            local workflow_name="$2"
-            local output_var="$3"
-            local temp_file="$TEMP_OUTPUT_DIR/${output_var}.txt"
-
-            if [ -z "$run_id" ] || [ "$run_id" = "" ]; then
-              echo "⚪ Skipping $workflow_name - not triggered"
-              return 0
+            if [ -z "$run_id" ]; then
+              echo "❌ Failed to get run ID for $DISPLAY_NAME"
+              echo "$OUTPUT_KEY=failure:unknown" >> $GITHUB_OUTPUT
+              exit 1
             fi
 
-            local retries=0
-            local timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
-            local elapsed=0
-            local run_url="https://github.com/tenstorrent/tt-metal/actions/runs/$run_id"
-            echo "🚀 Monitoring $workflow_name (run ID: $run_id) - $run_url"
-            while [ $retries -lt $MAX_RETRIES ]; do
-              while [ $elapsed -lt $timeout_seconds ]; do
-                status=$(gh run view "$run_id" --json status,conclusion --jq '.status + ":" + (.conclusion // "unknown")' --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "unknown:unknown")
-                run_status=$(echo "$status" | cut -d: -f1)
-                conclusion=$(echo "$status" | cut -d: -f2)
+            run_url="https://github.com/${{ env.METAL_REPO }}/actions/runs/$run_id"
+            echo "✅ $DISPLAY_NAME triggered: $run_url"
 
-                if [ "$run_status" = "completed" ]; then
-                  if [ "$conclusion" = "success" ]; then
-                    echo "🎯 $workflow_name passed: $run_url"
-                    echo "$output_var=success:$run_url" > "$temp_file"
-                    return 0
-                  else
-                    echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url/attempts/$(($retries + 1))"
-                    if [ $retries -ge $((MAX_RETRIES - 1)) ]; then
-                      echo "$output_var=failure:$run_url" > "$temp_file"
-                      return 1
-                    fi
-                    break
-                  fi
-                fi
-                sleep $POLL_INTERVAL
-                elapsed=$((elapsed + POLL_INTERVAL))
-              done
-              # Handle timeout
-              if [ $elapsed -ge $timeout_seconds ]; then
-                echo "⏰ $workflow_name timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
-                echo "$output_var=timeout:$run_url" > "$temp_file"
-                return 1
-              fi
-              # Retry logic
-              retries=$((retries + 1))
-              if [ $retries -lt $MAX_RETRIES ]; then
-                echo "🔄 Retrying $workflow_name (attempt $((retries + 1))/$MAX_RETRIES)"
-                if gh run rerun "$run_id" --failed --repo "${{ env.METAL_REPO }}"; then
-                  sleep 30
-                  elapsed=0 # Reset timer for retry
+            # Monitor workflow until completion
+            timeout_seconds=$((WORKFLOW_TIMEOUT * 60))
+            elapsed=0
+
+            while [ $elapsed -lt $timeout_seconds ]; do
+              status=$(gh run view "$run_id" --json status,conclusion \
+                --jq '.status + ":" + (.conclusion // "unknown")' \
+                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "unknown:unknown")
+              run_status=$(echo "$status" | cut -d: -f1)
+              conclusion=$(echo "$status" | cut -d: -f2)
+
+              if [ "$run_status" = "completed" ]; then
+                if [ "$conclusion" = "success" ]; then
+                  echo "🎯 $DISPLAY_NAME passed: $run_url"
+                  echo "$OUTPUT_KEY=success:$run_url" >> $GITHUB_OUTPUT
+                  exit 0
                 else
-                  echo "🛑 Failed to trigger retry for $workflow_name"
-                  echo "$output_var=failure:$run_url" > "$temp_file"
-                  return 1
+                  echo "🛑 $DISPLAY_NAME failed: $run_url"
+                  echo "$OUTPUT_KEY=failure:$run_url" >> $GITHUB_OUTPUT
+                  exit 1
                 fi
               fi
+
+              sleep $POLL_INTERVAL
+              elapsed=$((elapsed + POLL_INTERVAL))
             done
-            echo "$output_var=failure:$run_url" > "$temp_file"
-            return 1
-          }
 
-          # Monitor workflows using data-driven approach
-          declare -A workflow_configs
-          workflow_configs["all-post-commit-workflows.yaml"]="${{ inputs.run_all_post_commit }}:$ALL_POST_COMMIT_RUN_ID:all-post-commit-result"
-          workflow_configs["blackhole-post-commit.yaml"]="${{ inputs.run_blackhole_post_commit }}:$BLACKHOLE_RUN_ID:blackhole-result"
-          workflow_configs["tt-metal-l2-nightly.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$TT_METAL_L2_NIGHTLY_RUN_ID:tt-metal-l2-nightly-result"
-          workflow_configs["perf-device-models.yaml"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:$PERF_DEVICE_MODELS_RUN_ID:perf-device-models-result"
-          exit_code=0
+            # Timeout
+            echo "⏰ $DISPLAY_NAME timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
+            echo "$OUTPUT_KEY=timeout:$run_url" >> $GITHUB_OUTPUT
+            exit 1
 
-          echo "📊 Starting parallel monitoring of all triggered workflows..."
-          # Start monitoring all workflows in parallel
-          declare -a pids=()
-          for workflow_file in "${!workflow_configs[@]}"; do
-            IFS=':' read -r enabled run_id output_var <<< "${workflow_configs[$workflow_file]}"
-
-            if [ "$enabled" = "true" ]; then
-              # Run monitor_workflow in background
-              monitor_workflow "$run_id" "$workflow_file" "$output_var" &
-              pids+=("$!")
-            fi
-          done
-
-          # If no workflows were enabled, exit early with a log message
-          if [ ${#pids[@]} -eq 0 ]; then
-            echo "ℹ️ No workflows to monitor"
-            exit 0
-          fi
-          # Wait for all background processes to complete and collect exit codes
-          echo "⏳ Waiting for all workflows to complete..."
-          exit_code=0
-          for pid in "${pids[@]}"; do
-            if ! wait "$pid"; then
-              exit_code=1
-            fi
-          done
-
-          # Consolidate results from temp files into $GITHUB_OUTPUT
-          # This happens after all parallel processes complete, avoiding race conditions
-          echo "📝 Consolidating workflow results..."
-          for temp_file in "$TEMP_OUTPUT_DIR"/*.txt; do
-            if [ -f "$temp_file" ]; then
-              cat "$temp_file" >> $GITHUB_OUTPUT
-            fi
-          done
-
-          if [ "$exit_code" -eq 0 ]; then
-            echo "✅ All workflows completed successfully"
-          else
-            echo "❌ One or more workflows failed"
-          fi
-          exit $exit_code
-      - name: Terminate spawned workflows on cancellation
-        if: cancelled()
+  # Job 3: Terminate spawned workflows if parent is cancelled
+  cancel-on-failure:
+    needs: [setup, run-tests]
+    if: cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Terminate spawned workflows
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
-          PARENT_BRANCH_NAME: ${{ env.PARENT_BRANCH_NAME }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
+          PARENT_BRANCH_NAME: ${{ needs.setup.outputs.parent-branch-name }}
         run: |
           echo "🔄 Parent workflow cancelled - cleaning up spawned workflows..."
-          # Workflows spawned by this job
           SPAWNED_WORKFLOWS=("all-post-commit-workflows.yaml" "blackhole-post-commit.yaml" "tt-metal-l2-nightly.yaml" "perf-device-models.yaml")
-          # Consider both queued and in_progress runs
           STATUSES=("queued" "in_progress")
+
           for workflow in "${SPAWNED_WORKFLOWS[@]}"; do
             for status in "${STATUSES[@]}"; do
               echo "🔍 Checking for $status instances of $workflow on branch $PARENT_BRANCH_NAME..."
@@ -509,78 +413,109 @@ jobs:
           echo "✅ Spawned workflow cleanup completed"
 
   cleanup-and-report:
-    needs: setup-and-test
+    needs: [setup, run-tests]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Cleanup test branches
-        if: needs.setup-and-test.outputs.branch-exists == 'true'
+        if: needs.setup.outputs.branch-exists == 'true'
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
         run: |
-          TEST_BRANCH_NAME="${{ needs.setup-and-test.outputs.test-branch-name }}"
-          PARENT_BRANCH_NAME="${{ needs.setup-and-test.outputs.parent-branch-name }}"
+          TEST_BRANCH_NAME="${{ needs.setup.outputs.test-branch-name }}"
+          PARENT_BRANCH_NAME="${{ needs.setup.outputs.parent-branch-name }}"
 
           # Clean up test branch in submodule
-
           gh api --method DELETE "repos/${{ env.LLK_REPO }}/git/refs/heads/$TEST_BRANCH_NAME" 2>/dev/null || echo "Test branch already deleted or doesn't exist"
 
           # Clean up parent branch
           gh api --method DELETE "repos/${{ env.METAL_REPO }}/git/refs/heads/$PARENT_BRANCH_NAME" 2>/dev/null || echo "Parent branch already deleted or doesn't exist"
 
           echo "✅ Cleaned up test branches"
+
       - name: Generate test report
+        env:
+          GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
+          PARENT_BRANCH_NAME: ${{ needs.setup.outputs.parent-branch-name }}
         run: |
           echo "## Test Results Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ inputs.mirrored_branch }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.setup-and-test.outputs.branch-exists }}" = "true" ]; then
-            echo "**Test Branch:** ${{ needs.setup-and-test.outputs.test-branch-name }}" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.setup.outputs.branch-exists }}" = "true" ]; then
+            echo "**Test Branch:** ${{ needs.setup.outputs.test-branch-name }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Test Configuration:**" >> $GITHUB_STEP_SUMMARY
             echo "- All Post-Commit Tests: ${{ inputs.run_all_post_commit && '🟢 Enabled' || '⚪ Disabled' }}" >> $GITHUB_STEP_SUMMARY
             echo "- Blackhole Post-Commit Tests: ${{ inputs.run_blackhole_post_commit && '🟢 Enabled' || '⚪ Disabled' }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            # Display detailed test results with links
             echo "**Test Results:**" >> $GITHUB_STEP_SUMMARY
 
-            # Function to display test result
-            # Args: test_name, enabled (true/false), result (format: status:url or empty)
-            display_test_result() {
-              local test_name="$1"
-              local enabled="$2"
-              local result="$3"
+            # Function to check workflow status from GitHub API
+            check_workflow_result() {
+              local workflow_file="$1"
+              local test_name="$2"
+              local enabled="$3"
 
-              if [ "$enabled" = "true" ]; then
-                if [ -n "$result" ]; then
-                  # Result format is "status:url" where url contains "https://"
-                  # Use cut to extract status (field 1) and url (fields 2 onwards)
-                  local status=$(echo "$result" | cut -d: -f1)
-                  local url=$(echo "$result" | cut -d: -f2-)
-                  case "$status" in
-                    "success") echo "- 🎯 **$test_name:** Passed - [View run]($url)" >> $GITHUB_STEP_SUMMARY ;;
-                    "failure") echo "- 🛑 **$test_name:** Failed - [View run]($url)" >> $GITHUB_STEP_SUMMARY ;;
-                    "timeout") echo "- ⏰ **$test_name:** Timed Out - [View run]($url)" >> $GITHUB_STEP_SUMMARY ;;
-                    *) echo "- ⚪ **$test_name:** Status unknown ($status)" >> $GITHUB_STEP_SUMMARY ;;
-                  esac
-                else
-                  echo "- ⚪ **$test_name:** No result captured" >> $GITHUB_STEP_SUMMARY
-                fi
-              else
+              if [ "$enabled" != "true" ]; then
                 echo "- ⚪ **$test_name:** Not run" >> $GITHUB_STEP_SUMMARY
+                return
+              fi
+
+              # Get the latest run for this workflow on our branch
+              local run_data=$(gh run list \
+                --workflow "$workflow_file" \
+                --branch "$PARENT_BRANCH_NAME" \
+                --limit 1 \
+                --json conclusion,url,status \
+                --jq '.[0] // empty' \
+                --repo "${{ env.METAL_REPO }}" 2>/dev/null || echo "")
+
+              if [ -z "$run_data" ] || [ "$run_data" = "null" ]; then
+                echo "- ⚪ **$test_name:** No run found" >> $GITHUB_STEP_SUMMARY
+                return
+              fi
+
+              local status=$(echo "$run_data" | jq -r '.status // "unknown"')
+              local conclusion=$(echo "$run_data" | jq -r '.conclusion // "unknown"')
+              local url=$(echo "$run_data" | jq -r '.url // ""')
+
+              if [ "$status" != "completed" ]; then
+                echo "- 🔄 **$test_name:** In progress - [View run]($url)" >> $GITHUB_STEP_SUMMARY
+              elif [ "$conclusion" = "success" ]; then
+                echo "- 🎯 **$test_name:** Passed - [View run]($url)" >> $GITHUB_STEP_SUMMARY
+              elif [ "$conclusion" = "failure" ]; then
+                echo "- 🛑 **$test_name:** Failed - [View run]($url)" >> $GITHUB_STEP_SUMMARY
+              elif [ "$conclusion" = "cancelled" ]; then
+                echo "- ⏹️ **$test_name:** Cancelled - [View run]($url)" >> $GITHUB_STEP_SUMMARY
+              elif [ "$conclusion" = "timed_out" ]; then
+                echo "- ⏰ **$test_name:** Timed Out - [View run]($url)" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- ⚪ **$test_name:** Status: $conclusion - [View run]($url)" >> $GITHUB_STEP_SUMMARY
               fi
             }
 
-            # Display results for each test type directly (avoids IFS parsing issues)
-            display_test_result "All Post-Commit Tests" "${{ inputs.run_all_post_commit }}" "${{ needs.setup-and-test.outputs.all-post-commit-result }}"
-            display_test_result "Blackhole Post-Commit Tests" "${{ inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.blackhole-result }}"
-            display_test_result "TT-Metal L2 Nightly APC Tests" "${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
-            display_test_result "Device Perf Regressions" "${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.perf-device-models-result }}"
+            # Check results for each workflow type
+            check_workflow_result "all-post-commit-workflows.yaml" "All Post-Commit Tests" "${{ inputs.run_all_post_commit }}"
+            check_workflow_result "blackhole-post-commit.yaml" "Blackhole Post-Commit Tests" "${{ inputs.run_blackhole_post_commit }}"
+            check_workflow_result "tt-metal-l2-nightly.yaml" "TT-Metal L2 Nightly APC Tests" "${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}"
+            check_workflow_result "perf-device-models.yaml" "Device Perf Regressions" "${{ inputs.run_all_post_commit == true || inputs.run_blackhole_post_commit == true }}"
 
             echo "" >> $GITHUB_STEP_SUMMARY
+
+            # Overall status
+            if [ "${{ needs.run-tests.result }}" = "success" ]; then
+              echo "### ✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.run-tests.result }}" = "failure" ]; then
+              echo "### ❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.run-tests.result }}" = "cancelled" ]; then
+              echo "### ⏹️ Tests were cancelled" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.run-tests.result }}" = "skipped" ]; then
+              echo "### ⚪ Tests were skipped" >> $GITHUB_STEP_SUMMARY
+            fi
 
           else
             echo "❌ **Branch Setup:** Mirrored branch '${{ inputs.mirrored_branch }}' does not exist" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -267,13 +267,13 @@ jobs:
       perf-device-models-result: ${{ steps.monitor.outputs.perf-device-models-result }}
     steps:
       - name: Skip if not enabled
-        if: matrix.should-run != 'true'
+        if: matrix.should-run != true && matrix.should-run != 'true'
         run: |
           echo "⚪ Skipping ${{ matrix.name }} - not enabled for this run"
 
       - name: Trigger and monitor workflow
         id: monitor
-        if: matrix.should-run == 'true'
+        if: matrix.should-run == true || matrix.should-run == 'true'
         env:
           GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
           WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 720 }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -293,11 +293,18 @@ jobs:
           TT_METAL_L2_NIGHTLY_RUN_ID: ${{ steps.trigger-workflows.outputs.tt-metal-l2-nightly-run-id }}
           PERF_DEVICE_MODELS_RUN_ID: ${{ steps.trigger-workflows.outputs.perf-device-models-run-id }}
         run: |
+          # Create temporary directory for workflow results to avoid race conditions
+          # when multiple background processes write outputs simultaneously
+          TEMP_OUTPUT_DIR=$(mktemp -d)
+          trap "rm -rf $TEMP_OUTPUT_DIR" EXIT
+
           # Helper function for workflow monitoring
+          # Writes results to temp files instead of $GITHUB_OUTPUT to avoid race conditions
           monitor_workflow() {
             local run_id="$1"
             local workflow_name="$2"
             local output_var="$3"
+            local temp_file="$TEMP_OUTPUT_DIR/${output_var}.txt"
 
             if [ -z "$run_id" ] || [ "$run_id" = "" ]; then
               echo "⚪ Skipping $workflow_name - not triggered"
@@ -318,12 +325,12 @@ jobs:
                 if [ "$run_status" = "completed" ]; then
                   if [ "$conclusion" = "success" ]; then
                     echo "🎯 $workflow_name passed: $run_url"
-                    echo "$output_var=success:$run_url" >> $GITHUB_OUTPUT
+                    echo "$output_var=success:$run_url" > "$temp_file"
                     return 0
                   else
                     echo "🛑 $workflow_name failed (attempt $((retries + 1))): $run_url/attempts/$(($retries + 1))"
                     if [ $retries -ge $((MAX_RETRIES - 1)) ]; then
-                      echo "$output_var=failure:$run_url" >> $GITHUB_OUTPUT
+                      echo "$output_var=failure:$run_url" > "$temp_file"
                       return 1
                     fi
                     break
@@ -335,7 +342,7 @@ jobs:
               # Handle timeout
               if [ $elapsed -ge $timeout_seconds ]; then
                 echo "⏰ $workflow_name timed out after ${WORKFLOW_TIMEOUT}m: $run_url"
-                echo "$output_var=timeout:$run_url" >> $GITHUB_OUTPUT
+                echo "$output_var=timeout:$run_url" > "$temp_file"
                 return 1
               fi
               # Retry logic
@@ -347,12 +354,12 @@ jobs:
                   elapsed=0 # Reset timer for retry
                 else
                   echo "🛑 Failed to trigger retry for $workflow_name"
-                  echo "$output_var=failure:$run_url" >> $GITHUB_OUTPUT
+                  echo "$output_var=failure:$run_url" > "$temp_file"
                   return 1
                 fi
               fi
             done
-            echo "$output_var=failure:$run_url" >> $GITHUB_OUTPUT
+            echo "$output_var=failure:$run_url" > "$temp_file"
             return 1
           }
 
@@ -390,6 +397,16 @@ jobs:
               exit_code=1
             fi
           done
+
+          # Consolidate results from temp files into $GITHUB_OUTPUT
+          # This happens after all parallel processes complete, avoiding race conditions
+          echo "📝 Consolidating workflow results..."
+          for temp_file in "$TEMP_OUTPUT_DIR"/*.txt; do
+            if [ -f "$temp_file" ]; then
+              cat "$temp_file" >> $GITHUB_OUTPUT
+            fi
+          done
+
           if [ "$exit_code" -eq 0 ]; then
             echo "✅ All workflows completed successfully"
           else
@@ -473,14 +490,8 @@ jobs:
             # Display detailed test results with links
             echo "**Test Results:**" >> $GITHUB_STEP_SUMMARY
 
-            # Display test results using data-driven approach
-            declare -A test_configs
-            test_configs["All Post-Commit Tests"]="${{ inputs.run_all_post_commit }}:${{ needs.setup-and-test.outputs.all-post-commit-result }}"
-            test_configs["Blackhole Post-Commit Tests"]="${{ inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.blackhole-result }}"
-            test_configs["TT-Metal L2 Nightly APC Tests"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
-            test_configs["Device Perf Regressions"]="${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}:${{ needs.setup-and-test.outputs.perf-device-models-result }}"
-
             # Function to display test result
+            # Args: test_name, enabled (true/false), result (format: status:url or empty)
             display_test_result() {
               local test_name="$1"
               local enabled="$2"
@@ -488,6 +499,8 @@ jobs:
 
               if [ "$enabled" = "true" ]; then
                 if [ -n "$result" ]; then
+                  # Result format is "status:url" where url contains "https://"
+                  # Use cut to extract status (field 1) and url (fields 2 onwards)
                   local status=$(echo "$result" | cut -d: -f1)
                   local url=$(echo "$result" | cut -d: -f2-)
                   case "$status" in
@@ -504,11 +517,11 @@ jobs:
               fi
             }
 
-            # Display results for all test types
-            for test_name in "${!test_configs[@]}"; do
-              IFS=':' read -r enabled result <<< "${test_configs[$test_name]}"
-              display_test_result "$test_name" "$enabled" "$result"
-            done
+            # Display results for each test type directly (avoids IFS parsing issues)
+            display_test_result "All Post-Commit Tests" "${{ inputs.run_all_post_commit }}" "${{ needs.setup-and-test.outputs.all-post-commit-result }}"
+            display_test_result "Blackhole Post-Commit Tests" "${{ inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.blackhole-result }}"
+            display_test_result "TT-Metal L2 Nightly APC Tests" "${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.tt-metal-l2-nightly-result }}"
+            display_test_result "Device Perf Regressions" "${{ inputs.run_all_post_commit || inputs.run_blackhole_post_commit }}" "${{ needs.setup-and-test.outputs.perf-device-models-result }}"
 
             echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -267,13 +267,13 @@ jobs:
       perf-device-models-result: ${{ steps.monitor.outputs.perf-device-models-result }}
     steps:
       - name: Skip if not enabled
-        if: matrix.should-run != true && matrix.should-run != 'true'
+        if: matrix.should-run != 'true'
         run: |
           echo "⚪ Skipping ${{ matrix.name }} - not enabled for this run"
 
       - name: Trigger and monitor workflow
         id: monitor
-        if: matrix.should-run == true || matrix.should-run == 'true'
+        if: matrix.should-run == 'true'
         env:
           GH_TOKEN: ${{ secrets.LLK_UPLIFT_PAT }}
           WORKFLOW_TIMEOUT: ${{ inputs.workflow_timeout || 720 }}

--- a/.github/workflows/test-llk-metal-integration.yaml
+++ b/.github/workflows/test-llk-metal-integration.yaml
@@ -385,7 +385,7 @@ jobs:
               exit_code=1
             fi
           done
-          if [ $exit_code -eq 0 ]; then
+          if [ "$exit_code" -eq 0 ]; then
             echo "✅ All workflows completed successfully"
           else
             echo "❌ One or more workflows failed"


### PR DESCRIPTION
### Ticket
None

### Problem description
The LLK integration testing workflow monitored 4 different test workflows sequentially, causing significant delays. When testing LLK changes against tt-metal, users had to wait for each workflow to complete before the next one started, resulting in total execution times exceeding 5+ hours in some cases. Additionally, the workflow's concurrency settings conflicted with the calling workflow in tt-llk repository.

**Before:** https://github.com/tenstorrent/tt-llk/actions/runs/21484780592

### What's changed
Refactored the workflow to use GitHub Actions matrix strategy for parallel execution:
1. Split monolithic job into separate setup, run-tests (with matrix), and cleanup-and-report jobs
2. Each of the 4 test workflows now triggers and monitors in parallel using matrix strategy with fail-fast: false
3. Added proactive cancellation logic to clean up previous spawned workflows and stale branches before starting new runs
4. Removed local concurrency control to allow caller (tt-llk) to manage concurrency, preventing conflicts

**After:** https://github.com/tenstorrent/tt-llk/actions/runs/21486966368