### PR TITLE
Implement Prepacked Rotary Positional Embeddings (RoPE) for Multi-Sequence Packing Overview

### DIFF
--- a/models/demos/deepseek_v3/reference/test_prepacked_rope_reference_cpu.py
+++ b/models/demos/deepseek_v3/reference/test_prepacked_rope_reference_cpu.py
@@ -1,0 +1,111 @@
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class ModelArgs:
+    original_seq_len: int = 32
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    qk_rope_head_dim: int = 4
+    max_seq_len: int = 64  # 128K bank
+
+
+def precompute_freqs_cis_original(args: ModelArgs) -> torch.Tensor:
+    dim = args.qk_rope_head_dim
+    seqlen = args.max_seq_len
+    beta_fast = args.beta_fast
+    beta_slow = args.beta_slow
+    base = args.rope_theta
+    factor = args.rope_factor
+
+    def find_correction_dim(num_rotations, dim, base, max_seq_len):
+        return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+    def find_correction_range(low_rot, high_rot, dim, base, max_seq_len):
+        low = math.floor(find_correction_dim(low_rot, dim, base, max_seq_len))
+        high = math.ceil(find_correction_dim(high_rot, dim, base, max_seq_len))
+        return max(low, 0), min(high, dim - 1)
+
+    def linear_ramp_factor(min, max, dim):
+        if min == max:
+            max += 0.001
+        linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+        ramp_func = torch.clamp(linear_func, 0, 1)
+        return ramp_func
+
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    if seqlen > args.original_seq_len:
+        low, high = find_correction_range(beta_fast, beta_slow, dim, base, args.original_seq_len)
+        smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = torch.arange(seqlen)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    return freqs_cis
+
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))
+    freqs_cis = freqs_cis.view(1, x.size(1), 1, x.size(-1))
+    y = torch.view_as_real(x * freqs_cis).flatten(3)
+    return y.to(dtype)
+
+
+def apply_rotary_emb_packed(x: torch.Tensor, freqs_cis_bank: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+    """
+    x: [batch, total_seq_len, n_heads, dim]
+    freqs_cis_bank: [128k, dim // 2]
+    positions: [batch, total_seq_len] -> contains local indices (e.g. 0, 1, 2, 0, 1...)
+    """
+    dtype = x.dtype
+    x_complex = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))
+
+    selected_freqs = freqs_cis_bank[positions].unsqueeze(2)
+
+    y = torch.view_as_real(x_complex * selected_freqs).flatten(3)
+    return y.to(dtype)
+
+
+def run_test():
+    args = ModelArgs()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    print("Precomputing 128K bank...")
+    global_bank = precompute_freqs_cis_original(args).to(device)
+
+    lengths = [8, 16, 40]
+    seqs = [torch.randn(1, l, 1, args.qk_rope_head_dim, device=device) for l in lengths]
+
+    ground_truth_outputs = []
+    for s in seqs:
+        slen = s.size(1)
+        freqs_slice = global_bank[0:slen]
+        ground_truth_outputs.append(apply_rotary_emb(s, freqs_slice))
+
+    packed_x = torch.cat(seqs, dim=1)  # [1, 8192, 1, 64]
+    pos_map = torch.cat([torch.arange(l) for l in lengths]).unsqueeze(0).to(device)
+    packed_output = apply_rotary_emb_packed(packed_x, global_bank, pos_map)
+
+    print("\nVerification:")
+    curr_ptr = 0
+    for i, l in enumerate(lengths):
+        truth = ground_truth_outputs[i]
+        test_slice = packed_output[:, curr_ptr : curr_ptr + l, :, :]
+
+        max_err = torch.max(torch.abs(truth - test_slice)).item()
+        print(f"Sub-sequence {i} (len {l}): Max Error = {max_err:.2e}")
+        assert max_err < 1e-6
+        curr_ptr += l
+
+    print("\nSuccess! The packed implementation matches the original bank-slicing logic.")
+
+
+if __name__ == "__main__":
+    run_test()

--- a/models/demos/deepseek_v3/tests/test_rope_prepacked.py
+++ b/models/demos/deepseek_v3/tests/test_rope_prepacked.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from dataclasses import dataclass
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.t3000.llama2_70b.reference.llama.llama.model import apply_rotary_emb
+from models.tt_transformers.tt.common import get_rot_transformation_mat
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+MAX_SEQ_LEN = 128 * 1024
+
+
+@dataclass
+class ModelArgs:
+    original_seq_len: int = 4096
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    qk_rope_head_dim: int = 128
+    max_seq_len: int = MAX_SEQ_LEN
+
+
+def precompute_freqs_cis_bank(dim: int, args: ModelArgs):
+    """Precomputes the 128K bank with DeepSeek V3 YaRN scaling."""
+    seqlen = args.max_seq_len
+    base = args.rope_theta
+    factor = args.rope_factor
+
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+
+    # Apply YaRN
+    if seqlen > args.original_seq_len:
+
+        def find_correction_dim(num_rotations):
+            return dim * math.log(args.original_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+        low = math.floor(find_correction_dim(args.beta_fast))
+        high = math.ceil(find_correction_dim(args.beta_slow))
+        ramp = torch.clamp(
+            (torch.arange(dim // 2, dtype=torch.float32) - low) / (high - low if high > low else 0.001), 0, 1
+        )
+        smooth = 1.0 - ramp
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = torch.arange(seqlen)
+    freqs = torch.outer(t, freqs)
+    return freqs  # Returning raw freqs to allow cos/sin derivation
+
+
+def compute_packed_cos_sin(freqs_bank, position_ids):
+    """
+    Gather pre-selected frequencies based on packed position_ids
+    and format them for ttnn.experimental.rotary_embedding_llama.
+    """
+    # Gather frequencies: [total_seq_len, head_dim // 2]
+    selected_freqs = freqs_bank[position_ids]
+
+    cos = selected_freqs.cos()
+    sin = selected_freqs.sin()
+
+    # TTNN doubled format: [c0, c0, c1, c1, ...]
+    # Shape: [1, 1, total_seq_len, head_dim]
+    cos_ttnn = torch.stack([cos, cos], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+    sin_ttnn = torch.stack([sin, sin], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+
+    return cos_ttnn, sin_ttnn
+
+
+def run_test_rotary_packed(
+    device,
+    lengths,  # List of subsequence lengths, e.g., [1024, 2048]
+    n_heads,
+    head_dim,
+    pcc,
+    datatype=ttnn.bfloat16,
+):
+    args = ModelArgs(qk_rope_head_dim=head_dim)
+    total_seq_len = sum(lengths)
+    freqs_bank = precompute_freqs_cis_bank(head_dim, args)
+
+    torch_input = torch.randn(1, n_heads, total_seq_len, head_dim)
+    position_ids = torch.cat([torch.arange(l) for l in lengths])
+
+    cos_torch, sin_torch = compute_packed_cos_sin(freqs_bank, position_ids)
+
+    pytorch_outs = []
+    curr = 0
+    for l in lengths:
+        sub_x = torch_input[:, :, curr : curr + l, :].transpose(1, 2)
+        f_cis = torch.polar(torch.ones_like(freqs_bank[:l]), freqs_bank[:l])
+        out_q, _ = apply_rotary_emb(sub_x, sub_x, freqs_cis=f_cis)
+        pytorch_outs.append(out_q.transpose(1, 2))
+        curr += l
+    pytorch_gt = torch.cat(pytorch_outs, dim=2)
+
+    transformation_mat = ttnn.from_torch(
+        get_rot_transformation_mat(dhead=ttnn.TILE_SIZE), device=device, layout=ttnn.TILE_LAYOUT, dtype=datatype
+    )
+
+    tt_x = ttnn.from_torch(torch_input, device=device, dtype=datatype, layout=ttnn.TILE_LAYOUT)
+    tt_cos = ttnn.from_torch(cos_torch, device=device, dtype=datatype, layout=ttnn.TILE_LAYOUT)
+    tt_sin = ttnn.from_torch(sin_torch, device=device, dtype=datatype, layout=ttnn.TILE_LAYOUT)
+
+    tt_out = ttnn.experimental.rotary_embedding_llama(tt_x, tt_cos, tt_sin, transformation_mat, is_decode_mode=False)
+
+    tt_out_torch = ttnn.to_torch(tt_out)
+
+    # 7. Comparison
+    passing, output_pcc = comp_pcc(pytorch_gt, tt_out_torch, pcc)
+    logger.info(f"PCC: {output_pcc}")
+    assert passing
+
+
+@pytest.mark.parametrize("lengths", ([1024, 2048, 1024], [32, 64], [4096]))
+@pytest.mark.parametrize("head_dim", (64, 128))
+def test_packed_rotary(device, lengths, head_dim):
+    run_test_rotary_packed(device=device, lengths=lengths, n_heads=8, head_dim=head_dim, pcc=0.999)


### PR DESCRIPTION
### Ticket
Link to Github Issue


### Problem description
This PR introduces support for Prepacked RoPE, enabling the model to process multiple concatenated sequences (sub-prompts) in a single forward pass while maintaining correct positional encoding for each. This is achieved by moving from a global sequence-length slice to an indexed lookup from the precomputed 128K frequency bank.

### What's changed

Position Reset Logic: Added support for non-monotonic position IDs, allowing the "positional clock" to reset at the start of each packed sub-sequence.

<img width="830" height="127" alt="image" src="https://github.com/user-attachments/assets/ad7acca1-9022-45ef-866f-2ff6cd997702" />
<img width="930" height="119" alt="image" src="https://github.com/user-attachments/assets/a19fc967-3808-42ab-bcd9-25ef7705a825" />

### Why?
Currently, RoPE assumes a single contiguous sequence per batch. When packing multiple small prompts into a fixed 8K or 128K window to maximize throughput, the second and third sequences erroneously receive high-position embeddings. This PR ensures each sub-sequence starts at position 0, preserving attention quality and model performance.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ddjekic/rope_prepacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ddjekic/rope_prepacking)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/rope_prepacking)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/rope_prepacking)
- [ ] New/Existing tests provide coverage for changes

