### PR TITLE
Skip commenting clang tidy errors on forks

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -482,7 +482,7 @@ jobs:
         # # to be addressed.
         # [[ -s clang-tidy-result/fixes.yml ]] && exit 42
     - name: Run clang-tidy-pr-comments action
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.pull_request.head.repo.fork == false }}
       # v1.8.0
       uses: platisd/clang-tidy-pr-comments@28cfb84edafa771c044bde7e4a2a3fae57463818
       with:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36549)

### Problem description
Currently when we run commenting PRs on forked changes we get 403 error because GH doesn't allow this

### What's changed
Skip clang tidy comment PR step for forks