### PR TITLE
noc_semaphore_inc_multicast support

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -49,7 +49,7 @@ Both API versions run the same test cases but use different underlying implement
 | All to all                  | 300-308                         | Write transactions from multiple cores to multiple cores.                               |
 | All from all                | 310-318                         | Read transactions from multiple cores to multiple cores.                                |
 | Atomic Semaphore Increment  | 319-320                         | Atomic semaphore increment + atomic barrier performance tests.                          |
-| Multicast Atomic Semaphore  | 321-326                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
+| Multicast Atomic Semaphore  | 321-328                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
 | I2S Hardcoded               | 400-405                         | Tests interleaved to sharded data movement operations for different memory layouts.     |
 | Inline Direct Write         | 500-501                         | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -49,7 +49,7 @@ Both API versions run the same test cases but use different underlying implement
 | All to all                  | 300-308                         | Write transactions from multiple cores to multiple cores.                               |
 | All from all                | 310-318                         | Read transactions from multiple cores to multiple cores.                                |
 | Atomic Semaphore Increment  | 319-320                         | Atomic semaphore increment + atomic barrier performance tests.                          |
-| Multicast Atomic Semaphore  | 321-324                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
+| Multicast Atomic Semaphore  | 321-326                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
 | I2S Hardcoded               | 400-405                         | Tests interleaved to sharded data movement operations for different memory layouts.     |
 | Inline Direct Write         | 500-501                         | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -48,7 +48,8 @@ Both API versions run the same test cases but use different underlying implement
 | Deinterleave                | 200-201                         | Tests deinterleaving. **(Slow Dispatch)**                                               |
 | All to all                  | 300-308                         | Write transactions from multiple cores to multiple cores.                               |
 | All from all                | 310-318                         | Read transactions from multiple cores to multiple cores.                                |
-| Atomic Semaphore Increment  | 319-320                         | Atomic semaphore increment + atomic barrier performance tests.  |
+| Atomic Semaphore Increment  | 319-320                         | Atomic semaphore increment + atomic barrier performance tests.                          |
+| Multicast Atomic Semaphore  | 321-324                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
 | I2S Hardcoded               | 400-405                         | Tests interleaved to sharded data movement operations for different memory layouts.     |
 | Inline Direct Write         | 500-501                         | Inline DW transactions between two Tensix cores.                                        |
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -1,0 +1,56 @@
+# Multicast Atomic Semaphore Tests
+
+This directory contains tests for `noc_semaphore_inc_multicast` which performs atomic increment operations on semaphores using multicast to multiple destination cores simultaneously.
+
+## Overview
+
+The `noc_semaphore_inc_multicast` API allows a single core to atomically increment semaphores on a grid of destination cores in a single multicast operation. This is useful for synchronization patterns where multiple cores needs to signal multiple destination cores.
+
+## Mesh Device API Support
+
+This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
+
+## Test Flow
+
+1. **Sender Kernel**: Performs multicast atomic semaphore increments to a rectangular grid of destination cores using `noc_semaphore_inc_multicast`
+2. **Receiver Kernels**: Wait for the semaphore to reach the expected value using `noc_semaphore_wait`
+
+## Running the Tests
+
+```bash
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*MulticastAtomic*"
+```
+
+## Test Cases
+
+| Test Name                        | ID  | Description |
+| -------------------------------- | --- | ----------- |
+| MulticastAtomicSingleSource      | 321 | Single sender core multicasts atomic increment to 12 destinations (NOC_0) |
+| MulticastAtomicMultiSource       | 322 | 4 sender cores multicast atomic increment to 12 destinations (NOC_0)      |
+| MulticastAtomicSingleSourceNOC1  | 323 | Single sender core multicasts atomic increment to 12 destinations (NOC_1) |
+| MulticastAtomicMultiSourceNOC1   | 324 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
+
+### SingleSourceMulticastAtomic (IDs 321, 323)
+- **Description**: Single sender core multicasts atomic increment to a 3x4 grid of 12 destination cores
+- **Expected Result**: All 12 destination cores have semaphore value = 1
+
+### MultiSourceMulticastAtomic (IDs 322, 324)
+- **Description**: 4 sender cores each multicast atomic increment to the same 3x4 grid of 12 destination cores
+- **Expected Result**: All 12 destination cores have semaphore value = 4 (one increment from each sender)
+
+## Configuration Parameters
+
+| Parameter            | Type                  | Description |
+| -------------------- | --------------------- | ----------- |
+| sender_cores         | vector<CoreCoord>     | List of sender core coordinates |
+| dst_grid_start       | CoreCoord             | Start coordinate of destination grid |
+| dst_grid_size        | CoreCoord             | Size of destination grid (width x height) |
+| num_of_transactions  | uint32_t              | Number of multicast atomic increments per sender |
+| atomic_inc_value     | uint32_t              | Value to increment semaphore by |
+| noc_id               | NOC                   | Which NOC to use (NOC_0 or NOC_1) |
+
+## Important Notes
+
+- The multicast sender **cannot** be part of the multicast destination grid
+- Tests validate that all destination cores receive the expected accumulated value
+- Both NOC_0 and NOC_1 are tested for each scenario

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -4,7 +4,7 @@ This directory contains tests for `noc_semaphore_inc_multicast` which performs a
 
 ## Overview
 
-The `noc_semaphore_inc_multicast` API allows a single core to atomically increment semaphores on a grid of destination cores in a single multicast operation. This is useful for synchronization patterns where multiple cores needs to signal multiple destination cores.
+The `noc_semaphore_inc_multicast` API allows a single core to atomically increment semaphores on a grid of destination cores in a single multicast operation. This is useful for synchronization patterns where multiple cores need to signal multiple destination cores.
 
 ## Mesh Device API Support
 

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -23,12 +23,14 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 
 ## Test Cases
 
-| Test Name                        | ID  | Description |
-| -------------------------------- | --- | ----------- |
-| MulticastAtomicSingleSource      | 321 | Single sender core multicasts atomic increment to 12 destinations (NOC_0) |
-| MulticastAtomicMultiSource       | 322 | 4 sender cores multicast atomic increment to 12 destinations (NOC_0)      |
-| MulticastAtomicSingleSourceNOC1  | 323 | Single sender core multicasts atomic increment to 12 destinations (NOC_1) |
-| MulticastAtomicMultiSourceNOC1   | 324 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
+| Test Name                          | ID  | Description |
+| ---------------------------------- | --- | ----------- |
+| MulticastAtomicSingleSource        | 321 | Single sender core multicasts atomic increment to 12 destinations (NOC_0) |
+| MulticastAtomicMultiSource         | 322 | 4 sender cores multicast atomic increment to 12 destinations (NOC_0)      |
+| MulticastAtomicSingleSourceNOC1    | 323 | Single sender core multicasts atomic increment to 12 destinations (NOC_1) |
+| MulticastAtomicMultiSourceNOC1     | 324 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
+| MulticastAtomicLargerIncrement     | 325 | 4 senders, 3 transactions each, increment value 5 (NOC_0)                 |
+| MulticastAtomicLargerIncrementNOC1 | 326 | 4 senders, 3 transactions each, increment value 5 (NOC_1)                 |
 
 ### SingleSourceMulticastAtomic (IDs 321, 323)
 - **Description**: Single sender core multicasts atomic increment to a 3x4 grid of 12 destination cores
@@ -37,6 +39,10 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 ### MultiSourceMulticastAtomic (IDs 322, 324)
 - **Description**: 4 sender cores each multicast atomic increment to the same 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 4 (one increment from each sender)
+
+### LargerIncrementMulticastAtomic (IDs 325, 326)
+- **Description**: 4 sender cores each perform 3 multicast atomic increments with value 5 to a 3x4 grid of 12 destination cores
+- **Expected Result**: All 12 destination cores have semaphore value = 60 (4 senders × 3 transactions × 5 increment)
 
 ## Configuration Parameters
 

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -10,10 +10,14 @@ The `noc_semaphore_inc_multicast` API allows a single core to atomically increme
 
 This test suite uses the TT-Metal Mesh Device API, which provides a unified interface for single and multi-device operations. The tests use `GenericMeshDeviceFixture` and run on single-device unit meshes.
 
+## Device 2.0 API Support
+
+This test suite includes tests using both the standard NOC API and the experimental Device 2.0 API
+
 ## Test Flow
 
-1. **Sender Kernel**: Performs multicast atomic semaphore increments to a rectangular grid of destination cores using `noc_semaphore_inc_multicast`
-2. **Receiver Kernels**: Wait for the semaphore to reach the expected value using `noc_semaphore_wait`
+1. **Sender Kernel**: Performs multicast atomic semaphore increments to a rectangular grid of destination cores
+2. **Receiver Kernels**: Wait for the semaphore to reach the expected value
 
 ## Running the Tests
 
@@ -31,8 +35,10 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 | MulticastAtomicMultiSourceNOC1     | 324 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
 | MulticastAtomicLargerIncrement     | 325 | 4 senders, 3 transactions each, increment value 5 (NOC_0)                 |
 | MulticastAtomicLargerIncrementNOC1 | 326 | 4 senders, 3 transactions each, increment value 5 (NOC_1)                 |
+| MulticastAtomicSingleSource_2_0    | 327 | Single sender using experimental API                                      |
+| MulticastAtomicLargerIncrement_2_0 | 328 | 4 senders, 3 transactions each, increment value 5 using experimental API  |
 
-### SingleSourceMulticastAtomic (IDs 321, 323)
+### SingleSourceMulticastAtomic (IDs 321, 323, 327)
 - **Description**: Single sender core multicasts atomic increment to a 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 1
 
@@ -40,7 +46,7 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 - **Description**: 4 sender cores each multicast atomic increment to the same 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 4 (one increment from each sender)
 
-### LargerIncrementMulticastAtomic (IDs 325, 326)
+### LargerIncrementMulticastAtomic (IDs 325, 326, 328)
 - **Description**: 4 sender cores each perform 3 multicast atomic increments with value 5 to a 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 60 (4 senders × 3 transactions × 5 increment)
 
@@ -54,9 +60,11 @@ This test suite uses the TT-Metal Mesh Device API, which provides a unified inte
 | num_of_transactions  | uint32_t              | Number of multicast atomic increments per sender |
 | atomic_inc_value     | uint32_t              | Value to increment semaphore by |
 | noc_id               | NOC                   | Which NOC to use (NOC_0 or NOC_1) |
+| use_2_0_api          | bool                  | Use experimental Device 2.0 API (default: false) |
 
 ## Important Notes
 
 - The multicast sender **cannot** be part of the multicast destination grid
-- Tests validate that all destination cores receive the expected accumulated value
-- Both NOC_0 and NOC_1 are tested for each scenario
+- Verification is implicit - if the program completes, receivers received the expected semaphore value
+- Both NOC_0 and NOC_1 are tested for standard API scenarios
+- Both API versions use `CreateSemaphore` for proper semaphore management

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    // Compile-time arguments
+    const uint32_t semaphore_addr = get_compile_time_arg_val(0);
+    const uint32_t expected_value = get_compile_time_arg_val(1);
+
+    // Note: semaphore is initialized by the host before kernel launch
+    volatile uint32_t* local_semaphore = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+
+    // Wait for semaphore to reach expected value
+    noc_semaphore_wait(local_semaphore, expected_value);
+}

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver.cpp
@@ -8,10 +8,18 @@ void kernel_main() {
     // Compile-time arguments
     const uint32_t semaphore_addr = get_compile_time_arg_val(0);
     const uint32_t expected_value = get_compile_time_arg_val(1);
+    const uint32_t test_id = get_compile_time_arg_val(2);
 
     // Note: semaphore is initialized by the host before kernel launch
     volatile uint32_t* local_semaphore = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
 
-    // Wait for semaphore to reach expected value
-    noc_semaphore_wait(local_semaphore, expected_value);
+    {
+        DeviceZoneScopedN("RISCV1");
+        // Wait for semaphore to reach expected value
+        noc_semaphore_wait(local_semaphore, expected_value);
+    }
+
+    DeviceTimestampedData("Number of transactions", 1);
+    DeviceTimestampedData("Transaction size in bytes", 1);
+    DeviceTimestampedData("Test id", test_id);
 }

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver_2_0.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/noc_semaphore.h"
 
 void kernel_main() {
     // Compile-time arguments
@@ -10,13 +11,13 @@ void kernel_main() {
     constexpr uint32_t expected_value = get_compile_time_arg_val(1);
     constexpr uint32_t test_id = get_compile_time_arg_val(2);
 
-    // Get semaphore L1 address from semaphore ID
-    uint32_t semaphore_addr = get_semaphore(sem_id);
-    volatile tt_l1_ptr uint32_t* local_semaphore = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    // Create NOC 2.0 API objects
+    experimental::Noc noc(noc_index);
+    experimental::Semaphore semaphore(sem_id);
 
     {
         DeviceZoneScopedN("RISCV1");
-        noc_semaphore_wait(local_semaphore, expected_value);
+        semaphore.wait(expected_value);
     }
 
     DeviceTimestampedData("Number of transactions", 1);

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
@@ -14,6 +14,7 @@ void kernel_main() {
     const uint32_t dst_start_y = get_compile_time_arg_val(5);
     const uint32_t dst_end_x = get_compile_time_arg_val(6);
     const uint32_t dst_end_y = get_compile_time_arg_val(7);
+    const uint32_t test_id = get_compile_time_arg_val(8);
 
     // Get multicast NOC address for the destination grid
     // Note: For NOC_1, the coordinate system is inverted, so start/end need to be swapped
@@ -21,11 +22,18 @@ void kernel_main() {
         noc_index == 0 ? get_noc_multicast_addr(dst_start_x, dst_start_y, dst_end_x, dst_end_y, semaphore_addr)
                        : get_noc_multicast_addr(dst_end_x, dst_end_y, dst_start_x, dst_start_y, semaphore_addr);
 
-    for (uint32_t i = 0; i < num_of_transactions; i++) {
-        // Send multicast atomic increment to all destination cores
-        noc_semaphore_inc_multicast(dst_multicast_noc_addr, atomic_inc_value, num_dests);
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            // Send multicast atomic increment to all destination cores
+            noc_semaphore_inc_multicast(dst_multicast_noc_addr, atomic_inc_value, num_dests);
 
-        // Wait for atomic operation to complete before proceeding
+            // Wait for atomic operation to complete before proceeding
+        }
         noc_async_atomic_barrier();
     }
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", 4);
+    DeviceTimestampedData("Test id", test_id);
 }

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
@@ -27,9 +27,8 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_of_transactions; i++) {
             // Send multicast atomic increment to all destination cores
             noc_semaphore_inc_multicast(dst_multicast_noc_addr, atomic_inc_value, num_dests);
-
-            // Wait for atomic operation to complete before proceeding
         }
+        // Wait for atomic operation to complete before proceeding
         noc_async_atomic_barrier();
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    // Compile-time arguments
+    const uint32_t semaphore_addr = get_compile_time_arg_val(0);
+    const uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    const uint32_t atomic_inc_value = get_compile_time_arg_val(2);
+    const uint32_t num_dests = get_compile_time_arg_val(3);
+    const uint32_t dst_start_x = get_compile_time_arg_val(4);
+    const uint32_t dst_start_y = get_compile_time_arg_val(5);
+    const uint32_t dst_end_x = get_compile_time_arg_val(6);
+    const uint32_t dst_end_y = get_compile_time_arg_val(7);
+
+    // Get multicast NOC address for the destination grid
+    // Note: For NOC_1, the coordinate system is inverted, so start/end need to be swapped
+    uint64_t dst_multicast_noc_addr =
+        noc_index == 0 ? get_noc_multicast_addr(dst_start_x, dst_start_y, dst_end_x, dst_end_y, semaphore_addr)
+                       : get_noc_multicast_addr(dst_end_x, dst_end_y, dst_start_x, dst_start_y, semaphore_addr);
+
+    for (uint32_t i = 0; i < num_of_transactions; i++) {
+        // Send multicast atomic increment to all destination cores
+        noc_semaphore_inc_multicast(dst_multicast_noc_addr, atomic_inc_value, num_dests);
+
+        // Wait for atomic operation to complete before proceeding
+        noc_async_atomic_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -101,7 +101,8 @@ bool run_multicast_atomic_test(
             physical_dst_start.x,
             physical_dst_start.y,
             physical_dst_end.x,
-            physical_dst_end.y};
+            physical_dst_end.y,
+            test_config.test_id};
 
         CreateKernel(
             program,
@@ -121,7 +122,7 @@ bool run_multicast_atomic_test(
 
     CoreRangeSet dst_core_range_set({CoreRange(test_config.dst_grid_start, dst_grid_end)});
 
-    vector<uint32_t> receiver_compile_args = {semaphore_addr, expected_value};
+    vector<uint32_t> receiver_compile_args = {semaphore_addr, expected_value, test_config.test_id};
 
     CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "../dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace test_utils;
+
+namespace unit_tests::dm::multicast_atomics {
+
+struct MulticastAtomicConfig {
+    uint32_t test_id = 0;
+    vector<CoreCoord> sender_cores;
+    CoreCoord dst_grid_start = {0, 0};
+    CoreCoord dst_grid_size = {3, 4};
+    uint32_t num_of_transactions = 1;
+    uint32_t atomic_inc_value = 1;
+    NOC noc_id = NOC::NOC_0;
+};
+
+/// @brief Runs multicast atomic semaphore test
+/// @param mesh_device - MeshDevice to run the test on
+/// @param test_config - Configuration of the test
+/// @return true if test passes, false otherwise
+bool run_multicast_atomic_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, const MulticastAtomicConfig& test_config) {
+    IDevice* device = mesh_device->get_device(0);
+
+    /* ================ SETUP ================ */
+
+    Program program = CreateProgram();
+
+    // Calculate destination grid end coordinates
+    CoreCoord dst_grid_end = {
+        test_config.dst_grid_start.x + test_config.dst_grid_size.x - 1,
+        test_config.dst_grid_start.y + test_config.dst_grid_size.y - 1};
+
+    // Get physical coordinates for destination grid
+    CoreCoord physical_dst_start = device->worker_core_from_logical_core(test_config.dst_grid_start);
+    CoreCoord physical_dst_end = device->worker_core_from_logical_core(dst_grid_end);
+
+    // Calculate number of destination cores
+    uint32_t num_dests = test_config.dst_grid_size.x * test_config.dst_grid_size.y;
+
+    vector<CoreCoord> dst_cores;
+    for (uint32_t y = test_config.dst_grid_start.y; y <= dst_grid_end.y; y++) {
+        for (uint32_t x = test_config.dst_grid_start.x; x <= dst_grid_end.x; x++) {
+            dst_cores.push_back({x, y});
+        }
+    }
+
+    // Validate that sender cores are not in the destination grid
+    // The noc_semaphore_inc_multicast does not support loopback
+    for (const auto& sender_core : test_config.sender_cores) {
+        for (const auto& dst_core : dst_cores) {
+            if (sender_core.x == dst_core.x && sender_core.y == dst_core.y) {
+                log_error(
+                    LogTest,
+                    "Sender core ({},{}) is part of destination grid - this is not supported",
+                    sender_core.x,
+                    sender_core.y);
+                return false;
+            }
+        }
+    }
+
+    // Get L1 info from first destination core
+    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, dst_cores[0]);
+    uint32_t semaphore_addr = l1_info.base_address;
+
+    // Expected value: each sender increments by atomic_inc_value * num_of_transactions
+    // Total expected = num_senders * num_of_transactions * atomic_inc_value
+    uint32_t num_senders = test_config.sender_cores.size();
+    uint32_t expected_value = num_senders * test_config.num_of_transactions * test_config.atomic_inc_value;
+
+    log_info(
+        LogTest,
+        "Running test with {} sender(s), {} destinations, expected final value: {}",
+        num_senders,
+        num_dests,
+        expected_value);
+
+    // Create sender kernels
+    string sender_kernel_path =
+        "tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_sender.cpp";
+
+    for (const auto& sender_core : test_config.sender_cores) {
+        vector<uint32_t> sender_compile_args = {
+            semaphore_addr,
+            test_config.num_of_transactions,
+            test_config.atomic_inc_value,
+            num_dests,
+            physical_dst_start.x,
+            physical_dst_start.y,
+            physical_dst_end.x,
+            physical_dst_end.y};
+
+        CreateKernel(
+            program,
+            sender_kernel_path,
+            sender_core,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = test_config.noc_id,
+                .compile_args = sender_compile_args});
+
+        log_info(LogTest, "Created sender kernel on core ({},{})", sender_core.x, sender_core.y);
+    }
+
+    // Create receiver kernels on all destination cores
+    string receiver_kernel_path =
+        "tests/tt_metal/tt_metal/data_movement/multicast_atomics/kernels/multicast_atomic_receiver.cpp";
+
+    CoreRangeSet dst_core_range_set({CoreRange(test_config.dst_grid_start, dst_grid_end)});
+
+    vector<uint32_t> receiver_compile_args = {semaphore_addr, expected_value};
+
+    CreateKernel(
+        program,
+        receiver_kernel_path,
+        dst_core_range_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = test_config.noc_id,
+            .compile_args = receiver_compile_args});
+
+    // Assign unique runtime ID
+    log_info(LogTest, "Running Test ID: {}, Runtime ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    /* ================ RUNNING THE PROGRAM ================ */
+
+    // Initialize semaphores to zero on all destination cores
+    vector<uint32_t> zero_semaphore = {0};
+    for (const auto& dst_core : dst_cores) {
+        detail::WriteToDeviceL1(device, dst_core, semaphore_addr, zero_semaphore);
+    }
+
+    // Barrier to ensure initialization is complete
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    // Launch the program
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    /* ================ VERIFICATION ================ */
+
+    bool all_passed = true;
+    for (const auto& dst_core : dst_cores) {
+        vector<uint32_t> semaphore_result;
+        detail::ReadFromDeviceL1(device, dst_core, semaphore_addr, sizeof(uint32_t), semaphore_result);
+
+        uint32_t final_value = semaphore_result[0];
+
+        if (final_value != expected_value) {
+            log_error(
+                LogTest,
+                "Core ({},{}) semaphore check failed. Expected: {}, Got: {}",
+                dst_core.x,
+                dst_core.y,
+                expected_value,
+                final_value);
+            all_passed = false;
+        } else {
+            log_info(LogTest, "Core ({},{}) semaphore value correct: {}", dst_core.x, dst_core.y, final_value);
+        }
+    }
+
+    return all_passed;
+}
+
+/// @brief Test single source multicast atomic increment to a grid
+void single_source_multicast_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, NOC noc_id = NOC::NOC_0) {
+    MulticastAtomicConfig config = {
+        .test_id = test_id,
+        .sender_cores = {{4, 0}},
+        .dst_grid_start = {0, 0},
+        .dst_grid_size = {3, 4},  // 12 destination cores
+        .num_of_transactions = 1,
+        .atomic_inc_value = 1,
+        .noc_id = noc_id};
+
+    log_info(
+        LogTest,
+        "Single source multicast atomic test: 1 sender -> {} destinations",
+        config.dst_grid_size.x * config.dst_grid_size.y);
+
+    EXPECT_TRUE(run_multicast_atomic_test(mesh_device, config));
+}
+
+/// @brief Test multiple sources multicast atomic increment to same grid
+void multi_source_multicast_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id, NOC noc_id = NOC::NOC_0) {
+    MulticastAtomicConfig config = {
+        .test_id = test_id,
+        .sender_cores = {{4, 0}, {4, 1}, {4, 2}, {4, 3}},  // 4 senders in column 4
+        .dst_grid_start = {0, 0},
+        .dst_grid_size = {3, 4},  // 12 destination cores
+        .num_of_transactions = 1,
+        .atomic_inc_value = 1,
+        .noc_id = noc_id};
+
+    log_info(
+        LogTest,
+        "Multi source multicast atomic test: {} senders -> {} destinations, expected value: {}",
+        config.sender_cores.size(),
+        config.dst_grid_size.x * config.dst_grid_size.y,
+        config.sender_cores.size() * config.num_of_transactions * config.atomic_inc_value);
+
+    EXPECT_TRUE(run_multicast_atomic_test(mesh_device, config));
+}
+
+}  // namespace unit_tests::dm::multicast_atomics
+
+/* ========== TEST CASES ========== */
+
+TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
+    uint32_t test_id = 321;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    if (grid_size.x < 5 || grid_size.y < 4) {
+        GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
+    }
+
+    unit_tests::dm::multicast_atomics::single_source_multicast_test(mesh_device, test_id, NOC::NOC_0);
+}
+
+TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
+    uint32_t test_id = 322;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    if (grid_size.x < 5 || grid_size.y < 4) {
+        GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
+    }
+
+    unit_tests::dm::multicast_atomics::multi_source_multicast_test(mesh_device, test_id, NOC::NOC_0);
+}
+
+TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
+    uint32_t test_id = 323;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    if (grid_size.x < 5 || grid_size.y < 4) {
+        GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
+    }
+
+    unit_tests::dm::multicast_atomics::single_source_multicast_test(mesh_device, test_id, NOC::NOC_1);
+}
+
+TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
+    uint32_t test_id = 324;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    if (grid_size.x < 5 || grid_size.y < 4) {
+        GTEST_SKIP() << "Grid size too small for this test (need at least 5x4)";
+    }
+
+    unit_tests::dm::multicast_atomics::multi_source_multicast_test(mesh_device, test_id, NOC::NOC_1);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -576,6 +576,12 @@ tests:
   324:
     name: "Multi source Multicast Atomic Increment - NOC 1"
 
+  325:
+    name: "Multicast Atomic Larger Increment"
+
+  326:
+    name: "Multicast Atomic Larger Increment - NOC 1"
+
   400:
     name: "I2S - DRAM Sharded Row Major Writer"
     comment: |

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -564,6 +564,18 @@ tests:
   320:
     name: "Atomic Semaphore Non Adjacent Bandwidth Sweep"
 
+  321:
+    name: "Single source Multicast Atomic Increment"
+
+  322:
+    name: "Multi source Multicast Atomic Increment"
+
+  323:
+    name: "Single source Multicast Atomic Increment - NOC 1"
+
+  324:
+    name: "Multi source Multicast Atomic Increment - NOC 1"
+
   400:
     name: "I2S - DRAM Sharded Row Major Writer"
     comment: |

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -582,6 +582,12 @@ tests:
   326:
     name: "Multicast Atomic Larger Increment - NOC 1"
 
+  327:
+    name: "Single source Multicast Atomic Increment 2.0 API"
+
+  328:
+    name: "Multicast Atomic Larger Increment 2.0 API"
+
   400:
     name: "I2S - DRAM Sharded Row Major Writer"
     comment: |

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -25,5 +25,6 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     direct_write/test_direct_write.cpp
     pcie_read_bw/test_pcie_read_bw.cpp
     atomics/test_atomic_semaphore_bandwidth.cpp
+    tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
     noc_api_latency/test_noc_api_latency.cpp
 )

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -25,6 +25,6 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     direct_write/test_direct_write.cpp
     pcie_read_bw/test_pcie_read_bw.cpp
     atomics/test_atomic_semaphore_bandwidth.cpp
-    tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+    multicast_atomics/test_multicast_atomic_semaphore.cpp
     noc_api_latency/test_noc_api_latency.cpp
 )

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -57,6 +57,7 @@ enum watcher_features_t {
     SanitizeL1Overflow,
     SanitizeEthSrcL1Overflow,
     SanitizeEthDestL1Overflow,
+    SanitizeNOCMulticastInvalidRange,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -201,6 +202,9 @@ void RunTestOnCore(
     uint32_t l1_overflow_addr = 0;
     uint32_t eth_src_overflow_addr_words = 0;
     uint32_t eth_dest_overflow_addr_words = 0;
+    bool use_multicast_semaphore_inc = false;
+    uint32_t mcast_dst_end_x = 0;
+    uint32_t mcast_dst_end_y = 0;
     switch (feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -225,6 +229,14 @@ void RunTestOnCore(
         case SanitizeL1Overflow: l1_overflow_addr = 0xDDDDDDDD; break;
         case SanitizeEthSrcL1Overflow: eth_src_overflow_addr_words = 0xAAAAAAAA; break;
         case SanitizeEthDestL1Overflow: eth_dest_overflow_addr_words = 0xBBBBBBBB; break;
+        case SanitizeNOCMulticastInvalidRange:
+            // Use invalid multicast range: start > end (for NOC0, this is invalid)
+            use_multicast_semaphore_inc = true;
+            output_buf_noc_xy.x = 5;  // start_x
+            output_buf_noc_xy.y = 5;  // start_y
+            mcast_dst_end_x = 2;      // end_x < start_x (invalid for NOC0)
+            mcast_dst_end_y = 2;      // end_y < start_y (invalid for NOC0)
+            break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -247,7 +259,10 @@ void RunTestOnCore(
          bad_linked_transaction,
          l1_overflow_addr,
          eth_src_overflow_addr_words,
-         eth_dest_overflow_addr_words});
+         eth_dest_overflow_addr_words,
+         use_multicast_semaphore_inc,
+         mcast_dst_end_x,
+         mcast_dst_end_y});
 
     // Run the kernel, expect an exception here
     try {
@@ -432,6 +447,28 @@ void RunTestOnCore(
                 virtual_core.x,
                 virtual_core.y,
                 (eth_dest_overflow_addr_words << 4));
+        } break;
+        case SanitizeNOCMulticastInvalidRange: {
+            // For multicast, the error message format is different - it shows a range
+            // The start coords are output_buf_noc_xy (5,5), end coords are mcast_dst_end (2,2)
+            expected = fmt::format(
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to multicast write 4 "
+                "bytes from local L1[{:#08x}] to DRAM core range w/ virtual coords (x={},y={})-(x={},y={}) "
+                "DRAM[addr=0x{:08x}] (multicast invalid range).",
+                device->id(),
+                (is_eth_core) ? "acteth" : "worker",
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                risc_name,
+                noc,
+                0,  // l1_addr is 0 for address-only sanitization
+                output_buf_noc_xy.x,
+                output_buf_noc_xy.y,
+                mcast_dst_end_x,
+                mcast_dst_end_y,
+                output_buffer_addr);
         } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
@@ -652,6 +689,15 @@ TEST_F(MeshWatcherFixture, ActiveEthTestWatcherSanitizeEthDestL1Overflow) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             RunTestEth(fixture, mesh_device, SanitizeEthDestL1Overflow);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeMulticastSemaphoreInc) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMulticastInvalidRange);
         },
         this->devices_[0]);
 }

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2197,8 +2197,10 @@ FORCE_INLINE void noc_semaphore_inc(
  * | incr                       | The value to increment by                                                | uint32_t | Any uint32_t value                         | True     |
  * | num_dests                  | Number of destinations that the multicast source is targetting           | uint32_t | 0..(number of cores - 1)                   | True     |
  * | noc_id                     | Which NOC to use for the transaction                                     | uint8_t  | 0 or 1                                     | False    |
+ * | posted (template argument) | Whether the call is posted or nonposted (i.e. needs to be acked)         | bool     | true or false                              | False    |
  */
 // clang-format on
+template <bool posted = false>
 FORCE_INLINE void noc_semaphore_inc_multicast(
     uint64_t addr, uint32_t incr, uint32_t num_dests, uint8_t noc_id = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
@@ -2217,7 +2219,7 @@ FORCE_INLINE void noc_semaphore_inc_multicast(
         false /*linked*/,
         num_dests,
         /*multicast_path_reserve=*/true,
-        false /*posted*/);
+        posted);
     WAYPOINT("NIMD");
 }
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2177,6 +2177,52 @@ FORCE_INLINE void noc_semaphore_inc(
     WAYPOINT("NSID");
 }
 
+// clang-format off
+/**
+ * The Tensix core executing this function call initiates an atomic increment
+ * (with 32-bit wrap) to a rectangular destination grid. The destinations are
+ * specified using a uint64_t encoding referencing an on-chip grid of nodes
+ * located at NOC coordinate range (x_start,y_start,x_end,y_end) and a local
+ * address created using *get_noc_multicast_addr* function. This L1 memory
+ * address is used as a semaphore of size 4 Bytes, as a synchronization mechanism.
+ *
+ * With this API, the multicast sender cannot be part of the multicast
+ * destinations.
+ *
+ * Return value: None
+ *
+ * | Argument                   | Description                                                              | Type     | Valid Range                                | Required |
+ * |----------------------------|--------------------------------------------------------------------------|----------|--------------------------------------------|----------|
+ * | addr                       | Encoding of the destinations nodes (x_start,y_start,x_end,y_end)+address | uint64_t | Results of \a get_noc_multicast_addr calls | True     |
+ * | incr                       | The value to increment by                                                | uint32_t | Any uint32_t value                         | True     |
+ * | num_dests                  | Number of destinations that the multicast source is targetting           | uint32_t | 0..(number of cores - 1)                   | True     |
+ * | noc_id                     | Which NOC to use for the transaction                                     | uint8_t  | 0 or 1                                     | False    |
+ * | posted (template argument) | Whether the call is posted or nonposted (i.e. needs to be acked)         | bool     | true or false                              | False    |
+ */
+// clang-format on
+template <bool posted = false>
+FORCE_INLINE void noc_semaphore_inc_multicast(
+    uint64_t addr, uint32_t incr, uint32_t num_dests, uint8_t noc_id = noc_index) {
+    RECORD_NOC_EVENT_WITH_ADDR(
+        NocEventType::SEMAPHORE_INC_MULTICAST, 0, addr, 0, NOC_MULTICAST_WRITE_VC, posted, noc_id);
+
+    WAYPOINT("NIMW");
+    DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, addr, 4);
+    DEBUG_INSERT_DELAY(TransactionAtomic);
+    noc_fast_multicast_atomic_increment<noc_mode>(
+        noc_id,
+        write_at_cmd_buf,
+        addr,
+        NOC_MULTICAST_WRITE_VC,
+        incr,
+        31 /*wrap*/,
+        false /*linked*/,
+        num_dests,
+        /*multicast_path_reserve=*/true,
+        posted /*posted*/);
+    WAYPOINT("NIMD");
+}
+
 inline void RISC_POST_HEARTBEAT(uint32_t& heartbeat) {
     // Posting heartbeat at this address is only needed for Wormhole
 #if !defined(ARCH_BLACKHOLE)

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2197,10 +2197,8 @@ FORCE_INLINE void noc_semaphore_inc(
  * | incr                       | The value to increment by                                                | uint32_t | Any uint32_t value                         | True     |
  * | num_dests                  | Number of destinations that the multicast source is targetting           | uint32_t | 0..(number of cores - 1)                   | True     |
  * | noc_id                     | Which NOC to use for the transaction                                     | uint8_t  | 0 or 1                                     | False    |
- * | posted (template argument) | Whether the call is posted or nonposted (i.e. needs to be acked)         | bool     | true or false                              | False    |
  */
 // clang-format on
-template <bool posted = false>
 FORCE_INLINE void noc_semaphore_inc_multicast(
     uint64_t addr, uint32_t incr, uint32_t num_dests, uint8_t noc_id = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
@@ -2219,7 +2217,7 @@ FORCE_INLINE void noc_semaphore_inc_multicast(
         false /*linked*/,
         num_dests,
         /*multicast_path_reserve=*/true,
-        posted /*posted*/);
+        false /*posted*/);
     WAYPOINT("NIMD");
 }
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2202,7 +2202,7 @@ FORCE_INLINE void noc_semaphore_inc(
 FORCE_INLINE void noc_semaphore_inc_multicast(
     uint64_t addr, uint32_t incr, uint32_t num_dests, uint8_t noc_id = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::SEMAPHORE_INC_MULTICAST, 0, addr, 0, NOC_MULTICAST_WRITE_VC, posted, noc_id);
+        NocEventType::SEMAPHORE_INC_MULTICAST, 0, addr, 0, NOC_MULTICAST_WRITE_VC, false, noc_id);
 
     WAYPOINT("NIMW");
     DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, addr, 4);

--- a/tt_metal/hw/inc/api/dataflow/dataflow_api.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_api.h
@@ -2204,7 +2204,7 @@ template <bool posted = false>
 FORCE_INLINE void noc_semaphore_inc_multicast(
     uint64_t addr, uint32_t incr, uint32_t num_dests, uint8_t noc_id = noc_index) {
     RECORD_NOC_EVENT_WITH_ADDR(
-        NocEventType::SEMAPHORE_INC_MULTICAST, 0, addr, 0, NOC_MULTICAST_WRITE_VC, false, noc_id);
+        NocEventType::SEMAPHORE_INC_MULTICAST, 0, addr, 0, NOC_MULTICAST_WRITE_VC, posted, noc_id);
 
     WAYPOINT("NIMW");
     DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, addr, 4);

--- a/tt_metal/hw/inc/experimental/noc_semaphore.h
+++ b/tt_metal/hw/inc/experimental/noc_semaphore.h
@@ -141,6 +141,31 @@ public:
         }
     }
 
+    /**
+     * @brief Atomically increment the semaphore value on multiple cores in a specified rectangular region of the NoC.
+     * @note Sender cannot be part of the multicast destinations.
+     *
+     * @param noc The Noc object representing the NoC to use for the transaction.
+     * @param noc_x_start The starting X coordinate of the region (inclusive).
+     * @param noc_y_start The starting Y coordinate of the region (inclusive).
+     * @param noc_x_end The ending X coordinate of the region (inclusive).
+     * @param noc_y_end The ending Y coordinate of the region (inclusive).
+     * @param value The value to increment the semaphore by.
+     * @param num_dests The number of destination cores in the region.
+     */
+    void inc_multicast(
+        const Noc& noc,
+        uint32_t noc_x_start,
+        uint32_t noc_y_start,
+        uint32_t noc_x_end,
+        uint32_t noc_y_end,
+        uint32_t value,
+        uint32_t num_dests) {
+        uint64_t multicast_addr =
+            get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, local_l1_addr_, noc.get_noc_id());
+        noc_semaphore_inc_multicast(multicast_addr, value, num_dests, noc.get_noc_id());
+    }
+
 private:
     uint32_t local_l1_addr_;
 };

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -563,8 +563,8 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
     debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
     LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l) DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, true)
-#define DEBUG_SANITIZE_NOC_MULTI_ADDR_(noc_id, a, l, check_linked)                                                 \
-    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
+#define DEBUG_SANITIZE_NOC_MULTI_ADDR_(noc_id, a, l, check_linked)                                                  \
+    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_WRITE, check_linked); \
     LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, a, l) DEBUG_SANITIZE_NOC_MULTI_ADDR_(noc_id, a, l, true)
 #define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir)        \

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -563,6 +563,10 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
     debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
     LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l) DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, true)
+#define DEBUG_SANITIZE_NOC_MULTI_ADDR_(noc_id, a, l, check_linked)                                                 \
+    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
+    LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, a, l) DEBUG_SANITIZE_NOC_MULTI_ADDR_(noc_id, a, l, true)
 #define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir)        \
     debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, multicast, dir, true); \
     LOG_LEN(l)
@@ -653,6 +657,7 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 #else  // !WATCHER_ENABLED
 
 #define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_MULTI_ADDR(noc_id, a, l) LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir) LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1144,11 +1144,6 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     uint32_t num_dests,
     bool multicast_path_reserve,
     bool posted = false) {
-    // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
-    // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
-    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate force atomics to
-    // be non-posted.
-    posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (!posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1144,6 +1144,11 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     uint32_t num_dests,
     bool multicast_path_reserve,
     bool posted = false) {
+    // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
+    // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
+    // mechanism to allow one memory port to move ahead of another. Also, due to HW bug on BH, using posted with
+    // multicast can introduce hangs. To workaround this, we emulate force atomics to be non-posted.
+    posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (!posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1146,7 +1146,7 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     bool posted = false) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
-    // mechanism to allow one memory port to move ahead of another. Also, due to HW bug on BH, using posted with
+    // mechanism to allow one memory port to move ahead of another. Also, due to HW bug, using posted with
     // multicast can introduce hangs. To workaround this, we emulate force atomics to be non-posted.
     posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -1132,6 +1132,61 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     }
 }
 
+template <uint8_t noc_mode = DM_DEDICATED_NOC>
+inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint64_t addr,
+    uint32_t vc,
+    uint32_t incr,
+    uint32_t wrap,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false) {
+    // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
+    // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no
+    // mechanism to allow one memory port to move ahead of another. To workaround this hang, we emulate force atomics to
+    // be non-posted.
+    posted = false;
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if (!posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);
+        }
+    }
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc, 0, NOC_NODE_ID);
+        uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
+        uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
+        uint64_t atomic_ret_addr = NOC_XY_ADDR(my_x, my_y, 0);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(addr >> 32) & NOC_PCIE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_CTRL,
+        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
+            (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET |
+            (posted ? 0 : NOC_CMD_RESP_MARKED) | NOC_CMD_AT);
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_AT_LEN_BE,
+        NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr >> 2) & 0x3) | NOC_AT_IND_32_SRC(0));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if (!posted) {
+            noc_nonposted_atomics_acked[noc] += num_dests;
+        }
+    }
+}
+
 // issue noc reads while wait for outstanding transactions done
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -942,6 +942,47 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     }
 }
 
+template <uint8_t noc_mode = DM_DEDICATED_NOC>
+inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint64_t addr,
+    uint32_t vc,
+    uint32_t incr,
+    uint32_t wrap,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if (!posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);
+        }
+    }
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_CTRL,
+        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
+            (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET |
+            (posted ? 0 : NOC_CMD_RESP_MARKED) | NOC_CMD_AT);
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_AT_LEN_BE,
+        NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr >> 2) & 0x3) | NOC_AT_IND_32_SRC(0));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if (!posted) {
+            noc_nonposted_atomics_acked[noc] += num_dests;
+        }
+    }
+}
+
 // issue noc reads while wait for outstanding transactions done
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -954,6 +954,8 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     uint32_t num_dests,
     bool multicast_path_reserve,
     bool posted = false) {
+    // Due to a HW bug on WH, using posted with multicast can introduce hangs.
+    posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (!posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -954,7 +954,7 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     uint32_t num_dests,
     bool multicast_path_reserve,
     bool posted = false) {
-    // Due to a HW bug on WH, using posted with multicast can introduce hangs.
+    // Due to a HW bug, using posted with multicast can introduce hangs.
     posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (!posted) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1007,6 +1007,57 @@ inline __attribute__((always_inline)) void noc_fast_atomic_increment(
     }
 }
 
+template <uint8_t noc_mode = DM_DEDICATED_NOC>
+inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint64_t addr,
+    uint32_t vc,
+    uint32_t incr,
+    uint32_t wrap,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false) {
+    posted = false;
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if (!posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);
+        }
+    }
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc, 0, NOC_NODE_ID);
+        uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
+        uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
+        uint64_t atomic_ret_addr = NOC_XY_ADDR(my_x, my_y, 0);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(addr >> 32) & NOC_PCIE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_CTRL_LO,
+        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
+            (multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET |
+            (posted ? 0 : NOC_CMD_RESP_MARKED) | NOC_CMD_AT | NOC_RESP_STATIC_VC(READ_RESPONSE_STATIC_VC));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        cmd_buf,
+        NOC_AT_LEN,
+        NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr >> 2) & 0x3) | NOC_AT_IND_32_SRC(0));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if (!posted) {
+            noc_nonposted_atomics_acked[noc] += num_dests;
+        }
+    }
+}
+
 // issue noc reads while wait for outstanding transactions done
 template <uint8_t noc_mode = DM_DEDICATED_NOC, bool skip_ptr_update = false, bool skip_cmdbuf_chk = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_with_transaction_id(

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -1019,7 +1019,6 @@ inline __attribute__((always_inline)) void noc_fast_multicast_atomic_increment(
     uint32_t num_dests,
     bool multicast_path_reserve,
     bool posted = false) {
-    posted = false;
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
         if (!posted) {
             inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(noc, num_dests);

--- a/tt_metal/tools/profiler/event_metadata.hpp
+++ b/tt_metal/tools/profiler/event_metadata.hpp
@@ -48,19 +48,20 @@ struct alignas(uint64_t) KernelProfilerNocEventMetadata {
         SEMAPHORE_SET = 29,
         SEMAPHORE_SET_REMOTE = 30,
         SEMAPHORE_SET_MULTICAST = 31,
+        SEMAPHORE_INC_MULTICAST = 32,
 
         // NOTE: fabric events should be contiguous to allow quick range check!
-        FABRIC_UNICAST_WRITE = 32,
-        FABRIC_UNICAST_INLINE_WRITE = 33,
-        FABRIC_UNICAST_ATOMIC_INC = 34,
-        FABRIC_FUSED_UNICAST_ATOMIC_INC = 35,
-        FABRIC_MULTICAST_WRITE = 36,
-        FABRIC_MULTICAST_ATOMIC_INC = 37,
-        FABRIC_UNICAST_SCATTER_WRITE = 38,
-        FABRIC_ROUTING_FIELDS_1D = 39,
-        FABRIC_ROUTING_FIELDS_2D = 40,
+        FABRIC_UNICAST_WRITE = 33,
+        FABRIC_UNICAST_INLINE_WRITE = 34,
+        FABRIC_UNICAST_ATOMIC_INC = 35,
+        FABRIC_FUSED_UNICAST_ATOMIC_INC = 36,
+        FABRIC_MULTICAST_WRITE = 37,
+        FABRIC_MULTICAST_ATOMIC_INC = 38,
+        FABRIC_UNICAST_SCATTER_WRITE = 39,
+        FABRIC_ROUTING_FIELDS_1D = 40,
+        FABRIC_ROUTING_FIELDS_2D = 41,
 
-        UNSUPPORTED = 41,
+        UNSUPPORTED = 42,
     };
 
     enum class NocType : unsigned char { UNDEF = 0, NOC_0 = 1, NOC_1 = 2 };


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34934)

### Problem description
`noc_semaphore_inc_multicast` is needed for more optimal data movement patterns

### What's changed
Added `noc_semaphore_inc_multicast` to dataflow_api.h 
Also added data movement tests to test the new API.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/34934_noc_semaphore_inc_multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/34934_noc_semaphore_inc_multicast)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
