### PR TITLE
fix: disable failing DescriptorMergerTest's tests

### DIFF
--- a/tools/tests/scaleout/test_descriptor_merger.cpp
+++ b/tools/tests/scaleout/test_descriptor_merger.cpp
@@ -388,7 +388,8 @@ TEST_F(DescriptorMergerTest, RejectNonexistentFile) {
 // Torus Merge Tests: Torus-specific inter_board_connections merging
 // ============================================================================
 
-TEST_F(DescriptorMergerTest, MergeXTorusAndYTorusIntoXYTorus) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_MergeXTorusAndYTorusIntoXYTorus) {
     // Test that X_TORUS and Y_TORUS node types can merge into a combined XY_TORUS configuration
     // Both X and Y torus have the same Wormhole architecture and compatible topology
     // Their inter_board_connections should merge successfully to form an XY_TORUS
@@ -412,7 +413,8 @@ TEST_F(DescriptorMergerTest, MergeXTorusAndYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "X torus + Y torus should equal XY torus";
 }
 
-TEST_F(DescriptorMergerTest, MergeBHXTorusAndBHYTorusIntoXYTorus) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_MergeBHXTorusAndBHYTorusIntoXYTorus) {
     // Test that BH (Blackhole) X_TORUS and Y_TORUS can merge into XY_TORUS
     // Validates torus merging works for Blackhole architecture, not just Wormhole
     const std::string test_dir = create_test_dir("bh_xy_torus_merge");
@@ -435,7 +437,8 @@ TEST_F(DescriptorMergerTest, MergeBHXTorusAndBHYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "BH X torus + Y torus should equal BH XY torus";
 }
 
-TEST_F(DescriptorMergerTest, MergeTwoIdenticalXTorusDescriptors) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_MergeTwoIdenticalXTorusDescriptors) {
     // Test merging two identical X_TORUS descriptors
     // Both have the same torus type and architecture - should merge successfully
     // (duplicate connections will be deduplicated during merge)
@@ -459,7 +462,8 @@ TEST_F(DescriptorMergerTest, MergeTwoIdenticalXTorusDescriptors) {
     EXPECT_EQ(merged_gen, x_gen) << "Two identical X torus should merge into single X torus";
 }
 
-TEST_F(DescriptorMergerTest, MergeXYTorusWithXTorusDescriptors) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_MergeXYTorusWithXTorusDescriptors) {
     // Test merging XY_TORUS with X_TORUS descriptors
     // XY_TORUS already contains X-direction connections, X_TORUS adds more
     // Both are torus types with the same architecture (Wormhole) - should merge to XY_TORUS
@@ -487,7 +491,8 @@ TEST_F(DescriptorMergerTest, MergeXYTorusWithXTorusDescriptors) {
 // Split/Merge Tests: End-to-end split and merge workflows for all topologies
 // ============================================================================
 
-TEST_F(DescriptorMergerTest, SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
     // Test splitting the 8x16 WH_GALAXY_XY_TORUS superpod descriptor and merging it back
     const std::string source_path =
         "tools/tests/scaleout/cabling_descriptors/8x16_wh_galaxy_xy_torus_superpod.textproto";
@@ -522,7 +527,8 @@ TEST_F(DescriptorMergerTest, SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
     }
 }
 
-TEST_F(DescriptorMergerTest, SplitAndMerge5WhGalaxyYTorusSuperpod) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge5WhGalaxyYTorusSuperpod) {
     // Test splitting the 5 WH_GALAXY_Y_TORUS superpod descriptor and merging it back
     const std::string source_path = "tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto";
 
@@ -555,7 +561,8 @@ TEST_F(DescriptorMergerTest, SplitAndMerge5WhGalaxyYTorusSuperpod) {
     }
 }
 
-TEST_F(DescriptorMergerTest, SplitAndMerge16N300Cluster) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge16N300Cluster) {
     // Test splitting and merging the 16 N300 cluster descriptor
     // This validates split/merge works for N300 architecture (not just WH/BH)
     const std::string source_path = "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto";
@@ -644,7 +651,8 @@ TEST_F(DescriptorMergerTest, RejectWHAndBHMesh) {
     }
 }
 
-TEST_F(DescriptorMergerTest, RejectGraphTemplatesWithDifferentChildren_ForwardPass) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_RejectGraphTemplatesWithDifferentChildren_ForwardPass) {
     // Test forward pass: source has nodes that target doesn't have
     // File 1 has {node_a, node_b}, File 2 has {node_c, node_d} - completely different sets
     const std::string test_dir = create_test_dir("different_children_forward_test");
@@ -738,7 +746,8 @@ root_instance {
         << "Should reject graph_templates with different children (backward pass: target has extra nodes)";
 }
 
-TEST_F(DescriptorMergerTest, AllowCrossDescriptorConnectionsOnDifferentPorts) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_AllowCrossDescriptorConnectionsOnDifferentPorts) {
     // Test that the same node can connect to different nodes across multiple descriptors
     // as long as different ports are used. This is valid because:
     // 1. Each port is only used once (no duplicate connections within a descriptor)
@@ -1100,7 +1109,8 @@ TEST_F(DescriptorMergerTest, LoadAllAvailableDescriptors) {
     }
 }
 
-TEST_F(DescriptorMergerTest, MergeExistingBHTorusDescriptors) {
+// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+TEST_F(DescriptorMergerTest, DISABLED_MergeExistingBHTorusDescriptors) {
     // Test merging existing bh_galaxy_x_torus.textproto and bh_galaxy_y_torus.textproto
     // This demonstrates using actual existing descriptor files from the cabling_descriptors directory
     const std::string test_dir = create_test_dir("merge_existing_bh_torus");

--- a/tools/tests/scaleout/test_descriptor_merger.cpp
+++ b/tools/tests/scaleout/test_descriptor_merger.cpp
@@ -388,7 +388,7 @@ TEST_F(DescriptorMergerTest, RejectNonexistentFile) {
 // Torus Merge Tests: Torus-specific inter_board_connections merging
 // ============================================================================
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_MergeXTorusAndYTorusIntoXYTorus) {
     // Test that X_TORUS and Y_TORUS node types can merge into a combined XY_TORUS configuration
     // Both X and Y torus have the same Wormhole architecture and compatible topology
@@ -413,7 +413,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeXTorusAndYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "X torus + Y torus should equal XY torus";
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_MergeBHXTorusAndBHYTorusIntoXYTorus) {
     // Test that BH (Blackhole) X_TORUS and Y_TORUS can merge into XY_TORUS
     // Validates torus merging works for Blackhole architecture, not just Wormhole
@@ -437,7 +437,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeBHXTorusAndBHYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "BH X torus + Y torus should equal BH XY torus";
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_MergeTwoIdenticalXTorusDescriptors) {
     // Test merging two identical X_TORUS descriptors
     // Both have the same torus type and architecture - should merge successfully
@@ -462,7 +462,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeTwoIdenticalXTorusDescriptors) {
     EXPECT_EQ(merged_gen, x_gen) << "Two identical X torus should merge into single X torus";
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_MergeXYTorusWithXTorusDescriptors) {
     // Test merging XY_TORUS with X_TORUS descriptors
     // XY_TORUS already contains X-direction connections, X_TORUS adds more
@@ -491,7 +491,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeXYTorusWithXTorusDescriptors) {
 // Split/Merge Tests: End-to-end split and merge workflows for all topologies
 // ============================================================================
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
     // Test splitting the 8x16 WH_GALAXY_XY_TORUS superpod descriptor and merging it back
     const std::string source_path =
@@ -527,7 +527,7 @@ TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge8x16WhGalaxyXyTorusSuperpod) 
     }
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge5WhGalaxyYTorusSuperpod) {
     // Test splitting the 5 WH_GALAXY_Y_TORUS superpod descriptor and merging it back
     const std::string source_path = "tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto";
@@ -561,7 +561,7 @@ TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge5WhGalaxyYTorusSuperpod) {
     }
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge16N300Cluster) {
     // Test splitting and merging the 16 N300 cluster descriptor
     // This validates split/merge works for N300 architecture (not just WH/BH)
@@ -651,7 +651,7 @@ TEST_F(DescriptorMergerTest, RejectWHAndBHMesh) {
     }
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_RejectGraphTemplatesWithDifferentChildren_ForwardPass) {
     // Test forward pass: source has nodes that target doesn't have
     // File 1 has {node_a, node_b}, File 2 has {node_c, node_d} - completely different sets
@@ -746,7 +746,7 @@ root_instance {
         << "Should reject graph_templates with different children (backward pass: target has extra nodes)";
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_AllowCrossDescriptorConnectionsOnDifferentPorts) {
     // Test that the same node can connect to different nodes across multiple descriptors
     // as long as different ports are used. This is valid because:
@@ -1109,7 +1109,7 @@ TEST_F(DescriptorMergerTest, LoadAllAvailableDescriptors) {
     }
 }
 
-// TODO https://github.com/tenstorrent/tt-metal/issues/36811
+// TODO: Disabled due to #36811
 TEST_F(DescriptorMergerTest, DISABLED_MergeExistingBHTorusDescriptors) {
     // Test merging existing bh_galaxy_x_torus.textproto and bh_galaxy_y_torus.textproto
     // This demonstrates using actual existing descriptor files from the cabling_descriptors directory


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36811

### Problem description
Ten tests in test_descriptor_merger.cpp are deterministically failing for a few days, where nodes have conflicting host_id values (e.g., "Node 'node1' has conflicting host_id: 0 vs 1"). These failures occur across both Blackhole and Wormhole architectures and are blocking CI.

Failing pipelines:
https://github.com/tenstorrent/tt-metal/actions/runs/21513819486/job/61992766354
https://github.com/tenstorrent/tt-metal/actions/runs/21506379052/job/61974059630
https://github.com/tenstorrent/tt-metal/actions/runs/21496059427/job/61940328049
https://github.com/tenstorrent/tt-metal/actions/runs/21495455302/job/61930236145
https://github.com/tenstorrent/tt-metal/actions/runs/21488659891/job/61921576897
https://github.com/tenstorrent/tt-metal/actions/runs/21485953180/job/61898181441


### What's changed
Disabled 10 tests.