### PR TITLE
Skip for forks merge report for forks

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -154,6 +154,7 @@ jobs:
           cat $DEVICE_PERF_REPORT_FILENAME
 
       - name: Merge and check test reports
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
         timeout-minutes: 5
         env:
           TRACY_NO_INVARIANT_CHECK: 1


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36550)

### Problem description
Merge report was failing on APC for forks

### What's changed
On forks we don't have permission to manipulate with files so skip it for them