### PR TITLE
add *_ubench_2x2 to matrix

### DIFF
--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -33,6 +33,9 @@ jobs:
         test-group:
           - name: CCL APC test
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit
+          - name: Fabric Sanity Benchmark
+            cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
+
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service

--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -34,7 +34,7 @@ jobs:
           - name: CCL APC test
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit
           - name: Fabric Sanity Benchmark
-            cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
+            cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
 
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/30159)


### Problem description
Add *_ubench_at_least_2x2 fabric tests to the BH post-commit pipeline


### What's changed
Add the test to be run to the test-groups list. 

### Checklist

- [ ] [![Fabric tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=nzhao/enable-fabric-benchmakrs-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:nzhao/enable-fabric-benchmarks-bh)

New test failing on LLMBox, passing on Loudbox
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nzhao/enable-fabric-benchmarks-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nzhao/enable-fabric-benchmarks-bh)


#### Model tests
N/A