### PR TITLE
Add basic tests to BHPC

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -250,6 +250,32 @@ jobs:
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
       product: tt-metalium
+  metalium-basic-tests:
+    needs: [build-artifact, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+    uses: ./.github/workflows/basic.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      per-test-timeout: 11
+      runner: ${{ matrix.platform }}
+      product: tt-metalium
+  ttnn-basic-tests:
+    needs: [build-artifact, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.generate-matrix.outputs.civ2-viommu-matrix) }}
+    uses: ./.github/workflows/basic.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      per-test-timeout: 11
+      runner: ${{ matrix.platform }}
+      product: tt-nn
   ttnn-smoke-tests:
     needs: [build-artifact, generate-matrix]
     strategy:


### PR DESCRIPTION
### Ticket
None

### Problem description
We're not running merge gate basic tests on blackhole.
Unfortunately we don't have the capacity to run p150b on pr gate/merge gate for now, but we should verify that the tests still pass.

### What's changed
Add metalium and ttnn basic tests (+ 10min p150b) to blackhole post commit.

### Checklist

- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/0-add-basic-bhpc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/0-add-basic-bhpc)

