### PR TITLE
Pool Watcher Fixes

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -855,6 +855,9 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
             args.push_back((uint32_t)(start_col));
         }
         SetRuntimeArgs(program, reader0_kernel, core, args);
+        if (params.split_reader) {
+            SetRuntimeArgs(program, reader1_kernel, core, args);
+        }
         SetRuntimeArgs(program, compute_kernel, core, args);
     }
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -305,7 +305,8 @@ void kernel_main() {
             fill_with_val<num_elements_to_fill, pad_val>(get_write_ptr(pad_cb_id));
 
             const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
-            constexpr uint32_t padding_region_size = aligned_stick_nbytes / elem_nbytes;
+            // MaxChunkSize must be in bytes and >= StickNBytes to avoid misaligned NOC transactions
+            constexpr uint32_t padding_region_size = aligned_stick_nbytes;
             copy_padding<padding_config_cb_id, out_cb_id, aligned_stick_nbytes, padding_region_size>(padding_l1_addr);
         }
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Pool fails tests non-deterministically.

### What's changed
Pool runtime args have been set for the split reader and padding has been adjusted in halo.

### Checklist
In progress