### PR TITLE
Fix moreh failure

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow.py
@@ -70,6 +70,10 @@ def test_pow_arange_masking(exponent, device):
     [
         (ttnn.UnaryOpType.POWER_ITERATIVE, 0),
         (ttnn.UnaryOpType.POWER_ITERATIVE, 2),
+        (ttnn.UnaryOpType.POWER_ITERATIVE, 3.65),
+        (ttnn.UnaryOpType.POWER_ITERATIVE, -4.2),
+        (ttnn.UnaryOpType.POWER_ITERATIVE, -3.0),
+        (ttnn.UnaryOpType.POWER_ITERATIVE, 3.0),
         (ttnn.UnaryOpType.POWER, 0),
         (ttnn.UnaryOpType.POWER, 2),
         (ttnn.UnaryOpType.POWER, 1.5),
@@ -77,6 +81,11 @@ def test_pow_arange_masking(exponent, device):
     ],
 )
 def test_power_as_activation(device, op_type, exponent):
+    if op_type == ttnn.UnaryOpType.POWER_ITERATIVE and (exponent != int(exponent) or exponent < 0):
+        pytest.xfail(
+            "POWER_ITERATIVE only supports positive integer exponents (Non-integer values are truncated causing output mismatch with expected)"
+        )
+
     x_torch = torch.rand([16, 16], dtype=torch.bfloat16) + 1.5
     z_torch = torch.pow(x_torch + x_torch, exponent)
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -196,16 +196,21 @@ inline void calculate_unary_power_iterative(const uint32_t exponent) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result = 1.0f;
-        uint exp = exponent;
-        while (exp > 0) {
-            if (exp & 1) {
-                result *= in;
+        if (exponent == 0) {
+            sfpi::dst_reg[0] = 1.0f;
+        } else {
+            sfpi::vFloat result = in;
+            uint32_t exp = exponent - 1;
+
+            while (exp > 0) {
+                if (exp & 1) {
+                    result *= in;
+                }
+                in *= in;
+                exp >>= 1;
             }
-            in *= in;
-            exp >>= 1;
+            sfpi::dst_reg[0] = result;
         }
-        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -188,25 +188,22 @@ inline void calculate_unary_power(const uint32_t exponent) {
 /**
  * @brief Compute power operation using iterative approach
  *
- * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
+ * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_power_iterative(const uint32_t exponent) {
     // iterative approach for positive integer exponents
-    // exponent contains IEEE 754 float bits - convert to integer
-    const float exp_float = Converter::as_float(exponent);
-    const uint exp = (uint)exp_float;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = 1.0f;
-        uint e = exp;
-        while (e > 0) {
-            if (e & 1) {
+        uint exp = exponent;
+        while (exp > 0) {
+            if (exp & 1) {
                 result *= in;
             }
             in *= in;
-            e >>= 1;
+            exp >>= 1;
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -190,25 +190,22 @@ inline void calculate_unary_power(const uint32_t exponent) {
 /**
  * @brief Compute power operation using iterative approach
  *
- * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
+ * @param exponent Non-negative integer exponent value
  */
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_power_iterative(const uint32_t exponent) {
     // iterative approach for positive integer exponents
-    // exponent contains IEEE 754 float bits - convert to integer
-    const float exp_float = Converter::as_float(exponent);
-    const uint exp = (uint)exp_float;
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
         sfpi::vFloat result = 1.0f;
-        uint e = exp;
-        while (e > 0) {
-            if (e & 1) {
+        uint exp = exponent;
+        while (exp > 0) {
+            if (exp & 1) {
                 result *= in;
             }
             in *= in;
-            e >>= 1;
+            exp >>= 1;
         }
         sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -198,16 +198,21 @@ inline void calculate_unary_power_iterative(const uint32_t exponent) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat in = sfpi::dst_reg[0];
-        sfpi::vFloat result = 1.0f;
-        uint exp = exponent;
-        while (exp > 0) {
-            if (exp & 1) {
-                result *= in;
+        if (exponent == 0) {
+            sfpi::dst_reg[0] = 1.0f;
+        } else {
+            sfpi::vFloat result = in;
+            uint32_t exp = exponent - 1;
+
+            while (exp > 0) {
+                if (exp & 1) {
+                    result *= in;
+                }
+                in *= in;
+                exp >>= 1;
             }
-            in *= in;
-            exp >>= 1;
+            sfpi::dst_reg[0] = result;
         }
-        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -355,7 +355,7 @@ ALWI void power_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_init<APPRO
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | param0          | The integer exponent value                                                 | uint32_t | Must be a positive integer exponent                   | True     |
+ * | param0          | The integer exponent value                                                 | uint32_t | Must be a non-negative integer exponent               | True     |
  */
 // clang-format on
 ALWI void power_iterative_tile(uint32_t idst, uint32_t param0) {

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -355,7 +355,7 @@ ALWI void power_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_init<APPRO
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | param0          | The exponent as IEEE 754 float bits                                        | uint32_t | Must be a positive integer exponent                   | True     |
+ * | param0          | The integer exponent value                                                 | uint32_t | Must be a positive integer exponent                   | True     |
  */
 // clang-format on
 ALWI void power_iterative_tile(uint32_t idst, uint32_t param0) {

--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -1030,7 +1030,7 @@ ALWI void power_tile_to_cb(
     copy_tile(cb_x, 0, dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, p);
+    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
 
     if (p_is_negative) {
         recip_tile_init();
@@ -1125,7 +1125,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     abs_tile(dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, p);
+    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
 
     if (p_is_negative) {
         recip_tile_init();
@@ -1220,7 +1220,7 @@ ALWI void power_and_recip_tile_to_cb(
     copy_tile(cb_x, 0, dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, p);
+    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
 
     if (p_is_negative) {
         recip_tile_init();

--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -1030,7 +1030,7 @@ ALWI void power_tile_to_cb(
     copy_tile(cb_x, 0, dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
+    power_iterative_tile(dst0, p);
 
     if (p_is_negative) {
         recip_tile_init();
@@ -1125,7 +1125,7 @@ ALWI void power_tile_with_abs_x_to_cb(
     abs_tile(dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
+    power_iterative_tile(dst0, p);
 
     if (p_is_negative) {
         recip_tile_init();
@@ -1220,7 +1220,7 @@ ALWI void power_and_recip_tile_to_cb(
     copy_tile(cb_x, 0, dst0);
 
     power_iterative_tile_init();
-    power_iterative_tile(dst0, generic::bit_cast<uint32_t>(static_cast<float>(p)));
+    power_iterative_tile(dst0, p);
 
     if (p_is_negative) {
         recip_tile_init();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -828,7 +828,8 @@ Tensor ExecutePower::invoke(
     const std::optional<Tensor>& output_tensor) {
     float exponent_floor = std::floor(exponent);
     if (static_cast<int32_t>(exponent_floor) == exponent) {
-        return ExecutePower::invoke(input_a, static_cast<int32_t>(exponent), output_mem_config, output_tensor);
+        int32_t exp = exponent;
+        return ExecutePower::invoke(input_a, exp, output_mem_config, output_tensor);
     }
     return ttnn::operations::unary::ExecuteUnaryTSVariant<ttnn::operations::unary::UnaryOpType::POWER>::invoke(
         input_a, exponent, output_mem_config, output_tensor);
@@ -842,8 +843,9 @@ Tensor ExecutePower::invoke(
     const std::optional<Tensor>& output_tensor) {
     // For exponents 0, 1, 2, 3: use iterative approach
     if (exponent == 0 || exponent == 1 || exponent == 2 || exponent == 3) {
+        uint32_t exp = exponent;
         return ttnn::operations::unary::ExecuteUnaryTSVariant<ttnn::operations::unary::UnaryOpType::POWER_ITERATIVE>::
-            invoke(input, static_cast<uint32_t>(exponent), output_mem_config, output_tensor);
+            invoke(input, exp, output_mem_config, output_tensor);
     }
     return ttnn::operations::unary::ExecuteUnaryTSVariant<ttnn::operations::unary::UnaryOpType::POWER>::invoke(
         input, exponent, output_mem_config, output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -843,7 +843,7 @@ Tensor ExecutePower::invoke(
     // For exponents 0, 1, 2, 3: use iterative approach
     if (exponent == 0 || exponent == 1 || exponent == 2 || exponent == 3) {
         return ttnn::operations::unary::ExecuteUnaryTSVariant<ttnn::operations::unary::UnaryOpType::POWER_ITERATIVE>::
-            invoke(input, exponent, output_mem_config, output_tensor);
+            invoke(input, static_cast<uint32_t>(exponent), output_mem_config, output_tensor);
     }
     return ttnn::operations::unary::ExecuteUnaryTSVariant<ttnn::operations::unary::UnaryOpType::POWER>::invoke(
         input, exponent, output_mem_config, output_tensor);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -169,8 +169,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
         case UnaryOpType::POWER_ITERATIVE:
             // For exponents 0, 1, 2, 3: use iterative approach
             return {
-                "power_iterative_tile_init();",
-                fmt::format("power_iterative_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+                "power_iterative_tile_init();", fmt::format("power_iterative_tile({}, {}u);", idst, (uint32_t)param0)};
         case UnaryOpType::LEAKY_RELU:
             return {
                 "leaky_relu_tile_init();",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -168,8 +168,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 "power_tile_init();", fmt::format("power_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
         case UnaryOpType::POWER_ITERATIVE:
             // For exponents 0, 1, 2, 3: use iterative approach
-            return {
-                "power_iterative_tile_init();", fmt::format("power_iterative_tile({}, {}u);", idst, (uint32_t)param0)};
+            // param0_raw is uint32_t type of exponent
+            return {"power_iterative_tile_init();", fmt::format("power_iterative_tile({}, {});", idst, param0_raw)};
         case UnaryOpType::LEAKY_RELU:
             return {
                 "leaky_relu_tile_init();",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -168,7 +168,10 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 "power_tile_init();", fmt::format("power_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
         case UnaryOpType::POWER_ITERATIVE:
             // For exponents 0, 1, 2, 3: use iterative approach
-            // param0_raw is uint32_t type of exponent
+            TT_FATAL(
+                param0 >= 0.0f && param0 == std::floor(param0),
+                "POWER_ITERATIVE requires positive integer exponent, got {}",
+                param0);
             return {"power_iterative_tile_init();", fmt::format("power_iterative_tile({}, {});", idst, param0_raw)};
         case UnaryOpType::LEAKY_RELU:
             return {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -170,7 +170,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             // For exponents 0, 1, 2, 3: use iterative approach
             TT_FATAL(
                 param0 >= 0.0f && param0 == std::floor(param0),
-                "POWER_ITERATIVE requires positive integer exponent, got {}",
+                "POWER_ITERATIVE requires non-negative integer exponent, got {}",
                 param0);
             return {"power_iterative_tile_init();", fmt::format("power_iterative_tile({}, {});", idst, param0_raw)};
         case UnaryOpType::LEAKY_RELU:

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -16,12 +16,10 @@ namespace ttnn::operations::moreh::moreh_clip_grad_norm_step1 {
 
 std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     auto p = std::floor(ord);
-    auto decimal = ord - p;
+    auto fractional_part = ord - p;
     const bool p_is_negative = p < 0.0f;
-    if (p_is_negative) {
-        p = -p;
-    }
-    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
+    uint32_t integer_part = static_cast<uint32_t>(std::abs(p));
+    return std::make_tuple(integer_part, fractional_part, p_is_negative);
 }
 
 MorehClipGradNormStep1Operation::ProgramFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/device/moreh_clip_grad_norm_step1_program_factory.cpp
@@ -21,8 +21,7 @@ std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     if (p_is_negative) {
         p = -p;
     }
-    // Pass p as float bits (IEEE 754 format) since power_tile expects float bits
-    return std::make_tuple(std::bit_cast<uint32_t>(p), decimal, p_is_negative);
+    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
 }
 
 MorehClipGradNormStep1Operation::ProgramFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
@@ -20,8 +20,7 @@ std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     if (p_is_negative) {
         p = -p;
     }
-    // Pass p as float bits (IEEE 754 format) since power_tile expects float bits
-    return std::make_tuple(std::bit_cast<uint32_t>(p), decimal, p_is_negative);
+    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
 }
 
 MorehClipGradNormStep2Operation::ProgramFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/moreh_clip_grad_norm_step2_program_factory.cpp
@@ -15,12 +15,10 @@ namespace ttnn::operations::moreh::moreh_clip_grad_norm_step2 {
 
 std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     auto p = std::floor(ord);
-    auto decimal = ord - p;
+    auto fractional_part = ord - p;
     const bool p_is_negative = p < 0.0f;
-    if (p_is_negative) {
-        p = -p;
-    }
-    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
+    uint32_t integer_part = static_cast<uint32_t>(std::abs(p));
+    return std::make_tuple(integer_part, fractional_part, p_is_negative);
 }
 
 MorehClipGradNormStep2Operation::ProgramFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
@@ -16,12 +16,10 @@ namespace ttnn::operations::moreh::moreh_clip_grad_norm_step3 {
 
 std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     auto p = std::floor(ord);
-    auto decimal = ord - p;
+    auto fractional_part = ord - p;
     const bool p_is_negative = p < 0.0f;
-    if (p_is_negative) {
-        p = -p;
-    }
-    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
+    uint32_t integer_part = static_cast<uint32_t>(std::abs(p));
+    return std::make_tuple(integer_part, fractional_part, p_is_negative);
 }
 
 MorehClipGradNormStep3Operation::ProgramFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/device/moreh_clip_grad_norm_step3_program_factory.cpp
@@ -21,8 +21,7 @@ std::tuple<uint32_t, float, bool> get_p_decimal_p_is_negative(float ord) {
     if (p_is_negative) {
         p = -p;
     }
-    // Pass p as float bits (IEEE 754 format) since power_tile expects float bits
-    return std::make_tuple(std::bit_cast<uint32_t>(p), decimal, p_is_negative);
+    return std::make_tuple(static_cast<uint32_t>(p), decimal, p_is_negative);
 }
 
 MorehClipGradNormStep3Operation::ProgramFactory::cached_program_t


### PR DESCRIPTION
### Ticket
NA

### Problem description
The `power_tile_to_cb`, `power_tile_with_abs_x_to_cb`, and `power_and_recip_tile_to_cb` were passing the integer power p directly to `power_iterative_tile()`, but the iterative tile expected the exponent as IEEE 754 float bits, not a raw integer. 

Failing run : [Run #21506379052 (latest reproducible failure)](https://github.com/tenstorrent/tt-metal/actions/runs/21506379052/job/61963797049)

### What's changed
- Since `power_iterative_tile()` expects only positive integer exponents, the float conversion (which was introduced for `power_tile()` ) is no longer necessary.
- Reverted changes done in PR #33182 related to conversion. power_iterative tile accepts int values now which is better for iterative approach as it required int values, avoiding float conversion
- Test results (checked locally) : 
<img width="1180" height="320" alt="Screenshot 2026-01-31 at 12 47 49 AM" src="https://github.com/user-attachments/assets/8d766a82-40a5-4d19-8fa7-f7e5df6e4b46" />


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:virdhatchani/moreh_fix)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/moreh_fix) - Failed as in main
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/moreh_fix)
- For moreh category : All passed([Link](https://github.com/tenstorrent/tt-metal/actions/runs/21525209397))
- Latest run passed as in main for sdpa,eltwise,moreh
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/moreh_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/moreh_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/moreh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/moreh_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
