### PR TITLE
Fix tiled mesh_partition validation: verify no padding is introduced along partition dim

### DIFF
--- a/tests/nightly/t3000/ccl/test_mesh_partition.py
+++ b/tests/nightly/t3000/ccl/test_mesh_partition.py
@@ -350,3 +350,46 @@ def test_mesh_partition_rm(
         output_memory_config,
         scheme="random",
     )
+
+
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device", [pytest.param((2, 4), (2, 4), id="2x4_grid")], indirect=["mesh_device"]
+)
+@pytest.mark.parametrize("per_device_output_shape, dim", [((1, 4, 1, 576), 1), ((1, 4, 1, 576), 3)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("cluster_axis", [1])
+@pytest.mark.parametrize("mesh_axes", [[0, 1]])
+@pytest.mark.parametrize("input_memory_config", [ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize("output_memory_config", [ttnn.L1_MEMORY_CONFIG])
+def test_mesh_partition_tile(
+    mesh_device,
+    mesh_shape,
+    per_device_output_shape,
+    dtype,
+    layout,
+    dim,
+    cluster_axis,
+    mesh_axes,
+    input_memory_config,
+    output_memory_config,
+):
+    num_iters = 2
+    warmup_iters = 0
+
+    run_mesh_partition_test(
+        mesh_device,
+        per_device_output_shape,
+        dim,
+        num_iters,
+        warmup_iters,
+        False,
+        dtype,
+        layout,
+        cluster_axis,
+        mesh_axes,
+        mesh_shape,
+        input_memory_config,
+        output_memory_config,
+        scheme="random",
+    )

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -38,8 +38,9 @@ void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
             tensor_args.optional_output_tensor.value().tensor_spec() == output_spec,
             "Output tensor spec must match computed output spec");
     }
-    const auto& output_shape = output_spec.logical_shape();
     const auto& input_shape = input_tensor.logical_shape();
+    const auto& output_shape = output_spec.padded_shape();
+    const auto& output_padded_shape = output_spec.padded_shape();
 
     TT_FATAL(
         !(operation_attributes.cluster_axis.has_value() && operation_attributes.cluster_axis.value() > 1),
@@ -61,10 +62,10 @@ void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
 
     if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
         TT_FATAL(
-            output_shape == output_spec.padded_shape(),
-            "output shape {} must be equal to padded shape {} for tiled inputs",
-            output_shape,
-            output_spec.padded_shape());
+            output_shape[operation_attributes.dim] == output_padded_shape[operation_attributes.dim],
+            "for tiled inputs, partitioning along dim {} should not create padding in output shape {}",
+            operation_attributes.dim,
+            output_shape);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -46,7 +46,7 @@ auto compute_slice_parameters(
         cluster_index,
         cluster_size);
 
-    auto input_shape = input_tensor.logical_shape();
+    auto input_shape = input_tensor.padded_shape();
     uint32_t dim = operation_attributes.dim;
     uint32_t rank = input_shape.size();
     auto partitioned_dim_size = input_shape[dim] / cluster_size;


### PR DESCRIPTION
### Ticket
Blocking https://github.com/tenstorrent/tt-metal/issues/36742

### Problem description
Fixed check for padded shape, so now mesh_partion can partition padded tensors on dims which will not introduce padding in output tile.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/mesh_part_enable_padtile)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/mesh_part_enable_padtile)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/mesh_part_enable_padtile)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/mesh_part_enable_padtile)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/mesh_part_enable_padtile)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/mesh_part_enable_padtile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/mesh_part_enable_padtile)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
