### PR TITLE
Reduce number of noc writes using in padding path of transpose tile hc

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
                     uint32_t linear_idx = base_linear_idx + output_h_face_line * C_t * W_t;
 
                     // Compute the write address
-                    uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
 
                     // Perform asynchronous write
                     noc_async_write(l1_read_addr, write_noc_base_addr, SUBTILE_LINE_BYTES);
@@ -177,19 +177,20 @@ void kernel_main() {
 
                 // Sub-tile/face line where our padded data starts
                 uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
-
-                for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
-                    // Offset to the start of the current face along the width of the tile
-                    uint32_t face_w_offset = face_w * face_height_width;
-                    for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
-                        // offset to the start of the current sub-tile line
-                        uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line * FACE_WIDTH) * element_size;
-
-                        // Compute the write address
-                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
-
-                        // Perform asynchronous write
-                        noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
+                if (sub_tile_line_start == 0) {
+                    uint32_t offset = face_c_offset * element_size;
+                    uint32_t write_size = SUBTILE_LINE_BYTES * FACE_HEIGHT * NUM_FACES_W;
+                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
+                    noc_async_write(l1_read_ptr, write_noc_base_addr, write_size);
+                } else {
+                    for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                        // Offset to the start of the current face along the width of the tile
+                        uint32_t face_w_offset = face_w * face_height_width;
+                        uint32_t offset =
+                            (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
+                        uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
+                        uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
+                        noc_async_write(l1_read_ptr, write_noc_base_addr, write_size);
                     }
                 }
             }


### PR DESCRIPTION
### What's changed
Tried to reduce number of noc writes in tranpose tile hc
Performance comparison for shapes from tranpose testing and Deepseek model:
### HC TILE Transpose Performance Comparison

| Shape (W×Z×Y×X) | Main (µs) | New (µs) | Ratio |
|-----------------|----------|----------|-------|
| 1×4×128×512 | 89.09 | 31.62 | 2.82x |
| 1×1×32×576 | 21.63 | 8.29 | 2.61x |
| 1×1×1×1 | 3.59 | 1.81 | 1.98x |
| 1×1×1×17 | 3.59 | 1.82 | 1.97x |
| 1×1×1×2 | 3.59 | 1.82 | 1.97x |
| 1×1×1×35 | 3.72 | 1.90 | 1.96x |
| 2×1×1×1 | 3.63 | 1.86 | 1.95x |
| 1×3×2×1 | 3.66 | 2.07 | 1.77x |
| 1×2×32×100 | 9.18 | 5.53 | 1.66x |
| 1×1×16×32 | 5.19 | 3.20 | 1.62x |
| 1×1×16×1 | 5.13 | 3.21 | 1.60x |
| 1×1×17×1 | 5.19 | 3.30 | 1.57x |
| 1×35×7×7 | 4.57 | 3.04 | 1.50x |
| 1×5×10×15 | 4.51 | 3.05 | 1.48x |
| 1×1×32×64 | 5.86 | 3.99 | 1.47x |
| 1×6×33×34 | 8.16 | 5.59 | 1.46x |
| 1×16×32×512 | 21.68 | 15.24 | 1.42x |
| 1×12×32×100 | 9.36 | 6.59 | 1.42x |
| 1×17×1×1 | 2.85 | 2.03 | 1.40x |
| 2×33×33×33 | 28.23 | 20.35 | 1.39x |
| 1×2×34×8 | 6.89 | 5.07 | 1.36x |
| 1×1×32×32 | 6.42 | 4.87 | 1.32x |
| 1×32×1×64 | 1.32 | 1.31 | 1.00x |
| 1×32×1×12 | 1.80 | 1.80 | 1.00x |
| 3×64×128×96 | 250.00 | 249.42 | 1.00x |
| 1×32×12×100 | 6.18 | 6.18 | 1.00x |
| 1×128×384×96 | 477.29 | 477.58 | 1.00x |
| 1×128×4×128 | 7.13 | 7.14 | 1.00x |
| 1×32×16×128 | 4.48 | 4.49 | 1.00x |
| 1×32×1×32 | 1.80 | 1.82 | 0.99x |
| 32×32×32×32 | 76.94 | 78.12 | 0.98x |

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
