### PR TITLE
refactor(ttnn): Remove DataType::INVALID from codebase

### DIFF
--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -31,7 +31,6 @@ constexpr auto BFLOAT8_B = "Unsupported type: BFLOAT8_B";
 constexpr auto BFLOAT4_B = "Unsupported type: BFLOAT4_B";
 constexpr auto UINT8 = "Unsupported type: UINT8";
 constexpr auto UINT16 = "Unsupported type: UINT16";
-constexpr auto INVALID = "Unsupported type: INVALID";
 constexpr auto UNKNOWN = "Unsupported type: unknown";
 constexpr auto COMPLEX = "Unsupported type: Complex";
 constexpr auto BOOL = "Unsupported type: Bool";
@@ -53,7 +52,6 @@ constexpr bool is_supported_datatype(tt::tt_metal::DataType dt) {
             NB_THROW(nb::exception_type::type_error, UnsupportedMessages::BFLOAT4_B);
         case tt::tt_metal::DataType::UINT8: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UINT8);
         case tt::tt_metal::DataType::UINT16: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UINT16);
-        case tt::tt_metal::DataType::INVALID: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::INVALID);
         default: NB_THROW(nb::exception_type::type_error, UnsupportedMessages::UNKNOWN);
     }
 }

--- a/ttnn/api/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_impl.hpp
@@ -179,8 +179,8 @@ auto dispatch(DataType dtype, Func&& func, Args&&... args) {
             return (std::forward<Func>(func)).template operator()<bfloat8_b>(std::forward<Args>(args)...);
         case DataType::BFLOAT4_B:
             return (std::forward<Func>(func)).template operator()<bfloat4_b>(std::forward<Args>(args)...);
-        default: TT_THROW("Unsupported data type");
     }
+    TT_THROW("Unsupported data type");
 }
 
 }  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/api/ttnn/tensor/types.hpp
+++ b/ttnn/api/ttnn/tensor/types.hpp
@@ -52,7 +52,6 @@ enum class DataType {
     UINT8 = 5,
     UINT16 = 6,
     INT32 = 7,
-    INVALID = 8,
 };
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_type);

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -138,9 +138,8 @@ public:
             case tt::tt_metal::DataType::UINT8: return extract_logical_data.template operator()<uint8_t>(tensor);
             case tt::tt_metal::DataType::UINT16: return extract_logical_data.template operator()<uint16_t>(tensor);
             case tt::tt_metal::DataType::INT32: return extract_logical_data.template operator()<int32_t>(tensor);
-            case tt::tt_metal::DataType::INVALID: TT_THROW("Invalid data type: {}", tensor.tensor_spec().data_type());
         }
-        TT_THROW("Unreachable");
+        TT_THROW("Invalid data type: {}", tensor.tensor_spec().data_type());
     }
 
     template <typename T>
@@ -404,9 +403,8 @@ public:
             case tt::tt_metal::DataType::UINT8: return dispatch_to_concrete.template operator()<uint8_t>(tensor);
             case tt::tt_metal::DataType::UINT16: return dispatch_to_concrete.template operator()<uint16_t>(tensor);
             case tt::tt_metal::DataType::INT32: return dispatch_to_concrete.template operator()<int32_t>(tensor);
-            case tt::tt_metal::DataType::INVALID: TT_THROW("Invalid data type: {}", tensor.dtype());
         }
-        TT_THROW("Unreachable");
+        TT_THROW("Invalid data type: {}", tensor.dtype());
     }
 
 private:

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -84,9 +84,8 @@ tt::tt_metal::HostBuffer create_host_buffer_from_bytes(
             tt::stl::Span<bfloat16> typed_span(reinterpret_cast<bfloat16*>(data.data()), size_bytes / sizeof(bfloat16));
             return tt::tt_metal::HostBuffer(typed_span, memory_pin);
         }
-        case tt::tt_metal::DataType::INVALID: TT_THROW("Unsupported DataType");
     }
-    TT_THROW("Unreachable");
+    TT_THROW("Unsupported DataType");
 }
 
 flatbuffers::Offset<ttnn::flatbuffer::TensorTopology> to_flatbuffer(

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -59,7 +59,8 @@ tt::tt_metal::DataType from_flatbuffer(flatbuffer::DataType type) {
         case flatbuffer::DataType::UInt8: return tt::tt_metal::DataType::UINT8;
         case flatbuffer::DataType::UInt16: return tt::tt_metal::DataType::UINT16;
         case flatbuffer::DataType::Int32: return tt::tt_metal::DataType::INT32;
-        case flatbuffer::DataType::Invalid: return tt::tt_metal::DataType::INVALID;
+        case flatbuffer::DataType::Invalid:
+            TT_THROW("Invalid DataType is no longer supported. Cannot deserialize tensor with Invalid DataType.");
     }
     TT_THROW("Unsupported DataType from flatbuffer.");
 }
@@ -95,7 +96,6 @@ flatbuffer::DataType to_flatbuffer(tt::tt_metal::DataType type) {
         case tt::tt_metal::DataType::UINT8: return flatbuffer::DataType::UInt8;
         case tt::tt_metal::DataType::UINT16: return flatbuffer::DataType::UInt16;
         case tt::tt_metal::DataType::INT32: return flatbuffer::DataType::Int32;
-        case tt::tt_metal::DataType::INVALID: return flatbuffer::DataType::Invalid;
     }
     TT_THROW("Unsupported DataType to flatbuffer.");
 }

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -39,8 +39,8 @@ bool can_exec_ops_on_device(DataType type) {
             // Conversion from bfloat16 to bfloat4_b or bfloat8_b loses precision.
             // The test triggering this bug is test_matmul.py::test_tiny_tiles_bfloat
             return false;
-        default: return true;
     }
+    return true;
 };
 
 // Check if the tensor with the specified memory config and tiling can be
@@ -142,8 +142,8 @@ Tensor create_tt_tensor_from_host_data(
         case DataType::UINT16: return create_tensor_from_host_buffer.operator()<uint16_t>();
         case DataType::FLOAT32: return create_tensor_from_host_buffer.operator()<float>();
         case DataType::BFLOAT16: return create_tensor_from_host_buffer.operator()<bfloat16>();
-        default: TT_THROW("Unsupported data type");
     }
+    TT_THROW("Unsupported data type");
 }
 
 DataType compute_host_dtype(ttnn::PyDType src_dtype, const DataType& dst_dtype, bool is_sharded) {

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -532,9 +532,8 @@ HostBuffer allocate_host_buffer(const TensorSpec& tensor_spec) {
         case DataType::BFLOAT4_B:
         case DataType::BFLOAT8_B:
         case DataType::UINT32: return HostBuffer(std::vector<uint32_t>(size_bytes / sizeof(uint32_t)));
-        case DataType::INVALID: TT_THROW("Invalid data type");
     }
-    TT_THROW("Unreachable");
+    TT_THROW("Invalid data type");
 }
 
 Tensor to_host(const Tensor& tensor, bool blocking, std::optional<tt::tt_metal::QueueId> cq_id) {
@@ -1443,9 +1442,8 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
                 case DataType::UINT16: return with_src_and_dst.operator()<SrcType, uint16_t>();
                 case DataType::UINT32: return with_src_and_dst.operator()<SrcType, uint32_t>();
                 case DataType::INT32: return with_src_and_dst.operator()<SrcType, int32_t>();
-                case DataType::INVALID: TT_THROW("Unsupported data type conversion requested. Source type is invalid!");
             }
-            TT_THROW("Unreachable");
+            TT_THROW("Unsupported data type conversion requested.");
         };
 
         switch (src_type) {
@@ -1457,9 +1455,8 @@ Tensor to_dtype(const Tensor& input_tensor, DataType dtype) {
             case DataType::UINT16: return with_src.operator()<uint16_t>();
             case DataType::UINT32: return with_src.operator()<uint32_t>();
             case DataType::INT32: return with_src.operator()<int32_t>();
-            case DataType::INVALID: TT_THROW("Unsupported data type conversion requested. Source type is invalid!");
         }
-        TT_THROW("Unreachable");
+        TT_THROW("Unsupported data type conversion requested.");
     }();
 
     const auto layout =

--- a/ttnn/core/tensor/types.cpp
+++ b/ttnn/core/tensor/types.cpp
@@ -16,9 +16,8 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::DataType& data_ty
         case DataType::UINT8: return os << "DataType::UINT8";
         case DataType::UINT16: return os << "DataType::UINT16";
         case DataType::INT32: return os << "DataType::INT32";
-        case DataType::INVALID:
-        default: return os << "Invalid";
     }
+    return os << "Unknown DataType";
 }
 
 std::ostream& operator<<(std::ostream& os, const tt::tt_metal::NdShardSpec& spec) {
@@ -94,8 +93,8 @@ tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype)
         case tt::tt_metal::DataType::UINT32: return tt::DataFormat::UInt32;
         case tt::tt_metal::DataType::UINT16: return tt::DataFormat::UInt16;
         case tt::tt_metal::DataType::UINT8: return tt::DataFormat::UInt8;
-        default: TT_THROW("Unsupported DataType"); return tt::DataFormat::Float16_b;  // for clang-tidy
     }
+    TT_THROW("Unsupported DataType");
 }
 
 tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat) {

--- a/ttnn/cpp/ttnn-nanobind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/creation.cpp
@@ -121,11 +121,10 @@ auto create_nanobind_from_buffer_overload() {
                     return self(std::move(cpp_buffer), shape, dtype, device, layout, memory_config);
                 }
                 case DataType::BFLOAT8_B:
-                case DataType::BFLOAT4_B:
-                case DataType::INVALID: {
+                case DataType::BFLOAT4_B: {
                     // convert_to_data_type() in types.hpp has not an implementation for bfloat8_b and bfloat4_b
                     // Both are empty structs, so let's not allow users to use them for this particular operation
-                    TT_THROW("Unreachable");
+                    TT_THROW("Unsupported DataType for buffer creation");
                 }
             }
             // This is a fallback to make the compiler happy.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -686,7 +686,7 @@ void post_conv2d_op_memory_checks(
     const auto& memory_config = operation_attributes.memory_config;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
     const auto& block_config = operation_attributes.block_config;
-    const auto dtype = operation_attributes.dtype;
+    const auto dtype = operation_attributes.dtype.value();
     const auto& input_tensor_shape = operation_attributes.input_tensor_shape;
     const auto& enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
     const auto& enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -70,7 +70,7 @@ TensorSpec Conv2dDeviceOperation::compute_output_specs(
         return TensorSpec(
             output_shape,
             tt::tt_metal::TensorLayout(
-                args.dtype,
+                args.dtype.value(),
                 tt::tt_metal::PageConfig(output_layout),
                 mem_config,
                 tt::tt_metal::Alignment(
@@ -82,7 +82,7 @@ TensorSpec Conv2dDeviceOperation::compute_output_specs(
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout::fromPaddedShape(
-            args.dtype,
+            args.dtype.value(),
             tt::tt_metal::PageConfig(output_layout),
             args.memory_config,
             output_shape,
@@ -102,9 +102,9 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(!input_tensor_b.memory_config().is_sharded(), "Weights tensor should not be sharded.");
     if (args.untilize_out) {
         TT_FATAL(
-            (args.dtype == DataType::BFLOAT16) || (args.dtype == DataType::FLOAT32),
+            (args.dtype.value() == DataType::BFLOAT16) || (args.dtype.value() == DataType::FLOAT32),
             "Untilize output requires BFLOAT16 or FLOAT32 data type but got {}",
-            args.dtype);
+            args.dtype.value());
     }
     if (args.memory_config.is_sharded()) {
         uint32_t per_core_out_matrix_width_ntiles = args.parallelization_config.per_core_out_matrix_width_ntile;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -199,7 +199,7 @@ struct Conv2dParams {
     Conv2dParallelizationConfig parallelization_config{};
     Conv2dBlockConfig block_config{};
     tt::tt_metal::MemoryConfig memory_config;
-    tt::tt_metal::DataType dtype = tt::tt_metal::DataType::INVALID;
+    std::optional<tt::tt_metal::DataType> dtype;
     std::array<std::uint32_t, 4> input_tensor_shape{};
     DeviceComputeKernelConfig compute_kernel_config;
     bool enable_act_double_buffer = false;
@@ -220,7 +220,7 @@ struct Conv2dHashableParams {
     Conv2dParallelizationConfig parallelization_config{};
     Conv2dBlockConfig block_config{};
     tt::tt_metal::MemoryConfig memory_config;
-    tt::tt_metal::DataType dtype = tt::tt_metal::DataType::INVALID;
+    std::optional<tt::tt_metal::DataType> dtype;
     std::array<std::uint32_t, 4> input_tensor_shape{};
     DeviceComputeKernelConfig compute_kernel_config;
     bool enable_act_double_buffer = false;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -19,7 +19,7 @@ void InterleavedToShardedDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& output_mem_config = operation_attributes.output_mem_config;
-    const auto& output_dtype = operation_attributes.output_dtype;
+    const auto output_dtype = operation_attributes.output_dtype.value_or(input_tensor.dtype());
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
@@ -71,10 +71,10 @@ InterleavedToShardedDeviceOperation::spec_return_value_t InterleavedToShardedDev
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
         tt::tt_metal::TensorLayout::fromPaddedShape(
-            operation_attributes.output_dtype,
-            tt::tt_metal::PageConfig(input_tensor.layout()),
+            operation_attributes.output_dtype.value_or(tensor_args.input_tensor.dtype()),
+            tt::tt_metal::PageConfig(tensor_args.input_tensor.layout()),
             operation_attributes.output_mem_config,
-            input_tensor.logical_shape(),
+            tensor_args.input_tensor.logical_shape(),
             input_tensor.padded_shape()));
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op_types.hpp
@@ -11,7 +11,7 @@ namespace ttnn::prim {
 
 struct InterleavedToShardedParams {
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> output_dtype;
     bool keep_l1_aligned{};
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -23,7 +23,7 @@ void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_miss(
     const auto& num_slices = operation_attributes.num_slices;
     const auto& slice_index = operation_attributes.slice_index;
     const auto& grid_size = operation_attributes.grid_size;
-    const auto& output_dtype = operation_attributes.output_dtype;
+    const auto output_dtype = operation_attributes.output_dtype.value_or(input_tensor.dtype());
 
     // Validate output tensor
     TT_FATAL(
@@ -75,7 +75,9 @@ TensorSpec InterleavedToShardedPartialDeviceOperation::compute_output_specs(
     return TensorSpec(
         shape,
         tt::tt_metal::TensorLayout(
-            operation_attributes.output_dtype, tt::tt_metal::PageConfig(input_tensor.layout()), mem_config));
+            operation_attributes.output_dtype.value_or(input_tensor.dtype()),
+            tt::tt_metal::PageConfig(input_tensor.layout()),
+            mem_config));
 }
 
 Tensor InterleavedToShardedPartialDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op_types.hpp
@@ -16,7 +16,7 @@ struct InterleavedToShardedPartialParams {
     uint32_t num_slices{};
     uint32_t slice_index{};
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> output_dtype;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -139,7 +139,7 @@ TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_specs(
         return TensorSpec(
             input_shape,
             TensorLayout::fromPaddedShape(
-                operation_attributes.output_dtype,
+                operation_attributes.output_dtype.value_or(input_tensor.dtype()),
                 PageConfig(Layout::TILE),
                 mem_config,
                 input_shape,
@@ -149,7 +149,7 @@ TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_specs(
     return TensorSpec(
         input_shape,
         TensorLayout::fromPaddedShape(
-            operation_attributes.output_dtype,
+            operation_attributes.output_dtype.value_or(input_tensor.dtype()),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,
             input_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation_types.hpp
@@ -12,7 +12,7 @@ struct TilizeWithValPaddingParams {
     ttnn::Shape output_padded_shape{};
     tt::tt_metal::PadValue pad_value;
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> output_dtype;
     bool use_multicore{};
     bool enough_space_width{};
     bool enough_space_height{};

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -73,10 +73,10 @@ void UnaryDeviceOperation::validate_on_program_cache_miss(
     const auto& preallocated_output_tensor = tensor_args.preallocated_output;
 
     auto out_memory_config = args.output_memory_config;
-    auto output_datatype = args.output_dtype;
+    auto output_datatype = preallocated_output_tensor.has_value() ? preallocated_output_tensor->dtype()
+                                                                  : args.output_dtype.value_or(input_tensor.dtype());
     if (preallocated_output_tensor.has_value()) {
         out_memory_config = preallocated_output_tensor->memory_config();
-        output_datatype = preallocated_output_tensor->dtype();
     }
 
     auto input_datatype = input_tensor.dtype();
@@ -137,10 +137,11 @@ TensorSpec UnaryDeviceOperation::compute_output_specs(
     const auto output_layout = tensor_args.input.layout();
 
     const auto output_shape = tensor_args.input.logical_shape();
+    const auto output_dtype = args.output_dtype.value_or(tensor_args.input.dtype());
     return TensorSpec(
         output_shape,
         TensorLayout::fromPaddedShape(
-            args.output_dtype,
+            output_dtype,
             PageConfig(output_layout),
             args.output_memory_config,
             output_shape,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
@@ -16,7 +16,7 @@ using ttnn::operations::unary::EltwiseUnaryWithParam;
 
 struct UnaryParams {
     const std::vector<EltwiseUnaryWithParam> op_chain;
-    const tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
+    const std::optional<tt::tt_metal::DataType> output_dtype;
     const tt::tt_metal::MemoryConfig output_memory_config;
     const bool fp32_dest_acc_en = false;
     const bool preserve_fp32_precision = false;

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -54,7 +54,7 @@ void EmbeddingBackwardDeviceOperation::validate_on_program_cache_miss(
         grad_tensor.dtype() == DataType::BFLOAT16 or grad_tensor.dtype() == DataType::BFLOAT8_B,
         "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");
     TT_FATAL(
-        grad_tensor.dtype() == operation_attributes.output_dtype,
+        grad_tensor.dtype() == operation_attributes.output_dtype.value_or(grad_tensor.dtype()),
         "Output and input gradient tensors must have the same dtype");
 
     TT_FATAL(
@@ -87,7 +87,9 @@ EmbeddingBackwardDeviceOperation::spec_return_value_t EmbeddingBackwardDeviceOpe
     return TensorSpec(
         output_shape,
         TensorLayout(
-            operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config));
+            operation_attributes.output_dtype.value_or(tensor_args.grad_tensor.dtype()),
+            PageConfig(Layout::TILE),
+            operation_attributes.output_mem_config));
 }
 
 EmbeddingBackwardDeviceOperation::tensor_return_value_t EmbeddingBackwardDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation_types.hpp
@@ -10,7 +10,7 @@ namespace ttnn::prim {
 
 struct EmbeddingBackwardParams {
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
+    std::optional<tt::tt_metal::DataType> output_dtype;
     uint32_t num_embeddings = 0;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
@@ -9,7 +9,7 @@
 namespace ttnn::experimental::prim {
 
 struct DropoutParams {
-    const tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
+    const std::optional<tt::tt_metal::DataType> output_dtype;
     const tt::tt_metal::MemoryConfig output_memory_config;
 
     // Specifies the seed for the dropout operation.

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/nlp_create_qkv_heads_segformer_device_operation.cpp
@@ -66,16 +66,9 @@ void NlpCreateHeadsSegformerDeviceOperation::validate_on_program_cache_miss(
 
 NlpCreateQkvHeadsSegformerResultSpec NlpCreateHeadsSegformerDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    if (args.output_mem_config.is_sharded()) {
-        TT_FATAL(false, "Sharded output memory config is not supported for nlp_create_qkv_heads_segformer");
-        TensorSpec spec(
-            ttnn::Shape({}),
-            tt::tt_metal::TensorLayout(
-                tt::tt_metal::DataType::INVALID,
-                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
-                args.output_mem_config));
-        return {spec, spec, spec};
-    }
+    TT_FATAL(
+        !args.output_mem_config.is_sharded(),
+        "Sharded output memory config is not supported for nlp_create_qkv_heads_segformer");
 
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& input_shape = input_tensor.padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -27,11 +27,7 @@ void GeluBackwardDeviceOperation::validate_on_program_cache_miss(
     const auto& preallocated_input_grad = tensor_args.preallocated_input_grad;
     const auto& input_tensor = tensor_args.input;
     auto out_memory_config = args.output_memory_config;
-    auto output_datatype = args.output_dtype;
-
-    if (output_datatype == DataType::INVALID) {
-        output_datatype = input_tensor.dtype();
-    }
+    auto output_datatype = args.output_dtype.value_or(input_tensor.dtype());
 
     if (preallocated_input_grad.has_value()) {
         out_memory_config = preallocated_input_grad->memory_config();
@@ -96,10 +92,7 @@ TensorSpec GeluBackwardDeviceOperation::compute_output_specs(
         output_layout = tensor_args.input.layout();
     }
 
-    DataType output_dtype = args.output_dtype;
-    if (output_dtype == DataType::INVALID) {
-        output_dtype = tensor_args.input.dtype();
-    }
+    DataType output_dtype = args.output_dtype.value_or(tensor_args.input.dtype());
 
     const auto output_shape = tensor_args.input.logical_shape();
     return TensorSpec(output_shape, TensorLayout(output_dtype, output_layout, args.output_memory_config));

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation_types.hpp
@@ -10,7 +10,7 @@
 namespace ttnn::experimental::prim {
 
 struct GeluBackwardParams {
-    const tt::tt_metal::DataType output_dtype = tt::tt_metal::DataType::INVALID;
+    const std::optional<tt::tt_metal::DataType> output_dtype;
     const tt::tt_metal::MemoryConfig output_memory_config;
     const std::string approximate = "none";
 };

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -229,7 +229,7 @@ TensorSpec GroupNormDeviceOperation::compute_output_specs(
             return TensorSpec(
                 input_tensor.logical_shape(),
                 TensorLayout::fromPaddedShape(
-                    program_config.out_data_format,
+                    program_config.out_data_format.value(),
                     PageConfig(program_config.output_layout),
                     mem_config,
                     input_tensor.logical_shape(),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
@@ -15,8 +15,8 @@ namespace ttnn::prim {
 // Program config types
 struct GroupNormMultiCoreProgramConfig {
     CoreCoord compute_with_storage_grid_size;
-    tt::tt_metal::DataType im_data_format{tt::tt_metal::DataType::INVALID};
-    tt::tt_metal::DataType out_data_format{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> im_data_format;
+    std::optional<tt::tt_metal::DataType> out_data_format;
     bool inplace{};
     tt::tt_metal::Layout output_layout{tt::tt_metal::Layout::INVALID};
     int num_out_blocks{};
@@ -24,8 +24,8 @@ struct GroupNormMultiCoreProgramConfig {
 
 struct GroupNormShardedMultiCoreProgramConfig {
     CoreCoord compute_with_storage_grid_size;
-    tt::tt_metal::DataType im_data_format{tt::tt_metal::DataType::INVALID};
-    tt::tt_metal::DataType out_data_format{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> im_data_format;
+    std::optional<tt::tt_metal::DataType> out_data_format;
     bool inplace{};
     tt::tt_metal::Layout output_layout{tt::tt_metal::Layout::INVALID};
 };

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -34,7 +34,7 @@ GroupNormMcastProgramFactory::cached_program_t GroupNormMcastProgramFactory::cre
     float eps = operation_attributes.eps;
     uint32_t num_groups = operation_attributes.num_groups;
     uint32_t num_batches = a.padded_shape()[0];
-    DataType im_data_format = program_config.im_data_format;
+    DataType im_data_format = program_config.im_data_format.value();
     CoreCoord grid_size = program_config.compute_with_storage_grid_size;
     uint32_t num_out_blocks = program_config.num_out_blocks;
     bool use_welford = operation_attributes.use_welford;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -34,7 +34,7 @@ GroupNormNoMcastProgramFactory::cached_program_t GroupNormNoMcastProgramFactory:
     float eps = operation_attributes.eps;
     uint32_t num_groups = operation_attributes.num_groups;
     uint32_t num_batches = a.padded_shape()[0];
-    DataType im_data_format = program_config.im_data_format;
+    DataType im_data_format = program_config.im_data_format.value();
     CoreCoord grid_size = program_config.compute_with_storage_grid_size;
     uint32_t num_out_blocks = program_config.num_out_blocks;
     bool use_welford = operation_attributes.use_welford;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -34,7 +34,7 @@ GroupNormShardedProgramFactory::cached_program_t GroupNormShardedProgramFactory:
     float eps = operation_attributes.eps;
     uint32_t num_groups = operation_attributes.num_groups;
     uint32_t num_batches = a.padded_shape()[0];
-    DataType im_data_format = program_config.im_data_format;
+    DataType im_data_format = program_config.im_data_format.value();
     CoreCoord grid_size = program_config.compute_with_storage_grid_size;
     bool inplace = program_config.inplace;
     bool use_welford = operation_attributes.use_welford;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/device/accumulation_device_operation.cpp
@@ -76,10 +76,7 @@ AccumulationDeviceOperation::spec_return_value_t AccumulationDeviceOperation::co
         output_layout = tensor_args.input_tensor.layout();
     }
 
-    const DataType dtype =
-        tensor_args.opt_output
-            ? tensor_args.opt_output->dtype()
-            : ((attributes.dtype == DataType::INVALID) ? tensor_args.input_tensor.dtype() : attributes.dtype);
+    const DataType dtype = tensor_args.opt_output ? tensor_args.opt_output->dtype() : attributes.dtype;
 
     const auto output_shape{tensor_args.input_tensor.logical_shape()};
     return TensorSpec{output_shape, TensorLayout{dtype, output_layout, attributes.output_memory_config}};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -58,7 +58,7 @@ ReduceDeviceOperation::spec_return_value_t ReduceDeviceOperation::compute_output
     TensorSpec tensor_spec(
         output_shape,
         tt::tt_metal::TensorLayout(
-            operation_attributes.output_dtype,
+            operation_attributes.output_dtype.value(),
             tt::tt_metal::PageConfig(Layout::TILE),
             MemoryConfig(operation_attributes.output_mem_config.buffer_type())));
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -17,7 +17,7 @@ struct ReduceParams {
     tt::tt_metal::ReduceOpDim dim{};
     float scaler{1.0f};
     tt::tt_metal::MemoryConfig output_mem_config;
-    tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
+    std::optional<tt::tt_metal::DataType> output_dtype;
     ttnn::DeviceComputeKernelConfig compute_kernel_config;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
 };

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -59,7 +59,7 @@ The new TMP Device Operation is more verbose but allows precise input/output typ
 ```cpp
 struct operation_attributes_t {
     const std::vector<UnaryWithParam> op_chain;
-    const DataType output_dtype = DataType::INVALID;
+    const std::optional<DataType> output_dtype;
     const MemoryConfig output_memory_config;
     const bool fp32_dest_acc_en = false;
     const bool preserve_fp32_precision = false;


### PR DESCRIPTION
### Ticket
N/A - Code quality improvement

### Problem description
The `DataType::INVALID` enum value was used as a sentinel/default value throughout the codebase to indicate "no data type specified". This is problematic because:
- It's semantically incorrect - INVALID is not a valid data type
- It clutters switch statements with unreachable cases
- It doesn't provide compile-time safety when a data type is truly optional

### What's changed
Removed `DataType::INVALID` from the `DataType` enum and replaced all usages with `std::optional<DataType>` where appropriate.

**Key changes:**
- Removed `INVALID = 8` from `DataType` enum in `ttnn/api/ttnn/tensor/types.hpp`
- Updated all switch statements to remove `case DataType::INVALID` branches
- Changed struct field defaults from `DataType output_dtype = DataType::INVALID` to `std::optional<DataType>`
- Updated implementations to use `value_or()` and `has_value()` for optional handling

**Affected components:**
- Core tensor types (`types.hpp`, `types.cpp`, `tensor_impl.hpp/cpp`)
- Python bindings (`pytensor.cpp`, `ttnn_dtype_traits.hpp`)
- FlatBuffer serialization (`tensor_spec_flatbuffer.cpp`, `tensor_flatbuffer.cpp`)
- Operation types: conv2d, groupnorm, dropout, gelu_backward, unary, embedding_backward, tilize, sharded operations, reduce
- tt-train nanobind utilities

**Files modified:** 39 files

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=refactor/remove-datatype-invalid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:refactor/remove-datatype-invalid)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=refactor/remove-datatype-invalid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:refactor/remove-datatype-invalid)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=refactor/remove-datatype-invalid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:refactor/remove-datatype-invalid)
- [x] New/Existing tests provide coverage for changes