### PR TITLE
Fix `DPRINT << TSLICE` so it prints correct tiles in a loop

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -8,7 +8,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_before_finish.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_prepend_device_core_risc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tensix_dest.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -9,6 +9,7 @@ set(UNIT_TESTS_DEBUG_TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_prepend_device_core_risc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tensix_dest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_tiles_multiple.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dprint/test_print_config_register.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_link_training.cpp

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
@@ -36,6 +36,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A simple test for checking DPRINTs from all harts.
+// Note that in this test the kernels print only 1 tile.
 //////////////////////////////////////////////////////////////////////////////////////////
 using namespace tt;
 using namespace tt::tt_metal;
@@ -235,8 +236,8 @@ void RunTest(
 
     // Create an input CB with the right data format
     uint32_t tile_size = tt::tile_size(data_format);
-    CircularBufferConfig cb_src0_config = CircularBufferConfig(tile_size, {{CBIndex::c_0, data_format}})
-                                              .set_page_size(CBIndex::c_0, tile_size);
+    CircularBufferConfig cb_src0_config =
+        CircularBufferConfig(tile_size, {{CBIndex::c_0, data_format}}).set_page_size(CBIndex::c_0, tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
     CircularBufferConfig cb_intermed_config =
         CircularBufferConfig(tile_size, {{CBIndex::c_1, data_format}}).set_page_size(CBIndex::c_1, tile_size);
@@ -299,11 +300,11 @@ struct TestParams {
     tt::DataFormat data_format;
 };
 
-class PrintTilesFixture : public DPrintSeparateFilesFixture, public ::testing::WithParamInterface<TestParams> {};
+class PrintTileFixture : public DPrintSeparateFilesFixture, public ::testing::WithParamInterface<TestParams> {};
 
 INSTANTIATE_TEST_SUITE_P(
-    PrintTilesTests,
-    PrintTilesFixture,
+    PrintTileTests,
+    PrintTileFixture,
     ::testing::Values(
         TestParams{tt::DataFormat::Float32},
         TestParams{tt::DataFormat::Float16_b},
@@ -314,11 +315,11 @@ INSTANTIATE_TEST_SUITE_P(
         TestParams{tt::DataFormat::UInt8},
         TestParams{tt::DataFormat::UInt16},
         TestParams{tt::DataFormat::UInt32}),
-    [](const ::testing::TestParamInfo<PrintTilesFixture::ParamType>& info) {
+    [](const ::testing::TestParamInfo<PrintTileFixture::ParamType>& info) {
         return std::string(enchantum::to_string(info.param.data_format));
     });
 
-TEST_P(PrintTilesFixture, TestPrintTiles) {
+TEST_P(PrintTileFixture, TestPrintTile) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
             [&](DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
@@ -24,6 +24,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include "debug_tools_fixture.hpp"
+#include "print_tile_helpers.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/kernel_structs.h"
@@ -45,170 +46,8 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 
 namespace {
 
-constexpr uint32_t elements_in_tile = 32 * 32;
-
-std::vector<uint32_t> GenerateInputTile(tt::DataFormat data_format) {
-    std::vector<uint32_t> u32_vec;
-    if (data_format == tt::DataFormat::Float32) {
-        u32_vec.resize(elements_in_tile);
-        for (int i = 0; i < u32_vec.size(); i++) {
-            float val = -12.3345 + static_cast<float>(i);  // Rebias to force some negative #s to be printed
-            u32_vec.at(i) = *reinterpret_cast<uint32_t*>(&val);
-        }
-    } else if (data_format == tt::DataFormat::Float16_b) {
-        std::vector<bfloat16> fp16b_vec(elements_in_tile);
-        for (int i = 0; i < fp16b_vec.size(); i++) {
-            uint16_t val = 0x3dfb + i;  // Start at some known value (~0.1226) and increment for new numbers
-            fp16b_vec[i] = bfloat16(val);
-        }
-        u32_vec = pack_bfloat16_vec_into_uint32_vec(fp16b_vec);
-    } else if (data_format == tt::DataFormat::Bfp8_b) {
-        std::vector<float> float_vec(elements_in_tile);
-        for (int i = 0; i < float_vec.size(); i++) {
-            float_vec[i] = 0.012345 * i * (i % 32 == 0 ? -1 : 1);  // Small increments and force negatives for testing
-        }
-        u32_vec = pack_as_bfp8_tiles(tt::stl::make_const_span(float_vec), true, false);
-    } else if (data_format == tt::DataFormat::Bfp4_b) {
-        std::vector<float> float_vec(elements_in_tile);
-        for (int i = 0; i < float_vec.size(); i++) {
-            float_vec[i] = 0.012345 * i * (i % 16 == 0 ? -1 : 1);  // Small increments and force negatives for testing
-        }
-        u32_vec = pack_as_bfp4_tiles(tt::stl::make_const_span(float_vec), true, false);
-    } else if (data_format == tt::DataFormat::Int8) {
-        std::vector<int8_t> int8_vec(elements_in_tile);
-        for (int i = 0; i < int8_vec.size(); i++) {
-            int8_vec[i] = ((i / 2) % 256) - 128;  // Force prints to be different (/2), within the int8 range (%256),
-                                                  // and include negatives (-128) for testing purposes.
-        }
-        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
-        u32_vec.resize(elements_in_tile / datums_per_32);
-        std::memcpy(u32_vec.data(), int8_vec.data(), elements_in_tile * sizeof(int8_t));
-    } else if (data_format == tt::DataFormat::UInt8) {
-        std::vector<uint8_t> uint8_vec(elements_in_tile);
-        for (int i = 0; i < uint8_vec.size(); i++) {
-            uint8_vec[i] = ((i / 2) % 256);  // Same as int8, just no negatives
-        }
-        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
-        u32_vec.resize(elements_in_tile / datums_per_32);
-        std::memcpy(u32_vec.data(), uint8_vec.data(), elements_in_tile * sizeof(uint8_t));
-    } else if (data_format == tt::DataFormat::UInt16) {
-        std::vector<uint16_t> uint16_vec(elements_in_tile);
-        for (int i = 0; i < uint16_vec.size(); i++) {
-            uint16_vec[i] = (i % 0x10000);  // Force to within uint16 range
-        }
-        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
-        u32_vec.resize(elements_in_tile / datums_per_32);
-        std::memcpy(u32_vec.data(), uint16_vec.data(), elements_in_tile * sizeof(uint16_t));
-    } else if (data_format == tt::DataFormat::Int32) {
-        u32_vec.resize(elements_in_tile);
-        for (int i = 0; i < u32_vec.size(); i++) {
-            u32_vec[i] = (i % 2) ? i : i * -1;  // Make every other number negative for printing purposes
-        }
-    } else if (data_format == tt::DataFormat::UInt32) {
-        u32_vec.resize(elements_in_tile);
-        for (int i = 0; i < u32_vec.size(); i++) {
-            u32_vec[i] = i;
-        }
-    }
-    return u32_vec;
-}
-
-std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
-    std::string data;
-    if (data_format == tt::DataFormat::Float32) {
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
-                *reinterpret_cast<float*>(&input_tile[(col * 32) + 0]),
-                *reinterpret_cast<float*>(&input_tile[(col * 32) + 8]),
-                *reinterpret_cast<float*>(&input_tile[(col * 32) + 16]),
-                *reinterpret_cast<float*>(&input_tile[(col * 32) + 24]));
-        }
-    } else if (data_format == tt::DataFormat::Float16_b) {
-        std::vector<bfloat16> fp16b_vec = unpack_uint32_vec_into_bfloat16_vec(input_tile);
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
-                static_cast<float>(fp16b_vec[(col * 32) + 0]),
-                static_cast<float>(fp16b_vec[(col * 32) + 8]),
-                static_cast<float>(fp16b_vec[(col * 32) + 16]),
-                static_cast<float>(fp16b_vec[(col * 32) + 24]));
-        }
-    } else if (data_format == tt::DataFormat::Bfp8_b) {
-        std::vector<float> float_vec = unpack_bfp8_tiles_into_float_vec(input_tile, true, false);
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 24]));
-        }
-    } else if (data_format == tt::DataFormat::Bfp4_b) {
-        std::vector<float> float_vec = unpack_bfp4_tiles_into_float_vec(input_tile, true, false);
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{:.6} {:.6} {:.6} {:.6}",
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),
-                *reinterpret_cast<float*>(&float_vec[(col * 32) + 24]));
-        }
-    } else if (data_format == tt::DataFormat::Int8) {
-        int8_t* int8_ptr = reinterpret_cast<int8_t*>(input_tile.data());
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{} {} {} {}",
-                int8_ptr[(col * 32) + 0],
-                int8_ptr[(col * 32) + 8],
-                int8_ptr[(col * 32) + 16],
-                int8_ptr[(col * 32) + 24]);
-        }
-    } else if (data_format == tt::DataFormat::UInt8) {
-        uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(input_tile.data());
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{} {} {} {}",
-                uint8_ptr[(col * 32) + 0],
-                uint8_ptr[(col * 32) + 8],
-                uint8_ptr[(col * 32) + 16],
-                uint8_ptr[(col * 32) + 24]);
-        }
-    } else if (data_format == tt::DataFormat::UInt16) {
-        uint16_t* uint16_ptr = reinterpret_cast<uint16_t*>(input_tile.data());
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{} {} {} {}",
-                uint16_ptr[(col * 32) + 0],
-                uint16_ptr[(col * 32) + 8],
-                uint16_ptr[(col * 32) + 16],
-                uint16_ptr[(col * 32) + 24]);
-        }
-    } else if (data_format == tt::DataFormat::Int32) {
-        int32_t* int32_ptr = reinterpret_cast<int32_t*>(input_tile.data());
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{} {} {} {}",
-                int32_ptr[(col * 32) + 0],
-                int32_ptr[(col * 32) + 8],
-                int32_ptr[(col * 32) + 16],
-                int32_ptr[(col * 32) + 24]);
-        }
-    } else if (data_format == tt::DataFormat::UInt32) {
-        uint32_t* uint32_ptr = reinterpret_cast<uint32_t*>(input_tile.data());
-        for (uint32_t col = 0; col < 32; col += 8) {
-            data += fmt::format(
-                "\n{} {} {} {}",
-                uint32_ptr[(col * 32) + 0],
-                uint32_ptr[(col * 32) + 8],
-                uint32_ptr[(col * 32) + 16],
-                uint32_ptr[(col * 32) + 24]);
-        }
-    }
-    return data;
-}
-
 std::vector<std::string> GenerateGoldenOutput(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
+    using tt::tt_metal::test::dprint::GenerateExpectedData;
     std::string data = GenerateExpectedData(data_format, input_tile);
     std::vector<std::string> expected;
     expected.push_back(fmt::format("Print tile from Data0:{}", data));
@@ -276,6 +115,7 @@ void RunTest(
     tt_metal::SetRuntimeArgs(program_, ncrisc_print_kernel_id, core, {is_tilized});
     tt_metal::SetRuntimeArgs(program_, trisc_print_kernel_id, core, {is_tilized});
 
+    using tt::tt_metal::test::dprint::GenerateInputTile;
     // Create input tile
     std::vector<uint32_t> u32_vec = GenerateInputTile(data_format);
     /*for (int idx = 0; idx < u32_vec.size(); idx+= 16) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles_multiple.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles_multiple.cpp
@@ -91,7 +91,8 @@ void RunTest(
     using tt::tt_metal::test::dprint::GenerateInputTileWithOffset;
 
     std::vector<uint32_t> u32_vec{};
-    std::string expected_output;
+    std::string expected_output_write;
+    std::string expected_output_read;
 
     /* Generating input tiles so that all numbers are consecutive in the uint32_t representation.
        Tile with i=0 starts at 0, tile with i=1 starts at tile_size, etc.
@@ -103,13 +104,16 @@ void RunTest(
 
         using tt::tt_metal::test::dprint::GenerateExpectedData;
         std::string golden_output = GenerateExpectedData(data_format, tile);
-        expected_output += fmt::format("Print tile {}:{}\n", i, golden_output);
+        expected_output_write += fmt::format("Write tile {}:{}\n", i, golden_output);
+        expected_output_read += fmt::format("Read tile {}:{}\n", i, golden_output);
     }
 
     distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord, true);
     fixture->RunProgram(mesh_device, workload);
 
     const auto* filename = "generated/dprint/device-0_worker-core-0-0_BRISC.txt";
+    auto expected_output = expected_output_write + expected_output_read;
+
     EXPECT_TRUE(FilesMatchesString(filename, expected_output));
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles_multiple.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles_multiple.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gtest/gtest.h>
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/bfloat4.hpp>
+#include <tt-metalium/bfloat8.hpp>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include "debug_tools_fixture.hpp"
+#include "print_tile_helpers.hpp"
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include "hostdevcommon/kernel_structs.h"
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test checking that DPRINTS print multiple tiles correctly.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+namespace {
+
+constexpr uint32_t elements_in_tile = 32 * 32;
+
+/* Number of tiles in a circular buffer. The kernels will print num_tiles tiles. */
+constexpr uint32_t num_tiles = 4;
+
+void RunTest(
+    DPrintMeshFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    tt::DataFormat data_format) {
+    // Set up program + CQ, run on just one core
+    constexpr CoreCoord core = {0, 0};
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    Program program = Program();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto& cq = mesh_device->mesh_command_queue();
+
+    /* Creating input CB. Page size of CB = tile size. Each tile is a separate page for CB. */
+    uint32_t tile_size = tt::tile_size(data_format);
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(tile_size * num_tiles, {{CBIndex::c_0, data_format}})
+                                              .set_page_size(CBIndex::c_0, tile_size);
+    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
+
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = tile_size, .buffer_type = tt_metal::BufferType::DRAM};
+    dram_config.sharding_args = BufferShardingArgs(std::nullopt, TensorMemoryLayout::INTERLEAVED);
+
+    distributed::ReplicatedBufferConfig buffer_config{.size = tile_size * num_tiles};
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    uint32_t dram_buffer_src_addr = src_dram_buffer->address();
+
+    KernelHandle brisc_print_kernel_id = CreateKernel(
+        program_,
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
+            "tests/tt_metal/tt_metal/test_kernels/misc/print_tiles_multiple_brisc.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    bool is_tilized = (data_format == tt::DataFormat::Bfp8_b) || (data_format == tt::DataFormat::Bfp4_b);
+    tt_metal::SetRuntimeArgs(
+        program_, brisc_print_kernel_id, core, {dram_buffer_src_addr, (std::uint32_t)0, is_tilized, num_tiles});
+
+    using tt::tt_metal::test::dprint::GenerateInputTileWithOffset;
+
+    std::vector<uint32_t> u32_vec{};
+    std::string expected_output;
+
+    /* Generating input tiles so that all numbers are consecutive in the uint32_t representation.
+       Tile with i=0 starts at 0, tile with i=1 starts at tile_size, etc.
+    */
+    for (int i = 0; i < num_tiles; i++) {
+        std::vector<uint32_t> tile = GenerateInputTileWithOffset(data_format, i * elements_in_tile);
+
+        u32_vec.insert(u32_vec.end(), tile.begin(), tile.end());
+
+        using tt::tt_metal::test::dprint::GenerateExpectedData;
+        std::string golden_output = GenerateExpectedData(data_format, tile);
+        expected_output += fmt::format("Print tile {}:{}\n", i, golden_output);
+    }
+
+    distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord, true);
+    fixture->RunProgram(mesh_device, workload);
+
+    const auto* filename = "generated/dprint/device-0_worker-core-0-0_BRISC.txt";
+    EXPECT_TRUE(FilesMatchesString(filename, expected_output));
+}
+
+struct TestParams {
+    tt::DataFormat data_format;
+};
+
+class PrintTilesMultipleFixture : public DPrintSeparateFilesFixture,
+                                  public ::testing::WithParamInterface<TestParams> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    PrintTilesMultipleTests,
+    PrintTilesMultipleFixture,
+    ::testing::Values(
+        TestParams{tt::DataFormat::Float32},
+        TestParams{tt::DataFormat::Float16_b},
+        TestParams{tt::DataFormat::Bfp4_b},
+        TestParams{tt::DataFormat::Bfp8_b},
+        TestParams{tt::DataFormat::Int8},
+        TestParams{tt::DataFormat::Int32},
+        TestParams{tt::DataFormat::UInt8},
+        TestParams{tt::DataFormat::UInt16},
+        TestParams{tt::DataFormat::UInt32}),
+    [](const ::testing::TestParamInfo<PrintTilesMultipleFixture::ParamType>& info) {
+        return std::string(enchantum::to_string(info.param.data_format));
+    });
+
+TEST_P(PrintTilesMultipleFixture, TestPrintTilesMultiple) {
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [&](DPrintMeshFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunTest(fixture, mesh_device, GetParam().data_format);
+            },
+            mesh_device);
+    }
+}
+
+}  // namespace
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/bfloat4.hpp>
+#include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt_stl/span.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace tt::tt_metal::test::dprint {
+
+inline std::vector<uint32_t> GenerateInputTile(tt::DataFormat data_format) {
+    constexpr uint32_t elements_in_tile = 32 * 32;
+
+    std::vector<uint32_t> u32_vec;
+    if (data_format == tt::DataFormat::Float32) {
+        u32_vec.resize(elements_in_tile);
+        for (int i = 0; i < u32_vec.size(); i++) {
+            float val = -12.3345 + static_cast<float>(i);  // Rebias to force some negative #s to be printed
+            u32_vec.at(i) = *reinterpret_cast<uint32_t*>(&val);
+        }
+    } else if (data_format == tt::DataFormat::Float16_b) {
+        std::vector<bfloat16> fp16b_vec(elements_in_tile);
+        for (int i = 0; i < fp16b_vec.size(); i++) {
+            uint16_t val = 0x3dfb + i;  // Start at some known value (~0.1226) and increment for new numbers
+            fp16b_vec[i] = bfloat16(val);
+        }
+        u32_vec = pack_bfloat16_vec_into_uint32_vec(fp16b_vec);
+    } else if (data_format == tt::DataFormat::Bfp8_b) {
+        std::vector<float> float_vec(elements_in_tile);
+        for (int i = 0; i < float_vec.size(); i++) {
+            float_vec[i] = 0.012345 * i * (i % 32 == 0 ? -1 : 1);  // Small increments and force negatives for testing
+        }
+        u32_vec = pack_as_bfp8_tiles(ttsl::make_const_span(float_vec), true, false);
+    } else if (data_format == tt::DataFormat::Bfp4_b) {
+        std::vector<float> float_vec(elements_in_tile);
+        for (int i = 0; i < float_vec.size(); i++) {
+            float_vec[i] = 0.012345 * i * (i % 16 == 0 ? -1 : 1);  // Small increments and force negatives for testing
+        }
+        u32_vec = pack_as_bfp4_tiles(ttsl::make_const_span(float_vec), true, false);
+    } else if (data_format == tt::DataFormat::Int8) {
+        std::vector<int8_t> int8_vec(elements_in_tile);
+        for (int i = 0; i < int8_vec.size(); i++) {
+            int8_vec[i] = ((i / 2) % 256) - 128;  // Force prints to be different (/2), within the int8 range (%256),
+                                                  // and include negatives (-128) for testing purposes.
+        }
+        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
+        u32_vec.resize(elements_in_tile / datums_per_32);
+        std::memcpy(u32_vec.data(), int8_vec.data(), elements_in_tile * sizeof(int8_t));
+    } else if (data_format == tt::DataFormat::UInt8) {
+        std::vector<uint8_t> uint8_vec(elements_in_tile);
+        for (int i = 0; i < uint8_vec.size(); i++) {
+            uint8_vec[i] = ((i / 2) % 256);  // Same as int8, just no negatives
+        }
+        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
+        u32_vec.resize(elements_in_tile / datums_per_32);
+        std::memcpy(u32_vec.data(), uint8_vec.data(), elements_in_tile * sizeof(uint8_t));
+    } else if (data_format == tt::DataFormat::UInt16) {
+        std::vector<uint16_t> uint16_vec(elements_in_tile);
+        for (int i = 0; i < uint16_vec.size(); i++) {
+            uint16_vec[i] = (i % 0x10000);  // Force to within uint16 range
+        }
+        uint32_t datums_per_32 = sizeof(uint32_t) / tt::datum_size(data_format);
+        u32_vec.resize(elements_in_tile / datums_per_32);
+        std::memcpy(u32_vec.data(), uint16_vec.data(), elements_in_tile * sizeof(uint16_t));
+    } else if (data_format == tt::DataFormat::Int32) {
+        u32_vec.resize(elements_in_tile);
+        for (int i = 0; i < u32_vec.size(); i++) {
+            u32_vec[i] = (i % 2) ? i : i * -1;  // Make every other number negative for printing purposes
+        }
+    } else if (data_format == tt::DataFormat::UInt32) {
+        u32_vec.resize(elements_in_tile);
+        for (int i = 0; i < u32_vec.size(); i++) {
+            u32_vec[i] = i;
+        }
+    }
+    return u32_vec;
+}
+
+inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
+    std::string data;
+    if (data_format == tt::DataFormat::Float32) {
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{:.6} {:.6} {:.6} {:.6}",
+                *reinterpret_cast<float*>(&input_tile[(col * 32) + 0]),
+                *reinterpret_cast<float*>(&input_tile[(col * 32) + 8]),
+                *reinterpret_cast<float*>(&input_tile[(col * 32) + 16]),
+                *reinterpret_cast<float*>(&input_tile[(col * 32) + 24]));
+        }
+    } else if (data_format == tt::DataFormat::Float16_b) {
+        std::vector<bfloat16> fp16b_vec = unpack_uint32_vec_into_bfloat16_vec(input_tile);
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{:.6} {:.6} {:.6} {:.6}",
+                static_cast<float>(fp16b_vec[(col * 32) + 0]),
+                static_cast<float>(fp16b_vec[(col * 32) + 8]),
+                static_cast<float>(fp16b_vec[(col * 32) + 16]),
+                static_cast<float>(fp16b_vec[(col * 32) + 24]));
+        }
+    } else if (data_format == tt::DataFormat::Bfp8_b) {
+        std::vector<float> float_vec = unpack_bfp8_tiles_into_float_vec(input_tile, true, false);
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{:.6} {:.6} {:.6} {:.6}",
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 24]));
+        }
+    } else if (data_format == tt::DataFormat::Bfp4_b) {
+        std::vector<float> float_vec = unpack_bfp4_tiles_into_float_vec(input_tile, true, false);
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{:.6} {:.6} {:.6} {:.6}",
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 0]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 8]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 16]),
+                *reinterpret_cast<float*>(&float_vec[(col * 32) + 24]));
+        }
+    } else if (data_format == tt::DataFormat::Int8) {
+        int8_t* int8_ptr = reinterpret_cast<int8_t*>(input_tile.data());
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{} {} {} {}",
+                int8_ptr[(col * 32) + 0],
+                int8_ptr[(col * 32) + 8],
+                int8_ptr[(col * 32) + 16],
+                int8_ptr[(col * 32) + 24]);
+        }
+    } else if (data_format == tt::DataFormat::UInt8) {
+        uint8_t* uint8_ptr = reinterpret_cast<uint8_t*>(input_tile.data());
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{} {} {} {}",
+                uint8_ptr[(col * 32) + 0],
+                uint8_ptr[(col * 32) + 8],
+                uint8_ptr[(col * 32) + 16],
+                uint8_ptr[(col * 32) + 24]);
+        }
+    } else if (data_format == tt::DataFormat::UInt16) {
+        uint16_t* uint16_ptr = reinterpret_cast<uint16_t*>(input_tile.data());
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{} {} {} {}",
+                uint16_ptr[(col * 32) + 0],
+                uint16_ptr[(col * 32) + 8],
+                uint16_ptr[(col * 32) + 16],
+                uint16_ptr[(col * 32) + 24]);
+        }
+    } else if (data_format == tt::DataFormat::Int32) {
+        int32_t* int32_ptr = reinterpret_cast<int32_t*>(input_tile.data());
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{} {} {} {}",
+                int32_ptr[(col * 32) + 0],
+                int32_ptr[(col * 32) + 8],
+                int32_ptr[(col * 32) + 16],
+                int32_ptr[(col * 32) + 24]);
+        }
+    } else if (data_format == tt::DataFormat::UInt32) {
+        uint32_t* uint32_ptr = reinterpret_cast<uint32_t*>(input_tile.data());
+        for (uint32_t col = 0; col < 32; col += 8) {
+            data += fmt::format(
+                "\n{} {} {} {}",
+                uint32_ptr[(col * 32) + 0],
+                uint32_ptr[(col * 32) + 8],
+                uint32_ptr[(col * 32) + 16],
+                uint32_ptr[(col * 32) + 24]);
+        }
+    }
+    return data;
+}
+
+}  // namespace tt::tt_metal::test::dprint

--- a/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/print_tile_helpers.hpp
@@ -84,6 +84,14 @@ inline std::vector<uint32_t> GenerateInputTile(tt::DataFormat data_format) {
     return u32_vec;
 }
 
+inline std::vector<uint32_t> GenerateInputTileWithOffset(tt::DataFormat data_format, uint32_t offset) {
+    std::vector<uint32_t> u32_vec = GenerateInputTile(data_format);
+    for (unsigned int& i : u32_vec) {
+        i += offset;
+    }
+    return u32_vec;
+}
+
 inline std::string GenerateExpectedData(tt::DataFormat data_format, std::vector<uint32_t>& input_tile) {
     std::string data;
     if (data_format == tt::DataFormat::Float32) {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_tiles_multiple_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_tiles_multiple_brisc.cpp
@@ -24,9 +24,16 @@ void kernel_main() {
         noc_async_read(noc_addr, get_write_ptr(cb_id), tile_size_bytes);
         noc_async_read_barrier();
 
-        DPRINT << "Print tile " << i << ":" << ENDL();
+        DPRINT << "Write tile " << i << ":" << ENDL();
         DPRINT << TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_WR_PTR, true, is_tilized) << ENDL();
 
         cb_push_back(cb_id, 1);
+    }
+
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        cb_wait_front(cb_id, 1);
+        DPRINT << "Read tile " << i << ":" << ENDL();
+        DPRINT << TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_RD_PTR, true, is_tilized) << ENDL();
+        cb_pop_front(cb_id, 1);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_tiles_multiple_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_tiles_multiple_brisc.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/dprint.h"
+#include "api/debug/ring_buffer.h"
+
+#include "api/dataflow/dataflow_api.h"
+void kernel_main() {
+    constexpr uint32_t cb_id = tt::CBIndex::c_0;
+
+    uint32_t tile_size_bytes = get_tile_size(cb_id);
+    uint32_t log2_tile_size = __builtin_ctz(tile_size_bytes);
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t src_bank_id = get_arg_val<uint32_t>(1);
+    uint32_t is_tilized = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        uint64_t noc_addr = get_dram_noc_addr(i, tile_size_bytes, src_addr);
+
+        cb_reserve_back(cb_id, 1);
+        noc_async_read(noc_addr, get_write_ptr(cb_id), tile_size_bytes);
+        noc_async_read_barrier();
+
+        DPRINT << "Print tile " << i << ":" << ENDL();
+        DPRINT << TSLICE(cb_id, 0, SliceRange::hw0_32_8(), TSLICE_INPUT_CB, TSLICE_WR_PTR, true, is_tilized) << ENDL();
+
+        cb_push_back(cb_id, 1);
+    }
+}

--- a/tt_metal/hw/inc/api/debug/dprint_tile.h
+++ b/tt_metal/hw/inc/api/debug/dprint_tile.h
@@ -198,7 +198,7 @@ struct TileSlice : TileSliceHostDev<MAX_BYTES> {
 
         // DataFormat, rd/wr pointer, and Tile size all depend on RISC + in/out
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
-        tile_info_t tile_info = get_tile_info(cb, ptr_type, cb_type);
+        tile_info_t tile_info = get_tile_info(cb, cb_type, ptr_type);
 #else
         tile_info_t tile_info = get_tile_info(cb);
 #endif


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36863)

### Problem description
If we add tiles one by one to CB and print them one by one, the first tile will always be printed.

### What's changed

Fix a call of `get_tile_info` where the arguments were incorrectly swapped. Instead of `tile_info = get_tile_info(cb, ptr_type, cb_type);` it should be `tile_info = get_tile_info(cb, cb_type, ptr_type);`. Added a unit tests in `debug_tools` that prints the tiles read/written in a loop.

After a fix, the `DPRINT << TSLICE` macro prints the correct tiles in a loop.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ichovpan/fix-tile-slice)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/fix-tile-slice)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/fix-tile-slice)
- [X] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/fix-tile-slice)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/fix-tile-slice)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/fix-tile-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/fix-tile-slice)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
