### PR TITLE
[skip ci] temp skip BH GLX tests until another glx is back in CI

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -196,55 +196,55 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 
-  quick-bh-glx-health:
-    if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
-    runs-on:
-      - topology-6u
-      - arch-blackhole
-      - ${{ inputs.extra-tag }}
-    container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
-      env:
-        TT_METAL_HOME: /work
-        PYTHONPATH: /work
-        LD_LIBRARY_PATH: /work/build/lib
-        LOGURU_LEVEL: INFO
-        TT_METAL_ENABLE_ERISC_IRAM: 1
-      volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-      options: --device /dev/tenstorrent
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
-    steps:
-      - name: 🧬 Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          path: docker-job
-      - name: ⬇️  Setup Job
-        uses: ./docker-job/.github/actions/setup-job
-        timeout-minutes: 10
-        with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run health tests
-        timeout-minutes: 10
-        # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
-        run: |
-          ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
-          ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        if: ${{ failure() }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: UJ45FEC7M # Allan Liu
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
-          prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
+  # quick-bh-glx-health:
+  #   if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
+  #   runs-on:
+  #     - topology-6u
+  #     - arch-blackhole
+  #     - ${{ inputs.extra-tag }}
+  #   container:
+  #     image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
+  #     env:
+  #       TT_METAL_HOME: /work
+  #       PYTHONPATH: /work
+  #       LD_LIBRARY_PATH: /work/build/lib
+  #       LOGURU_LEVEL: INFO
+  #       TT_METAL_ENABLE_ERISC_IRAM: 1
+  #     volumes:
+  #       - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+  #       - /dev/hugepages-1G:/dev/hugepages-1G
+  #     options: --device /dev/tenstorrent
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: /work # https://github.com/actions/runner/issues/878
+  #   steps:
+  #     - name: 🧬 Checkout Repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         path: docker-job
+  #     - name: ⬇️  Setup Job
+  #       uses: ./docker-job/.github/actions/setup-job
+  #       timeout-minutes: 10
+  #       with:
+  #         build-artifact-name: ${{ inputs.build-artifact-name }}
+  #         wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+  #     - name: Run health tests
+  #       timeout-minutes: 10
+  #       # NOTE: These tests do not automatically get added to upstream tests. Please refer to dockerfile/upstream_test_images/.
+  #       run: |
+  #         ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tools/tests/scaleout/cabling_descriptors/bh_galaxy_xy_torus.textproto --hard-fail --send-traffic --num-iterations 1
+  #         ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
+  #     - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+  #       if: ${{ failure() }}
+  #       with:
+  #         slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+  #         owner: UJ45FEC7M # Allan Liu
+  #     - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+  #       timeout-minutes: 10
+  #       if: ${{ !cancelled() }}
+  #       with:
+  #         prefix: "test_reports_"
+  #     - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+  #       if: always()

--- a/.github/workflows/galaxy-quick.yaml
+++ b/.github/workflows/galaxy-quick.yaml
@@ -8,7 +8,7 @@ on:
         type: choice
         options:
           - wormhole_b0
-          - blackhole
+          # - blackhole
         default: wormhole_b0
       platform:
         required: false

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -46,24 +46,24 @@
   team: fabric
   timeout: 15
 
-# Blackhole Galaxy e2e tests
-- name: BH Galaxy CCL tests
-  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
-  sku: bh_galaxy
-  owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
-  team: ttnn
-  timeout: 40
+# Blackhole Galaxy e2e tests #issue #36869 for all BH GLX tests
+# - name: BH Galaxy CCL tests
+#   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
+#   sku: bh_galaxy
+#   owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
+#   team: ttnn
+#   timeout: 40
 
-- name: BH Galaxy Fabric unit tests
-  cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
-  sku: bh_galaxy
-  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-  team: fabric
-  timeout: 30
+# - name: BH Galaxy Fabric unit tests
+#   cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
+#   sku: bh_galaxy
+#   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
+#   team: fabric
+#   timeout: 30
 
-- name: BH Galaxy Fabric Torus Stability Tests
-  cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
-  sku: bh_galaxy
-  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-  team: fabric
-  timeout: 20
+# - name: BH Galaxy Fabric Torus Stability Tests
+#   cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
+#   sku: bh_galaxy
+#   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
+#   team: fabric
+#   timeout: 20


### PR DESCRIPTION
### Ticket
issue #36869 

the one CI BH GLX is OOS due to HW issues. Sorry for any inconvenience, I will re-enable these tests once the BH GLX is in good condition 