### PR TITLE
Move RTA sentinel constants

### DIFF
--- a/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
@@ -15,9 +15,3 @@ constexpr static std::uint32_t VALID = 1;
 constexpr static std::size_t DEFAULT_L1_SMALL_SIZE = 0;  //(1 << 15);  // 32KB
 constexpr static std::size_t DEFAULT_TRACE_REGION_SIZE = 0;
 constexpr static std::size_t DEFAULT_WORKER_L1_SIZE = 0;  // Size is dynamically determined based on the device type.
-
-// Sentinel used in launch_msg rta_offset/crta_offset to mark no args present shared by host and firmware.
-constexpr uint16_t RTA_CRTA_NO_ARGS_SENTINEL = 0xFFFF;
-// Watcher debug pattern: upper 16 bits mark uninitialized RTA slots
-// Lower 16 bits contain random value to prevent accidental matches
-constexpr uint32_t WATCHER_RTA_UNSET_PATTERN = 0xBEEF0000;

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -547,6 +547,7 @@ target_sources(
             # Interface Headers - Host-Device boundary
             inc/hostdev/dev_msgs.h
             inc/hostdev/fabric_telemetry_msgs.h
+            inc/hostdev/rta_constants.h
             inc/hostdev/socket.h
             # Interface Headers
             inc/internal/atomic_rwptr.h

--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -8,7 +8,7 @@
 #include "risc_common.h"
 #include <tensix.h>
 #include "hostdev/dev_msgs.h"
-#include "hostdevcommon/common_values.hpp"
+#include "hostdev/rta_constants.h"
 
 #include "tools/profiler/kernel_profiler.hpp"
 

--- a/tt_metal/hw/inc/hostdev/rta_constants.h
+++ b/tt_metal/hw/inc/hostdev/rta_constants.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Sentinel used in launch_msg rta_offset/crta_offset to mark no args present.
+// Shared by host and firmware.
+constexpr uint16_t RTA_CRTA_NO_ARGS_SENTINEL = 0xFFFF;
+
+// Watcher debug pattern: upper 16 bits mark uninitialized RTA slots.
+// Lower 16 bits contain random value to prevent accidental matches.
+constexpr uint32_t WATCHER_RTA_UNSET_PATTERN = 0xBEEF0000;

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -12,7 +12,7 @@
 #include "api/compile_time_args.h"
 #include "dev_mem_map.h"
 #include "hostdevcommon/kernel_structs.h"
-#include "hostdevcommon/common_values.hpp"
+#include "hostdev/rta_constants.h"
 #include "hostdev/dev_msgs.h"
 #include "noc/noc_parameters.h"
 #include "api/debug/dprint.h"

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -69,7 +69,7 @@
 #include <impl/dispatch/dispatch_query_manager.hpp>
 
 #include <impl/dispatch/dispatch_mem_map.hpp>
-#include "hostdevcommon/common_values.hpp"
+#include "hostdev/rta_constants.h"
 
 namespace tt::tt_metal {
 enum NOC : uint8_t;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36168

### Problem description
The `hostdevcommon` directory is being deprecated. RTA sentinel constants (`RTA_CRTA_NO_ARGS_SENTINEL`, `WATCHER_RTA_UNSET_PATTERN`) were added to `common_values.hpp` in PR #35007 but should be under `hw/inc/hostdev`  per cleanup effort.  

### What's changed
Moved RTA-related constants from `hostdevcommon/common_values.hpp` to new header `hw/inc/hostdev/rta_constants.h`. Updated includes in `dispatch.cpp`, `trisc.cc`, and `firmware_common.h`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/move_constants)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/move_constants)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/move_constants)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/move_constants)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/move_constants)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/move_constants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/move_constants)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
