### PR TITLE
[skip ci] Update CODEOWNERS and enhance Slack group handling in workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -345,9 +345,9 @@ models/demos/wormhole/bge_large_en @arginugaTT @tenstorrent/cse-developer-ttnn @
 models/perf/ @yieldthought @esmalTT @skhorasganiTT @uaydonat @tenstorrent/codeowner-bypass
 models/perf/benchmarking_utils.py @skhorasganiTT @williamlyTT @uaydonat @tenstorrent/codeowner-bypass
 models/demos/utils/llm_demo_utils.py @skhorasganiTT @mtairum @uaydonat @tenstorrent/codeowner-bypass
-models/experimental/bevformer/ @njovanovicTT @mbezuljTT @ddjekicTT @tenstorrent/codeowner-bypass
-models/experimental/oft @mbezuljTT @pavlepopovic @ianastasijevicTT @ddjekicTT @njovanovicTT
-models/experimental/panoptic_deeplab @mbezuljTT @ianastasijevicTT @pavlepopovic @ddjekicTT @njovanovicTT
+models/experimental/bevformer/ @mbezuljTT @ddjekicTT @tenstorrent/codeowner-bypass
+models/experimental/oft @mbezuljTT @pavlepopovic @ianastasijevicTT @ddjekicTT
+models/experimental/panoptic_deeplab @mbezuljTT @ianastasijevicTT @pavlepopovic @ddjekicTT
 models/experimental/stable_diffusion_xl_base @mbezuljTT @pavlepopovic @ipotkonjak-tt @tenstorrent/codeowner-bypass
 models/demos/vision/classification/mobilenetv2 @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 models/experimental/mobileNetV3 @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1415,6 +1415,9 @@ jobs:
               "@tenstorrent/metalium-developers-ops-data-movement")
                 echo "S09QQRK1CF8"
                 ;;
+              "@tenstorrent/metalium-developers-eltwise")
+                echo "S0ABKSS1D3R"
+                ;;
               *)
                 echo ""  # No Slack group available
                 ;;
@@ -1909,6 +1912,9 @@ jobs:
               "@tenstorrent/metalium-developers-ops-data-movement")
                 echo "S09QQRK1CF8"
                 ;;
+              "@tenstorrent/metalium-developers-eltwise")
+                echo "S0ABKSS1D3R"
+                ;;
               *)
                 echo ""  # No Slack group available
                 ;;
@@ -2119,8 +2125,29 @@ jobs:
 
               if [ -n "$SLACK_GROUP_ID" ]; then
                 echo "Team $team has Slack group: $SLACK_GROUP_ID"
-                SELECTED_SLACK_GROUPS="$SELECTED_SLACK_GROUPS$SLACK_GROUP_ID,"
-                echo "Added pending Slack group: $team -> $SLACK_GROUP_ID"
+
+                # Special handling for metalium-developers-eltwise - only ping group if none of the 3 key members approved
+                if [ "$team" = "@tenstorrent/metalium-developers-eltwise" ]; then
+                  ELTWISE_KEY_MEMBERS="dchenTT mateusznowakTT cmaryanTT"
+                  ELTWISE_APPROVED=false
+                  for key_member in $ELTWISE_KEY_MEMBERS; do
+                    if echo "$APPROVED_REVIEWERS" | grep -q "$key_member"; then
+                      echo "✅ Key eltwise member $key_member has approved, skipping group ping"
+                      ELTWISE_APPROVED=true
+                      break
+                    fi
+                  done
+
+                  if [ "$ELTWISE_APPROVED" = "false" ]; then
+                    echo "⚠️  No key eltwise member approved yet, adding Slack group ping"
+                    SELECTED_SLACK_GROUPS="$SELECTED_SLACK_GROUPS$SLACK_GROUP_ID,"
+                    echo "Added pending Slack group: $team -> $SLACK_GROUP_ID"
+                  fi
+                else
+                  # Standard behavior for other teams with Slack groups
+                  SELECTED_SLACK_GROUPS="$SELECTED_SLACK_GROUPS$SLACK_GROUP_ID,"
+                  echo "Added pending Slack group: $team -> $SLACK_GROUP_ID"
+                fi
               else
                 echo "Team $team has no Slack group, using individual selection"
                 # Select individuals from team
@@ -2460,6 +2487,9 @@ jobs:
                 ;;
               "@tenstorrent/metalium-developers-ops-data-movement")
                 echo "S09QQRK1CF8"
+                ;;
+              "@tenstorrent/metalium-developers-eltwise")
+                echo "S0ABKSS1D3R"
                 ;;
               *)
                 echo ""  # No Slack group available


### PR DESCRIPTION
### Ticket
NA

### Problem description
CODEOWNERS fix needed

### What's changed
- Removed CODEOWNERS entries of njovanovicTT as no longer working with us
- Enhanced the `codeowners-group-analysis.yaml` workflow to include a new Slack group for `@tenstorrent/metalium-developers-eltwise`, with conditional notifications based on key member approvals.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/codeowners_patch_jan31)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/codeowners_patch_jan31)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
