### PR TITLE
Revert "Reduce number of noc writes using in padding path of transpose tile hc (#36842)"

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
                     uint32_t linear_idx = base_linear_idx + output_h_face_line * C_t * W_t;
 
                     // Compute the write address
-                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
+                    uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
 
                     // Perform asynchronous write
                     noc_async_write(l1_read_addr, write_noc_base_addr, SUBTILE_LINE_BYTES);
@@ -177,20 +177,19 @@ void kernel_main() {
 
                 // Sub-tile/face line where our padded data starts
                 uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
-                if (sub_tile_line_start == 0) {
-                    uint32_t offset = face_c_offset * element_size;
-                    uint32_t write_size = SUBTILE_LINE_BYTES * FACE_HEIGHT * NUM_FACES_W;
-                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
-                    noc_async_write(l1_read_ptr, write_noc_base_addr, write_size);
-                } else {
-                    for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
-                        // Offset to the start of the current face along the width of the tile
-                        uint32_t face_w_offset = face_w * face_height_width;
-                        uint32_t offset =
-                            (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
-                        uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
-                        uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
-                        noc_async_write(l1_read_ptr, write_noc_base_addr, write_size);
+
+                for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                    // Offset to the start of the current face along the width of the tile
+                    uint32_t face_w_offset = face_w * face_height_width;
+                    for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
+                        // offset to the start of the current sub-tile line
+                        uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line * FACE_WIDTH) * element_size;
+
+                        // Compute the write address
+                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+
+                        // Perform asynchronous write
+                        noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
                     }
                 }
             }


### PR DESCRIPTION
…
This reverts commit ad4bd6c011820288182f614671cc8a0bf8a12f8e.

This commit broke reduction ops in APC.

### Ticket
APC breakage!

### Problem description

Weekend APC breakage on max!

### What's changed

revert the noc optimizations and ask team to look at monday 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rkim/0-revert-ad4bd6c011820288182f614671cc8a0bf8a12f8e)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
