### PR TITLE
Reduce number of noc writes using in padding path of transpose tile hc again

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
                     uint32_t linear_idx = base_linear_idx + output_h_face_line * C_t * W_t;
 
                     // Compute the write address
-                    uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
 
                     // Perform asynchronous write
                     noc_async_write(l1_read_addr, write_noc_base_addr, SUBTILE_LINE_BYTES);
@@ -181,16 +181,10 @@ void kernel_main() {
                 for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
                     // Offset to the start of the current face along the width of the tile
                     uint32_t face_w_offset = face_w * face_height_width;
-                    for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
-                        // offset to the start of the current sub-tile line
-                        uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line * FACE_WIDTH) * element_size;
-
-                        // Compute the write address
-                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
-
-                        // Perform asynchronous write
-                        noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
-                    }
+                    uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
+                    uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
+                    uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
+                    noc_async_write(l1_read_ptr, write_noc_base_addr, write_size);
                 }
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -134,11 +134,11 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
     CircularBufferConfig cb_src0_config = CircularBufferConfig(2 * single_tile_size, {{src0_cb_index, cb_data_format}})
                                               .set_page_size(src0_cb_index, single_tile_size);
     CreateCircularBuffer(program, total_cores, cb_src0_config);
-
+    auto max_padding_write = face_shape[0] * face_shape[1];
     if (needs_padding) {
         CircularBufferConfig cb_src1_config =
-            CircularBufferConfig(face_shape[1] * input_tensor.element_size(), {{padding_cb_index, cb_data_format}})
-                .set_page_size(padding_cb_index, face_shape[1] * input_tensor.element_size());
+            CircularBufferConfig(max_padding_write * input_tensor.element_size(), {{padding_cb_index, cb_data_format}})
+                .set_page_size(padding_cb_index, max_padding_write * input_tensor.element_size());
         CreateCircularBuffer(program, total_cores, cb_src1_config);
     }
 
@@ -150,7 +150,7 @@ TransposeHCTiledInterleavedProgramFactory::cached_program_t TransposeHCTiledInte
 
     if (C % tile_shape[1] != 0) {
         uint32_t num_packed_values = sizeof(uint32_t) / element_size;
-        num_writes = face_shape[1] / num_packed_values;
+        num_writes = max_padding_write / num_packed_values;
         switch (input_tensor.dtype()) {
             case DataType::INT32:
             case DataType::UINT32: padding_val_packed = pad_value; break;


### PR DESCRIPTION
### What's changed
Tried to reduce number of noc writes in tranpose tile hc.
Additional to https://github.com/tenstorrent/tt-metal/pull/36842 fixed circular buffer size and pad fill argument

Performance comparison for shapes from tranpose testing and Deepseek
model:
### HC TILE Transpose Performance Comparison

| Shape (W×Z×Y×X) | Main (µs) | New (µs) | Ratio |
|-----------------|----------|----------|-------|
| 1×4×128×512 | 86.95 | 33.10 | 2.63x |
| 1×1×32×576 | 21.53 | 8.38 | 2.57x |
| 1×2×32×100 | 9.06 | 5.54 | 1.63x |
| 1×1×16×1 | 5.14 | 3.30 | 1.56x |
| 1×1×17×1 | 5.18 | 3.34 | 1.55x |
| 1×1×16×32 | 5.19 | 3.36 | 1.54x |
| 1×12×32×100 | 9.50 | 6.25 | 1.52x |
| 1×1×1×1 | 3.59 | 2.44 | 1.47x |
| 1×1×1×17 | 3.60 | 2.45 | 1.47x |
| 1×1×1×2 | 3.59 | 2.46 | 1.46x |
| 1×3×2×1 | 3.64 | 2.51 | 1.45x |
| 1×35×7×7 | 4.59 | 3.17 | 1.45x |
| 1×5×10×15 | 4.51 | 3.12 | 1.45x |
| 2×1×1×1 | 3.62 | 2.51 | 1.44x |
| 1×1×32×64 | 5.78 | 4.01 | 1.44x |
| 1×6×33×34 | 8.15 | 5.72 | 1.43x |
| 1×16×32×512 | 21.66 | 15.40 | 1.41x |
| 1×1×1×35 | 3.72 | 2.66 | 1.40x |
| 2×33×33×33 | 28.29 | 20.49 | 1.38x |
| 1×2×34×8 | 6.86 | 5.10 | 1.34x |
| 1×1×32×32 | 6.41 | 4.86 | 1.32x |
| 1×17×1×1 | 2.87 | 2.59 | 1.11x |
| 1×32×1×64 | 1.30 | 1.29 | 1.01x |
| 3×64×128×96 | 252.33 | 251.38 | 1.00x |
| 1×32×16×128 | 4.49 | 4.48 | 1.00x |
| 1×32×1×32 | 1.88 | 1.87 | 1.00x |
| 1×128×384×96 | 480.91 | 481.25 | 1.00x |
| 1×32×1×12 | 1.88 | 1.88 | 1.00x |
| 1×128×4×128 | 7.15 | 7.16 | 1.00x |
| 1×32×12×100 | 6.19 | 6.21 | 1.00x |
| 32×32×32×32 | 77.45 | 77.94 | 0.99x |
### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/opt-trans-tile-hc)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/opt-trans-tile-hc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/opt-trans-tile-hc)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
