### PR TITLE
Fix Blackhole op performance model FPU and DRAM utilization calculations

### DIFF
--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -78,6 +78,7 @@ public:
     virtual int num_dram_channels() const = 0;
     virtual uint32_t l1_size_per_core() const = 0;
     virtual uint32_t dram_size_per_channel() const = 0;
+    virtual int get_clock_rate_mhz() const = 0;
     virtual CoreCoord grid_size() const = 0;
     virtual CoreCoord logical_grid_size() const = 0;
     virtual CoreCoord dram_grid_size() const = 0;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -78,6 +78,9 @@ public:
     virtual int num_dram_channels() const = 0;
     virtual uint32_t l1_size_per_core() const = 0;
     virtual uint32_t dram_size_per_channel() const = 0;
+    // Returns the AI clock frequency in MHz for this device.
+    // This value is queried from the actual hardware via the cluster API
+    // and reflects the device's current operating frequency.
     virtual int get_clock_rate_mhz() const = 0;
     virtual CoreCoord grid_size() const = 0;
     virtual CoreCoord logical_grid_size() const = 0;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -96,6 +96,7 @@ public:
     int num_dram_channels() const override;
     uint32_t l1_size_per_core() const override;
     uint32_t dram_size_per_channel() const override;
+    int get_clock_rate_mhz() const override;
 
     CoreCoord grid_size() const override;
     CoreCoord logical_grid_size() const override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -96,6 +96,9 @@ public:
     int num_dram_channels() const override;
     uint32_t l1_size_per_core() const override;
     uint32_t dram_size_per_channel() const override;
+    // Returns the AI clock frequency in MHz for this device.
+    // This value is queried from the actual hardware via the cluster API
+    // and reflects the device's current operating frequency.
     int get_clock_rate_mhz() const override;
 
     CoreCoord grid_size() const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -986,6 +986,8 @@ uint32_t MeshDeviceImpl::num_worker_cores(HalProgrammableCoreType core_type, Sub
 // Bank and memory management methods
 int MeshDeviceImpl::num_dram_channels() const { return reference_device()->num_dram_channels(); }
 
+int MeshDeviceImpl::get_clock_rate_mhz() const { return reference_device()->get_clock_rate_mhz(); }
+
 CoreCoord MeshDeviceImpl::logical_core_from_dram_channel(uint32_t dram_channel) const {
     return validate_and_get_reference_value(this->get_devices(), [dram_channel](const auto* device) {
         return device->logical_core_from_dram_channel(dram_channel);
@@ -1325,6 +1327,7 @@ bool MeshDevice::is_initialized() const { return pimpl_->is_initialized(); }
 int MeshDevice::num_dram_channels() const { return pimpl_->num_dram_channels(); }
 uint32_t MeshDevice::l1_size_per_core() const { return pimpl_->l1_size_per_core(); }
 uint32_t MeshDevice::dram_size_per_channel() const { return pimpl_->dram_size_per_channel(); }
+int MeshDevice::get_clock_rate_mhz() const { return pimpl_->get_clock_rate_mhz(); }
 CoreCoord MeshDevice::grid_size() const { return pimpl_->grid_size(); }
 CoreCoord MeshDevice::logical_grid_size() const { return pimpl_->logical_grid_size(); }
 CoreCoord MeshDevice::dram_grid_size() const { return pimpl_->dram_grid_size(); }

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -183,6 +183,7 @@ public:
     int num_dram_channels() const override;
     uint32_t l1_size_per_core() const override;
     uint32_t dram_size_per_channel() const override;
+    int get_clock_rate_mhz() const override;
 
     CoreCoord grid_size() const override;
     CoreCoord logical_grid_size() const override;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -489,6 +489,10 @@ uint32_t Device::dram_size_per_channel() const {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).dram_view_size;
 }
 
+int Device::get_clock_rate_mhz() const {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(id_);
+}
+
 CoreCoord Device::grid_size() const {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).grid_size;
 }

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -64,6 +64,7 @@ public:
     int num_dram_channels() const override;
     uint32_t l1_size_per_core() const override;
     uint32_t dram_size_per_channel() const override;
+    int get_clock_rate_mhz() const override;
     CoreCoord grid_size() const override;
     CoreCoord logical_grid_size() const override;
     CoreCoord dram_grid_size() const override;

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -138,6 +138,7 @@ target_sources(
         core/events.cpp
         core/global_circular_buffer.cpp
         core/global_semaphore.cpp
+        core/operation.cpp
         core/graph/graph_argument_serializer.cpp
         core/graph/graph_processor.cpp
         core/graph/graph_trace_utils.cpp

--- a/ttnn/core/operation.cpp
+++ b/ttnn/core/operation.cpp
@@ -67,6 +67,10 @@ OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
         }
     } else if constexpr (std::is_same_v<OutputTensors, Tensor>) {
         this->outputs_bytes.push_back(output_tensors.physical_volume() * output_tensors.element_size());
+        auto output_ns = tensor_ns(output_tensors);
+        if (output_ns > this->ideal_bandwidth_ns) {
+            this->ideal_bandwidth_ns = output_ns;
+        }
     } else if constexpr (
         std::is_same_v<OutputTensors, std::array<std::vector<Tensor>, 2>> ||
         std::is_same_v<OutputTensors, std::array<Tensor, 2>>) {

--- a/ttnn/core/operation.cpp
+++ b/ttnn/core/operation.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/ttnn/operation.hpp"
+#include <array>
+#include <tuple>
+
+namespace tt::tt_metal::operation {
+
+template <typename OutputTensorsT>
+OpPerformanceModelGeneral<OutputTensorsT>::OpPerformanceModelGeneral(
+    Tensors input_tensors, const OutputTensors& output_tensors, int ideal_compute_cycles) :
+    ideal_compute_cycles(ideal_compute_cycles) {
+    const auto& t = input_tensors.at(0);
+    const auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : ARCH::WORMHOLE_B0;
+
+    // Get clock rate dynamically from device
+    float clock_rate_ghz;
+    if (t.storage_type() == StorageType::DEVICE) {
+        int freq_mhz = t.device()->get_clock_rate_mhz();
+        clock_rate_ghz = freq_mhz / 1000.0f;
+    } else {
+        // Fallback for non-device tensors (defaults to WH)
+        clock_rate_ghz = 1.0;
+    }
+    this->ideal_compute_ns = std::ceil(ideal_compute_cycles / clock_rate_ghz);
+
+    // WH L1 Bisection bandwidth: 512 B/cycle = sqrt(64) * 32 B/cycle * 2
+    // 512 * 1.0 GHz = 512 GB/s
+    // WH DRAM bandwidth: 258 GB/s = 21.5 GB/s * 6 channels * 2 banks
+
+    // BH DRAM bandwidth: 512 GB/s (32GB GDDR6 @ 16 GT/sec)
+
+    float peak_dram_bw;
+    if (arch == ARCH::WORMHOLE_B0) {
+        peak_dram_bw = 6 * 2 * 21.5;  // 258 GB/s
+    } else if (arch == ARCH::BLACKHOLE) {
+        peak_dram_bw = 512.0;  // 512 GB/s
+    } else {
+        TT_THROW("Unsupported architecture for OpPerformanceModel");
+    }
+
+    auto tensor_ns = [peak_dram_bw](const Tensor& t) {
+        int size_bytes = t.physical_volume() * t.element_size();
+        if (t.memory_config().is_dram()) {
+            return size_bytes / peak_dram_bw / 1024 / 1024 / 1024 * 1000 * 1000 * 1000;
+        }
+        if (t.memory_config().is_l1()) {
+            return 1.0f;  // TODO: figure out better modelling scheme for L1->L1 Transfers
+        }
+        return 0.0f;
+    };
+
+    for (const auto& t : input_tensors) {
+        this->inputs_bytes.push_back(t.physical_volume() * t.element_size());
+        if (tensor_ns(t) > this->ideal_bandwidth_ns) {
+            this->ideal_bandwidth_ns = tensor_ns(t);
+        }
+    }
+    if constexpr (std::is_same_v<OutputTensors, Tensors>) {
+        for (const auto& t : output_tensors) {
+            this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
+            if (tensor_ns(t) > this->ideal_bandwidth_ns) {
+                this->ideal_bandwidth_ns = tensor_ns(t);
+            }
+        }
+    } else if constexpr (std::is_same_v<OutputTensors, Tensor>) {
+        this->outputs_bytes.push_back(output_tensors.physical_volume() * output_tensors.element_size());
+    } else if constexpr (
+        std::is_same_v<OutputTensors, std::array<std::vector<Tensor>, 2>> ||
+        std::is_same_v<OutputTensors, std::array<Tensor, 2>>) {
+        // Handle std::array types - iterate over array elements
+        for (const auto& element : output_tensors) {
+            if constexpr (std::is_same_v<decltype(element), const std::vector<Tensor>&>) {
+                // Array of vectors - process each tensor in each vector
+                for (const auto& t : element) {
+                    this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
+                    if (tensor_ns(t) > this->ideal_bandwidth_ns) {
+                        this->ideal_bandwidth_ns = tensor_ns(t);
+                    }
+                }
+            } else {
+                // Array of tensors - process each tensor
+                this->outputs_bytes.push_back(element.physical_volume() * element.element_size());
+                if (tensor_ns(element) > this->ideal_bandwidth_ns) {
+                    this->ideal_bandwidth_ns = tensor_ns(element);
+                }
+            }
+        }
+    } else if constexpr (std::is_same_v<OutputTensors, std::tuple<Tensor, Tensor>>) {
+        // Handle std::tuple<Tensor, Tensor>
+        auto process_tuple_element = [&](const auto& t) {
+            this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
+            if (tensor_ns(t) > this->ideal_bandwidth_ns) {
+                this->ideal_bandwidth_ns = tensor_ns(t);
+            }
+        };
+        process_tuple_element(std::get<0>(output_tensors));
+        process_tuple_element(std::get<1>(output_tensors));
+    } else {
+        // Handle optional types
+        for (const auto& ot : output_tensors) {
+            if (!ot.has_value()) {
+                continue;
+            }
+            auto& t = ot.value();
+            this->outputs_bytes.push_back(t.physical_volume() * t.element_size());
+            if (tensor_ns(t) > this->ideal_bandwidth_ns) {
+                this->ideal_bandwidth_ns = tensor_ns(t);
+            }
+        }
+    }
+
+    this->ideal_ns = std::max(this->ideal_compute_ns, this->ideal_bandwidth_ns);
+}
+
+// Note: Only instantiate the constructor for common types.
+// get_input_bws/get_output_bws are kept inline in header to avoid needing
+// explicit instantiation for every custom result type.
+template OpPerformanceModelGeneral<Tensors>::OpPerformanceModelGeneral(Tensors, const Tensors&, int);
+template OpPerformanceModelGeneral<Tensor>::OpPerformanceModelGeneral(Tensors, const Tensor&, int);
+template OpPerformanceModelGeneral<OptionalTensors>::OpPerformanceModelGeneral(Tensors, const OptionalTensors&, int);
+
+}  // namespace tt::tt_metal::operation


### PR DESCRIPTION
Replace hardcoded clock rates with dynamic device query to fix incorrect FPU and DRAM bandwidth utilization reporting for Blackhole architecture in operation performance models. Previously, Blackhole incorrectly used 1.2 GHz (should be 1.35 GHz) and 96 GB/s DRAM bandwidth (should be 512 GB/s), causing performance metrics to be underreported by ~12-15% on Blackhole devices.

Add IDevice::get_clock_rate_mhz() virtual method to dynamically query actual device frequency via MetalContext cluster API, ensuring Blackhole and other architectures automatically use correct hardware specifications.

Changes:
- Add get_clock_rate_mhz() to IDevice and implement in Device/MeshDevice using MetalContext::instance().get_cluster().get_device_aiclk()
- Fix Blackhole DRAM bandwidth: 96 GB/s → 512 GB/s (32GB GDDR6 @ 16 GT/sec)
- Fix Blackhole clock rate: now correctly uses 1.35 GHz from device
- Remove deprecated Grayskull support from performance model
- Move OpPerformanceModelGeneral constructor to ttnn/core/operation.cpp to improve build times and reduce header dependencies
- Add support for std::array and std::tuple tensor return types
- Clean up unused includes

Fixes FPU utilization discrepancies observed in Blackhole SDPA microbenchmarks where C++ performance model reported different utilization than Python calculations.


- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix_bh_op_utilisation)](https://github.com/tenstorrent/tt-metal/actions/runs/21548816607)                                                             
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix_bh_op_utilisation)](https://github.com/tenstorrent/tt-metal/actions/runs/21548819228)
- [ ] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/fix_bh_op_utilisation)](https://github.com/tenstorrent/tt-metal/actions/runs/21548826306) 

Note: pipelines are red, but same state as on main branch.