### PR TITLE
Restore optimized reduce_c codepath for SDPA prefill

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1582,8 +1582,8 @@ void sdpa_inner_loop(
              *  cur_max = max(qk, dim=-1)
              */
             reconfig_data_format(cb_qk_im, cb_identity_scale_in);
-            reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, Sq_chunk_t>(
-                alias_cur_max, alias_prev_max, Sk_chunk_t, processed_k_chunks > 0);
+            reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_qk_im, cb_identity_scale_in, Sq_chunk_t, Sk_chunk_t>(
+                alias_cur_max, alias_prev_max, processed_k_chunks > 0);
 
             /**
              * sub_exp fuses a few operations.
@@ -1676,8 +1676,8 @@ void sdpa_inner_loop(
             //    This compares the previous max with the sink logit
             reconfig_data_format(cb_attention_sink, cb_identity_scale_in);
 
-            reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_attention_sink, cb_identity_scale_in, Sq_chunk_t>(
-                alias_cur_max, alias_prev_max, 1, true);
+            reduce_c<PoolType::MAX, ReduceDim::REDUCE_ROW, cb_attention_sink, cb_identity_scale_in, Sq_chunk_t, 1>(
+                alias_cur_max, alias_prev_max, true);
 
             // 2. Compute exp((prev_max - cur_max) * scale) to rescale previous statistics
             sub_exp_block<scale_fp32>(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);


### PR DESCRIPTION
Use compile-time cols template parameter to enable reduce_block_max_row optimization introduced in 0fc2d6d4 (PR #34092). This was inadvertently disabled by 9a8afd2e (PR #34133) which switched to runtime cols for API uniformity with sdpa_decode.

Since Sk_chunk_t is a compile-time template parameter in sdpa_inner_loop, passing it as a template arg restores the optimized path without affecting sdpa_decode which still needs runtime cols.

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/sdpa_restore_optimized_reduce_c)](https://github.com/tenstorrent/tt-metal/actions/runs/21565962197)                             
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa_restore_optimized_reduce_c)](https://github.com/tenstorrent/tt-metal/actions/runs/21565966064)                                 
- [ ] [![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa_restore_optimized_reduce_c)](https://github.com/tenstorrent/tt-metal/actions/runs/21566441764)                               
- [ ] [![Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/sdpa_restore_optimized_reduce_c)](https://github.com/tenstorrent/tt-metal/actions/runs/21566451637)  
