### PR TITLE
H2D Sockets

### DIFF
--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -33,6 +33,8 @@ jobs:
         test-group:
           - name: CCL APC test
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit
+          - name: Socket tests
+            cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*H2DSocket*"
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service

--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         test_mesh_device_view.cpp
         test_mesh_workload.cpp
         test_mesh_socket.cpp
+        test_h2d_socket.cpp
         test_mesh_sub_device.cpp
         test_mesh_allocator.cpp
         test_mesh_events.cpp

--- a/tests/tt_metal/distributed/test_h2d_socket.cpp
+++ b/tests/tt_metal/distributed/test_h2d_socket.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/work_split.hpp>
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <algorithm>
+#include <chrono>
+#include <random>
+#include "gmock/gmock.h"
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include "tt_metal/fabric/fabric_host_utils.hpp"
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/hw/inc/hostdev/socket.h"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/distributed/mesh_socket_utils.hpp"
+#include "tt_metal/distributed/mesh_socket_serialization.hpp"
+#include <tt-metalium/experimental/sockets/h2d_socket.hpp>
+#include <tt-metalium/system_mesh.hpp>
+#include <cstring>
+#include <tt-metalium/tt_align.hpp>
+#include "tt_metal/llrt/tt_cluster.hpp"
+#include "tt_metal/distributed/fd_mesh_command_queue.hpp"
+
+namespace tt::tt_metal::distributed {
+
+void test_h2d_socket(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    std::size_t socket_fifo_size,
+    std::size_t page_size,
+    std::size_t data_size,
+    H2DMode h2d_mode,
+    uint32_t num_iterations = 10,
+    const MeshCoreCoord& recv_core = {MeshCoordinate(0, 0), CoreCoord(0, 0)}) {
+    auto input_socket = H2DSocket(mesh_device, recv_core, BufferType::L1, socket_fifo_size, h2d_mode);
+    input_socket.set_page_size(page_size);
+
+    TT_FATAL(data_size % page_size == 0, "Data size must be a multiple of page size");
+
+    // Create recv data buffer to drain data into
+    const ReplicatedBufferConfig buffer_config{.size = data_size};
+    auto recv_data_shard_params =
+        ShardSpecBuffer(CoreRangeSet(recv_core.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+
+    const DeviceLocalBufferConfig recv_device_local_config{
+        .page_size = data_size,
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(recv_data_shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
+        .bottom_up = false,
+    };
+    auto recv_data_buffer = MeshBuffer::create(buffer_config, recv_device_local_config, mesh_device.get());
+    // Create Recv MeshWorkload
+    auto recv_program = CreateProgram();
+    CreateKernel(
+        recv_program,
+        h2d_mode == H2DMode::DEVICE_PULL ? "tests/tt_metal/tt_metal/test_kernels/misc/socket/pcie_socket_receiver.cpp"
+                                         : "tests/tt_metal/tt_metal/test_kernels/misc/socket/receiver_worker.cpp",
+        recv_core.core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {
+                static_cast<uint32_t>(input_socket.get_config_buffer_address()),
+                static_cast<uint32_t>(recv_data_buffer->address()),
+                static_cast<uint32_t>(page_size),
+                static_cast<uint32_t>(data_size),
+                static_cast<uint32_t>(num_iterations),
+            }});
+
+    auto mesh_workload = MeshWorkload();
+    MeshCoordinateRange devices = MeshCoordinateRange(recv_core.device_coord);
+    mesh_workload.add_program(devices, std::move(recv_program));
+    EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
+
+    uint32_t num_writes = data_size / page_size;
+    std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
+
+    auto recv_core_virtual = mesh_device->worker_core_from_logical_core(recv_core.core_coord);
+    uint32_t page_size_words = page_size / sizeof(uint32_t);
+
+    // Write a single page at a time
+    const auto& cluster = MetalContext::instance().get_cluster();
+    for (int i = 0; i < num_iterations; i++) {
+        std::iota(src_vec.begin(), src_vec.end(), i);
+        for (uint32_t j = 0; j < num_writes; j++) {
+            input_socket.write(src_vec.data() + j * page_size_words, 1);
+        }
+        input_socket.barrier();
+        std::vector<uint32_t> recv_data_readback(data_size / sizeof(uint32_t));
+        cluster.read_core(
+            recv_data_readback.data(),
+            data_size,
+            tt_cxy_pair(mesh_device->get_device(recv_core.device_coord)->id(), recv_core_virtual),
+            recv_data_buffer->address());
+        EXPECT_EQ(src_vec, recv_data_readback);
+    }
+}
+
+TEST_F(MeshDevice1x2Fixture, H2DSocket) {
+    for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
+        for (const auto& recv_coord : MeshCoordinateRange(mesh_device_->shape())) {
+            // No wrap
+            test_h2d_socket(mesh_device_, 1024, 64, 1024, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(0, 0)));
+            // Even wrap
+            test_h2d_socket(mesh_device_, 1024, 64, 32768, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(1, 1)));
+            // Uneven wrap
+            test_h2d_socket(mesh_device_, 4096, 1088, 78336, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(0, 1)));
+        }
+    }
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/distributed/test_h2d_socket.cpp
+++ b/tests/tt_metal/distributed/test_h2d_socket.cpp
@@ -87,7 +87,7 @@ void test_h2d_socket(
     for (int i = 0; i < num_iterations; i++) {
         std::iota(src_vec.begin(), src_vec.end(), i);
         for (uint32_t j = 0; j < num_writes; j++) {
-            input_socket.write(src_vec.data() + j * page_size_words, 1);
+            input_socket.write(src_vec.data() + (j * page_size_words), 1);
         }
         input_socket.barrier();
         std::vector<uint32_t> recv_data_readback(data_size / sizeof(uint32_t));

--- a/tests/tt_metal/distributed/test_h2d_socket.cpp
+++ b/tests/tt_metal/distributed/test_h2d_socket.cpp
@@ -101,14 +101,19 @@ void test_h2d_socket(
 }
 
 TEST_F(MeshDevice1x2Fixture, H2DSocket) {
+    // Skip if mapping to NOC isn't supported on this system
+    if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+    }
+
     for (auto h2d_mode : {H2DMode::HOST_PUSH, H2DMode::DEVICE_PULL}) {
         for (const auto& recv_coord : MeshCoordinateRange(mesh_device_->shape())) {
             // No wrap
-            test_h2d_socket(mesh_device_, 1024, 64, 1024, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(0, 0)));
+            test_h2d_socket(mesh_device_, 1024, 64, 1024, h2d_mode, 50, MeshCoreCoord(recv_coord, CoreCoord(0, 0)));
             // Even wrap
-            test_h2d_socket(mesh_device_, 1024, 64, 32768, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(1, 1)));
+            test_h2d_socket(mesh_device_, 1024, 64, 32768, h2d_mode, 50, MeshCoreCoord(recv_coord, CoreCoord(1, 1)));
             // Uneven wrap
-            test_h2d_socket(mesh_device_, 4096, 1088, 78336, h2d_mode, 10, MeshCoreCoord(recv_coord, CoreCoord(0, 1)));
+            test_h2d_socket(mesh_device_, 4096, 1088, 78336, h2d_mode, 50, MeshCoreCoord(recv_coord, CoreCoord(0, 1)));
         }
     }
 }

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -119,14 +119,14 @@ void verify_socket_configs(
     EXPECT_EQ(recv_config.read_ptr, recv_socket.get_data_buffer()->address());
     EXPECT_EQ(recv_config.fifo_addr, recv_socket.get_data_buffer()->address());
     EXPECT_EQ(recv_config.fifo_total_size, socket_fifo_size);
-    EXPECT_EQ(recv_config.upstream_mesh_id, 0);
-    EXPECT_EQ(recv_config.upstream_chip_id, upstream_device_id);
-    EXPECT_EQ(recv_config.upstream_noc_y, sender_virtual_coord.y);
-    EXPECT_EQ(recv_config.upstream_noc_x, sender_virtual_coord.x);
+    EXPECT_EQ(recv_config.d2d.upstream_mesh_id, 0);
+    EXPECT_EQ(recv_config.d2d.upstream_chip_id, upstream_device_id);
+    EXPECT_EQ(recv_config.d2d.upstream_noc_y, sender_virtual_coord.y);
+    EXPECT_EQ(recv_config.d2d.upstream_noc_x, sender_virtual_coord.x);
     EXPECT_EQ(
-        recv_config.upstream_bytes_acked_addr,
+        recv_config.d2d.upstream_bytes_acked_addr,
         send_socket.get_config_buffer()->address() + tt::align(sizeof(sender_socket_md), l1_alignment));
-    EXPECT_EQ(recv_config.upstream_bytes_acked_addr % l1_alignment, 0);
+    EXPECT_EQ(recv_config.d2d.upstream_bytes_acked_addr % l1_alignment, 0);
 }
 
 void test_single_connection_single_device_socket(
@@ -248,7 +248,8 @@ void test_single_connection_single_device_socket(
                     static_cast<uint32_t>(recv_socket.get_config_buffer()->address()),
                     static_cast<uint32_t>(recv_data_buffer->address()),
                     static_cast<uint32_t>(page_size),
-                    static_cast<uint32_t>(data_size)}});
+                    static_cast<uint32_t>(data_size),
+                    1}});
     }
 
     auto mesh_workload = MeshWorkload();

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -196,6 +196,11 @@ protected:
     GenericMultiCQMeshDeviceFixture() : MeshDeviceFixtureBase(Config{.num_cqs = 2}) {}
 };
 
+class MeshDevice1x2Fixture : public MeshDeviceFixtureBase {
+protected:
+    MeshDevice1x2Fixture() : MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 2}}) {}
+};
+
 // Fixtures that specify the mesh device type explicitly.
 // The associated test will be run if the cluster topology matches
 // what is specified.

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/pcie_socket_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/pcie_socket_receiver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <cstdint>
@@ -12,32 +12,27 @@ void kernel_main() {
     constexpr uint32_t page_size = get_compile_time_arg_val(2);
     constexpr uint32_t data_size = get_compile_time_arg_val(3);
     constexpr uint32_t num_iterations = get_compile_time_arg_val(4);
-
     SocketReceiverInterface receiver_socket = create_receiver_socket_interface(socket_config_addr);
+
     set_receiver_socket_page_size(receiver_socket, page_size);
 
-    // Reads one page at a time and sends ack to sender, can be optimized to notify
-    // receiver after reading larger chunks
-    // In this example the local_cb isn't actually needed (we can just get the rptr)
-    // from the socket itself
-    // Its there to illustrate how a local CB can be connected to the socket interface
-    // If the local CB was being used for compute:
-    //  - The reader (this kernel) would:
-    //     - Handshake with sender
-    //     - Call cb_reserve_back on the recv_cb_id (shared between reader and compute)
-    //     - Call cb_push_back to notify the compute kernel of data
-    //  - The compute kernel would:
-    //     - Call cb_wait_front
-    //     - Call cb_pop_front to notify the receiver that pages are available
-    //  - In this case, an additional CB would be needed to synchronize the receiver and
-    //    compute kernels (socket_notify_sender cannot be called until compute is done with
-    //    pages in the local CB)
+    uint64_t pcie_data_addr = (static_cast<uint64_t>(receiver_socket.h2d.data_addr_hi) << 32) |
+                              (static_cast<uint64_t>(receiver_socket.h2d.data_addr_lo));
+    uint32_t pcie_xy_enc = receiver_socket.h2d.pcie_xy_enc;
 
     for (uint32_t i = 0; i < num_iterations; i++) {
         uint32_t outstanding_data_size = data_size;
         uint64_t dst_noc_addr = get_noc_addr(local_l1_buffer_addr);
         while (outstanding_data_size) {
             socket_wait_for_pages(receiver_socket, 1);
+            noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                NOC_INDEX,
+                pcie_xy_enc,
+                pcie_data_addr + receiver_socket.read_ptr - receiver_socket.fifo_addr,
+                receiver_socket.read_ptr,
+                page_size);
+            noc_async_read_barrier();
+
             noc_async_write(receiver_socket.read_ptr, dst_noc_addr, page_size);
             dst_noc_addr += page_size;
             outstanding_data_size -= page_size;

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -15,30 +15,134 @@ class TlbWindow;
 
 namespace tt::tt_metal::distributed {
 
+/**
+ * @brief Specifies the data transfer mode for Host-to-Device communication.
+ */
 enum class H2DMode : uint8_t {
-    HOST_PUSH,    // Host pushes data to device over UMD.
-    DEVICE_PULL,  // Device pulls data from host over PCIe. This uses PinnedMemory -> requires systems to have vIOMMU
-                  // enabled.
+    HOST_PUSH,    ///< Host pushes data to device via UMD TLB writes.
+    DEVICE_PULL,  ///< Device pulls data from pinned host memory via PCIe NOC reads.
+                  ///< Requires vIOMMU to be enabled on the system.
 };
 
+/**
+ * @brief A socket for streaming data from host to a device core.
+ *
+ * H2DSocket provides a FIFO-based interface for transferring data from the host CPU
+ * to a specific core on a Tenstorrent device. It supports two transfer modes:
+ *
+ * - **HOST_PUSH**: The host writes data directly to device L1 memory via TLB-mapped
+ *   PCIe writes.
+ *
+ * - **DEVICE_PULL**: The host writes data to pinned host memory, and the device core
+ *   pulls data via PCIe NOC reads.
+ *
+ * The socket uses a circular FIFO buffer with flow control. The host tracks `bytes_sent`
+ * and the device kernel updates `bytes_acked` to indicate consumed data. The host blocks
+ * on write() if the FIFO is full until the device acknowledges data.
+ *
+ * Usage:
+ * @code
+ *   auto socket = H2DSocket(mesh_device, recv_core, BufferType::L1, fifo_size, H2DMode::HOST_PUSH);
+ *   socket.set_page_size(page_size);
+ *   socket.write(data_ptr, num_pages);
+ *   socket.barrier();  // Wait for device to consume all data
+ * @endcode
+ */
 class H2DSocket {
 public:
+    /**
+     * @brief Constructs an H2DSocket for streaming data to a device core.
+     *
+     * @param mesh_device The mesh device containing the target core.
+     * @param recv_core The target core coordinate (device + core) to receive data.
+     * @param buffer_type Memory type for the device-side FIFO buffer (L1 or DRAM).
+     * @param fifo_size Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
+     * @param h2d_mode Transfer mode: HOST_PUSH or DEVICE_PULL.
+     */
     H2DSocket(
         const std::shared_ptr<MeshDevice>& mesh_device,
         const MeshCoreCoord& recv_core,
         BufferType buffer_type,
         uint32_t fifo_size,
         H2DMode h2d_mode);
+
+    /**
+     * @brief Returns the currently configured page size.
+     */
     uint32_t get_page_size() const { return page_size_; }
+
+    /**
+     * @brief Returns the L1 address of the socket configuration buffer on the device.
+     *
+     * This address is passed to the device kernel to access socket metadata.
+     */
     uint32_t get_config_buffer_address() const { return config_buffer_->address(); }
+
+    /**
+     * @brief Sets the page size for subsequent write operations.
+     *
+     * The page size determines the granularity of data transfers. Must be PCIe-aligned
+     * and less than or equal to the FIFO size. The write pointer is aligned to the new
+     * page size boundary.
+     *
+     * @param page_size Page size in bytes. Must be PCIe-aligned.
+     */
     void set_page_size(uint32_t page_size);
+
+    /**
+     * @brief Writes data pages to the socket FIFO.
+     *
+     * Blocks if the FIFO does not have enough space, waiting for the device to
+     * acknowledge previously written data. After writing, notifies the device
+     * that new data is available.
+     *
+     * @param data Pointer to the source data buffer.
+     * @param num_pages Number of pages to write.
+     */
     void write(void* data, uint32_t num_pages);
+
+    /**
+     * @brief Blocks until the device has acknowledged all written data.
+     *
+     * Waits until `bytes_acked` equals `bytes_sent`, indicating the device has
+     * consumed all data in the FIFO.
+     */
     void barrier();
+
+    /**
+     * @brief Returns the host-side buffer used for tracking device acknowledgements.
+     *
+     * The device writes to this pinned memory location to signal data consumption.
+     */
     std::shared_ptr<tt::tt_metal::vector_aligned<uint32_t>> get_bytes_acked_buffer() const {
         return bytes_acked_buffer_;
     }
 
 private:
+    // Helper struct for pinned buffer NOC address info
+    struct PinnedBufferInfo {
+        uint32_t pcie_xy_enc = 0;
+        uint32_t addr_lo = 0;
+        uint32_t addr_hi = 0;
+    };
+
+    // Initialization helpers
+    PinnedBufferInfo init_bytes_acked_buffer(
+        const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoordinateRangeSet& device_range);
+
+    PinnedBufferInfo init_host_data_buffer(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        const MeshCoordinateRangeSet& device_range,
+        uint32_t pcie_alignment);
+
+    void init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device);
+    void init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment);
+    void write_socket_metadata(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        const PinnedBufferInfo& bytes_acked_info,
+        const PinnedBufferInfo& data_info);
+    void init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device);
+
     void reserve_bytes(uint32_t num_bytes);
     void push_bytes(uint32_t num_bytes);
     void notify_receiver();
@@ -58,7 +162,8 @@ private:
     std::unique_ptr<tt::tt_metal::experimental::PinnedMemory> bytes_acked_pinned_memory_ = nullptr;
     std::unique_ptr<tt::tt_metal::experimental::PinnedMemory> data_pinned_memory_ = nullptr;
     std::shared_ptr<tt::tt_metal::vector_aligned<uint32_t>> bytes_acked_buffer_ = nullptr;
-    std::shared_ptr<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, 64>>> host_data_buffer_ = nullptr;
+    std::shared_ptr<uint32_t[]> host_data_buffer_ = nullptr;
+    size_t host_data_buffer_size_ = 0;
     H2DMode h2d_mode_ = H2DMode::HOST_PUSH;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -21,7 +21,6 @@ namespace tt::tt_metal::distributed {
 enum class H2DMode : uint8_t {
     HOST_PUSH,    ///< Host pushes data to device via UMD TLB writes.
     DEVICE_PULL,  ///< Device pulls data from pinned host memory via PCIe NOC reads.
-                  ///< Requires vIOMMU to be enabled on the system.
 };
 
 /**
@@ -35,6 +34,7 @@ enum class H2DMode : uint8_t {
  *
  * - **DEVICE_PULL**: The host writes data to pinned host memory, and the device core
  *   pulls data via PCIe NOC reads.
+ * Both Modes require vIOMMU to be enabled on the system, based on the current implementation.
  *
  * The socket uses a circular FIFO buffer with flow control. The host tracks `bytes_sent`
  * and the device kernel updates `bytes_acked` to indicate consumed data. The host blocks

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -164,6 +164,7 @@ private:
     std::shared_ptr<tt::tt_metal::vector_aligned<uint32_t>> bytes_acked_buffer_ = nullptr;
     std::shared_ptr<uint32_t[]> host_data_buffer_ = nullptr;
     size_t host_data_buffer_size_ = 0;
+    std::function<void(void*, uint32_t, uint64_t)> pcie_writer = nullptr;
     H2DMode h2d_mode_ = H2DMode::HOST_PUSH;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/sockets/mesh_socket.hpp>
+#include <tt-metalium/experimental/pinned_memory.hpp>
+#include <tt-metalium/vector_aligned.hpp>
+#include <utility>
+
+namespace tt::umd {
+class TlbWindow;
+}
+
+namespace tt::tt_metal::distributed {
+
+enum class H2DMode : uint8_t {
+    HOST_PUSH,    // Host pushes data to device over UMD.
+    DEVICE_PULL,  // Device pulls data from host over PCIe. This uses PinnedMemory -> requires systems to have vIOMMU
+                  // enabled.
+};
+
+class H2DSocket {
+public:
+    H2DSocket(
+        const std::shared_ptr<MeshDevice>& mesh_device,
+        const MeshCoreCoord& recv_core,
+        BufferType buffer_type,
+        uint32_t fifo_size,
+        H2DMode h2d_mode);
+    uint32_t get_page_size() const { return page_size_; }
+    uint32_t get_config_buffer_address() const { return config_buffer_->address(); }
+    void set_page_size(uint32_t page_size);
+    void write(void* data, uint32_t num_pages);
+    void barrier();
+    std::shared_ptr<tt::tt_metal::vector_aligned<uint32_t>> get_bytes_acked_buffer() const {
+        return bytes_acked_buffer_;
+    }
+
+private:
+    void reserve_bytes(uint32_t num_bytes);
+    void push_bytes(uint32_t num_bytes);
+    void notify_receiver();
+
+    std::shared_ptr<MeshBuffer> config_buffer_ = nullptr;
+    std::shared_ptr<MeshBuffer> data_buffer_ = nullptr;
+    MeshCoreCoord recv_core_;
+    BufferType buffer_type_ = BufferType::L1;
+    uint32_t fifo_size_ = 0;
+    uint32_t page_size_ = 0;
+    uint32_t bytes_sent_ = 0;
+    uint32_t bytes_acked_ = 0;
+    uint32_t write_ptr_ = 0;
+    uint32_t fifo_curr_size_ = 0;
+    uint32_t aligned_data_buf_start_ = 0;
+    tt::umd::TlbWindow* receiver_core_tlb_ = nullptr;
+    std::unique_ptr<tt::tt_metal::experimental::PinnedMemory> bytes_acked_pinned_memory_ = nullptr;
+    std::unique_ptr<tt::tt_metal::experimental::PinnedMemory> data_pinned_memory_ = nullptr;
+    std::shared_ptr<tt::tt_metal::vector_aligned<uint32_t>> bytes_acked_buffer_ = nullptr;
+    std::shared_ptr<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, 64>>> host_data_buffer_ = nullptr;
+    H2DMode h2d_mode_ = H2DMode::HOST_PUSH;
+};
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/distributed_host_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/multihost/distributed_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/h2d_socket.cpp
 )
 
 # Include helper functions and generate headers from flatbuffer schemas

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -9,71 +9,65 @@
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
+#include <cstdlib>
+#include <cstring>
 
 namespace tt::tt_metal::distributed {
 
-H2DSocket::H2DSocket(
-    const std::shared_ptr<MeshDevice>& mesh_device,
-    const MeshCoreCoord& recv_core,
-    BufferType buffer_type,
-    uint32_t fifo_size,
-    H2DMode h2d_mode) :
-    recv_core_(recv_core),
-    buffer_type_(buffer_type),
-    fifo_size_(fifo_size),
-    page_size_(0),
-    bytes_acked_pinned_memory_(nullptr),
-    data_pinned_memory_(nullptr),
-    h2d_mode_(h2d_mode) {
-    // Allocate memory for the config buffer
-    MeshCoordinateRangeSet recv_device_range_set;
-    recv_device_range_set.merge(MeshCoordinateRange(recv_core_.device_coord));
-
-    const uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-    TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIE-aligned.");
-
-    bytes_acked_buffer_ = std::make_shared<tt::tt_metal::vector_aligned<uint32_t>>(4, 0);
+H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
+    const std::shared_ptr<MeshDevice>& mesh_device, const MeshCoordinateRangeSet& device_range) {
+    bytes_acked_buffer_ = std::make_shared<tt::tt_metal::vector_aligned<uint32_t>>(1, 0);
     tt::tt_metal::HostBuffer bytes_acked_buffer_view(
         tt::stl::Span<uint32_t>(bytes_acked_buffer_->data(), bytes_acked_buffer_->size()),
         tt::tt_metal::MemoryPin(bytes_acked_buffer_));
-    bytes_acked_pinned_memory_ = tt::tt_metal::experimental::PinnedMemory::Create(
-        *mesh_device, recv_device_range_set, bytes_acked_buffer_view, true);
+    bytes_acked_pinned_memory_ =
+        tt::tt_metal::experimental::PinnedMemory::Create(*mesh_device, device_range, bytes_acked_buffer_view, true);
 
-    const auto& bytes_acked_noc_addr =
+    const auto& noc_addr =
         bytes_acked_pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
-    TT_FATAL(bytes_acked_noc_addr.has_value(), "Failed to get NOC address for bytes_acked pinned memory.");
+    TT_FATAL(noc_addr.has_value(), "Failed to get NOC address for bytes_acked pinned memory.");
 
-    uint32_t bytes_acked_pcie_xy_enc = bytes_acked_noc_addr.value().pcie_xy_enc;
-    uint32_t bytes_acked_addr_lo = static_cast<uint32_t>(bytes_acked_noc_addr.value().addr & 0xFFFFFFFFull);
-    uint32_t bytes_acked_addr_hi = static_cast<uint32_t>(bytes_acked_noc_addr.value().addr >> 32);
+    return PinnedBufferInfo{
+        .pcie_xy_enc = noc_addr.value().pcie_xy_enc,
+        .addr_lo = static_cast<uint32_t>(noc_addr.value().addr & 0xFFFFFFFFull),
+        .addr_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32)};
+}
 
-    uint32_t data_pcie_xy_enc = 0;
-    uint32_t data_addr_lo = 0;
-    uint32_t data_addr_hi = 0;
-    if (h2d_mode_ == H2DMode::DEVICE_PULL) {
-        host_data_buffer_ = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, 64>>>(
-            fifo_size_ / sizeof(uint32_t), 0);
-        tt::tt_metal::HostBuffer host_data_buffer_view(
-            tt::stl::Span<uint32_t>(host_data_buffer_->data(), host_data_buffer_->size()),
-            tt::tt_metal::MemoryPin(host_data_buffer_));
-        data_pinned_memory_ = tt::tt_metal::experimental::PinnedMemory::Create(
-            *mesh_device, recv_device_range_set, host_data_buffer_view, true);
-        const auto& data_noc_addr =
-            data_pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
-        TT_FATAL(data_noc_addr.has_value(), "Failed to get NOC address for data pinned memory.");
-        data_pcie_xy_enc = data_noc_addr.value().pcie_xy_enc;
-        data_addr_lo = static_cast<uint32_t>(data_noc_addr.value().addr & 0xFFFFFFFFull);
-        data_addr_hi = static_cast<uint32_t>(data_noc_addr.value().addr >> 32);
-        TT_FATAL(
-            bytes_acked_pcie_xy_enc == data_pcie_xy_enc,
-            "Bytes_acked and data pinned memory must be mapped to the same PCIe core.");
-    }
+H2DSocket::PinnedBufferInfo H2DSocket::init_host_data_buffer(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const MeshCoordinateRangeSet& device_range,
+    uint32_t pcie_alignment) {
+    host_data_buffer_size_ = fifo_size_ / sizeof(uint32_t);
+    void* aligned_ptr = std::aligned_alloc(pcie_alignment, fifo_size_);
+    TT_FATAL(aligned_ptr != nullptr, "Failed to allocate aligned memory for host data buffer.");
+    std::memset(aligned_ptr, 0, fifo_size_);
+    host_data_buffer_ =
+        std::shared_ptr<uint32_t[]>(static_cast<uint32_t*>(aligned_ptr), [](uint32_t* p) { std::free(p); });
 
+    tt::tt_metal::HostBuffer host_data_buffer_view(
+        tt::stl::Span<uint32_t>(host_data_buffer_.get(), host_data_buffer_size_),
+        tt::tt_metal::MemoryPin(host_data_buffer_));
+    data_pinned_memory_ =
+        tt::tt_metal::experimental::PinnedMemory::Create(*mesh_device, device_range, host_data_buffer_view, true);
+
+    const auto& noc_addr = data_pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
+    TT_FATAL(noc_addr.has_value(), "Failed to get NOC address for data pinned memory.");
+
+    return PinnedBufferInfo{
+        .pcie_xy_enc = noc_addr.value().pcie_xy_enc,
+        .addr_lo = static_cast<uint32_t>(noc_addr.value().addr & 0xFFFFFFFFull),
+        .addr_hi = static_cast<uint32_t>(noc_addr.value().addr >> 32)};
+}
+
+void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_device) {
     uint32_t config_buffer_size = sizeof(receiver_socket_md);
     auto num_cores = 1;
-    auto total_config_buffer_size = config_buffer_size;
     auto shard_params = ShardSpecBuffer(
-        CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {static_cast<uint32_t>(num_cores), 1});
+        CoreRangeSet(recv_core_.core_coord),
+        {1, 1},
+        ShardOrientation::ROW_MAJOR,
+        {1, 1},
+        {static_cast<uint32_t>(num_cores), 1});
 
     DeviceLocalBufferConfig config_buffer_specs = {
         .page_size = config_buffer_size,
@@ -84,10 +78,12 @@ H2DSocket::H2DSocket(
     };
 
     MeshBufferConfig config_mesh_buffer_specs = ReplicatedBufferConfig{
-        .size = total_config_buffer_size,
+        .size = config_buffer_size,
     };
     config_buffer_ = MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get());
+}
 
+void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment) {
     auto num_data_cores = mesh_device->num_worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
     auto shard_grid = mesh_device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
 
@@ -109,6 +105,12 @@ H2DSocket::H2DSocket(
     data_buffer_ = MeshBuffer::create(data_mesh_buffer_specs, data_buffer_specs, mesh_device.get());
     aligned_data_buf_start_ = tt::align(data_buffer_->address(), pcie_alignment);
     write_ptr_ = 0;
+}
+
+void H2DSocket::write_socket_metadata(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const PinnedBufferInfo& bytes_acked_info,
+    const PinnedBufferInfo& data_info) {
     const auto& core_to_core_id = config_buffer_->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
 
     std::vector<receiver_socket_md> config_data(
@@ -121,15 +123,17 @@ H2DSocket::H2DSocket(
     md.fifo_addr = aligned_data_buf_start_;
     md.fifo_total_size = fifo_size_;
     md.is_h2d = 1;
-    md.h2d.bytes_acked_addr_lo = bytes_acked_addr_lo;
-    md.h2d.bytes_acked_addr_hi = bytes_acked_addr_hi;
-    md.h2d.data_addr_lo = data_addr_lo;
-    md.h2d.data_addr_hi = data_addr_hi;
-    md.h2d.pcie_xy_enc = bytes_acked_pcie_xy_enc;
+    md.h2d.bytes_acked_addr_lo = bytes_acked_info.addr_lo;
+    md.h2d.bytes_acked_addr_hi = bytes_acked_info.addr_hi;
+    md.h2d.data_addr_lo = data_info.addr_lo;
+    md.h2d.data_addr_hi = data_info.addr_hi;
+    md.h2d.pcie_xy_enc = bytes_acked_info.pcie_xy_enc;
 
     distributed::WriteShard(
         mesh_device->mesh_command_queue(0), config_buffer_, config_data, recv_core_.device_coord, true);
+}
 
+void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device) {
     const auto& cluster = MetalContext::instance().get_cluster();
     auto recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
     auto recv_virtual_core = mesh_device->worker_core_from_logical_core(recv_core_.core_coord);
@@ -137,6 +141,41 @@ H2DSocket::H2DSocket(
                              ->get_chip(recv_device_id)
                              ->get_tlb_manager()
                              ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+}
+
+H2DSocket::H2DSocket(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const MeshCoreCoord& recv_core,
+    BufferType buffer_type,
+    uint32_t fifo_size,
+    H2DMode h2d_mode) :
+    recv_core_(recv_core),
+    buffer_type_(buffer_type),
+    fifo_size_(fifo_size),
+    page_size_(0),
+    bytes_acked_pinned_memory_(nullptr),
+    data_pinned_memory_(nullptr),
+    h2d_mode_(h2d_mode) {
+    MeshCoordinateRangeSet recv_device_range_set;
+    recv_device_range_set.merge(MeshCoordinateRange(recv_core_.device_coord));
+
+    const uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIE-aligned.");
+
+    auto bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set);
+
+    PinnedBufferInfo data_info = {};
+    if (h2d_mode_ == H2DMode::DEVICE_PULL) {
+        data_info = init_host_data_buffer(mesh_device, recv_device_range_set, pcie_alignment);
+        TT_FATAL(
+            bytes_acked_info.pcie_xy_enc == data_info.pcie_xy_enc,
+            "Bytes_acked and data pinned memory must be mapped to the same PCIe core.");
+    }
+
+    init_config_buffer(mesh_device);
+    init_data_buffer(mesh_device, pcie_alignment);
+    write_socket_metadata(mesh_device, bytes_acked_info, data_info);
+    init_receiver_tlb(mesh_device);
 }
 
 void H2DSocket::reserve_bytes(uint32_t num_bytes) {
@@ -200,7 +239,7 @@ void H2DSocket::write(void* data, uint32_t num_pages) {
         receiver_core_tlb_->write_block(data_addr, data, num_bytes);
         tt_driver_atomics::sfence();
     } else {
-        uint32_t* data_ptr = host_data_buffer_->data() + (write_ptr_ / sizeof(uint32_t));
+        uint32_t* data_ptr = host_data_buffer_.get() + (write_ptr_ / sizeof(uint32_t));
         std::memcpy(data_ptr, data, num_bytes);
     }
     this->push_bytes(num_bytes);

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/sockets/h2d_socket.hpp>
+#include "tt_metal/distributed/mesh_socket_utils.hpp"
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/hw/inc/hostdev/socket.h"
+#include "tt_metal/llrt/tt_cluster.hpp"
+#include <tt-metalium/tt_align.hpp>
+#include <umd/device/chip_helpers/tlb_manager.hpp>
+
+namespace tt::tt_metal::distributed {
+
+H2DSocket::H2DSocket(
+    const std::shared_ptr<MeshDevice>& mesh_device,
+    const MeshCoreCoord& recv_core,
+    BufferType buffer_type,
+    uint32_t fifo_size,
+    H2DMode h2d_mode) :
+    recv_core_(recv_core),
+    buffer_type_(buffer_type),
+    fifo_size_(fifo_size),
+    page_size_(0),
+    bytes_acked_pinned_memory_(nullptr),
+    data_pinned_memory_(nullptr),
+    h2d_mode_(h2d_mode) {
+    // Allocate memory for the config buffer
+    MeshCoordinateRangeSet recv_device_range_set;
+    recv_device_range_set.merge(MeshCoordinateRange(recv_core_.device_coord));
+
+    const uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIE-aligned.");
+
+    bytes_acked_buffer_ = std::make_shared<tt::tt_metal::vector_aligned<uint32_t>>(4, 0);
+    tt::tt_metal::HostBuffer bytes_acked_buffer_view(
+        tt::stl::Span<uint32_t>(bytes_acked_buffer_->data(), bytes_acked_buffer_->size()),
+        tt::tt_metal::MemoryPin(bytes_acked_buffer_));
+    bytes_acked_pinned_memory_ = tt::tt_metal::experimental::PinnedMemory::Create(
+        *mesh_device, recv_device_range_set, bytes_acked_buffer_view, true);
+
+    const auto& bytes_acked_noc_addr =
+        bytes_acked_pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
+    TT_FATAL(bytes_acked_noc_addr.has_value(), "Failed to get NOC address for bytes_acked pinned memory.");
+
+    uint32_t bytes_acked_pcie_xy_enc = bytes_acked_noc_addr.value().pcie_xy_enc;
+    uint32_t bytes_acked_addr_lo = static_cast<uint32_t>(bytes_acked_noc_addr.value().addr & 0xFFFFFFFFull);
+    uint32_t bytes_acked_addr_hi = static_cast<uint32_t>(bytes_acked_noc_addr.value().addr >> 32);
+
+    uint32_t data_pcie_xy_enc = 0;
+    uint32_t data_addr_lo = 0;
+    uint32_t data_addr_hi = 0;
+    if (h2d_mode_ == H2DMode::DEVICE_PULL) {
+        host_data_buffer_ = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, 64>>>(
+            fifo_size_ / sizeof(uint32_t), 0);
+        tt::tt_metal::HostBuffer host_data_buffer_view(
+            tt::stl::Span<uint32_t>(host_data_buffer_->data(), host_data_buffer_->size()),
+            tt::tt_metal::MemoryPin(host_data_buffer_));
+        data_pinned_memory_ = tt::tt_metal::experimental::PinnedMemory::Create(
+            *mesh_device, recv_device_range_set, host_data_buffer_view, true);
+        const auto& data_noc_addr =
+            data_pinned_memory_->get_noc_addr(mesh_device->get_device(recv_core_.device_coord)->id());
+        TT_FATAL(data_noc_addr.has_value(), "Failed to get NOC address for data pinned memory.");
+        data_pcie_xy_enc = data_noc_addr.value().pcie_xy_enc;
+        data_addr_lo = static_cast<uint32_t>(data_noc_addr.value().addr & 0xFFFFFFFFull);
+        data_addr_hi = static_cast<uint32_t>(data_noc_addr.value().addr >> 32);
+        TT_FATAL(
+            bytes_acked_pcie_xy_enc == data_pcie_xy_enc,
+            "Bytes_acked and data pinned memory must be mapped to the same PCIe core.");
+    }
+
+    uint32_t config_buffer_size = sizeof(receiver_socket_md);
+    auto num_cores = 1;
+    auto total_config_buffer_size = config_buffer_size;
+    auto shard_params = ShardSpecBuffer(
+        CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {static_cast<uint32_t>(num_cores), 1});
+
+    DeviceLocalBufferConfig config_buffer_specs = {
+        .page_size = config_buffer_size,
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(shard_params, TensorMemoryLayout::HEIGHT_SHARDED),
+        .bottom_up = std::nullopt,
+        .sub_device_id = std::nullopt,
+    };
+
+    MeshBufferConfig config_mesh_buffer_specs = ReplicatedBufferConfig{
+        .size = total_config_buffer_size,
+    };
+    config_buffer_ = MeshBuffer::create(config_mesh_buffer_specs, config_buffer_specs, mesh_device.get());
+
+    auto num_data_cores = mesh_device->num_worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
+    auto shard_grid = mesh_device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
+
+    // Allocate buffer at a PCIe aligned address. This requires extra memory to be allocated.
+    auto total_data_buffer_size = num_data_cores * (fifo_size_ + pcie_alignment);
+
+    DeviceLocalBufferConfig data_buffer_specs = {
+        .page_size = fifo_size_ + pcie_alignment,
+        .buffer_type = buffer_type_,
+        .sharding_args = BufferShardingArgs(
+            ShardSpecBuffer(shard_grid, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_data_cores, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED),
+        .bottom_up = std::nullopt,
+        .sub_device_id = std::nullopt,
+    };
+    MeshBufferConfig data_mesh_buffer_specs = ReplicatedBufferConfig{
+        .size = total_data_buffer_size,
+    };
+    data_buffer_ = MeshBuffer::create(data_mesh_buffer_specs, data_buffer_specs, mesh_device.get());
+    aligned_data_buf_start_ = tt::align(data_buffer_->address(), pcie_alignment);
+    write_ptr_ = 0;
+    const auto& core_to_core_id = config_buffer_->get_backing_buffer()->get_buffer_page_mapping()->core_to_core_id;
+
+    std::vector<receiver_socket_md> config_data(
+        config_buffer_->size() / sizeof(receiver_socket_md), receiver_socket_md());
+
+    auto& md = config_data[core_to_core_id.at(recv_core_.core_coord)];
+    md.bytes_sent = 0;
+    md.bytes_acked = 0;
+    md.read_ptr = aligned_data_buf_start_;
+    md.fifo_addr = aligned_data_buf_start_;
+    md.fifo_total_size = fifo_size_;
+    md.is_h2d = 1;
+    md.h2d.bytes_acked_addr_lo = bytes_acked_addr_lo;
+    md.h2d.bytes_acked_addr_hi = bytes_acked_addr_hi;
+    md.h2d.data_addr_lo = data_addr_lo;
+    md.h2d.data_addr_hi = data_addr_hi;
+    md.h2d.pcie_xy_enc = bytes_acked_pcie_xy_enc;
+
+    distributed::WriteShard(
+        mesh_device->mesh_command_queue(0), config_buffer_, config_data, recv_core_.device_coord, true);
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    auto recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
+    auto recv_virtual_core = mesh_device->worker_core_from_logical_core(recv_core_.core_coord);
+    receiver_core_tlb_ = cluster.get_driver()
+                             ->get_chip(recv_device_id)
+                             ->get_tlb_manager()
+                             ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+}
+
+void H2DSocket::reserve_bytes(uint32_t num_bytes) {
+    uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
+    while (bytes_free < num_bytes) {
+        volatile uint32_t bytes_acked_value = bytes_acked_buffer_->at(0);
+        bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
+        bytes_acked_ = bytes_acked_value;
+    }
+}
+
+void H2DSocket::push_bytes(uint32_t num_bytes) {
+    if (write_ptr_ + num_bytes >= fifo_curr_size_) {
+        write_ptr_ = write_ptr_ + num_bytes - fifo_curr_size_;
+        bytes_sent_ += num_bytes + fifo_size_ - fifo_curr_size_;
+    } else {
+        write_ptr_ += num_bytes;
+        bytes_sent_ += num_bytes;
+    }
+}
+
+void H2DSocket::notify_receiver() {
+    uint32_t bytes_sent_addr = config_buffer_->address() + offsetof(receiver_socket_md, bytes_sent);
+    receiver_core_tlb_->write_block(bytes_sent_addr, &bytes_sent_, sizeof(bytes_sent_));
+    tt_driver_atomics::sfence();
+}
+
+void H2DSocket::set_page_size(uint32_t page_size) {
+    const auto pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    TT_FATAL(page_size % pcie_alignment == 0, "Page size must be PCIE-aligned.");
+    TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
+
+    uint32_t next_fifo_wr_ptr = align(write_ptr_, page_size);
+    uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);
+
+    if (next_fifo_wr_ptr >= fifo_page_aligned_size) {
+        bytes_sent_ += fifo_size_ - next_fifo_wr_ptr;
+        next_fifo_wr_ptr = 0;
+    }
+    write_ptr_ = next_fifo_wr_ptr;
+    page_size_ = page_size;
+    fifo_curr_size_ = fifo_page_aligned_size;
+}
+
+void H2DSocket::barrier() {
+    volatile uint32_t bytes_acked_value = bytes_acked_buffer_->at(0);
+    while (bytes_sent_ - bytes_acked_value != 0) {
+        tt_driver_atomics::mfence();
+        bytes_acked_value = bytes_acked_buffer_->at(0);
+    }
+}
+
+void H2DSocket::write(void* data, uint32_t num_pages) {
+    TT_FATAL(page_size_ > 0, "Page size must be set before writing.");
+    uint32_t num_bytes = num_pages * page_size_;
+    TT_FATAL(num_bytes <= fifo_curr_size_, "Cannot write more pages than the socket FIFO size.");
+    auto data_addr = aligned_data_buf_start_ + write_ptr_;
+    this->reserve_bytes(num_bytes);
+
+    if (h2d_mode_ == H2DMode::HOST_PUSH) {
+        receiver_core_tlb_->write_block(data_addr, data, num_bytes);
+        tt_driver_atomics::sfence();
+    } else {
+        uint32_t* data_ptr = host_data_buffer_->data() + (write_ptr_ / sizeof(uint32_t));
+        std::memcpy(data_ptr, data, num_bytes);
+    }
+    this->push_bytes(num_bytes);
+    this->notify_receiver();
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -408,13 +408,13 @@ void write_socket_configs(
                 md.read_ptr = local_descriptor.data_buffer_address;
                 md.fifo_addr = local_descriptor.data_buffer_address;
                 md.fifo_total_size = config.socket_mem_config.fifo_size;
-                md.upstream_mesh_id = *upstream_mesh_id;
-                md.upstream_chip_id = upstream_chip_id;
-                md.upstream_noc_y = sender_virtual_core.y;
-                md.upstream_noc_x = sender_virtual_core.x;
-                md.upstream_bytes_acked_addr = peer_config_buf_addr + sender_size.md_size_bytes +
-                                               sender_size.ack_size_bytes * receiver_ids_per_sender.at(connection);
-                md.is_sender = is_sender;
+                md.is_h2d = 0;
+                md.d2d.upstream_mesh_id = *upstream_mesh_id;
+                md.d2d.upstream_chip_id = upstream_chip_id;
+                md.d2d.upstream_noc_y = sender_virtual_core.y;
+                md.d2d.upstream_noc_x = sender_virtual_core.x;
+                md.d2d.upstream_bytes_acked_addr = peer_config_buf_addr + sender_size.md_size_bytes +
+                                                   sender_size.ack_size_bytes * receiver_ids_per_sender.at(connection);
             }
             distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
         }

--- a/tt_metal/hw/inc/api/socket_api.h
+++ b/tt_metal/hw/inc/api/socket_api.h
@@ -26,10 +26,12 @@ constexpr bool always_false = false;
 
 template <typename SocketT>
 void fabric_set_unicast_route(volatile tt_l1_ptr PACKET_HEADER_TYPE* fabric_header_addr, const SocketT& socket) {
+    // Communication over fabric only works for D2D sockets
     if constexpr (std::is_same_v<PACKET_HEADER_TYPE, tt::tt_fabric::HybridMeshPacketHeader>) {
         if constexpr (std::is_same_v<SocketT, sender_downstream_encoding>) {
             fabric_set_unicast_route(fabric_header_addr, socket.downstream_chip_id, socket.downstream_mesh_id);
         } else if constexpr (std::is_same_v<SocketT, SocketReceiverInterface>) {
+            ASSERT(socket.is_h2d == 0);
             fabric_set_unicast_route(fabric_header_addr, socket.d2d.upstream_chip_id, socket.d2d.upstream_mesh_id);
         } else {
             static_assert(always_false<SocketT>, "Unsupported socket type passed to set_fabric_unicast_route");
@@ -38,6 +40,7 @@ void fabric_set_unicast_route(volatile tt_l1_ptr PACKET_HEADER_TYPE* fabric_head
         if constexpr (std::is_same_v<SocketT, sender_downstream_encoding>) {
             fabric_set_unicast_route<false>((LowLatencyPacketHeader*)fabric_header_addr, socket.downstream_chip_id);
         } else if constexpr (std::is_same_v<SocketT, SocketReceiverInterface>) {
+            ASSERT(socket.is_h2d == 0);
             fabric_set_unicast_route<false>((LowLatencyPacketHeader*)fabric_header_addr, socket.d2d.upstream_chip_id);
         } else {
             static_assert(always_false<SocketT>, "Unsupported socket type passed to fabric_set_unicast_route");

--- a/tt_metal/hw/inc/api/socket_api.h
+++ b/tt_metal/hw/inc/api/socket_api.h
@@ -302,9 +302,9 @@ void socket_notify_sender(const SocketReceiverInterface& socket) {
         uint32_t local_bytes_acked_addr = socket.config_addr + offsetof(receiver_socket_md, bytes_acked);
         uint64_t pcie_addr = (static_cast<uint64_t>(socket.h2d.bytes_acked_addr_hi) << 32) |
                              static_cast<uint64_t>(socket.h2d.bytes_acked_addr_lo);
-        noc_write_init_state<0>(NOC_0, NOC_UNICAST_WRITE_VC);
-        noc_wwrite_with_state<DM_DEDICATED_NOC, 0, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
-            NOC_0, local_bytes_acked_addr, socket.h2d.pcie_xy_enc, pcie_addr, 4, 1);
+        noc_write_init_state<write_cmd_buf>(noc_index, NOC_UNICAST_WRITE_VC);
+        noc_wwrite_with_state<DM_DEDICATED_NOC, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+            noc_index, local_bytes_acked_addr, socket.h2d.pcie_xy_enc, pcie_addr, sizeof(socket.bytes_acked));
     } else {
         auto upstream_bytes_acked_noc_addr =
             get_noc_addr(socket.d2d.upstream_noc_x, socket.d2d.upstream_noc_y, socket.d2d.upstream_bytes_acked_addr);

--- a/tt_metal/hw/inc/hostdev/socket.h
+++ b/tt_metal/hw/inc/hostdev/socket.h
@@ -31,22 +31,50 @@ struct sender_socket_md {
 // sender_downstream_encoding[num_downstreams]
 
 // Config Buffer on Receiver Cores will be populated as follows
+
+struct h2d_socket_md {
+    uint32_t bytes_acked_addr_lo;
+    uint32_t bytes_acked_addr_hi;
+    uint32_t data_addr_lo;
+    uint32_t data_addr_hi;
+    uint32_t pcie_xy_enc;
+};
+
+struct d2d_socket_md {
+    uint32_t upstream_mesh_id;
+    uint32_t upstream_chip_id;
+    uint32_t upstream_noc_y;
+    uint32_t upstream_noc_x;
+    uint32_t upstream_bytes_acked_addr;
+};
+
 struct receiver_socket_md {
-    // Standard Config Entries
-    uint32_t bytes_sent = 0;
-    uint32_t bytes_acked = 0;
-    uint32_t read_ptr = 0;
-    uint32_t fifo_addr = 0;
-    uint32_t fifo_total_size = 0;
+    uint32_t bytes_sent;
+    uint32_t read_ptr;
+    uint32_t fifo_addr;
+    uint32_t fifo_total_size;
+    uint32_t bytes_acked;
+    uint32_t is_h2d;
+    union {
+        h2d_socket_md h2d;
+        d2d_socket_md d2d;
+    } __attribute__((packed));
+};
 
-    // Upstream Socket Metadata
-    uint32_t upstream_mesh_id = 0;
-    uint32_t upstream_chip_id = 0;
-    uint32_t upstream_noc_y = 0;
-    uint32_t upstream_noc_x = 0;
-    uint32_t upstream_bytes_acked_addr = 0;
+struct H2DSocketInterface {
+    uint32_t bytes_acked_addr_lo;
+    uint32_t bytes_acked_addr_hi;
+    uint32_t data_addr_lo;
+    uint32_t data_addr_hi;
+    uint32_t pcie_xy_enc;
+};
 
-    uint32_t is_sender = 0;
+struct D2DSocketInterface {
+    uint32_t upstream_mesh_id;
+    uint32_t upstream_chip_id;
+    uint32_t upstream_noc_y;
+    uint32_t upstream_noc_x;
+    uint32_t upstream_bytes_acked_addr;
 };
 
 struct SocketSenderInterface {
@@ -72,11 +100,9 @@ struct SocketReceiverInterface {
     uint32_t fifo_addr;
     uint32_t fifo_total_size;
     uint32_t fifo_curr_size;
-
-    // Upstream Socket Metadata
-    uint32_t upstream_mesh_id;
-    uint32_t upstream_chip_id;
-    uint32_t upstream_noc_y;
-    uint32_t upstream_noc_x;
-    uint32_t upstream_bytes_acked_addr;
+    uint32_t is_h2d;
+    union {
+        H2DSocketInterface h2d;
+        D2DSocketInterface d2d;
+    } __attribute__((packed));
 };


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34274

### Problem description
- Existing Socket APIs only enable Device to Device data movement and flow control over NOC or Fabric
- Applications such as Blitz Decode, require host to stream data directly to worker cores without multiple intermediate data-copies
- These applications need a dedicated mechanism & API for direct host-to-device communication with proper flow control

### What's changed
**Host Changes**
- Added `H2DSocket` for streaming data host data directly to worker cores. Two transfer modes currently supported:
   - `HOST_PUSH`: Host writes data directly to device L1 via Static TLB-mapped PCIe writes
   - `DEVICE_PULL`: Host writes to pinned memory and device pulls via PCIe NOC reads
- Both modes require vIOMMU to be enabled, since the D -> H ack is written to NOC Mapped Memory on host. Additional variants of this mechanism bypassing vIOMMU can be built in future
- API Spec for `H2DSocket` and the basic flow control mechanism is provided in `tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp`

**Device Changes**
- `receiver_socket_md` and `SocketReceiverInterface` in `socket.h` and now use a union to support both H2D and D2D configurations
- `is_h2d` flag in struct toggles whether to use `h2d_socket_md` or `d2d_socket_md`
- `socket_notify_sender()` handles H2D acknowledgement via PCIe NOC writes to pinned host memory

**TODO: Perf Characterization for the 2 Modes, Data and Packet Sizes**
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/H2D_Sockets)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/H2D_Sockets)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/H2D_Sockets)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/H2D_Sockets)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/H2D_Sockets)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/H2D_Sockets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/H2D_Sockets)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
