### PR TITLE
Fix non-deterministic pytest test collection in ttnn unit tests

### DIFF
--- a/tests/ttnn/conftest.py
+++ b/tests/ttnn/conftest.py
@@ -26,6 +26,13 @@ def pytest_addoption(parser):
 def pytest_make_parametrize_id(config, val, argname):
     if isinstance(val, ModuleType):
         val = val.__name__
+    # Handle FastOperation objects to avoid memory addresses in test IDs
+    # This ensures deterministic test names for pytest-xdist compatibility
+    elif hasattr(val, "python_fully_qualified_name"):
+        val = val.python_fully_qualified_name
+    # Handle TensorSpec objects - create deterministic ID from shape/dtype/layout
+    elif type(val).__name__ == "TensorSpec":
+        val = f"TensorSpec({val.shape},{val.dtype},{val.layout})"
     return f"{argname}={val}"
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_init.py
@@ -116,7 +116,7 @@ def test_binary_comp_opt_out(input_shapes, out_dtype, mem_configs, ttnn_function
 )
 @pytest.mark.parametrize(
     "scalar",
-    {2.3, 15.6, 55.4, 72.5, 120.6},
+    (2.3, 15.6, 55.4, 72.5, 120.6),
 )
 @pytest.mark.parametrize("out_dtype", (ttnn.uint32, ttnn.uint16))
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -407,18 +407,15 @@ def test_shape_remainder(device, shapes):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_remainder_ttnn(input_shapes, scalar, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
-    output_tensor = ttnn.remainder(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.remainder)
-    golden_tensor = golden_function(in_data1, scalar, device=device)
+def test_remainder_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+        output_tensor = ttnn.remainder(input_tensor1, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.remainder)
+        golden_tensor = golden_function(in_data1, scalar, device=device)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -471,19 +468,16 @@ def test_binary_fmod_decimal_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_fmod_ttnn(input_shapes, scalar, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+def test_fmod_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
 
-    output_tensor = ttnn.fmod(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.fmod)
-    golden_tensor = golden_function(in_data1, scalar, device=device)
+        output_tensor = ttnn.fmod(input_tensor1, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.fmod)
+        golden_tensor = golden_function(in_data1, scalar, device=device)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_pcc([output_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -650,18 +644,15 @@ def test_binary_gti_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_gti_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.gt_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.gt_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_gti_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.gt_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.gt_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -691,18 +682,15 @@ def test_binary_gei_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_gei_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.ge_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.ge_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_gei_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.ge_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.ge_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -732,18 +720,15 @@ def test_binary_lti_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_lti_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.lt_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.lt_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_lti_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.lt_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.lt_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -773,18 +758,15 @@ def test_binary_lei_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_lei_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.le_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.le_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_lei_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.le_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.le_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -814,18 +796,15 @@ def test_binary_eqi_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_eqi_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.eq_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.eq_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_eqi_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.eq_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.eq_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -855,18 +834,15 @@ def test_binary_nei_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(-100, 100) + 0.5 for _ in range(5)},
-)
-def test_nei_ttnn(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    ttnn.ne_(input_tensor, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.ne_)
-    golden_tensor = golden_function(in_data, scalar)
+def test_nei_ttnn(input_shapes, device):
+    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
+        in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+        ttnn.ne_(input_tensor, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.ne_)
+        golden_tensor = golden_function(in_data, scalar)
 
-    comp_pass = compare_equal([input_tensor], [golden_tensor])
-    assert comp_pass
+        comp_pass = compare_equal([input_tensor], [golden_tensor])
+        assert comp_pass, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -913,7 +889,7 @@ def test_binary_prelu_ttnn(input_shapes, device):
 )
 @pytest.mark.parametrize(
     "scalar",
-    {-0.25, -2.7, 0.45, 6.4},
+    (-2.7, -0.25, 0.45, 6.4),
 )
 def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
@@ -1022,22 +998,19 @@ def test_binary_right_shift(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(0, 31)},
-)
-def test_unary_left_shift(input_shapes, device, scalar):
-    torch.manual_seed(213919)
-    in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+def test_unary_left_shift(input_shapes, device):
+    for scalar in [random.randint(0, 31) for _ in range(5)]:
+        torch.manual_seed(213919)
+        in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
+        input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.bitwise_left_shift(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.bitwise_left_shift)
-    golden_tensor = golden_function(in_data1, scalar)
-    output_tensor = ttnn.to_torch(output_tensor)
+        output_tensor = ttnn.bitwise_left_shift(input_tensor1, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.bitwise_left_shift)
+        golden_tensor = golden_function(in_data1, scalar)
+        output_tensor = ttnn.to_torch(output_tensor)
 
-    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
-    assert pcc >= 0.99
+        pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+        assert pcc >= 0.99, f"Failed for scalar={scalar}"
 
 
 @pytest.mark.parametrize(
@@ -1049,19 +1022,16 @@ def test_unary_left_shift(input_shapes, device, scalar):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {random.randint(0, 31)},
-)
-def test_unary_right_shift(input_shapes, device, scalar):
-    torch.manual_seed(213919)
-    in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+def test_unary_right_shift(input_shapes, device):
+    for scalar in [random.randint(0, 31) for _ in range(5)]:
+        torch.manual_seed(213919)
+        in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
+        input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.bitwise_right_shift(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.bitwise_right_shift)
-    golden_tensor = golden_function(in_data1, scalar)
-    output_tensor = ttnn.to_torch(output_tensor)
+        output_tensor = ttnn.bitwise_right_shift(input_tensor1, scalar)
+        golden_function = ttnn.get_golden_function(ttnn.bitwise_right_shift)
+        golden_tensor = golden_function(in_data1, scalar)
+        output_tensor = ttnn.to_torch(output_tensor)
 
-    pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
-    assert pcc >= 0.99
+        pcc = ttnn.pearson_correlation_coefficient(golden_tensor, output_tensor)
+        assert pcc >= 0.99, f"Failed for scalar={scalar}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1073,7 +1073,7 @@ def test_unary_atanh_ttnn(input_shapes, torch_dtype, ttnn_dtype, low, high, devi
 )
 @pytest.mark.parametrize(
     "param",
-    {0.65, 7.7, 36.49, 58.6, 97.2},
+    (0.65, 7.7, 36.49, 58.6, 97.2),
 )
 @pytest.mark.parametrize(
     "ttnn_function",
@@ -1103,7 +1103,7 @@ def test_unary_shrink_functions_ttnn(input_shapes, param, torch_dtype, ttnn_dtyp
 )
 @pytest.mark.parametrize(
     "param",
-    {7.0, 36.49, 58.5, 97.2},
+    (7.0, 36.49, 58.5, 97.2),
 )
 @pytest.mark.parametrize(
     "ttnn_function",
@@ -1131,7 +1131,7 @@ def test_unary_shrink_functions_bf8b_ttnn(input_shapes, param, ttnn_function, de
 )
 @pytest.mark.parametrize(
     "param",
-    {0.45, 7.7, 197.2, 1e5},
+    (0.45, 7.7, 197.2, 1e5),
 )
 @pytest.mark.parametrize(
     "ttnn_function",
@@ -1911,7 +1911,7 @@ def test_unary_root_ops_ttnn(input_shapes, torch_dtype, ttnn_dtype, ttnn_op, fas
 
 @pytest.mark.parametrize(
     "param",
-    {-1.5, 1.7, 0.0},
+    (-1.5, 0.0, 1.7),
 )
 @pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
 def test_unary_rdiv_inf_nan_check(param, rounding_mode, device):
@@ -1944,7 +1944,7 @@ def test_unary_rdiv_inf_nan_check(param, rounding_mode, device):
 )
 @pytest.mark.parametrize(
     "param",
-    {-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9},
+    (-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9),
 )
 @pytest.mark.parametrize(
     "torch_dtype, ttnn_dtype",

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -972,7 +972,7 @@ def test_fill(device, h, w, scalar, torch_dtype, ttnn_dtype):
 )
 @pytest.mark.parametrize(
     "param",
-    {-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9, float("inf"), float("-inf"), float("nan")},
+    (-98.5, -43.7, -8.5, 0.45, 7.7, 58.4, 89.9, float("-inf"), float("inf"), float("nan")),
 )
 def test_unary_celu(input_shapes, param, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)


### PR DESCRIPTION
### Ticket
N/A - Infrastructure improvement

### Problem description
Test collection in `tests/ttnn/unit_tests/` was non-deterministic due to two issues:

1. **Set literals in `@pytest.mark.parametrize`**: Python sets have non-deterministic iteration order across processes, causing `pytest-xdist` workers to disagree on test ordering.

2. **Object memory addresses in test IDs**: `FastOperation` objects (e.g., `ttnn.lt`, `ttnn.gt`) and `TensorSpec` objects include memory addresses in their `__repr__`, which differ across processes.

This breaks:
- **pytest-xdist**: Workers fail with "Different tests were collected between gw0 and gw2"
- **Superset database tracking**: Non-deterministic test names prevent reliable test result tracking

### What's changed

**1. Converted set literals to tuples in parametrize decorators:**
- `test_binary_comp_init.py`: 1 set → tuple
- `test_unary.py`: 5 sets → tuples
- `test_unary_ops_ttnn.py`: 1 set → tuple

**2. Moved randomized scalar parameters inside test functions (test_binary_composite.py):**

Instead of parameterizing with random values (which requires global seeding and causes issues when test order changes), the scalar iteration is now inside the test body:

```python
# Before (non-deterministic test names, requires global seed)
@pytest.mark.parametrize("scalar", tuple(sorted({random.randint(-100, 100) + 0.5 for _ in range(5)})))
def test_gti_ttnn(input_shapes, scalar, device):
    ...

# After (deterministic test name, true randomization each run)
def test_gti_ttnn(input_shapes, device):
    for scalar in [random.randint(-100, 100) + 0.5 for _ in range(5)]:
        ...
        assert comp_pass, f"Failed for scalar={scalar}"
```

This approach:
- ✅ Keeps test names deterministic (for xdist and Superset)
- ✅ Allows true randomization on each test run (better coverage over time)
- ✅ No global `random.seed()` affecting other tests
- ✅ Failure messages include the scalar value for debugging

**3. Enhanced `pytest_make_parametrize_id` hook in `tests/ttnn/conftest.py`:**
- Handle `FastOperation` objects: Use `python_fully_qualified_name` attribute instead of memory address
- Handle `TensorSpec` objects: Generate deterministic ID from shape/dtype/layout

**Before:** `ttnn_function=FastOperation(...object at 0x7f40abea6ab0...)`  
**After:** `ttnn_function=ttnn.lt`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano-fix-ttnn-pytest-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano-fix-ttnn-pytest-determinism)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano-fix-ttnn-pytest-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano-fix-ttnn-pytest-determinism)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano-fix-ttnn-pytest-determinism)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano-fix-ttnn-pytest-determinism)
- [x] New/Existing tests provide coverage for changes
