### PR TITLE
Fix validation_tools test to expect passing RMSNorm metrics

### DIFF
--- a/models/common/tests/test_validation_tools.py
+++ b/models/common/tests/test_validation_tools.py
@@ -158,13 +158,12 @@ def test_validation_rmsnorm_host_and_device(ttnn_mesh_device: ttnn.MeshDevice):
     x2_tt = ttnn.from_torch(x2.unsqueeze(0), device=ttnn_mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     _ = rms_host(x2_tt)
 
-    assert len(registry.results) >= 2
-    # Expect the last two validations to fail max_abs_error and mean_abs_error checks (known issue??)
-    assert not registry.results[0].metrics[Metric.MAX_ABS_ERROR].passed
-    assert not registry.results[1].metrics[Metric.MAX_ABS_ERROR].passed
-    assert not registry.results[2].metrics[Metric.MAX_ABS_ERROR].passed
-    assert not registry.results[2].metrics[Metric.MEAN_ABS_ERROR].passed
-    # Expect the last two validations to pass pcc check
+    assert len(registry.results) >= 3
+    # Expect all validations to pass
+    assert registry.results[0].metrics[Metric.MAX_ABS_ERROR].passed
+    assert registry.results[1].metrics[Metric.MAX_ABS_ERROR].passed
+    assert registry.results[2].metrics[Metric.MAX_ABS_ERROR].passed
+    assert registry.results[2].metrics[Metric.MEAN_ABS_ERROR].passed
     assert registry.results[0].metrics[Metric.PCC].passed
     assert registry.results[1].metrics[Metric.PCC].passed
     assert registry.results[2].metrics[Metric.PCC].passed


### PR DESCRIPTION
## Summary
- Update `test_validation_rmsnorm_host_and_device` assertions to expect passing metrics
- The test previously expected MAX_ABS_ERROR and MEAN_ABS_ERROR to fail (marked as "known issue??")
- RMSNorm implementation now works correctly with 0.0 max_abs_error and 1.0 PCC

## Test plan
- [x] Run `pytest models/common/tests/test_validation_tools.py::test_validation_rmsnorm_host_and_device[1x1]`
- [x] t3k unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/21577847725