### PR TITLE
[Quasar DFB]: Add support for multi-threaded producer/consumer + make blocked consumer use remapper

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
+#include "tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp"
+#include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel.hpp"
+
+namespace tt::tt_metal {
+
+void run_dfb_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, experimental::dfb::DataflowBufferConfig& dfb_config) {
+    Program program = CreateProgram();
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    uint32_t buffer_size = dfb_config.entry_size * dfb_config.num_entries;
+    distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+    auto in_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
+    auto out_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
+
+    log_info(tt::LogTest, "In Buffer: [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
+    log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
+
+    CoreCoord logical_core = CoreCoord(0, 0);
+
+    uint32_t num_entries_per_producer = dfb_config.num_entries / dfb_config.num_producers;
+    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address(), num_entries_per_producer};
+    tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
+    auto producer_kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        logical_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_processors_per_cluster = dfb_config.num_producers, .compile_args = producer_cta});
+
+    uint32_t num_entries_per_consumer = dfb_config.cap == ::experimental::AccessPattern::STRIDED
+                                            ? dfb_config.num_entries / dfb_config.num_consumers
+                                            : dfb_config.num_entries;
+    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address(), num_entries_per_consumer};
+    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
+    auto consumer_kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
+        logical_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_processors_per_cluster = dfb_config.num_consumers, .compile_args = consumer_cta});
+
+    auto producer_quasar = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(
+        program.impl().get_kernel(producer_kernel));
+    auto consumer_quasar = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(
+        program.impl().get_kernel(consumer_kernel));
+    TT_FATAL(producer_quasar && consumer_quasar, "DFB test kernels must be QuasarDataMovementKernel");
+    const auto& producer_dms = producer_quasar->get_dm_processors();
+    const auto& consumer_dms = consumer_quasar->get_dm_processors();
+
+    dfb_config.producer_risc_mask = 0;
+    for (DataMovementProcessor dm : producer_dms) {
+        dfb_config.producer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
+    }
+    dfb_config.consumer_risc_mask = 0;
+    for (DataMovementProcessor dm : consumer_dms) {
+        dfb_config.consumer_risc_mask |= (1u << static_cast<std::underlying_type_t<DataMovementProcessor>>(dm));
+    }
+
+    log_info(
+        tt::LogTest,
+        "Producer risc mask: 0x{:x}. Consumer risc mask: 0x{:x}",
+        dfb_config.producer_risc_mask,
+        dfb_config.consumer_risc_mask);
+
+    /*auto logical_dfb_id = */ experimental::dfb::CreateDataflowBuffer(program, logical_core, dfb_config);
+
+    SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)dfb_config.producer_risc_mask});
+    SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)dfb_config.consumer_risc_mask});
+
+    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, buffer_size / sizeof(uint32_t));
+    distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
+
+    // Execute using slow dispatch (DFBs not yet supported in MeshWorkload path)
+    IDevice* device = mesh_device->get_devices()[0];
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+
+    std::vector<uint32_t> output;
+    distributed::ReadShard(mesh_device->mesh_command_queue(), output, out_buffer, zero_coord, true);
+
+    if (input != output) {
+        log_info(tt::LogTest, "Printing input");
+        for (auto i : input) {
+            std::cout << i << " ";
+        }
+        std::cout << std::endl;
+        log_info(tt::LogTest, "Printing output");
+        for (auto i : output) {
+            std::cout << i << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    EXPECT_EQ(input, output);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx4S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx4S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB2Sx4S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 2,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx2S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 2,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx1B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx2B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 2,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB2Sx4B) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .num_producers = 2,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    run_dfb_program(this->devices_.at(0), config);
+}
+
+}  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -3,7 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <set>
+#include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -17,68 +22,335 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "device_fixture.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
 #include "tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp"
+#include "impl/program/program_impl.hpp"
+#include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {
 
-void run_dfb_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const experimental::dfb::DataflowBufferConfig& dfb_config) {
-    Program program = CreateProgram();
+// These tests create a DFB and validate that the tile counter and remapper config is correct
 
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    uint32_t buffer_size = dfb_config.entry_size * dfb_config.num_entries;
-    distributed::DeviceLocalBufferConfig local_buffer_config{.page_size = buffer_size, .buffer_type = BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
-    auto in_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
-    auto out_buffer = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get());
+// Validation structure for DFB tile counter configuration
+struct DFBTileCounterExpectation {
+    uint8_t expected_producer_tc_count;  // TCs per producer
+    uint8_t expected_consumer_tc_count;  // TCs per consumer
 
-    log_info(tt::LogTest, "In Buffer: [address: {} B, size: {} B]", in_buffer->address(), in_buffer->size());
-    log_info(tt::LogTest, "Out Buffer: [address: {} B, size: {} B]", out_buffer->address(), out_buffer->size());
+    // Map of producer risc_id -> vector of (consumer risc_id, producer_tc_slot, consumer_tc_slot)
+    std::map<uint8_t, std::vector<std::tuple<uint8_t, uint8_t, uint8_t>>> producer_to_consumer_pairings;
+};
 
-    CoreCoord logical_core = CoreCoord(0, 0);
-    /*auto logical_dfb_id = */ experimental::dfb::CreateDataflowBuffer(program, logical_core, dfb_config);
+// Validates DFB tile counter configuration against expected pairings
+void validate_dfb_tile_counters(
+    Program& program,
+    const CoreCoord& logical_core,
+    const experimental::dfb::DataflowBufferConfig& config,
+    const DFBTileCounterExpectation& expectation) {
+    auto dfbs = program.impl().dataflow_buffers_on_core(logical_core);
+    ASSERT_EQ(dfbs.size(), 1) << "Expected exactly 1 DFB on core";
 
-    std::vector<uint32_t> producer_cta = {(uint32_t)in_buffer->address()};
-    tt::tt_metal::TensorAccessorArgs(in_buffer).append_to(producer_cta);
-    /*auto producer_kernel = */ CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
-        logical_core,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = producer_cta});
+    const auto& dfb = dfbs[0];
 
-    std::vector<uint32_t> consumer_cta = {(uint32_t)out_buffer->address()};
-    tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(consumer_cta);
-    /*auto consumer_kernel = */ CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
-        logical_core,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_0, .compile_args = consumer_cta});
+    ASSERT_EQ(dfb->risc_mask, config.producer_risc_mask | config.consumer_risc_mask);
+    ASSERT_EQ(dfb->risc_configs.size(), config.num_producers + config.num_consumers);
 
-    // SetRuntimeArgs(program, producer_kernel, logical_core, {(uint32_t)in_buffer->address()});
-    // SetRuntimeArgs(program, consumer_kernel, logical_core, {(uint32_t)out_buffer->address()});
+    // risc ID to risc config maps
+    std::map<uint8_t, const experimental::dfb::detail::DFBRiscConfig*> producer_configs;
+    std::map<uint8_t, const experimental::dfb::detail::DFBRiscConfig*> consumer_configs;
 
-    auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, buffer_size / sizeof(uint32_t));
-    distributed::WriteShard(mesh_device->mesh_command_queue(), in_buffer, input, zero_coord, true);
+    for (const auto& rc : dfb->risc_configs) {
+        if (rc.is_producer) {
+            producer_configs[rc.risc_id] = &rc;
+        } else {
+            consumer_configs[rc.risc_id] = &rc;
+        }
+    }
 
-    // Execute using slow dispatch (DFBs not yet supported in MeshWorkload path)
-    IDevice* device = mesh_device->get_devices()[0];
-    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+    for (const auto& [risc_id, rc] : producer_configs) {
+        EXPECT_EQ(rc->config.num_tcs_to_rr, expectation.expected_producer_tc_count)
+            << "Producer RISC " << (int)risc_id << " has wrong TC count";
+    }
 
-    std::vector<uint32_t> output;
-    distributed::ReadShard(mesh_device->mesh_command_queue(), output, out_buffer, zero_coord, true);
+    for (const auto& [risc_id, rc] : consumer_configs) {
+        EXPECT_EQ(rc->config.num_tcs_to_rr, expectation.expected_consumer_tc_count)
+            << "Consumer RISC " << (int)risc_id << " has wrong TC count";
+    }
 
-    EXPECT_EQ(input, output);
+    // For BLOCKED mode, validate remapper pair indices
+    if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+        std::set<uint8_t> seen_remapper_indices;
+        for (const auto& [risc_id, rc] : producer_configs) {
+            uint8_t remapper_idx = rc->config.remapper_pair_index;
+
+            // Check valid range (0-63)
+            EXPECT_LT(remapper_idx, 64) << "BLOCKED: Producer RISC " << (int)risc_id
+                                        << " has invalid remapper_pair_index " << (int)remapper_idx
+                                        << " (must be 0-63)";
+
+            // Check uniqueness among producers
+            EXPECT_EQ(seen_remapper_indices.count(remapper_idx), 0)
+                << "BLOCKED: Producer RISC " << (int)risc_id << " has duplicate remapper_pair_index "
+                << (int)remapper_idx;
+            seen_remapper_indices.insert(remapper_idx);
+
+            log_info(tt::LogTest, "BLOCKED: Producer {} has remapper_pair_index {}", risc_id, remapper_idx);
+        }
+    }
+
+    for (const auto& [producer_risc_id, pairings] : expectation.producer_to_consumer_pairings) {
+        auto producer_it = producer_configs.find(producer_risc_id);
+        ASSERT_NE(producer_it, producer_configs.end());
+
+        const auto* producer_rc = producer_it->second;
+
+        // For BLOCKED mode, accumulate expected_consumer_tcs across all pairings for this producer
+        uint32_t expected_consumer_tcs = 0;
+        size_t consumer_idx = 0;
+
+        for (const auto& [consumer_risc_id, producer_tc_slot, consumer_tc_slot] : pairings) {
+            auto consumer_it = consumer_configs.find(consumer_risc_id);
+            ASSERT_NE(consumer_it, consumer_configs.end());
+
+            const auto* consumer_rc = consumer_it->second;
+
+            ASSERT_LT(producer_tc_slot, 4) << "Max of 4 TCs allowed per producer";
+            ASSERT_LT(consumer_tc_slot, 4) << "Max of 4 TCs allowed per consumer";
+
+            auto producer_ptc = producer_rc->config.packed_tile_counter[producer_tc_slot];
+            auto consumer_ptc = consumer_rc->config.packed_tile_counter[consumer_tc_slot];
+
+            if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+                // For BLOCKED mode, consumer TCs are different from producer TC (remapper-based)
+                // Accumulate the consumer TC IDs into expected_consumer_tcs
+                if (consumer_idx < 4) {
+                    uint8_t consumer_tc_id = ::experimental::get_counter_id(consumer_ptc);
+                    expected_consumer_tcs |= (consumer_tc_id & 0x1F) << (consumer_idx * 5);
+                    consumer_idx++;
+                }
+
+                log_info(
+                    tt::LogTest,
+                    "BLOCKED: Producer {} TC[{}]=(tensix:{}, tc:{}) -> Consumer {} TC[{}]=(tensix:{}, tc:{})",
+                    producer_risc_id,
+                    producer_tc_slot,
+                    ::experimental::get_tensix_id(producer_ptc),
+                    ::experimental::get_counter_id(producer_ptc),
+                    consumer_risc_id,
+                    consumer_tc_slot,
+                    ::experimental::get_tensix_id(consumer_ptc),
+                    ::experimental::get_counter_id(consumer_ptc));
+            } else {
+                // For STRIDED mode, producer and consumer should share the exact same TC
+                EXPECT_EQ(producer_ptc, consumer_ptc)
+                    << "STRIDED: Producer " << (int)producer_risc_id << " TC[" << (int)producer_tc_slot
+                    << "] should share TC with Consumer " << (int)consumer_risc_id << " TC[" << (int)consumer_tc_slot
+                    << "]. Producer has (tensix:" << (int)::experimental::get_tensix_id(producer_ptc)
+                    << ", tc:" << (int)::experimental::get_counter_id(producer_ptc)
+                    << "), Consumer has (tensix:" << (int)::experimental::get_tensix_id(consumer_ptc)
+                    << ", tc:" << (int)::experimental::get_counter_id(consumer_ptc) << ")";
+
+                log_info(
+                    tt::LogTest,
+                    "STRIDED: Producer {} TC[{}] and Consumer {} TC[{}] share (tensix:{}, tc:{})",
+                    producer_risc_id,
+                    producer_tc_slot,
+                    consumer_risc_id,
+                    consumer_tc_slot,
+                    ::experimental::get_tensix_id(producer_ptc),
+                    ::experimental::get_counter_id(producer_ptc));
+            }
+        }
+
+        if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            uint32_t actual_consumer_tcs = producer_rc->config.consumer_tcs;
+            ASSERT_EQ(actual_consumer_tcs, expected_consumer_tcs)
+                << "BLOCKED: Producer " << (int)producer_risc_id << " consumer_tcs mismatch. "
+                << "Expected: 0x" << std::hex << expected_consumer_tcs << ", Actual: 0x" << actual_consumer_tcs
+                << std::dec;
+
+            log_info(
+                tt::LogTest,
+                "BLOCKED: Producer {} consumer_tcs validated: 0x{:x}",
+                producer_risc_id,
+                actual_consumer_tcs);
+        }
+    }
 }
 
-TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx1S) {
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx4SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x1E,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 4,  // 1 producer with 4 consumers -> 4 TCs per producer
+        .expected_consumer_tc_count = 1,  // Each consumer pairs with 1 producer -> 1 TC per consumer
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {1, 0, 0},  // Producer 0 TC[0] pairs with Consumer risc 1 TC[0]
+                 {2, 1, 0},  // Producer 0 TC[1] pairs with Consumer risc 2 TC[0]
+                 {3, 2, 0},  // Producer 0 TC[2] pairs with Consumer risc 3 TC[0]
+                 {4, 3, 0},  // Producer 0 TC[3] pairs with Consumer risc 4 TC[0]
+             }}}};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx1SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x10,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // Each producer pairs with 1 consumer -> 1 TC per producer
+        .expected_consumer_tc_count = 4,  // 1 consumer with 4 producers -> 4 TCs per consumer
+        .producer_to_consumer_pairings = {
+            {0, {{4, 0, 0}}},  // Producer 0 TC[0] pairs with Consumer risc 4 TC[0]
+            {1, {{4, 0, 1}}},  // Producer 1 TC[0] pairs with Consumer risc 4 TC[1]
+            {2, {{4, 0, 2}}},  // Producer 2 TC[0] pairs with Consumer risc 4 TC[2]
+            {3, {{4, 0, 3}}},  // Producer 3 TC[0] pairs with Consumer risc 4 TC[3]
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx4SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0xF0,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // Equal producers and consumers -> 1 TC per producer
+        .expected_consumer_tc_count = 1,  // Equal producers and consumers -> 1 TC per consumer
+        .producer_to_consumer_pairings = {
+            {0, {{4, 0, 0}}},  // Producer 0 TC[0] pairs with Consumer risc 4 TC[0]
+            {1, {{5, 0, 0}}},  // Producer 1 TC[0] pairs with Consumer risc 5 TC[0]
+            {2, {{6, 0, 0}}},  // Producer 2 TC[0] pairs with Consumer risc 6 TC[0]
+            {3, {{7, 0, 0}}},  // Producer 3 TC[0] pairs with Consumer risc 7 TC[0]
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB2Sx4SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x3,
+        .num_producers = 2,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x3C,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 2,  // 4 consumers / 2 producers = 2 TCs per producer
+        .expected_consumer_tc_count = 1,  // 2 producers / 4 consumers = 1 TC per consumer (min 1)
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {2, 0, 0},  // Producer 0 TC[0] pairs with Consumer risc 2 TC[0]
+                 {4, 1, 0},  // Producer 0 TC[1] pairs with Consumer risc 4 TC[0]
+             }},
+            {1,
+             {
+                 {3, 0, 0},  // Producer 1 TC[0] pairs with Consumer risc 3 TC[0]
+                 {5, 1, 0},  // Producer 1 TC[1] pairs with Consumer risc 5 TC[0]
+             }},
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx2SConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x30,
+        .num_consumers = 2,
+        .cap = ::experimental::AccessPattern::STRIDED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // 2 consumers / 4 producers = 1 TC per producer (min 1)
+        .expected_consumer_tc_count = 2,  // 4 producers / 2 consumers = 2 TCs per consumer
+        .producer_to_consumer_pairings = {
+            {0, {{4, 0, 0}}},  // Producer 0 TC[0] pairs with Consumer risc 4 TC[0]
+            {1, {{5, 0, 0}}},  // Producer 1 TC[0] pairs with Consumer risc 5 TC[0]
+            {2, {{4, 0, 1}}},  // Producer 2 TC[0] pairs with Consumer risc 4 TC[1]
+            {3, {{5, 0, 1}}},  // Producer 3 TC[0] pairs with Consumer risc 5 TC[1]
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx1BConfig) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
@@ -90,10 +362,237 @@ TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx1S) {
         .pap = ::experimental::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
-        .cap = ::experimental::AccessPattern::STRIDED,
+        .cap = ::experimental::AccessPattern::BLOCKED,
         .enable_implicit_sync = false};
 
-    run_dfb_program(this->devices_.at(0), config);
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 1,  // BLOCKED: each consumer has num_producers TCs = 1
+        .producer_to_consumer_pairings = {
+            {0, {{1, 0, 0}}},  // Producer 0 TC[0] maps to Consumer risc 1 TC[0] via remapper
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB1Sx4BConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x1E,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 1,  // BLOCKED: each consumer has num_producers TCs = 1
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {1, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 1 TC[0] via remapper
+                 {2, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 2 TC[0] via remapper
+                 {3, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 3 TC[0] via remapper
+                 {4, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 4 TC[0] via remapper
+             }}}};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx1BConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x10,
+        .num_consumers = 1,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 4,  // BLOCKED: each consumer has num_producers TCs = 4
+        .producer_to_consumer_pairings = {
+            {0, {{4, 0, 0}}},  // Producer 0 TC[0] maps to Consumer risc 4 TC[0] via remapper
+            {1, {{4, 0, 1}}},  // Producer 1 TC[0] maps to Consumer risc 4 TC[1] via remapper
+            {2, {{4, 0, 2}}},  // Producer 2 TC[0] maps to Consumer risc 4 TC[2] via remapper
+            {3, {{4, 0, 3}}},  // Producer 3 TC[0] maps to Consumer risc 4 TC[3] via remapper
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx4BConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0xF0,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 4,  // BLOCKED: each consumer has num_producers TCs = 4
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {4, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 4 TC[0]
+                 {5, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 5 TC[0]
+                 {6, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 6 TC[0]
+                 {7, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 7 TC[0]
+             }},
+            {1,
+             {
+                 {4, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 4 TC[1]
+                 {5, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 5 TC[1]
+                 {6, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 6 TC[1]
+                 {7, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 7 TC[1]
+             }},
+            {2,
+             {
+                 {4, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 4 TC[2]
+                 {5, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 5 TC[2]
+                 {6, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 6 TC[2]
+                 {7, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 7 TC[2]
+             }},
+            {3,
+             {
+                 {4, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 4 TC[3]
+                 {5, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 5 TC[3]
+                 {6, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 6 TC[3]
+                 {7, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 7 TC[3]
+             }},
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+TEST_F(MeshDeviceFixture, TensixTest1xDFB4Sx2BConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0xF,
+        .num_producers = 4,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x30,
+        .num_consumers = 2,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 4,  // BLOCKED: each consumer has num_producers TCs = 4
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {4, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 4 TC[0]
+                 {5, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 5 TC[0]
+             }},
+            {1,
+             {
+                 {4, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 4 TC[1]
+                 {5, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 5 TC[1]
+             }},
+            {2,
+             {
+                 {4, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 4 TC[2]
+                 {5, 0, 2},  // Producer 2 TC[0] maps to Consumer risc 5 TC[2]
+             }},
+            {3,
+             {
+                 {4, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 4 TC[3]
+                 {5, 0, 3},  // Producer 3 TC[0] maps to Consumer risc 5 TC[3]
+             }},
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
+}
+
+// 2S x 4B: 2 producers (riscs 0,1) with 4 blocked consumers (riscs 2,3,4,5)
+// Each producer has 1 TC, each consumer has 2 TCs (num_producers TCs)
+// BLOCKED: Each consumer's TC[i] pairs with producer[i]
+TEST_F(MeshDeviceFixture, TensixTest1xDFB2Sx4BConfig) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x3,
+        .num_producers = 2,
+        .pap = ::experimental::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x3C,
+        .num_consumers = 4,
+        .cap = ::experimental::AccessPattern::BLOCKED,
+        .enable_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+
+    // consumer_risc_mask 0x3C = riscs 2,3,4,5
+    DFBTileCounterExpectation expectation{
+        .expected_producer_tc_count = 1,  // BLOCKED: each producer has 1 TC
+        .expected_consumer_tc_count = 2,  // BLOCKED: each consumer has num_producers TCs = 2
+        .producer_to_consumer_pairings = {
+            {0,
+             {
+                 {2, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 2 TC[0]
+                 {3, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 3 TC[0]
+                 {4, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 4 TC[0]
+                 {5, 0, 0},  // Producer 0 TC[0] maps to Consumer risc 5 TC[0]
+             }},
+            {1,
+             {
+                 {2, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 2 TC[1]
+                 {3, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 3 TC[1]
+                 {4, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 4 TC[1]
+                 {5, 0, 1},  // Producer 1 TC[0] maps to Consumer risc 5 TC[1]
+             }},
+        }};
+
+    validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -18,6 +18,7 @@ set(UNIT_TESTS_API_SOURCES
     core_coord/test_CoreRangeSet_contains.cpp
     core_coord/test_CoreRangeSet_intersects.cpp
     core_coord/test_CoreRangeSet_merge.cpp
+    dataflow_buffer/test_dataflow_buffer.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
     tensor/test_tensor_sharding.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -9,19 +9,37 @@
 
 void kernel_main() {
     const uint32_t dst_addr_base = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
+    const uint32_t num_entries_per_consumer = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+
+    uint32_t consumer_mask = get_arg_val<uint32_t>(0);
+    const uint32_t num_consumers = static_cast<uint32_t>(__builtin_popcount(consumer_mask));
 
     experimental::DataflowBuffer dfb(0);
     experimental::Noc noc;
+
+    std::uint64_t hartid;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    uint32_t consumer_idx = static_cast<uint32_t>(__builtin_popcount(consumer_mask & ((1u << hartid) - 1u)));
+
+    // DPRINT << "consumer_idx: " << consumer_idx << " num_entries_per_consumer: " << num_entries_per_consumer <<
+    // ENDL();
 
     // uint32_t dst_addr_base = get_arg_val<uint32_t>(0);
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(dst_args, dst_addr_base, entry_size);
 
-    for (uint32_t tile_id = 0; tile_id < 16; tile_id++) {
+    for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
+        // DPRINT << "wfw" << ENDL();
         dfb.wait_front(1);
-        noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = tile_id});
+        // in blocked case maybe each consumer can modify the data so host knows that each have consumed it
+        // DPRINT << "wfd" << ENDL();
+        // DPRINT << "consumer tile id " << tile_id << " page id " << ((tile_id * num_consumers) + consumer_idx) <<
+        // ENDL();
+        noc.async_write(dfb, tensor_accessor, entry_size, {}, {.page_id = tile_id * num_consumers + consumer_idx});
+        // DPRINT << "pfw" << ENDL();
         dfb.pop_front(1);
+        // DPRINT << "pfd" << ENDL();
     }
     noc.async_write_barrier();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -9,20 +9,38 @@
 
 void kernel_main() {
     const uint32_t src_addr_base = get_compile_time_arg_val(0);
-    constexpr auto src_args = TensorAccessorArgs<1>();
+    const uint32_t num_entries_per_producer = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+
+    uint32_t producer_mask = get_arg_val<uint32_t>(0);
+    const uint32_t num_producers = static_cast<uint32_t>(__builtin_popcount(producer_mask));
 
     experimental::DataflowBuffer dfb(0);
     experimental::Noc noc;
 
-    // uint32_t src_addr_base = get_arg_val<uint32_t>(0);
+    // kinda weird to do this to get the producer idx
+    std::uint64_t hartid;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    uint32_t producer_idx = static_cast<uint32_t>(__builtin_popcount(producer_mask & ((1u << hartid) - 1u)));
+
+    // DPRINT << "producer_idx: " << producer_idx << " num_entries_per_producer: " << num_entries_per_producer <<
+    // ENDL();
+
     uint32_t entry_size = dfb.get_entry_size();
     const auto tensor_accessor = TensorAccessor(src_args, src_addr_base, entry_size);
 
-    for (uint32_t tile_id = 0; tile_id < 16; tile_id++) {
+    for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
+        // DPRINT << "rbw" << ENDL();
         dfb.reserve_back(1);
-        noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id}, {});
+        // DPRINT << "rbd" << ENDL();
+        // DPRINT << "rdi" << ENDL();
+        // DPRINT << "producer tile id " << tile_id << " page id " << ((tile_id * num_producers) + producer_idx) <<
+        // ENDL();
+        noc.async_read(tensor_accessor, dfb, entry_size, {.page_id = tile_id * num_producers + producer_idx}, {});
         noc.async_read_barrier();
+        // DPRINT << "rdd" << ENDL();
         dfb.push_back(1);
+        // DPRINT << "pbd" << ENDL();
     }
     dfb.finish();
 }

--- a/tt_metal/experimental/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/experimental/dataflow_buffer/dataflow_buffer.cpp
@@ -26,27 +26,83 @@ uint32_t CreateDataflowBuffer(
 namespace detail {
 
 ::experimental::PackedTileCounter TileCounterAllocator::allocate(uint8_t tensix_id) {
-    // 16 exposed to overlay
-    // TODO: Update for remapper
-    TT_FATAL(next_tc_id_ < 16, "Out of tile counters for tensix {}", (uint32_t)tensix_id);
-    uint8_t tc_id = next_tc_id_++;
-    return static_cast<::experimental::PackedTileCounter>((tensix_id << 5) | tc_id);
+    TT_FATAL(tensix_id < ::experimental::NUM_TENSIX, "Invalid tensix_id: {}", tensix_id);
+    TT_FATAL(
+        next_tc_id_[tensix_id] < ::experimental::NUM_TENSIX_TILE_COUNTERS_FOR_DM,
+        "Out of tile counters for tensix {}",
+        tensix_id);
+    uint8_t tc_id = next_tc_id_[tensix_id]++;
+    return static_cast<::experimental::PackedTileCounter>(
+        (tensix_id << ::experimental::PACKED_TC_COUNTER_ID_BITS) | tc_id);
 }
+
+uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
+    uint8_t idx = next_index_[core_coord]++;
+    TT_FATAL(
+        idx < ::experimental::NUM_REMAPPER_PAIRINGS,
+        "Out of remapper pairs for core ({}, {})",
+        core_coord.x,
+        core_coord.y);
+    return idx;
+}
+
+void RemapperIndexAllocator::reset() { next_index_.clear(); }
 
 uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
     if (config.cap == ::experimental::AccessPattern::BLOCKED) {
-        return is_producer ? config.num_consumers : 1;
+        return is_producer ? 1 : config.num_producers;
     }
-    return (config.num_consumers + config.num_producers - 1) / config.num_producers;
+    // Strided mode:
+    // Producer: num_consumers / num_producers (number of consumers each producer is paired with)
+    // Consumer: num_producers / num_consumers (number of producers each consumer is paired with)
+    // When the ratio is < 1, use 1 (each pairs with exactly one of the other)
+    if (is_producer) {
+        if (config.num_consumers >= config.num_producers) {
+            TT_FATAL(
+                config.num_consumers % config.num_producers == 0,
+                "num_consumers {} must be divisible by num_producers {} for strided producer",
+                config.num_consumers,
+                config.num_producers);
+            return config.num_consumers / config.num_producers;
+        }
+        // More producers than consumers: each producer pairs with 1 consumer
+        return 1;
+    }
+
+    if (config.num_producers >= config.num_consumers) {
+        TT_FATAL(
+            config.num_producers % config.num_consumers == 0,
+            "num_producers {} must be divisible by num_consumers {} for strided consumer",
+            config.num_producers,
+            config.num_consumers);
+        return config.num_producers / config.num_consumers;
+    }
+    // More consumers than producers: each consumer pairs with 1 producer
+    return 1;
 }
 
-::experimental::PackedTileCounter get_shared_tc_for_consumer(
-    const DataflowBufferImpl* dfb, uint8_t consumer_idx, uint8_t tc_idx) {
-    // In strided mode, consumers share TCs with producers (unless remapper is used and we have diff 1:1 remappings)
-    // TODO: this needs to be updated when remapper is added
-    uint8_t producer_idx = (consumer_idx * dfb->config.num_producers) / dfb->config.num_consumers;
-    return dfb->risc_configs[producer_idx].config.packed_tile_counter[tc_idx];
+// Extract tensix IDs from risc_mask (bits 8-11)
+// Returns vector of tensix_ids (0-3) that are being used
+std::vector<uint8_t> extract_tensix_ids(uint16_t risc_mask) {
+    std::vector<uint8_t> tensix_ids;
+    uint16_t tensix_mask = (risc_mask >> 8) & 0x0F;  // bits 8-11
+    for (uint8_t i = 0; i < ::experimental::NUM_TENSIX; i++) {
+        if (tensix_mask & (1 << i)) {
+            tensix_ids.push_back(i);
+        }
+    }
+    return tensix_ids;
 }
+
+// Get tensix_id for allocation when only DM RISCs are used
+// Round-robins through 0-3 based on pair index
+uint8_t get_dm_tensix_id_for_pair(uint8_t pair_index) { return pair_index % 4; }
+
+// Holds tile counters allocated together for a producer-consumer group
+struct TileCounterGroup {
+    ::experimental::PackedTileCounter producer_tc{};
+    std::vector<::experimental::PackedTileCounter> consumer_tcs;
+};
 
 uint32_t DataflowBufferImpl::serialized_size() const {
     // One dfb_initializer_t + one dfb_initializer_per_risc_t per risc
@@ -67,13 +123,13 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
     init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
     init.risc_mask_bits.reserved = 0;
     init.risc_mask_bits.tc_initialized = 0;  // set by device after init
-    init.remapper_pair_index = this->remapper_pair_index;
     init.num_txn_ids = this->num_txn_ids;
     for (int i = 0; i < 4; i++) {
         init.txn_ids[i] = this->txn_ids[i];
     }
     init.num_entries_per_txn_id = this->num_entries_per_txn_id;
     init.num_entries_per_txn_id_per_tc = this->num_entries_per_txn_id_per_tc;
+    init.remapper_consumer_mask = this->remapper_consumer_mask;
 
     log_info(
         tt::LogMetal,
@@ -83,29 +139,46 @@ std::vector<uint8_t> DataflowBufferImpl::serialize() const {
         this->config.num_consumers,
         this->risc_mask);
 
+    log_info(tt::LogMetal, "Entry size: {}", this->entry_size);
+    log_info(tt::LogMetal, "Stride size: {}", this->stride_size);
+    log_info(tt::LogMetal, "Capacity: {}", this->capacity);
+    log_info(tt::LogMetal, "Risc mask: 0x{:x}", this->risc_mask);
+    log_info(tt::LogMetal, "Num txn ids: {}", this->num_txn_ids);
+    for (int i = 0; i < ::experimental::NUM_TXN_IDS; i++) {
+        log_info(tt::LogMetal, "Txn id {}: {}", i, this->txn_ids[i]);
+    }
+    log_info(tt::LogMetal, "Num entries per txn id: {}", this->num_entries_per_txn_id);
+    log_info(tt::LogMetal, "Num entries per txn id per tc: {}", this->num_entries_per_txn_id_per_tc);
+    log_info(tt::LogMetal, "Remapper consumer mask: 0x{:x}", this->remapper_consumer_mask);
+
     const auto* init_bytes = reinterpret_cast<const uint8_t*>(&init);
     data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
 
     // Write one dfb_initializer_per_risc_t per risc
     for (const auto& rc : risc_configs) {
+        log_info(tt::LogMetal, "New risc config");
         ::experimental::dfb_initializer_per_risc_t per_risc = {};
 
         // Copy per-risc arrays
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < ::experimental::MAX_NUM_TILE_COUNTERS_TO_RR; i++) {
             per_risc.base_addr[i] = rc.config.base_addr[i];
             per_risc.limit[i] = rc.config.limit[i];
             per_risc.packed_tile_counter[i] = rc.config.packed_tile_counter[i];
+            log_info(tt::LogMetal, "Base addr {}: {}", i, static_cast<uint32_t>(per_risc.base_addr[i]));
+            log_info(tt::LogMetal, "Limit {}: {}", i, static_cast<uint32_t>(per_risc.limit[i]));
+            log_info(tt::LogMetal, "Packed tile counter {}: {}", i, (uint32_t)per_risc.packed_tile_counter[i]);
         }
         per_risc.num_tcs_to_rr = rc.config.num_tcs_to_rr;
-        per_risc.should_init_tc = rc.config.should_init_tc ? 1 : 0;
-
-        log_info(
-            tt::LogMetal,
-            "\tRisc {}: base_addr[0]={}, limit[0]={}, num_tcs_to_rr={}",
-            rc.risc_id,
-            rc.config.base_addr[0],
-            rc.config.limit[0],
-            rc.config.num_tcs_to_rr);
+        log_info(tt::LogMetal, "Num tcs to rr: {}", per_risc.num_tcs_to_rr);
+        per_risc.flags.remapper_pair_index = static_cast<uint8_t>(rc.config.remapper_pair_index) & 0x3F;
+        per_risc.flags.remapper_en =
+            this->config.cap ==
+            ::experimental::AccessPattern::BLOCKED;  // TODO: update this when there is 1 consumer to not use remapper
+                                                     // and en when there are multiple dfbs on a core where any use
+                                                     // remapper
+        per_risc.flags.should_init_tc = rc.config.should_init_tc;
+        per_risc.consumer_tcs = rc.config.consumer_tcs;
+        log_info(tt::LogMetal, "Should init tc: {}", rc.config.should_init_tc);
 
         const auto* cfg_bytes = reinterpret_cast<const uint8_t*>(&per_risc);
         data.insert(data.end(), cfg_bytes, cfg_bytes + sizeof(per_risc));
@@ -192,30 +265,27 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     TT_FATAL(
         (config.producer_risc_mask & config.consumer_risc_mask) == 0,
         "producer_risc_mask and consumer_risc_mask must not overlap");
-    TT_FATAL(config.num_producers == 1, "DFB only supports one producer for now");
-    TT_FATAL(config.num_consumers == 1, "DFB only supports one consumer for now");
     TT_FATAL(config.pap != ::experimental::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
-    TT_FATAL(config.cap != ::experimental::AccessPattern::BLOCKED, "Blocked consumer pattern not supported yet");
     TT_FATAL(!config.enable_implicit_sync, "Implicit sync not supported yet");
     TT_FATAL(
         core_range_set.num_cores() == 1,
         "DFB only supports single core, but CoreRangeSet contains {} cores: {}",
         core_range_set.num_cores(),
         core_range_set.str());
+    TT_FATAL(
+        config.cap != ::experimental::AccessPattern::BLOCKED || config.num_consumers <= 4,
+        "Blocked consumer pattern supports at most 4 consumers, but {} were specified",
+        config.num_consumers);
 
     auto dfb = std::make_shared<DataflowBufferImpl>();
 
-    // Assign logical ID (0, 1, 2, ...)
     dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
 
-    // Use risc_mask from config
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;
 
-    // Set shared config fields
     dfb->entry_size = config.entry_size;
-    dfb->stride_size = config.entry_size * std::max(config.num_producers, config.num_consumers);
 
     log_info(
         tt::LogMetal,
@@ -235,6 +305,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
                 config.num_entries,
                 std::max(config.num_producers, config.num_consumers));
             capacity = config.num_entries / std::max(config.num_producers, config.num_consumers);
+            dfb->stride_size = config.entry_size * std::max(config.num_producers, config.num_consumers);
             break;
         case ::experimental::AccessPattern::BLOCKED:
             TT_FATAL(
@@ -243,19 +314,111 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
                 config.num_entries,
                 config.num_producers);
             capacity = config.num_entries / config.num_producers;
+            dfb->stride_size = config.entry_size;
             break;
         default: TT_FATAL(false, "Invalid access pattern", (uint32_t)config.cap);
     }
     dfb->capacity = capacity;
+    log_info(tt::LogMetal, "Capacity: {}", capacity);
+
+    if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+        dfb->remapper_consumer_mask = config.consumer_risc_mask & 0xFF;
+    }
 
     uint8_t num_producer_tcs = calculate_num_tile_counters(config, true);
     uint8_t num_consumer_tcs = calculate_num_tile_counters(config, false);
 
-    // Iterate over producer_risc_mask to create producer risc_configs
+    std::vector<uint8_t> producer_risc_ids;
+    std::vector<uint8_t> consumer_risc_ids;
     for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
-        if (!(config.producer_risc_mask & (1 << risc_id))) {
-            continue;
+        if (config.producer_risc_mask & (1 << risc_id)) {
+            producer_risc_ids.push_back(risc_id);
         }
+        if (config.consumer_risc_mask & (1 << risc_id)) {
+            consumer_risc_ids.push_back(risc_id);
+        }
+    }
+
+    // Extract tensix IDs from risc masks
+    std::vector<uint8_t> producer_tensix_ids = extract_tensix_ids(config.producer_risc_mask);
+    std::vector<uint8_t> consumer_tensix_ids = extract_tensix_ids(config.consumer_risc_mask);
+    bool has_tensix_riscs = !producer_tensix_ids.empty() || !consumer_tensix_ids.empty();
+
+    // Determine tensix_id to use for allocation
+    // If tensix RISCs are used, use those specific tensix_ids
+    // If only DM RISCs, round-robin through 0-3 per producer-consumer pair
+    auto get_tensix_id_for_pair = [&](uint8_t pair_index) -> uint8_t {
+        if (has_tensix_riscs) {
+            // Use tensix_ids from masks, round-robin if multiple
+            std::vector<uint8_t> all_tensix_ids = producer_tensix_ids;
+            all_tensix_ids.insert(all_tensix_ids.end(), consumer_tensix_ids.begin(), consumer_tensix_ids.end());
+            if (all_tensix_ids.empty()) {
+                return get_dm_tensix_id_for_pair(pair_index);
+            }
+            return all_tensix_ids[pair_index % all_tensix_ids.size()];
+        }
+        return get_dm_tensix_id_for_pair(pair_index);
+    };
+
+    std::vector<std::vector<TileCounterGroup>> tc_groups;  // [producer_idx][tc_slot]
+    tc_groups.resize(producer_risc_ids.size());
+
+    // For each producer, allocate TC groups (one per TC slot)
+    for (size_t producer_idx = 0; producer_idx < producer_risc_ids.size(); producer_idx++) {
+        tc_groups[producer_idx].resize(num_producer_tcs);
+
+        for (uint8_t tc_slot = 0; tc_slot < num_producer_tcs; tc_slot++) {
+            TileCounterGroup& group = tc_groups[producer_idx][tc_slot];
+
+            if (config.cap == ::experimental::AccessPattern::STRIDED) {
+                // Determine which consumer(s) this producer TC slot pairs with
+                // Strided pairing: producer N pairs with consumers N, N+num_producers, N+2*num_producers, etc.
+                uint8_t consumer_idx = (producer_idx + tc_slot * producer_risc_ids.size()) % consumer_risc_ids.size();
+
+                // Determine tensix_id based on consumer (all producers pairing with same consumer use same tensix_id)
+                uint8_t tensix_id = get_tensix_id_for_pair(consumer_idx);
+
+                group.producer_tc = tile_counter_allocator_.allocate(tensix_id);
+                group.consumer_tcs.push_back(group.producer_tc);  // Shared TC for strided
+
+                log_info(
+                    tt::LogMetal,
+                    "Strided: Producer[{}] TC[{}] (tensix_id={}) pairs with Consumer[{}]",
+                    producer_idx,
+                    tc_slot,
+                    tensix_id,
+                    consumer_idx);
+            } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+                // Determine tensix_id for this producer TC slot
+                uint8_t tensix_id = get_tensix_id_for_pair((producer_idx * num_producer_tcs) + tc_slot);
+
+                group.producer_tc = tile_counter_allocator_.allocate(tensix_id);
+
+                // Allocate separate consumer TCs for Remapper 1-to-many mapping
+                for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
+                    uint8_t consumer_tensix_id = get_tensix_id_for_pair((producer_idx * num_producer_tcs) + tc_slot);
+                    ::experimental::PackedTileCounter consumer_tc =
+                        tile_counter_allocator_.allocate(consumer_tensix_id);
+                    group.consumer_tcs.push_back(consumer_tc);
+                }
+
+                log_info(
+                    tt::LogMetal,
+                    "Blocked: Producer[{}] TC[{}] (tensix_id={}) maps to {} consumer TCs via Remapper",
+                    producer_idx,
+                    tc_slot,
+                    tensix_id,
+                    group.consumer_tcs.size());
+            } else {
+                TT_FATAL(false, "Unsupported consumer access pattern");
+            }
+        }
+    }
+
+    // Create producer risc_configs and assign TCs from groups
+    CoreCoord core = dfb->core_ranges.ranges()[0].start_coord;
+    for (size_t producer_idx = 0; producer_idx < producer_risc_ids.size(); producer_idx++) {
+        uint8_t risc_id = producer_risc_ids[producer_idx];
 
         DFBRiscConfig risc_config;
         risc_config.risc_id = risc_id;
@@ -264,22 +427,33 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
         log_info(tt::LogMetal, "Producer risc {} uses {} TCs", risc_id, num_producer_tcs);
 
-        // Fill arrays for round-robin TCs
         for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
-            risc_config.config.packed_tile_counter[tc] = tile_counter_allocator_.allocate(risc_id);
-            log_info(tt::LogMetal, "\tAssigned TC[{}]: {}", tc, (uint32_t)risc_config.config.packed_tile_counter[tc]);
+            risc_config.config.packed_tile_counter[tc] = tc_groups[producer_idx][tc].producer_tc;
+            log_info(
+                tt::LogMetal,
+                "\tAssigned TC[{}]: (0x{:x}, 0x{:x})",
+                tc,
+                (uint32_t)::experimental::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
+                (uint32_t)::experimental::get_counter_id(risc_config.config.packed_tile_counter[tc]));
         }
         risc_config.config.num_tcs_to_rr = num_producer_tcs;
+
+        if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+            risc_config.config.remapper_pair_index = remapper_index_allocator_.allocate(core);
+            const TileCounterGroup& group = tc_groups[producer_idx][0];
+            uint32_t packed = 0;
+            for (size_t i = 0; i < group.consumer_tcs.size() && i < ::experimental::MAX_NUM_TILE_COUNTERS_TO_RR; i++) {
+                packed |= (::experimental::get_counter_id(group.consumer_tcs[i]) & 0x1F) << (i * 5);
+            }
+            risc_config.config.consumer_tcs = packed;
+        }
 
         dfb->risc_configs.push_back(risc_config);
     }
 
-    // Iterate over consumer_risc_mask to create consumer risc_configs
-    uint8_t consumer_count = 0;
-    for (uint8_t risc_id = 0; risc_id < 16; risc_id++) {
-        if (!(config.consumer_risc_mask & (1 << risc_id))) {
-            continue;
-        }
+    // Create consumer risc_configs and assign TCs from groups
+    for (size_t consumer_idx = 0; consumer_idx < consumer_risc_ids.size(); consumer_idx++) {
+        uint8_t risc_id = consumer_risc_ids[consumer_idx];
 
         DFBRiscConfig risc_config;
         risc_config.risc_id = risc_id;
@@ -287,18 +461,48 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
         log_info(tt::LogMetal, "Consumer risc {} uses {} TCs", risc_id, num_consumer_tcs);
 
-        // Fill arrays for round-robin TCs
         for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
             if (config.cap == ::experimental::AccessPattern::STRIDED) {
-                risc_config.config.packed_tile_counter[tc] = get_shared_tc_for_consumer(dfb.get(), consumer_count, tc);
-                log_info(
-                    tt::LogMetal, "\tAssigned TC[{}]: {}", tc, (uint32_t)risc_config.config.packed_tile_counter[tc]);
+                // Strided pairing inverse: find which producer pairs with this consumer
+                // Producer pairing: consumer_idx = (producer_idx + tc_slot * num_producers) % num_consumers
+                uint8_t producer_idx;
+                uint8_t producer_tc_slot;
+
+                if (producer_risc_ids.size() > consumer_risc_ids.size()) {
+                    // More producers than consumers: each consumer pairs with multiple producers
+                    // The t-th producer pairing with consumer C is: C + t * num_consumers
+                    producer_idx = consumer_idx + tc * consumer_risc_ids.size();
+                    producer_tc_slot = 0;
+                } else if (consumer_risc_ids.size() > producer_risc_ids.size()) {
+                    // More consumers than producers: each producer pairs with multiple consumers
+                    producer_idx = consumer_idx % producer_risc_ids.size();
+                    producer_tc_slot = consumer_idx / producer_risc_ids.size();
+                } else {
+                    // Equal: 1:1 mapping
+                    producer_idx = consumer_idx;
+                    producer_tc_slot = tc;
+                }
+
+                risc_config.config.packed_tile_counter[tc] = tc_groups[producer_idx][producer_tc_slot].producer_tc;
+            } else if (config.cap == ::experimental::AccessPattern::BLOCKED) {
+                // For blocked mode, each consumer has num_producers TCs, one per producer
+                // The tc-th TC on this consumer pairs with the tc-th producer
+                // Consumer uses its own allocated TC from consumer_tcs, not the producer's TC
+                uint8_t producer_idx = tc;
+                uint8_t producer_tc_slot = 0;
+                risc_config.config.packed_tile_counter[tc] =
+                    tc_groups[producer_idx][producer_tc_slot].consumer_tcs[consumer_idx];
             } else {
-                TT_FATAL(false, "Need to implement blocked consumer access pattern");
+                TT_FATAL(false, "Unsupported consumer access pattern");
             }
+            log_info(
+                tt::LogMetal,
+                "\tAssigned TC[{}]: (0x{:x}, 0x{:x})",
+                tc,
+                (uint32_t)::experimental::get_tensix_id(risc_config.config.packed_tile_counter[tc]),
+                (uint32_t)::experimental::get_counter_id(risc_config.config.packed_tile_counter[tc]));
         }
         risc_config.config.num_tcs_to_rr = num_consumer_tcs;
-        consumer_count++;
 
         dfb->risc_configs.push_back(risc_config);
     }
@@ -366,15 +570,49 @@ void ProgramImpl::allocate_dataflow_buffers(const IDevice* device) {
         }
         dfb->allocated_address = computed_addr;
 
-        // Populate base_addr[] and limit[] arrays for each risc config
+        // Populate base_addr[] and limit[] arrays for each risc config.
+        // Layout is column-major by (tile_counter, producer/consumer): all producers' tc0 first, then all tc1, etc.
         uint32_t entry_size = dfb->config.entry_size;
         uint32_t max_prod_cons = std::max(dfb->config.num_producers, dfb->config.num_consumers);
 
-        for (auto& rc : dfb->risc_configs) {
-            for (uint8_t tc = 0; tc < rc.config.num_tcs_to_rr; tc++) {
-                rc.config.base_addr[tc] = static_cast<uint32_t>(computed_addr) + (tc * entry_size);
+        uint8_t num_producer_tcs = 0;
+        for (const auto& rc : dfb->risc_configs) {
+            if (rc.is_producer) {
+                num_producer_tcs = rc.config.num_tcs_to_rr;
+                break;
+            }
+        }
+        uint32_t base_addr = static_cast<uint32_t>(computed_addr);
+        for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
+            for (auto& rc : dfb->risc_configs) {
+                if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
+                    rc.config.base_addr[tc] = base_addr;
+                    rc.config.limit[tc] =
+                        rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
+                    base_addr += entry_size;
+                }
+            }
+        }
+
+        uint8_t num_consumer_tcs = 0;
+        for (const auto& rc : dfb->risc_configs) {
+            if (!rc.is_producer) {
+                num_consumer_tcs = rc.config.num_tcs_to_rr;
+                break;
+            }
+        }
+        base_addr = static_cast<uint32_t>(computed_addr);
+        for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
+            for (auto& rc : dfb->risc_configs) {
+                if (rc.is_producer) {
+                    continue;
+                }
+                rc.config.base_addr[tc] = base_addr;
                 rc.config.limit[tc] =
                     rc.config.base_addr[tc] + ((entry_size * max_prod_cons) * (dfb->capacity - 1)) + entry_size;
+                if (dfb->config.cap == ::experimental::AccessPattern::STRIDED && tc < rc.config.num_tcs_to_rr) {
+                    base_addr += entry_size;
+                }
             }
         }
     }

--- a/tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -49,7 +50,9 @@ struct LocalDFBInterfaceHost {
     std::array<uint32_t, 4> limit = {0};
     std::array<::experimental::PackedTileCounter, 4> packed_tile_counter = {0};
     uint8_t num_tcs_to_rr = 1;
+    uint8_t remapper_pair_index = 0;
     bool should_init_tc = false;
+    uint32_t consumer_tcs = 0;
 };
 
 struct DFBRiscConfig {
@@ -73,7 +76,7 @@ struct DataflowBufferImpl {
     std::array<uint8_t, 4> txn_ids = {0};
     uint8_t num_entries_per_txn_id = 0;
     uint8_t num_entries_per_txn_id_per_tc = 0;
-    uint8_t remapper_pair_index = 0xFF;
+    uint8_t remapper_consumer_mask = 0;
     uint8_t num_txn_ids = 0;
 
     std::optional<uint32_t> allocated_address;
@@ -86,10 +89,19 @@ struct DataflowBufferImpl {
 class TileCounterAllocator {
 public:
     ::experimental::PackedTileCounter allocate(uint8_t tensix_id);
-    void reset() { next_tc_id_ = 0; }
+    void reset() { next_tc_id_.fill(0); }
 
 private:
-    uint8_t next_tc_id_ = 0;
+    std::array<uint8_t, 4> next_tc_id_ = {0};
+};
+
+class RemapperIndexAllocator {
+public:
+    uint8_t allocate(const CoreCoord& core_coord);
+    void reset();
+
+private:
+    std::unordered_map<CoreCoord, uint8_t> next_index_;
 };
 
 uint32_t finalize_dfbs(

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -52,6 +52,7 @@ tt_l1_ptr subordinate_map_t* const subordinate_sync = (subordinate_map_t*)mailbo
 
 // Definition of the global DFB interface array (declared extern in dataflow_buffer_init.h)
 thread_local ::experimental::LocalDFBInterface g_dfb_interface[32] __attribute__((used));
+RemapperAPI g_remapper_configurator __attribute__((used));
 
 void device_setup() {
     // instn_buf
@@ -282,6 +283,11 @@ extern "C" uint32_t _start1() {
                     noc_local_state_init(noc_index);
                 }
 #endif
+                // Need to ensure that Remapper state is cleared for next kernel launch
+                if (g_remapper_configurator.is_remapper_enabled()) {
+                    g_remapper_configurator.clear_all_pairs();
+                    g_remapper_configurator.disable_remapper();
+                }
 
                 uint32_t go_message_index = mailboxes->go_message_index;
                 mailboxes->go_messages[go_message_index].signal = RUN_MSG_DONE;

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -56,11 +56,13 @@ public:
 #endif
 
         local_dfb_interface.wr_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
+        // DPRINT << "push_back: updated wr_ptr: " << local_dfb_interface.wr_ptr[counter_idx_] << ENDL();
         if (local_dfb_interface.wr_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
             local_dfb_interface.wr_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
         }
 
         counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
+        // DPRINT << "push_back: updated counter_idx: " << (uint32_t)counter_idx_ << ENDL();
     }
 
     void wait_front(uint16_t num_entries) {
@@ -71,6 +73,9 @@ public:
 #error "Not implemented"
 #else
         uint8_t tensix_id = get_tensix_id(packed_tc);
+        // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " <<
+        // static_cast<uint32_t>(tc_id)
+        //        << " occupancy: " << static_cast<uint32_t>(llk_intf_get_occupancy(tensix_id, tc_id)) << ENDL();
         while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
     }
@@ -88,10 +93,12 @@ public:
 #endif
 
         local_dfb_interface.rd_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
+        // DPRINT << "pop_front: updated rd_ptr: " << local_dfb_interface.rd_ptr[counter_idx_] << ENDL();
         if (local_dfb_interface.rd_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
             local_dfb_interface.rd_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
         }
         counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
+        // DPRINT << "pop_front: updated counter_idx: " << (uint32_t)counter_idx_ << ENDL();
     }
     // Explicit sync APIs end
 

--- a/tt_metal/hw/inc/internal/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_init.h
@@ -10,6 +10,7 @@
 #include "internal/circular_buffer_interface.h"  // for cb_addr_shift
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
+#include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
 #endif
 
 #include "api/debug/dprint.h"
@@ -17,6 +18,7 @@
 // Global DFB interface array - defined in firmware, declared here for use by setup functions
 // For kernels (NCRISC/BRISC/TRISC), provide a definition since they're compiled separately
 extern thread_local ::experimental::LocalDFBInterface g_dfb_interface[32];
+extern RemapperAPI g_remapper_configurator;
 
 namespace experimental {
 
@@ -28,6 +30,8 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
     uint32_t num_dfbs =
         local_dfb_mask;  // kernel config holds local_cb_mask but it gets hijacked to hold number of dfbs
     volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+
+    bool enable_remapper = false;  // if remapper used once then needs to be globally set
 
     for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
         // Read dfb_initializer_t (shared config)
@@ -48,38 +52,75 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             // Populate LocalDFBInterface from combined dfb_initializer_t + dfb_initializer_per_risc_t
             LocalDFBInterface& dfb_interface = ::g_dfb_interface[logical_dfb_id];
 
+            // DPRINT << "risc_index: " << static_cast<uint32_t>(risc_index) << ENDL();
+
             // Copy per-risc fields
             for (uint8_t i = 0; i < 4; i++) {
                 dfb_interface.base_addr[i] = per_risc_ptr->base_addr[i] >> cb_addr_shift;
+                // DPRINT << "base_addr[" << static_cast<uint32_t>(i) << "]: " << dfb_interface.base_addr[i] << ENDL();
                 dfb_interface.limit[i] = per_risc_ptr->limit[i] >> cb_addr_shift;
+                // DPRINT << "limit[" << static_cast<uint32_t>(i) << "]: " << dfb_interface.limit[i] << ENDL();
                 dfb_interface.rd_ptr[i] = per_risc_ptr->base_addr[i] >> cb_addr_shift;
+                // DPRINT << "rd_ptr[" << static_cast<uint32_t>(i) << "]: " << dfb_interface.rd_ptr[i] << ENDL();
                 dfb_interface.wr_ptr[i] = per_risc_ptr->base_addr[i] >> cb_addr_shift;
+                // DPRINT << "wr_ptr[" << static_cast<uint32_t>(i) << "]: " << dfb_interface.wr_ptr[i] << ENDL();
                 dfb_interface.packed_tile_counter[i] = per_risc_ptr->packed_tile_counter[i];
+                // DPRINT << "packed_tile_counter[" << static_cast<uint32_t>(i)
+                //        << "]: " << (uint32_t)dfb_interface.packed_tile_counter[i] << ENDL();
             }
             dfb_interface.num_tcs_to_rr = per_risc_ptr->num_tcs_to_rr;
-
+            // DPRINT << "num_tcs_to_rr: " << static_cast<uint32_t>(dfb_interface.num_tcs_to_rr) << ENDL();
             dfb_interface.entry_size = init_ptr->entry_size;
+            // DPRINT << "entry_size: " << static_cast<uint32_t>(dfb_interface.entry_size) << ENDL();
             dfb_interface.stride_size = init_ptr->stride_size;
-            dfb_interface.remapper_pair_index = init_ptr->remapper_pair_index;
+            // DPRINT << "stride_size: " << static_cast<uint32_t>(dfb_interface.stride_size) << ENDL();
+
             dfb_interface.num_txn_ids = init_ptr->num_txn_ids;
-            for (uint8_t i = 0; i < 4; i++) {
+            for (uint8_t i = 0; i < init_ptr->num_txn_ids; i++) {
                 dfb_interface.txn_ids[i] = init_ptr->txn_ids[i];
             }
             dfb_interface.num_entries_per_txn_id = init_ptr->num_entries_per_txn_id;
             dfb_interface.num_entries_per_txn_id_per_tc = init_ptr->num_entries_per_txn_id_per_tc;
 
-#ifndef COMPILE_FOR_TRISC
-            // Initialize TCs - only the RISC marked as responsible should do this
-            if (per_risc_ptr->should_init_tc) {  //
-                for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_to_rr; tc++) {
-                    PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
-                    uint8_t tensix_id = get_tensix_id(ptc);
-                    uint8_t tc_id = get_counter_id(ptc);
+            dfb_interface.remapper_pair_index = per_risc_ptr->flags.remapper_pair_index;
+            // DPRINT << "remapper_pair_index: " << static_cast<uint32_t>(dfb_interface.remapper_pair_index) << ENDL();
 
-                    llk_intf_reset(tensix_id, tc_id);
-                    llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
+#ifndef COMPILE_FOR_TRISC
+            // Configure remapper if needed (must be done before TC init)
+            if (per_risc_ptr->flags.should_init_tc && per_risc_ptr->flags.remapper_en) {
+                if (risc_index == 0) {  // update this
+                    enable_remapper = true;
                 }
-                init_ptr->risc_mask_bits.tc_initialized = 1;
+                uint8_t remapper_consumer_mask = init_ptr->remapper_consumer_mask;
+                uint8_t num_clientRs = __builtin_popcount(remapper_consumer_mask);
+                uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
+                g_remapper_configurator.set_pair_index(dfb_interface.remapper_pair_index);
+                // DPRINT << "Setting clientL fields " << static_cast<uint32_t>(risc_index) << " id: " <<
+                // static_cast<uint32_t>(get_counter_id(per_risc_ptr->packed_tile_counter[0])) << " mask: " <<
+                // static_cast<uint32_t>(clientR_valid_mask) << ENDL();
+                g_remapper_configurator.configure_clientL_all_fields(
+                    risc_index,                                            // id_L
+                    get_counter_id(per_risc_ptr->packed_tile_counter[0]),  // in SxB mode, producers have 1 TC
+                    clientR_valid_mask,
+                    1,  // is_producer
+                    1,  // group mode
+                    0   // distribute mode
+                );
+                // explore each consumer programming their R slot rather than producer doing all
+                for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
+                    uint8_t mask = remapper_consumer_mask;
+                    for (uint8_t i = 0; i < clientR_idx; i++) {
+                        mask &= mask - 1;
+                    }
+                    uint8_t id_R = 4;  //__builtin_ctz(mask);
+                    uint8_t tc_R =
+                        (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;  // TC can be value between 0 and 31
+                    // DPRINT << "Setting clientR slot " << static_cast<uint32_t>(clientR_idx) << " id: " <<
+                    // static_cast<uint32_t>(id_R) << " tc: " << static_cast<uint32_t>(tc_R) << ENDL();
+                    g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
+                }
+                // DPRINT << "Writing all remapper configs" << ENDL();
+                g_remapper_configurator.write_all_configs();
             }
 #endif
         }
@@ -87,6 +128,48 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
         // Jump to next DFB: skip dfb_initializer_t + (num_riscs * dfb_initializer_per_risc_t)
         base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
     }
+
+    // all DFBs were initialized, safe to enable remapper if used
+    if (enable_remapper && hartid == 0) {  // update how one risc enables the remapper
+        // DPRINT << "Enabling remapper" << ENDL();
+        g_remapper_configurator.enable_remapper();
+    }
+
+#ifndef COMPILE_FOR_TRISC
+    // Initialize TCs after remapper is enabled - only the RISC marked as responsible should do this (producer)
+    base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+    for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
+        volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
+        uint16_t risc_mask = init_ptr->risc_mask_bits.dm_mask;
+        uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
+
+        volatile dfb_initializer_per_risc_t* per_risc_base =
+            reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
+
+        if (risc_mask & hart_bit) {
+            uint8_t risc_index = static_cast<uint8_t>(__builtin_popcount(risc_mask & ((1 << hartid) - 1)));
+            volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
+
+            if (per_risc_ptr->flags.should_init_tc) {
+                for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_to_rr; tc++) {
+                    PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
+                    uint8_t tensix_id = get_tensix_id(ptc);
+                    uint8_t tc_id = get_counter_id(ptc);
+
+                    // DPRINT << "initializing tc tensix_id: " << static_cast<uint32_t>(tensix_id)
+                    //        << " tc_id: " << static_cast<uint32_t>(tc_id) << ENDL();
+
+                    llk_intf_reset(tensix_id, tc_id);
+                    llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
+                }
+
+                init_ptr->risc_mask_bits.tc_initialized = 1;
+            }
+        }
+
+        base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
+    }
+#endif
 
     // After setting up g_dfb_interface, wait for all TCs to be initialized
     bool all_tcs_initialized = false;

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -14,14 +14,32 @@ enum AccessPattern : uint8_t {  // this should be put into experimental/hostdev 
     UNKNOWN,
 };
 
-using PackedTileCounter = uint8_t;  // top 2 bits identify tensix id, bottom 5 bits for counter id
+constexpr uint8_t NUM_TENSIX = 4;
+constexpr uint8_t NUM_TILE_COUNTERS_PER_TENSIX = 32;
+constexpr uint8_t NUM_TENSIX_TILE_COUNTERS_FOR_DM = 16;
+constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
+constexpr uint8_t NUM_TXN_IDS = 4;
+constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 4;
+
+using PackedTileCounter = uint8_t;  // bits 5-6: tensix_id (2 bits), bits 0-4: counter_id (5 bits)
+
+// PackedTileCounter bit layout constants
+constexpr uint8_t PACKED_TC_COUNTER_ID_BITS = 5;  // Number of bits for counter_id
+constexpr uint8_t PACKED_TC_COUNTER_ID_MASK =
+    (1 << PACKED_TC_COUNTER_ID_BITS) - 1;                                 // 0x1F - mask for 5-bit counter_id (0-31)
+constexpr uint8_t PACKED_TC_TENSIX_ID_SHIFT = PACKED_TC_COUNTER_ID_BITS;  // 5 - shift to access tensix_id
+constexpr uint8_t PACKED_TC_TENSIX_ID_BITS = 2;                           // Number of bits for tensix_id
+constexpr uint8_t PACKED_TC_TENSIX_ID_MASK =
+    (1 << PACKED_TC_TENSIX_ID_BITS) - 1;  // 0x03 - mask for 2-bit tensix_id (0-3)
 
 // NOLINTBEGIN(readability-redundant-inline-specifier)
-inline __attribute__((always_inline)) constexpr uint8_t get_tensix_id(const PackedTileCounter& p) {
-    return (p >> 5) & 0x03;
+inline __attribute__((always_inline)) constexpr uint8_t get_tensix_id(PackedTileCounter p) {
+    return (p >> PACKED_TC_TENSIX_ID_SHIFT) & PACKED_TC_TENSIX_ID_MASK;
 }
 
-inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(const PackedTileCounter& p) { return p & 0x1F; }
+inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTileCounter p) {
+    return p & PACKED_TC_COUNTER_ID_MASK;
+}
 // NOLINTEND(readability-redundant-inline-specifier)
 
 // move configs and LocalDFBInterface structs to hw/inc/hostdev
@@ -39,7 +57,7 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(const Pac
     | dfb_initializer_per_risc_t | risc 0
     | dfb_initializer_per_risc_t | risc 1
     ...
-    (24 + (40 * 12)) * 16 = 8064 bytes
+    (24 + (44 * 12)) * 16 = 8320 bytes
 */
 struct dfb_initializer_t {  // 24 bytes
     uint32_t logical_id;
@@ -52,19 +70,25 @@ struct dfb_initializer_t {  // 24 bytes
         uint16_t reserved : 3;        // bits 12-14: unused
         uint16_t tc_initialized : 1;  // bit 15: tile counter initialized flag
     } risc_mask_bits;
-    uint8_t remapper_pair_index;
     uint8_t num_txn_ids;
-    uint8_t txn_ids[4];
+    uint8_t txn_ids[NUM_TXN_IDS];
     uint8_t num_entries_per_txn_id;
     uint8_t num_entries_per_txn_id_per_tc;
+    uint8_t remapper_consumer_mask;  // used to program remapper, for a L:R mapping, indicates which riscs make up R
 } __attribute__((packed));
 
-struct dfb_initializer_per_risc_t {  // 40 bytes
-    uint32_t base_addr[4];
-    uint32_t limit[4];
-    PackedTileCounter packed_tile_counter[4];
+struct dfb_initializer_per_risc_t {  // 44 bytes
+    uint32_t base_addr[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t limit[MAX_NUM_TILE_COUNTERS_TO_RR];
+    PackedTileCounter packed_tile_counter[MAX_NUM_TILE_COUNTERS_TO_RR];
     uint8_t num_tcs_to_rr;
-    uint8_t should_init_tc;  // 1 = this RISC should initialize tile counters
+    struct {
+        uint8_t remapper_pair_index : 6;  // bits 0-5: 0..63
+        uint8_t remapper_en : 1;          // bit 6
+        uint8_t should_init_tc : 1;  // bit 7: 1 = this RISC should initialize tile counters and program the remapper
+    } __attribute__((packed)) flags;
+    uint32_t consumer_tcs;  // used to program remapper, for a L:R mapping contains all the TCs on the consumer side
+                            // (R). TC can be value between 0 and 31 (5 bits, max of 4 TCs)
     uint8_t padding[2];
 } __attribute__((packed));
 
@@ -83,21 +107,21 @@ struct dfb_initializer_intra_tensix_t {  // 24 bytes
 
 // on WH/BH arrays will be sized to 1
 struct LocalDFBInterface {
-    uint32_t rd_ptr[4];
-    uint32_t wr_ptr[4];
-    uint32_t base_addr[4];
-    uint32_t limit[4];
+    uint32_t rd_ptr[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t wr_ptr[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t base_addr[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint32_t limit[MAX_NUM_TILE_COUNTERS_TO_RR];
 
     uint32_t entry_size;   // shared across riscs so can be factored out and put into sep initialization struct
     uint32_t stride_size;  // shared across riscs so can be factored out and put into sep initialization struct
 
-    PackedTileCounter packed_tile_counter[4];
-    uint8_t txn_ids[4];  // shared across riscs so can be factored out and put into sep initialization struct
+    PackedTileCounter packed_tile_counter[MAX_NUM_TILE_COUNTERS_TO_RR];
+    uint8_t txn_ids[NUM_TXN_IDS];  // shared across riscs so can be factored out and put into sep initialization struct
     uint8_t
         num_entries_per_txn_id;  // shared across riscs so can be factored out and put into sep initialization struct
     uint8_t num_entries_per_txn_id_per_tc;  // shared across riscs so can be factored out and put into sep
                                             // initialization struct
-    uint8_t remapper_pair_index;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t remapper_pair_index;
     uint8_t num_tcs_to_rr;
     uint8_t num_txn_ids;  // shared across riscs so can be factored out and put into sep initialization struct
 
@@ -117,5 +141,10 @@ struct LocalDFBInterface {
     //     };
     // #endif
 } __attribute__((packed));
+
+static_assert(sizeof(dfb_initializer_t) == 24, "dfb_initializer_t size is incorrect");
+static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
+static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 88, "LocalDFBInterface size is incorrect");
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
@@ -6,9 +6,10 @@
 #ifndef __OVERLAY_ADDRESSES_HPP__
 #define __OVERLAY_ADDRESSES_HPP__
 
-#include <tt_tensix_noc_overlay_reg.h>
-#include <overlay_reg.h>
-#include <noc_config_reg.h>
+#include <cstdint>
+#include "internal/tt-2xx/quasar/noc/tt_tensix_noc_overlay_reg.h"
+#include "internal/tt-2xx/quasar/overlay/meta/registers/overlay_reg.h"
+#include "internal/tt-2xx/quasar/noc/registers/noc_config_reg.h"
 
 #define MEM_PORT_CACHEABLE_BASE_ADDR (uint64_t)MEMORY_PORT_CACHEABLE_MEM_PORT_MEM_BASE_ADDR
 #define MEM_PORT_NONCACHEABLE_BASE_ADDR (uint64_t)MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR
@@ -17,8 +18,8 @@
 #define L2_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_INVALIDATE64_REG_ADDR
 #define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR
 
-#define WRITE_REG32(addr, val) ((*((volatile uint32_t*)(addr))) = (val))
-#define READ_REG32(addr) (*((volatile uint32_t*)(addr)))
+#define WRITE_REG32(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr))) = (val))
+#define READ_REG32(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))
 
 #define WRITE_REG64(addr, val) ((*((volatile uint64_t*)(addr))) = (val))
 #define READ_REG64(addr) (*((volatile uint64_t*)(addr)))

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -36,6 +36,7 @@
 
 #include <cstdint>
 #include "remapper_common.hpp"
+#include "overlay_addresses.h"
 
 /**
  * @brief Generic API for Counter Remapper Configuration
@@ -46,8 +47,8 @@
  */
 class RemapperAPI {
 private:
-    tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS];  // Uninitialized to avoid memset
-    tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS];  // Uninitialized to avoid memset
+    tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
+    tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
     uint32_t current_pair_idx;
 
 public:
@@ -55,13 +56,9 @@ public:
      * @brief Constructor - initializes pair index only
      * @param pair_idx Initial pair index to use (0-63, default 0)
      *
-     * WARNING: Config arrays are left uninitialized to avoid linker issues with memset.
      * User MUST configure registers using set_* methods before calling write_* methods.
      */
-    RemapperAPI(uint32_t pair_idx = 0) : current_pair_idx(pair_idx) {
-        // Arrays intentionally left uninitialized to avoid memset() calls
-        // which cause linker errors with soft-float ABI
-    }
+    constexpr RemapperAPI(uint32_t pair_idx = 0) : current_pair_idx(pair_idx) {}
 
     // ========================================================================
     // Pair Management Methods

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -374,6 +374,8 @@ public:
 
     std::string_view get_linker_opt_level() const override;
 
+    const std::vector<DataMovementProcessor>& get_dm_processors() const { return this->dm_cores_; }
+
 private:
     const QuasarDataMovementConfig config_;
     const std::vector<DataMovementProcessor> dm_cores_;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -381,6 +381,7 @@ private:
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
         dataflow_buffer_by_id_;
     tt::tt_metal::experimental::dfb::detail::TileCounterAllocator tile_counter_allocator_;
+    tt::tt_metal::experimental::dfb::detail::RemapperIndexAllocator remapper_index_allocator_;
     std::unordered_map<CoreCoord, uint8_t> per_core_num_dfbs_;
     std::vector<CircularBufferAllocator> dfb_allocators_;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36887
https://github.com/tenstorrent/tt-metal/issues/36888

### What's changed
- Updated tile counter assignment to handle multiple producer/consumer by grouping producer-consumer pairs and allocating TCs together (v1 impl just assigned for producer and consumer did lookup)
- added remapper index allocator (each core has 64 remapper pairs that can be programmed)
- updated host -> device DFB interface to hold required remapper config 
- exposed getter on Quasar DM kernels to get assigned dms so a dfb could be bound to correct producer/consumer (this is not how it will work in production but is done ot enable the experimental host apis) 

Note: these tests only pass if using 64B aligned workaround until emulator fix is propagated to Metal

Next:
- pr for isr changes
- support tensix
- tests with multiple dfb (outstanding change here is to make nSxmS use remapper when any DFB on the core uses remapper)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=abhullar/dfb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/dfb2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb2)
- [x] New/Existing tests provide coverage for changes
