### PR TITLE
PDL: Optimize matmuls for BH150 110 cores

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -54,7 +54,7 @@ def test_device_perf_pdl_20_cores(
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_110_cores",
-            6_900_000,
+            6_412_537,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            4_398_000,
+            4_252_383,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,

--- a/models/experimental/panoptic_deeplab/tt/tt_aspp.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_aspp.py
@@ -9,6 +9,7 @@ from loguru import logger
 from models.tt_cnn.tt.builder import TtConv2d
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.panoptic_deeplab.tt.common import reshape_flattened_conv_output
+from tracy import signpost
 
 
 class TtASPP(LightweightModule):
@@ -104,10 +105,13 @@ class TtASPP(LightweightModule):
         return TtConv2d(final_config, self.device)
 
     def forward(self, x):
+        signpost("ASPP_START")
         if self.is_20_core:
-            return self.forward_20_cores(x)
+            ret = self.forward_20_cores(x)
         else:
-            return self.forward_110_cores(x)
+            ret = self.forward_110_cores(x)
+        signpost("ASPP_END")
+        return ret
 
     def forward_20_cores(self, x):
         input_shape = x.shape

--- a/models/experimental/panoptic_deeplab/tt/tt_aspp.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_aspp.py
@@ -9,7 +9,13 @@ from loguru import logger
 from models.tt_cnn.tt.builder import TtConv2d
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.panoptic_deeplab.tt.common import reshape_flattened_conv_output
-from tracy import signpost
+
+try:
+    from tracy import signpost
+except ImportError:
+
+    def signpost(*_args, **_kwargs):
+        pass
 
 
 class TtASPP(LightweightModule):

--- a/models/experimental/panoptic_deeplab/tt/tt_insemb.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_insemb.py
@@ -8,6 +8,7 @@ from loguru import logger
 from models.experimental.panoptic_deeplab.tt.tt_semseg import TtDeepLabV3PlusHead
 from models.experimental.panoptic_deeplab.tt.tt_upsample import BilinearUpsampleMatmulTTNN as TtBilinearUpsample
 from models.experimental.panoptic_deeplab.reference.pytorch_semseg import ShapeSpec
+from tracy import signpost
 
 
 class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
@@ -146,7 +147,9 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
             center_logits = ttnn.to_memory_config(center_logits, ttnn.L1_MEMORY_CONFIG)
 
         # Matmul based upsample
+        signpost("FINAL_UPSAMPLE_INSEMB_CENTER_START")
         center_logits = self.final_upsample(center_logits)
+        signpost("FINAL_UPSAMPLE_INSEMB_CENTER_END")
 
         # --- Final Upsample for Offset ---
         # Use saved spatial dimensions
@@ -170,7 +173,9 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
 
         # Calculate scale factors
         # Matmul based upsample
+        signpost("FINAL_UPSAMPLE_INSEMB_OFFSET_START")
         offset_logits = self.final_upsample(offset_logits)
+        signpost("FINAL_UPSAMPLE_INSEMB_OFFSET_END")
 
         # Apply offset scaling
         offset_logits = ttnn.mul(offset_logits, self.common_stride)
@@ -189,6 +194,7 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
 
     def _execute_center_branch(self, y: ttnn.Tensor, use_memory_config_conversion: bool = False) -> ttnn.Tensor:
         """Execute center prediction branch with optional memory config handling"""
+        signpost("INSEMB_HEAD_CENTER_PREDICTION_START")
         logger.info(f"🔷 Executing conv: instance_head.center_head.0")
         center_y = self.center_head_0(y)
 
@@ -204,11 +210,12 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
 
         logger.info(f"🔷 Executing conv: instance_head.center_predictor")
         center_logits = self.center_predictor(center_y)
-
+        signpost("INSEMB_HEAD_CENTER_PREDICTION_END")
         return center_logits
 
     def _execute_offset_branch(self, y: ttnn.Tensor, use_memory_config_conversion: bool = False) -> ttnn.Tensor:
         """Execute offset prediction branch with optional memory config handling"""
+        signpost("INSEMB_HEAD_OFFSET_PREDICTION_START")
         logger.info(f"🔷 Executing conv: instance_head.offset_head.0")
         offset_y = self.offset_head_0(y)
 
@@ -224,7 +231,7 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
 
         logger.info(f"🔷 Executing conv: instance_head.offset_predictor")
         offset_logits = self.offset_predictor(offset_y)
-
+        signpost("INSEMB_HEAD_OFFSET_PREDICTION_END")
         return offset_logits
 
     def layers(self, features: Dict[str, ttnn.Tensor]) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
@@ -234,7 +241,9 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
             return self.layers_110_cores(features)
 
     def layers_20_cores(self, features: Dict[str, ttnn.Tensor]) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
+        signpost("INSEMB_HEAD_DECODER_START")
         y = super().layers_20_cores(features)
+        signpost("INSEMB_HEAD_DECODER_END")
 
         y = ttnn.to_memory_config(y, ttnn.DRAM_MEMORY_CONFIG)
 
@@ -248,7 +257,9 @@ class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):
         return center_logits, offset_logits
 
     def layers_110_cores(self, features: Dict[str, ttnn.Tensor]) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
+        signpost("INSEMB_HEAD_DECODER_START")
         y = super().layers_110_cores(features)
+        signpost("INSEMB_HEAD_DECODER_END")
 
         # Save spatial dimensions for upsample
         self._save_spatial_dimensions(y)

--- a/models/experimental/panoptic_deeplab/tt/tt_insemb.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_insemb.py
@@ -8,7 +8,13 @@ from loguru import logger
 from models.experimental.panoptic_deeplab.tt.tt_semseg import TtDeepLabV3PlusHead
 from models.experimental.panoptic_deeplab.tt.tt_upsample import BilinearUpsampleMatmulTTNN as TtBilinearUpsample
 from models.experimental.panoptic_deeplab.reference.pytorch_semseg import ShapeSpec
-from tracy import signpost
+
+try:
+    from tracy import signpost
+except ImportError:
+
+    def signpost(*_args, **_kwargs):
+        pass
 
 
 class TtPanopticDeepLabInsEmbedHead(TtDeepLabV3PlusHead):

--- a/models/experimental/panoptic_deeplab/tt/tt_resnet.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_resnet.py
@@ -9,7 +9,13 @@ from models.experimental.panoptic_deeplab.tt.tt_stem import TtStem
 from models.experimental.panoptic_deeplab.tt.tt_bottleneck import TtBottleneck
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.panoptic_deeplab.tt.common import reshape_flattened_conv_output
-from tracy import signpost
+
+try:
+    from tracy import signpost
+except ImportError:
+
+    def signpost(*_args, **_kwargs):
+        pass
 
 
 class TtResNet(LightweightModule):

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -11,7 +11,13 @@ from models.tt_cnn.tt.builder import TtConv2d
 from models.experimental.panoptic_deeplab.reference.pytorch_semseg import ShapeSpec
 from models.common.lightweightmodule import LightweightModule
 from models.experimental.panoptic_deeplab.tt.common import reshape_flattened_conv_output
-from tracy import signpost
+
+try:
+    from tracy import signpost
+except ImportError:
+
+    def signpost(*_args, **_kwargs):
+        pass
 
 
 class TtDeepLabV3PlusHead(LightweightModule):

--- a/models/experimental/panoptic_deeplab/tt/tt_semseg.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_semseg.py
@@ -612,7 +612,11 @@ class TtPanopticDeepLabSemSegHead(TtDeepLabV3PlusHead):
 
         # Matmul based upsample
         logger.debug(f"y shape: {y.shape}")
-        y = ttnn.reshape(y, (y.shape[0], 128, 256, y.shape[3]))
+        assert y.shape[1] == current_h and y.shape[2] == current_w, (
+            f"Final upsample reshape mismatch: "
+            f"tensor has {y.shape[1]}x{y.shape[2]}, "
+            f"but tracked dims are {current_h}x{current_w}"
+        )
         signpost("FINAL_UPSAMPLE_SEMSEG_START")
         y = self.final_upsample(y)
         signpost("FINAL_UPSAMPLE_SEMSEG_END")

--- a/models/experimental/panoptic_deeplab/tt/tt_stem.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_stem.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from models.tt_cnn.tt.builder import TtConv2d, TtMaxPool2d
 from models.common.lightweightmodule import LightweightModule
+from tracy import signpost
 
 
 class TtStem(LightweightModule):
@@ -110,6 +111,7 @@ class TtStem(LightweightModule):
         return conv_layer, output_shape
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        signpost("STEM_START")
         logger.debug(f"TtStem forward - input: {x.shape}")
 
         assert x.storage_type() == ttnn.StorageType.DEVICE, "Input tensor must be on device"
@@ -119,5 +121,5 @@ class TtStem(LightweightModule):
         x = self.conv2(x)  # self._conv_relu_block(self.conv2, x, "Conv2", self.conv2_out_shape)
         x = self.conv3(x)
         x = self.maxpool(x)
-
+        signpost("STEM_END")
         return x

--- a/models/experimental/panoptic_deeplab/tt/tt_stem.py
+++ b/models/experimental/panoptic_deeplab/tt/tt_stem.py
@@ -6,7 +6,13 @@ from loguru import logger
 
 from models.tt_cnn.tt.builder import TtConv2d, TtMaxPool2d
 from models.common.lightweightmodule import LightweightModule
-from tracy import signpost
+
+try:
+    from tracy import signpost
+except ImportError:
+
+    def signpost(*_args, **_kwargs):
+        pass
 
 
 class TtStem(LightweightModule):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/34674#issue-3743296444)

### Problem description
For full PDL there are 6 matmuls of `BilinearUpsampleMatmulTTNN` total but they contribute to almost a whole 1ms of perf time when not using an explicit program config. With low util of 8.6% and 13.3% there is room for improvement. 

### What's changed
Firstly the `ttnn.upsample` was profiled as an alternative but the perf was worse than the default `BilinearUpsampleMatmulTTNN`. Using unit tests 1d and 2d matmul program configs with all valid combinations of `out_subblock_h`, `out_subblock_w`, `out_block_h`, `out_block_w` were tested and chosen the best one which is now set inside `model_configs.py` for core grid 11x10.
On a side note, module level signposts are also added to make navigating throughout reports easier.

### Panoptic-DeepLab (Before these changes)

<img width="1800" height="2400" alt="image" src="https://github.com/user-attachments/assets/b5cf0204-22bd-4abb-9270-286fd85c69f5" />

### Panoptic-DeepLab (After these changes)

<img width="1800" height="2400" alt="image" src="https://github.com/user-attachments/assets/f58ec9e0-586c-465e-bae1-e2be1b321ec0" />

### DeepLab V3 (After these changes)
<img width="1800" height="2400" alt="image" src="https://github.com/user-attachments/assets/e3a349cc-4ec6-4f95-8c00-23eedfa112bc" />

### Checklist

- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=nmilicevic/pdl-optimize-matmuls-110-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmilicevic/pdl-optimize-matmuls-110-cores)

- [x] [![(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=nmilicevic/pdl-optimize-matmuls-110-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml?query=branch:nmilicevic/pdl-optimize-matmuls-110-cores) PDL PASS

- [x] [![(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml/badge.svg?branch=nmilicevic/pdl-optimize-matmuls-110-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml?query=branch:nmilicevic/pdl-optimize-matmuls-110-cores) PDL PASS

- [x] New/Existing tests provide coverage for changes

