### PR TITLE
#36917: Add uint16 support for fill op

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/fill_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/fill_tile.rst
@@ -3,5 +3,5 @@ fill_tile
 
 .. doxygenfunction:: fill_tile_init
 .. doxygenfunction:: fill_tile(uint32_t idst, float param0)
-.. doxygenfunction:: fill_tile_int(uint32_t idst, uint param0)
+.. doxygenfunction:: fill_tile_int(uint32_t idst, uint32_t param0)
 .. doxygenfunction:: fill_tile_bitcast(uint32_t idst, uint32_t param0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
@@ -79,3 +79,17 @@ def test_fill_uint32(device, fill_value):
 
     result = ttnn.eq(output, torch_output)
     assert torch.all(ttnn.to_torch(result))
+
+
+@pytest.mark.parametrize("fill_value", [2, 43.5, 65535])
+def test_fill_uint16(device, fill_value):
+    torch_input_tensor = torch.ones((1, 2), dtype=torch.uint16)
+    golden_function = ttnn.get_golden_function(ttnn.fill)
+    torch_output_tensor = golden_function(torch_input_tensor, fill_value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+    output = ttnn.fill(input_tensor, fill_value)
+    torch_output = ttnn.from_torch(torch_output_tensor, dtype=ttnn.uint16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    result = ttnn.eq(output, torch_output)
+    assert torch.all(ttnn.to_torch(result))

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -56,6 +56,17 @@
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
         ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
+// For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
+#define SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(                                                        \
+    FN, MODE, APPROXIMATE, DATA_FORMAT, EXTRA_PARAM, DST_IDX, PARAM0)                                               \
+    static_assert(                                                                                                  \
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16, \
+        "Unsupported data format. Supported: Int32, UInt32, UInt16");                                               \
+    constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
+        (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -56,6 +56,17 @@
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \
         ckernel::sfpu::FN<APPROXIMATE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
 
+// For unary ops with one extra uint parameter AND additional template params (DATA_FORMAT, ITERATIONS)
+#define SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(                                                        \
+    FN, MODE, APPROXIMATE, DATA_FORMAT, EXTRA_PARAM, DST_IDX, PARAM0)                                               \
+    static_assert(                                                                                                  \
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 || DATA_FORMAT == DataFormat::UInt16, \
+        "Unsupported data format. Supported: Int32, UInt32, UInt16");                                               \
+    constexpr InstrModLoadStore _INSTRUCTION_MODE =                                                                 \
+        (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;                   \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+        ckernel::sfpu::FN<APPROXIMATE, _INSTRUCTION_MODE, EXTRA_PARAM>, DST_IDX, (int)VectorMode::MODE, PARAM0)
+
 // For ops with exactly two extra uint parameters (and no custom init callback)
 #define SFPU_UNARY_TWO_PARAM_KERNEL_FN(FN, MODE, APPROXIMATE, DST_IDX, PARAM0, PARAM1) \
     _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                 \

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/fill.h
@@ -35,6 +35,9 @@ ALWI void fill_tile(uint32_t idst, float param0) {
  * register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available on the
  * compute engine.
  *
+ * @tparam data_format Template argument specifying the data type.
+ * Supported data formats are: DataFormat::Int32, DataFormat::UInt32, DataFormat::UInt16.
+ *
  * Return value: None
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
@@ -42,8 +45,9 @@ ALWI void fill_tile(uint32_t idst, float param0) {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | Value to fill tile with (unsigned integer)                                 | uint32_t |                                                       | True     |
  */
-ALWI void fill_tile_int(uint32_t idst, uint param0) {
-    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_EXTRA_PARAM(_calculate_fill_int_, RC, APPROX, 8, idst, param0));
+template <DataFormat DATA_FORMAT>
+ALWI void fill_tile_int(uint32_t idst, uint32_t param0) {
+    MATH(SFPU_UNARY_ONE_PARAM_KERNEL_DATA_FORMAT_EXTRA_PARAM(_calculate_fill_int_, RC, APPROX, DATA_FORMAT, 8, idst, param0));
 }
 
 // clang-format off

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -766,8 +766,11 @@ BinaryNgDeviceOperation::ProgramFactory::cached_program_t BinaryNgDeviceOperatio
     if (op_type == BinaryOpType::WHERE_TTS || op_type == BinaryOpType::WHERE_TST) {
         // Add common fill defines
         compute_kernel_defines["FILL_LLK"] = "fill_tile";
-        if (b_dtype == DataType::INT32 || b_dtype == DataType::UINT32) {
-            compute_kernel_defines["FILL_LLK"] = "fill_tile_int";
+        if (b_dtype == DataType::INT32) {
+            compute_kernel_defines["FILL_LLK"] = "fill_tile_int<DataFormat::Int32>";
+            compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+        } else if (b_dtype == DataType::UINT32) {
+            compute_kernel_defines["FILL_LLK"] = "fill_tile_uint<DataFormat::UInt32>";
             compute_kernel_defines["FILL_WITH_VALUE_INT"] = "1";
         } else {
             compute_kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1237,7 +1237,10 @@ TernaryDeviceOperation::TernaryProgramFactory::cached_program_t TernaryDeviceOpe
     // Add common fill defines
     kernel_defines["FILL_LLK"] = "fill_tile";
     if (predicate_tensor.dtype() == DataType::INT32) {
-        kernel_defines["FILL_LLK"] = "fill_tile_int";
+        kernel_defines["FILL_LLK"] = "fill_tile_int<DataFormat::Int32>";
+        kernel_defines["FILL_WITH_VALUE_INT"] = "1";
+    } else if (predicate_tensor.dtype() == DataType::UINT32) {
+        kernel_defines["FILL_LLK"] = "fill_tile_uint<DataFormat::UInt32>";
         kernel_defines["FILL_WITH_VALUE_INT"] = "1";
     } else {
         kernel_defines["FILL_WITH_VALUE_FLOAT"] = "1";

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -110,18 +110,35 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
     float param0 = static_cast<float>(params[0]);
     switch (op_type) {
         case UnaryOpType::FILL:
-            // NOLINTNEXTLINE(bugprone-branch-clone)
-            if (input_dtype == DataType::INT32) {
-                return {"fill_tile_init();", fmt::format("fill_tile_int({}, {}u);", idst, (uint)params[0])};
-            } else if (input_dtype == DataType::UINT32) {
-                // TODO: Use uint32_t tile API here once implemented
-                return {"fill_tile_init();", fmt::format("fill_tile_int({}, {}u);", idst, (uint)params[0])};
-            } else {
-                // Note: bit casted to int float is used to properly pass nan/+-inf
+            if (input_dtype == DataType::INT32 || input_dtype == DataType::UINT32 || input_dtype == DataType::UINT16) {
+                // Validate and convert fill value
+                std::uint32_t fill_val;
+                if (input_dtype == DataType::UINT16) {
+                    const auto as_int = static_cast<std::int32_t>(param0_raw);
+                    TT_FATAL(
+                        as_int >= 0 && as_int <= std::numeric_limits<std::uint16_t>::max(),
+                        "FILL value {} out of range for UInt16",
+                        as_int);
+                    fill_val = static_cast<std::uint32_t>(as_int);
+                } else {
+                    fill_val = static_cast<std::uint32_t>(param0_raw);
+                }
+                // select data format based on input dtype
+                const char* data_format;
+                if (input_dtype == DataType::INT32) {
+                    data_format = "Int32";
+                } else if (input_dtype == DataType::UINT32) {
+                    data_format = "UInt32";
+                } else {
+                    data_format = "UInt16";
+                }
                 return {
                     "fill_tile_init();",
-                    fmt::format("fill_tile_bitcast({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+                    fmt::format("fill_tile_int<DataFormat::{}>({}, {:#x}u);", data_format, idst, fill_val)};
             }
+            return {
+                "fill_tile_init();",
+                fmt::format("fill_tile_bitcast({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
         case UnaryOpType::ROUND:
             return {"rounding_op_tile_init();", fmt::format("round_tile({}, {});", idst, (int)params[0])};
         case UnaryOpType::RELU_MAX:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp
@@ -11,6 +11,7 @@
 #include "api/compute/mul_int_sfpu.h"
 #include "api/compute/eltwise_unary/rpow.h"
 #include "api/compute/eltwise_unary/rdiv.h"
+#include "api/compute/eltwise_unary/fill.h"
 
 void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/where_tss_kernel.cpp
@@ -33,13 +33,13 @@ void kernel_main() {
 
             fill_tile_init();
             #if defined(INP_INT32) || defined(INP_UINT32)
-                fill_tile_int(1, packed_scalar1);
-                fill_tile_int(2, packed_scalar2);
-            #endif
-            #if defined(INP_FLOAT) || defined(INP_FLOAT32)
-                fill_tile(1, *true_value);
-                fill_tile(2, *false_value);
-            #endif
+            fill_tile_int<DataFormat::Int32>(1, packed_scalar1);
+            fill_tile_int<DataFormat::Int32>(2, packed_scalar2);
+#endif
+#if defined(INP_FLOAT) || defined(INP_FLOAT32)
+            fill_tile(1, *true_value);
+            fill_tile(2, *false_value);
+#endif
             SFPU_OP_CHAIN_0
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -2248,7 +2248,7 @@ void py_module(nb::module_& mod) {
         "fill_value",
         "The value to be filled in the output tensor",
         "This will create a tensor of same shape and dtype as input reference tensor with fill_value.",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32)doc",
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT32, UINT16)doc",
         R"doc(Host memory is not supported.)doc");
 
     // Unary ops with dim parameter


### PR DESCRIPTION
### Ticket
Link to Github Issue #36917 
.

### What's changed
Added uint16 support for fill op

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/fill_uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/fill_uint16)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/fill_uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/fill_uint16)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/fill_uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/fill_uint16)
- [x] [single card Model perf
](https://github.com/tenstorrent/tt-metal/actions/runs/21659629466)
