### PR TITLE
[skip ci] Enable weka permissions input for galaxy and t3k demo tests

### DIFF
--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -52,6 +52,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
   schedule:
     - cron: "0 0 * * *" # This cron schedule runs demo tests every day at 12am UTC
 jobs:
@@ -75,3 +80,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
       topology: topology-6u
+      mlperf-read-only: ${{ inputs.mlperf-read-only }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -61,6 +61,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
   schedule:
     - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
   workflow_call:
@@ -90,6 +95,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Set to false to allow write access to MLPerf mount"
 
 jobs:
   build-artifact:
@@ -112,3 +122,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       model: ${{ inputs.model || 'all' }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}
+      mlperf-read-only: ${{ inputs.mlperf-read-only }}


### PR DESCRIPTION
### Problem description
Currently when weights are not written to weka we need to change permissions manually in branch.

### What's changed
Add input in GH UI so we can do that from `main`

