### PR TITLE
[skip ci]: upstream image: allow unstrict modes for ssh authorized keys

### DIFF
--- a/dockerfile/upstream_test_images/Dockerfile.template
+++ b/dockerfile/upstream_test_images/Dockerfile.template
@@ -40,7 +40,7 @@ RUN TRACY_NO_INVARIANT_CHECK=1 python3 -c 'import ttnn'
 # Give other full access to the user directory (for cross-user MPI runs)
 RUN sudo chmod -R 777 /home/user
 
-# Allow files with non-script modes to be used as authorized keys (for MPI operator key mounts)
+# Allow files with insecure permissions to be used as authorized keys by disabling SSH StrictModes (for MPI operator key mounts)
 RUN sudo mkdir -p /run/sshd
 RUN echo "StrictModes no" | sudo tee -a /etc/ssh/sshd_config
 

--- a/dockerfile/upstream_test_images/Dockerfile.template
+++ b/dockerfile/upstream_test_images/Dockerfile.template
@@ -40,5 +40,9 @@ RUN TRACY_NO_INVARIANT_CHECK=1 python3 -c 'import ttnn'
 # Give other full access to the user directory (for cross-user MPI runs)
 RUN sudo chmod -R 777 /home/user
 
+# Allow files with non-script modes to be used as authorized keys (for MPI operator key mounts)
+RUN sudo mkdir -p /run/sshd
+RUN echo "StrictModes no" | sudo tee -a /etc/ssh/sshd_config
+
 ENTRYPOINT ["$TEST_COMMAND"]
 CMD ["$HW_TOPOLOGY"]


### PR DESCRIPTION
MPI Operator mounts the authorized_keys in the non-strict mode.
This change allows to use the upstream image with MPI Operator.