### PR TITLE
Add option to pass chunk_start_idx as tensor.

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -637,7 +637,7 @@ def run_test_chunked_sdpa(
         tt_Q_chunk = ttnn.Tensor(Q[:, :, 0:prefill_chunk_size], q_dtype).to(ttnn.TILE_LAYOUT).to(device)
         chunk_start_idx_tensor = ttnn.Tensor(torch.tensor([0], dtype=torch.int32), ttnn.int32).to(device)
         # Compile: run chunk 0 once
-        tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
+        ttnn.transformer.chunked_scaled_dot_product_attention(
             tt_Q_chunk,
             tt_paged_K,
             tt_paged_V,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -4,6 +4,7 @@
 
 import os
 import math
+import time
 import torch
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
@@ -527,8 +528,19 @@ def run_test_chunked_sdpa(
     q_dtype,
     k_dtype,
     use_high_precision_compute,
+    flexible=False,
     grid_size=None,
+    trace=False,
 ):
+    """Run chunked SDPA over paged K/V and compare to PyTorch SDPA.
+
+    flexible: If True, pass chunk_start_idx as a device tensor (ttnn.Tensor [1] int32).
+              If False, pass chunk_start_idx as a Python int (legacy). Use flexible for
+              trace capture/replay or prefix caching so the offset can change without recompile.
+    trace: If True, compile once, capture one SDPA call, then replay for each chunk after
+           updating Q and chunk_start_idx_tensor on device. Requires flexible=True and a
+           device created with trace_region_size (see test parametrization).
+    """
     program_config = ttnn.SDPAProgramConfig(
         compute_with_storage_grid_size=grid_size or device.compute_with_storage_grid_size(),
         q_chunk_size=q_chunk_size,
@@ -606,26 +618,113 @@ def run_test_chunked_sdpa(
     tt_paged_V = ttnn.Tensor(page_cache(V), k_dtype).to(ttnn.TILE_LAYOUT).to(device)
     page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
 
-    for chunk_idx in range(num_prefill_chunks):
-        # Chunk Q
-        Q_chunk = Q[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
-        tt_Q_chunk = ttnn.Tensor(Q_chunk, q_dtype).to(ttnn.TILE_LAYOUT).to(device)
-        chunk_start_idx = chunk_idx * prefill_chunk_size
+    def _params_str(chunk_idx=None, op="sdpa"):
+        parts = [
+            f"b={b} nh={nh} nkv={nkv} s={s} d={d}",
+            f"q_chunk={q_chunk_size} k_chunk={k_chunk_size}",
+            f"prefill_chunk={prefill_chunk_size} page_block={page_block_size}",
+            f"flexible={flexible} trace={trace}",
+        ]
+        if chunk_idx is not None:
+            parts.append(f"chunk_idx={chunk_idx}/{num_prefill_chunks}")
+        parts.append(f"op={op}")
+        return " | ".join(parts)
 
+    if trace:
+        # trace=True requires flexible (chunk_start_idx_tensor) so replay can update offset on device
+        assert flexible, "trace=True requires flexible=True"
+        # Persistent device tensors for capture and replay (same buffers used by trace)
+        tt_Q_chunk = ttnn.Tensor(Q[:, :, 0:prefill_chunk_size], q_dtype).to(ttnn.TILE_LAYOUT).to(device)
+        chunk_start_idx_tensor = ttnn.Tensor(torch.tensor([0], dtype=torch.int32), ttnn.int32).to(device)
+        # Compile: run chunk 0 once
         tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
             tt_Q_chunk,
             tt_paged_K,
             tt_paged_V,
             page_table_tt,
-            chunk_start_idx,
+            chunk_start_idx_tensor=chunk_start_idx_tensor,
             program_config=program_config,
             compute_kernel_config=compute_kernel_config,
         )
-        tt_back = tt_back.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
-        gt_chunk = gt[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
-        out_pass, out_pcc = comp_pcc(gt_chunk, tt_back, 0.998)
-        logger.debug(f"python vs pytorch: {out_pcc}")
-        assert out_pass
+        # Capture: record one SDPA call
+        tid = ttnn.begin_trace_capture(device, cq_id=0)
+        tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
+            tt_Q_chunk,
+            tt_paged_K,
+            tt_paged_V,
+            page_table_tt,
+            chunk_start_idx_tensor=chunk_start_idx_tensor,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+        ttnn.end_trace_capture(device, tid, cq_id=0)
+
+        # Execute: for each chunk, update inputs on device and replay; use replay output for PCC
+        for chunk_idx in range(num_prefill_chunks):
+            Q_chunk = Q[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+            chunk_start_idx = chunk_idx * prefill_chunk_size
+            ttnn.copy(
+                ttnn.Tensor(Q_chunk, q_dtype).to(ttnn.TILE_LAYOUT).to(device),
+                tt_Q_chunk,
+            )
+            ttnn.copy(
+                ttnn.Tensor(torch.tensor([chunk_start_idx], dtype=torch.int32), ttnn.int32).to(device),
+                chunk_start_idx_tensor,
+            )
+            ttnn.synchronize_device(device)
+            t0 = time.perf_counter()
+            ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+            ttnn.synchronize_device(device)
+            elapsed = time.perf_counter() - t0
+            logger.info(f"execute_trace time={elapsed:.4f}s | {_params_str(chunk_idx=chunk_idx, op='replay')}")
+            tt_back_cpu = tt_back.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            gt_chunk = gt[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+            out_pass, out_pcc = comp_pcc(gt_chunk, tt_back_cpu, 0.998)
+            logger.debug(f"trace replay chunk {chunk_idx} vs pytorch: {out_pcc}")
+            assert out_pass
+        ttnn.release_trace(device, tid)
+    else:
+        for chunk_idx in range(num_prefill_chunks):
+            # Chunk Q
+            Q_chunk = Q[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+            tt_Q_chunk = ttnn.Tensor(Q_chunk, q_dtype).to(ttnn.TILE_LAYOUT).to(device)
+            chunk_start_idx = chunk_idx * prefill_chunk_size
+
+            if flexible:
+                chunk_start_idx_tensor = ttnn.Tensor(torch.tensor([chunk_start_idx], dtype=torch.int32), ttnn.int32).to(
+                    device
+                )
+                ttnn.synchronize_device(device)
+                t0 = time.perf_counter()
+                tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
+                    tt_Q_chunk,
+                    tt_paged_K,
+                    tt_paged_V,
+                    page_table_tt,
+                    chunk_start_idx_tensor=chunk_start_idx_tensor,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                )
+            else:
+                ttnn.synchronize_device(device)
+                t0 = time.perf_counter()
+                tt_back = ttnn.transformer.chunked_scaled_dot_product_attention(
+                    tt_Q_chunk,
+                    tt_paged_K,
+                    tt_paged_V,
+                    page_table_tt,
+                    chunk_start_idx,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                )
+            ttnn.synchronize_device(device)
+            elapsed = time.perf_counter() - t0
+            logger.info(f"chunked_sdpa time={elapsed:.4f}s | {_params_str(chunk_idx=chunk_idx, op='sdpa')}")
+            tt_back = tt_back.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            gt_chunk = gt[:, :, chunk_idx * prefill_chunk_size : (chunk_idx + 1) * prefill_chunk_size]
+            out_pass, out_pcc = comp_pcc(gt_chunk, tt_back, 0.998)
+            logger.debug(f"python vs pytorch: {out_pcc}")
+            assert out_pass
 
 
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
@@ -635,6 +734,15 @@ def run_test_chunked_sdpa(
 @pytest.mark.parametrize("k_chunk_size", [128, 256], ids=["k128", "k256"])
 @pytest.mark.parametrize("prefill_chunk_size", [1024, 2048])
 @pytest.mark.parametrize("page_block_size", [64, 128])
+# @pytest.mark.parametrize("flexible", [False, True], ids=["legacy", "flexible"])
+@pytest.mark.parametrize("flexible", [True], ids=["flexible"])
+# @pytest.mark.parametrize("flexible", [False], ids=["legacy"])
+@pytest.mark.parametrize(
+    "trace,device_params",
+    [(False, {}), (True, {"trace_region_size": 256 * 1024})],
+    indirect=["device_params"],
+    ids=["no_trace", "trace"],
+)
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d",
     [
@@ -652,10 +760,16 @@ def test_sdpa_chunked(
     k_chunk_size,
     prefill_chunk_size,
     page_block_size,
+    flexible,
+    trace,
     q_dtype,
     k_dtype,
     use_high_precision_compute=False,
 ):
+    """Chunked SDPA: legacy (chunk_start_idx int) vs flexible (chunk_start_idx_tensor).
+    When trace=True, device is created with trace_region_size; test captures one SDPA then replays per chunk."""
+    if trace and not flexible:
+        pytest.skip("Trace is not supported for legacy chunked SDPA")
     for _ in range(2):
         run_test_chunked_sdpa(
             device,
@@ -671,11 +785,17 @@ def test_sdpa_chunked(
             q_dtype,
             k_dtype,
             use_high_precision_compute,
+            flexible=flexible,
+            trace=trace,
         )
 
-    # Print number of program cache entries
-    assert device.num_program_cache_entries() == 1, "Program cache should only have 1 entry but has {}".format(
-        device.num_program_cache_entries()
+    # Program cache: non-trace path only runs SDPA (1 entry). Trace path also runs two
+    # ttnn.copy calls per chunk (Q chunk and chunk_start_idx_tensor), so 3 entries total.
+    expected_entries = 3 if trace else 1
+    assert (
+        device.num_program_cache_entries() == expected_entries
+    ), "Program cache should have {} entry/entries but has {}".format(
+        expected_entries, device.num_program_cache_entries()
     )
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -54,10 +54,11 @@ void kernel_main() {
     const uint32_t local_q_end = get_arg_val<uint32_t>(6);
     // const uint32_t chunked_q_chunk_offset = get_arg_val<uint32_t>(7);
     const uint32_t num_phases = get_arg_val<uint32_t>(7);
-    const uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(8);
+    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(8);
+    uint32_t chunked_q_chunk_offset_phase_1 = get_arg_val<uint32_t>(9);
     uint32_t chunked_q_chunk_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(9);
+        chunked_q_chunk_offset_phase_2 = get_arg_val<uint32_t>(10);
     }
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
@@ -86,8 +87,22 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
 
+    constexpr uint32_t cb_chunk_start_idx = tt::CBIndex::c_8;
     uint32_t chunked_q_chunk_offset = 0;
     mm_init(cb_q_in, cb_k_in, cb_out);
+
+    if constexpr (is_chunked) {
+        if (use_chunk_start_idx_tensor != 0) {
+            cb_wait_front(cb_chunk_start_idx, 1);
+            uint32_t chunk_start_idx = ckernel::read_tile_value(cb_chunk_start_idx, 0, 0);
+            cb_pop_front(cb_chunk_start_idx, 1);
+            const uint32_t q_chunk_size = Sq_chunk_t * TILE_HEIGHT;
+            chunked_q_chunk_offset_phase_1 = chunk_start_idx / q_chunk_size;
+            if (num_phases == 2) {
+                chunked_q_chunk_offset_phase_2 = chunked_q_chunk_offset_phase_1;
+            }
+        }
+    }
 
     for (uint32_t phase = 0; phase < num_phases; ++phase) {
         if (phase == 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -40,13 +40,14 @@ void kernel_main() {
     const uint32_t local_q_start = get_arg_val<uint32_t>(6);
     const uint32_t local_q_end = get_arg_val<uint32_t>(7);
     const uint32_t num_phases = get_arg_val<uint32_t>(8);
-    const uint32_t chunk_start_t_in_q_chunks_phase_1 = get_arg_val<uint32_t>(9);
-    const uint32_t write_offset_phase_1 = get_arg_val<uint32_t>(10);
+    const uint32_t use_chunk_start_idx_tensor = get_arg_val<uint32_t>(9);
+    uint32_t chunk_start_t_in_q_chunks_phase_1 = get_arg_val<uint32_t>(10);
+    const uint32_t write_offset_phase_1 = get_arg_val<uint32_t>(11);
     uint32_t chunk_start_t_in_q_chunks_phase_2 = 0;
     uint32_t write_offset_phase_2 = 0;
     if (num_phases == 2) {
-        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(11);
-        write_offset_phase_2 = get_arg_val<uint32_t>(12);
+        chunk_start_t_in_q_chunks_phase_2 = get_arg_val<uint32_t>(12);
+        write_offset_phase_2 = get_arg_val<uint32_t>(13);
     }
 
     const uint32_t q_chunks_per_core = local_q_end - local_q_start;
@@ -56,6 +57,7 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_mask_in = tt::CBIndex::c_3;
+    constexpr uint32_t cb_chunk_start_idx = tt::CBIndex::c_9;
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
 
@@ -70,6 +72,20 @@ void kernel_main() {
 
     generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+
+    if constexpr (is_chunked) {
+        if (use_chunk_start_idx_tensor != 0) {
+            cb_wait_front(cb_chunk_start_idx, 1);
+            auto chunk_start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_chunk_start_idx));
+            uint32_t chunk_start_idx = chunk_start_ptr[0];
+            cb_pop_front(cb_chunk_start_idx, 1);
+            const uint32_t q_chunk_size = Sq_chunk_t * tt::constants::TILE_HEIGHT;
+            chunk_start_t_in_q_chunks_phase_1 = chunk_start_idx / q_chunk_size;
+            if (num_phases == 2) {
+                chunk_start_t_in_q_chunks_phase_2 = chunk_start_t_in_q_chunks_phase_1;
+            }
+        }
+    }
 
     uint32_t chunk_start_t_in_q_chunks = 0;
     uint32_t write_offset = 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -522,7 +522,8 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
              v_addr,
              0,  // mask_addr,
              page_table_addr,
-             0,  // attention sink addr,
+             0,  // attention_sink_addr,
+             0,  // chunk_start_idx_addr (ring has no chunk_start_idx_tensor)
              i,
              local_batch_start,
              local_batch_end,
@@ -700,6 +701,7 @@ void RingDistributedSdpaMeshWorkloadFactory::override_runtime_arguments(
             reader_args[1] = k_addr;
             reader_args[2] = v_addr;
             reader_args[4] = page_table_addr;  // Update page_table_addr (index 4 is after mask_addr)
+            reader_args[6] = 0;                // chunk_start_idx_addr (ring has no chunk_start_idx_tensor)
 
             writer_args[0] = out_addr;
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -278,6 +278,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
     TensorAccessorArgs(page_table.has_value() ? page_table->buffer() : nullptr)
         .append_to(reader_compile_time_args);                  // page table
     TensorAccessorArgs().append_to(reader_compile_time_args);  // attention sink (not used in ring)
+    TensorAccessorArgs().append_to(reader_compile_time_args);  // chunk_start_idx_tensor (ring has no flexible chunked)
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -549,6 +549,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
              local_q_start,
              local_q_end,
              2,
+             0,  // use_chunk_start_idx_tensor (ring has no chunk_start_idx_tensor)
              chunked_q_chunk_offset_phase_1,
              write_offset_phase_1,
              chunked_q_chunk_offset_phase_2,
@@ -565,6 +566,7 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
              local_q_start,
              local_q_end,
              2,
+             0,  // use_chunk_start_idx_tensor (ring has no chunk_start_idx_tensor)
              chunked_q_chunk_offset_phase_1,
              chunked_q_chunk_offset_phase_2});
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -165,8 +165,27 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
     };
 
     auto validate_chunked_mode = [&]() {
-        TT_FATAL(attrs.chunk_start_idx.has_value(), "chunk_start_idx must be provided for chunked mode");
-        TT_FATAL(attrs.chunk_start_idx.value() >= 0, "chunk_start_idx must be non-negative");
+        const bool flexible_chunked = attrs.chunk_start_idx_tensor.has_value();
+        const bool legacy_chunked = attrs.chunk_start_idx.has_value() && !flexible_chunked;
+        TT_FATAL(
+            legacy_chunked || flexible_chunked,
+            "chunked mode requires either chunk_start_idx (scalar) or chunk_start_idx_tensor");
+        if (legacy_chunked) {
+            TT_FATAL(attrs.chunk_start_idx.value() >= 0, "chunk_start_idx must be non-negative");
+        }
+        if (flexible_chunked) {
+            const auto& csi_tensor = attrs.chunk_start_idx_tensor.value();
+            TT_FATAL(csi_tensor.storage_type() == StorageType::DEVICE, "chunk_start_idx tensor must be on device");
+            TT_FATAL(
+                csi_tensor.dtype() == DataType::INT32,
+                "chunk_start_idx tensor must be int32. Got {}",
+                csi_tensor.dtype());
+            auto csi_shape = csi_tensor.logical_shape();
+            TT_FATAL(
+                csi_shape.size() == 1 && csi_shape[0] == 1,
+                "chunk_start_idx tensor must have shape [1]. Got {}",
+                csi_shape);
+        }
         // Validate page table tensor
         const auto& page_table = tensors.page_table.value();
         TT_FATAL(page_table.storage_type() == StorageType::DEVICE, "Page table tensor must be on device");
@@ -236,31 +255,43 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
                 k_chunk_size,
                 tt::constants::TILE_WIDTH);
 
-            // Validate that chunk_start_idx is a multiple of q_chunk_size
-            // This is required because chunk_start_idx is divided by q_chunk_size to compute chunked_q_chunk_offset
-            TT_FATAL(
-                attrs.chunk_start_idx.value() % q_chunk_size == 0,
-                "chunk_start_idx must be a multiple of q_chunk_size. Got chunk_start_idx: {}, q_chunk_size: {}",
-                attrs.chunk_start_idx.value(),
-                q_chunk_size);
+            if (legacy_chunked) {
+                // Validate that chunk_start_idx is a multiple of q_chunk_size
+                // This is required because chunk_start_idx is divided by q_chunk_size to compute chunked_q_chunk_offset
+                TT_FATAL(
+                    attrs.chunk_start_idx.value() % q_chunk_size == 0,
+                    "chunk_start_idx must be a multiple of q_chunk_size. Got chunk_start_idx: {}, q_chunk_size: {}",
+                    attrs.chunk_start_idx.value(),
+                    q_chunk_size);
 
-            // Validate that chunk_start_idx is a multiple of k_chunk_size
-            // Workaround for https://github.com/tenstorrent/tt-metal/issues/35225
-            TT_FATAL(
-                attrs.chunk_start_idx.value() % k_chunk_size == 0,
-                "chunk_start_idx must be a multiple of k_chunk_size. Got chunk_start_idx: {}, k_chunk_size: {}",
-                attrs.chunk_start_idx.value(),
-                k_chunk_size);
+                // Validate that chunk_start_idx is a multiple of k_chunk_size
+                // Workaround for https://github.com/tenstorrent/tt-metal/issues/35225
+                TT_FATAL(
+                    attrs.chunk_start_idx.value() % k_chunk_size == 0,
+                    "chunk_start_idx must be a multiple of k_chunk_size. Got chunk_start_idx: {}, k_chunk_size: {}",
+                    attrs.chunk_start_idx.value(),
+                    k_chunk_size);
+            }
         }
 
-        // In chunked mode, K's sequence dimension should be >= Q's sequence dimension + chunk_start_idx
-        TT_FATAL(
-            kv_length >= q_shape[2] + attrs.chunk_start_idx.value(),
-            "K's sequence length must be >= Q's sequence length + chunk_start_idx. Got K: {}, Q: {}, chunk_start_idx: "
-            "{}",
-            kv_length,
-            q_shape[2],
-            attrs.chunk_start_idx.value());
+        if (legacy_chunked) {
+            // In chunked mode, K's sequence dimension should be >= Q's sequence dimension + chunk_start_idx
+            TT_FATAL(
+                kv_length >= q_shape[2] + attrs.chunk_start_idx.value(),
+                "K's sequence length must be >= Q's sequence length + chunk_start_idx. Got K: {}, Q: {}, "
+                "chunk_start_idx: "
+                "{}",
+                kv_length,
+                q_shape[2],
+                attrs.chunk_start_idx.value());
+        } else {
+            // Flexible: only require KV length to cover Q
+            TT_FATAL(
+                kv_length >= q_shape[2],
+                "K's sequence length must be >= Q's sequence length. Got K: {}, Q: {}",
+                kv_length,
+                q_shape[2]);
+        }
     };
 
     auto validate_attention_sink = [&]() {
@@ -297,16 +328,16 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
     };
 
     auto check_conditions = [&]() {
-        bool has_chunk_start = attrs.chunk_start_idx.has_value();
+        bool has_chunk_start_scalar = attrs.chunk_start_idx.has_value();
+        bool has_chunk_start_tensor = attrs.chunk_start_idx_tensor.has_value();
         bool has_page_table = tensors.page_table.has_value();
-        // For chunked mode, we need at least 2 optional inputs (mask placeholder and page_table)
-        if (has_chunk_start) {
-            TT_FATAL(has_page_table, "page_table must be provided when chunk_start_idx is set");
+        if (has_chunk_start_scalar || has_chunk_start_tensor) {
+            TT_FATAL(has_page_table, "page_table must be provided for chunked mode");
         }
     };
 
     check_conditions();
-    bool is_chunked_mode = attrs.chunk_start_idx.has_value();
+    bool is_chunked_mode = attrs.chunk_start_idx.has_value() || attrs.chunk_start_idx_tensor.has_value();
 
     if (is_chunked_mode) {
         validate_chunked_mode();
@@ -339,12 +370,14 @@ SDPAOperation::tensor_return_value_t SDPAOperation::create_output_tensors(
 }
 
 tt::stl::hash::hash_t SDPAOperation::compute_program_hash(const SDPAParams& attrs, const SDPAInputs& tensors) {
-    bool is_chunked_prefill = attrs.chunk_start_idx.has_value();
+    bool is_chunked_prefill = attrs.chunk_start_idx.has_value() || attrs.chunk_start_idx_tensor.has_value();
+    bool flexible_chunked = attrs.chunk_start_idx_tensor.has_value();
 
     const Tensor& q = tensors.q;
     const Tensor& k = tensors.k;
     const Tensor& v = attrs.use_mla ? tensors.k : tensors.v.value_or(tensors.k);
 
+    const std::optional<Tensor> page_table_for_hash = flexible_chunked ? std::nullopt : tensors.page_table;
     operation::Hash hash = operation::hash_operation<SDPAOperation>(
         attrs.head_dim_v,
         attrs.scale,
@@ -353,12 +386,13 @@ tt::stl::hash::hash_t SDPAOperation::compute_program_hash(const SDPAParams& attr
         attrs.program_config,
         attrs.is_causal,
         is_chunked_prefill,
+        flexible_chunked,
         attrs.compute_kernel_config,
         q,
         k,
         v,
         tensors.attn_mask,
-        tensors.page_table,
+        page_table_for_hash,
         tensors.attention_sink);
     return hash;
 }
@@ -398,7 +432,7 @@ SDPAOperation::create_op_performance_model(
         TT_ASSERT(v_shape.size() == 4, "ScaledDotProductAttention perf model: input tensor V rank != 4");
     }
 
-    bool is_chunked_prefill = args.chunk_start_idx.has_value();
+    bool is_chunked_prefill = args.chunk_start_idx.has_value() || args.chunk_start_idx_tensor.has_value();
 
     uint32_t batch_size_q = q_shape[0];
     uint32_t batch_size_k = k_shape[0];
@@ -406,7 +440,10 @@ SDPAOperation::create_op_performance_model(
     uint32_t num_heads_q = q_shape[1];
 
     const auto Sq = q_shape[2];
-    const auto Sk = (is_chunked_prefill) ? q_shape[-2] + args.chunk_start_idx.value() : k_shape[2];
+    const auto Sk = (is_chunked_prefill) ? (args.chunk_start_idx.has_value()
+                                                ? q_shape[2] + args.chunk_start_idx.value()
+                                                : k_shape[2])  // flexible: use K length as upper bound for perf model
+                                         : k_shape[2];
     const auto DH = q_shape[3];
 
     uint32_t Sv, DV;
@@ -466,6 +503,7 @@ Tensor sdpa(
     std::optional<float> scale,
     std::optional<uint32_t> sliding_window_size,
     std::optional<int64_t> chunk_start_idx,
+    const std::optional<Tensor>& chunk_start_idx_tensor,
     bool use_mla,
     std::optional<uint32_t> head_dim_v,
     const tt::tt_metal::MemoryConfig& output_mem_config,
@@ -479,6 +517,7 @@ Tensor sdpa(
             .program_config = std::move(program_config),
             .is_causal = is_causal,
             .chunk_start_idx = chunk_start_idx,
+            .chunk_start_idx_tensor = chunk_start_idx_tensor,
             .compute_kernel_config = compute_kernel_config,
             .use_mla = use_mla,
             .head_dim_v = head_dim_v,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
@@ -47,6 +47,7 @@ Tensor sdpa(
     std::optional<float> scale,
     std::optional<uint32_t> sliding_window_size,
     std::optional<int64_t> chunk_start_idx,
+    const std::optional<Tensor>& chunk_start_idx_tensor,
     bool use_mla,
     std::optional<uint32_t> head_dim_v,
     const tt::tt_metal::MemoryConfig& output_mem_config,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
@@ -16,7 +16,8 @@ struct SDPAParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config;
     bool is_causal = false;
-    std::optional<int64_t> chunk_start_idx;
+    std::optional<int64_t> chunk_start_idx;        // Chunked legacy: scalar offset, part of program cache key
+    std::optional<Tensor> chunk_start_idx_tensor;  // Chunked flexible: device tensor [1] int32, read at runtime
     DeviceComputeKernelConfig compute_kernel_config;
     bool use_mla = false;
     std::optional<uint32_t> head_dim_v;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -57,9 +57,20 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     const uint32_t NKH = k_shape[1];
 
     // Paged cache parameters when in chunked mode
-    bool is_chunked = chunk_start_idx.has_value();
-    // In chunked mode, we only need to process K/V up to chunk_start_idx + Sq
-    const uint32_t Sk = is_chunked ? (chunk_start_idx.value() + Sq) : k_shape[2];
+    const bool flexible_chunked = operation_attributes.chunk_start_idx_tensor.has_value();
+    const bool is_chunked_legacy = chunk_start_idx.has_value() && !flexible_chunked;
+    const bool is_chunked = is_chunked_legacy || flexible_chunked;
+    // For flexible chunked: max prefix length = page_table num_pages * block_size (from K/V layout).
+    uint32_t max_prefix_tokens_flexible = 0;
+    if (is_chunked && flexible_chunked) {
+        const uint32_t block_size_for_sk = k_shape[2];
+        const uint32_t max_blocks = page_table.value().padded_shape()[1];
+        max_prefix_tokens_flexible = max_blocks * block_size_for_sk;
+    }
+    // In chunked mode: legacy uses chunk_start_idx + Sq; flexible uses Sq + max prefix from page table.
+    const uint32_t Sk = is_chunked
+                            ? (flexible_chunked ? (Sq + max_prefix_tokens_flexible) : (chunk_start_idx.value() + Sq))
+                            : k_shape[2];
 
     /*
     Note about tensor shapes:
@@ -129,20 +140,25 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     tt::DataFormat page_table_df = tt::DataFormat::Int32;
 
     if (is_chunked) {
-        // chunk_start_idx must be a multiple of q_chunk_size (validated in sdpa_device_operation.cpp)
-        chunked_q_chunk_offset = chunk_start_idx.value() / q_chunk_size;
+        if (is_chunked_legacy) {
+            // chunk_start_idx must be a multiple of q_chunk_size (validated in sdpa_device_operation.cpp)
+            chunked_q_chunk_offset = chunk_start_idx.value() / q_chunk_size;
+        }
+        // else: flexible_chunked - chunked_q_chunk_offset set inside of the op
         const auto& page_table_tensor = page_table.value();
         block_size = k_shape[2];  // K's sequence dimension represents block size
         block_size_t = block_size / TILE_HEIGHT;
-        max_blocks_per_seq = page_table_tensor.padded_shape()[1];
-        page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
-        TT_FATAL(
-            page_table_stick_size % 32 == 0,
-            "page table page size in bytes must be a multiple of 32 due to address alignment");
-
-        TT_FATAL(
-            page_table_stick_size % 32 == 0,
-            "page table page size in bytes must be a multiple of 32 due to address alignment");
+        if (flexible_chunked) {
+            max_blocks_per_seq = page_table_tensor.padded_shape()[1];
+            page_table_stick_size = max_blocks_per_seq * sizeof(int32_t);
+            TT_FATAL(page_table_stick_size % 32 == 0, "page table stick size must be a multiple of 32");
+        } else {
+            max_blocks_per_seq = page_table_tensor.padded_shape()[1];
+            page_table_stick_size = page_table_tensor.buffer()->aligned_page_size();
+            TT_FATAL(
+                page_table_stick_size % 32 == 0,
+                "page table page size in bytes must be a multiple of 32 due to address alignment");
+        }
     }
     // Log page table info
     log_debug(tt::LogOp, "is_chunked: {}", is_chunked);
@@ -379,6 +395,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     TensorAccessorArgs(page_table.has_value() ? page_table->buffer() : nullptr).append_to(reader_compile_time_args);
     TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
         .append_to(reader_compile_time_args);
+    TensorAccessorArgs(flexible_chunked ? operation_attributes.chunk_start_idx_tensor.value().buffer() : nullptr)
+        .append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
@@ -558,6 +576,17 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                                 .set_page_size(tt::CBIndex::c_6, page_table_stick_size);
         CreateCircularBuffer(program, core_grid, c_in6_config);
     }
+    if (flexible_chunked) {
+        constexpr uint32_t chunk_start_idx_page_size = 32;
+        auto c_chunk_start_compute_config =
+            CircularBufferConfig(chunk_start_idx_page_size, {{tt::CBIndex::c_8, tt::DataFormat::Int32}})
+                .set_page_size(tt::CBIndex::c_8, chunk_start_idx_page_size);
+        CreateCircularBuffer(program, core_grid, c_chunk_start_compute_config);
+        auto c_chunk_start_writer_config =
+            CircularBufferConfig(chunk_start_idx_page_size, {{tt::CBIndex::c_9, tt::DataFormat::Int32}})
+                .set_page_size(tt::CBIndex::c_9, chunk_start_idx_page_size);
+        CreateCircularBuffer(program, core_grid, c_chunk_start_writer_config);
+    }
 
     // Create attention sink buffer if provided
     if (use_attention_sink) {
@@ -670,6 +699,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 mask_addr,
                 is_chunked ? page_table.value().buffer()->address() : 0,
                 attention_sink_addr,
+                flexible_chunked ? operation_attributes.chunk_start_idx_tensor.value().buffer()->address() : 0,
                 i,
                 local_batch_start,
                 local_batch_end,
@@ -694,6 +724,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
              local_q_start,
              local_q_end,
              num_phases,
+             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
              chunked_q_chunk_offset,
              write_offset});  // write_offset
         SetRuntimeArgs(
@@ -708,6 +739,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
              local_q_start,
              local_q_end,
              num_phases,
+             static_cast<uint32_t>(flexible_chunked ? 1 : 0),
              chunked_q_chunk_offset});
     }
 
@@ -733,7 +765,8 @@ void SDPAProgramFactory::override_runtime_arguments(
     auto& shared_vars = cached_program.shared_variables;
     auto& program = cached_program.program;
 
-    const bool is_chunked = operation_attributes.chunk_start_idx.has_value();
+    const bool flexible_chunked = operation_attributes.chunk_start_idx_tensor.has_value();
+    const bool is_chunked = operation_attributes.chunk_start_idx.has_value() || flexible_chunked;
     const bool use_mla = operation_attributes.use_mla;
     std::size_t q_chunk_size =
         operation_attributes.program_config ? operation_attributes.program_config->q_chunk_size : 32;
@@ -755,10 +788,16 @@ void SDPAProgramFactory::override_runtime_arguments(
 
     uint32_t page_table_addr = 0;
     uint32_t chunked_q_chunk_offset = 0;
+    uint32_t chunk_start_idx_addr = 0;
+    const uint32_t use_chunk_start_idx_tensor = flexible_chunked ? 1 : 0;
     if (is_chunked) {
         page_table_addr = tensor_args.page_table.value().buffer()->address();
-        // chunk_start_idx must be a multiple of q_chunk_size (validated in sdpa_device_operation.cpp)
-        chunked_q_chunk_offset = operation_attributes.chunk_start_idx.value() / q_chunk_size;
+        if (!flexible_chunked) {
+            // chunk_start_idx must be a multiple of q_chunk_size (validated in sdpa_device_operation.cpp)
+            chunked_q_chunk_offset = operation_attributes.chunk_start_idx.value() / q_chunk_size;
+        } else {
+            chunk_start_idx_addr = operation_attributes.chunk_start_idx_tensor.value().buffer()->address();
+        }
     }
 
     auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernels_id);
@@ -781,12 +820,15 @@ void SDPAProgramFactory::override_runtime_arguments(
         reader_args[3] = mask_addr;
         reader_args[4] = page_table_addr;
         reader_args[5] = attention_sink_addr;
-        reader_args[14] = chunked_q_chunk_offset;
+        reader_args[6] = chunk_start_idx_addr;
+        reader_args[15] = chunked_q_chunk_offset;
 
         writer_args[0] = out_addr;
-        writer_args[9] = chunked_q_chunk_offset;
+        writer_args[9] = use_chunk_start_idx_tensor;
+        writer_args[10] = chunked_q_chunk_offset;
 
-        compute_args[8] = chunked_q_chunk_offset;
+        compute_args[8] = use_chunk_start_idx_tensor;
+        compute_args[9] = chunked_q_chunk_offset;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -27,13 +27,28 @@ struct ExecuteScaledDotProductAttention {
         const std::optional<ttnn::Tensor>& attention_sink = std::nullopt);
 };
 
+/// Chunked SDPA over paged K/V: one Q chunk per call, K/V in paged layout.
+/// Two overloads: legacy (chunk_start_idx as int) or flexible (chunk_start_idx_tensor on device).
 struct ExecuteChunkedScaledDotProductAttention {
+    /// Legacy: chunk start index as scalar.
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor_q,
         const ttnn::Tensor& input_tensor_k,
         const ttnn::Tensor& input_tensor_v,
         const ttnn::Tensor& page_table_tensor,
         int64_t chunk_start_idx,  // Must be a multiple of program_config.q_chunk_size
+        std::optional<float> scale = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<SDPAProgramConfig> program_config = std::nullopt,
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+    /// Flexible: chunk start index in device tensor [1] (int32). Read at runtime; use for trace.
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor_q,
+        const ttnn::Tensor& input_tensor_k,
+        const ttnn::Tensor& input_tensor_v,
+        const ttnn::Tensor& page_table_tensor,
+        const ttnn::Tensor& chunk_start_idx_tensor,
         std::optional<float> scale = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<SDPAProgramConfig> program_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -109,7 +109,7 @@ void bind_sdpa(nb::module_& mod) {
         The kernel reads the start index from device memory at runtime. Use for:
         - Trace capture/replay: capture one SDPA call, then replay with different
           chunk_start_idx by updating the tensor on device (no recompile).
-          One pogram handles variable prefix lengths by updating
+          One program handles variable prefix lengths by updating
           the tensor each step.
         The program is compiled once (fixed max page table size); the trace key does not
         include the runtime offset.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -152,7 +152,7 @@ void bind_sdpa(nb::module_& mod) {
                const ttnn::Tensor& input_tensor_k,
                const ttnn::Tensor& input_tensor_v,
                const ttnn::Tensor& page_table_tensor,
-               const nb::object chunk_start_idx_arg,
+               const nb::object& chunk_start_idx_arg,
                std::optional<ttnn::Tensor> chunk_start_idx_tensor_opt,
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -95,17 +95,36 @@ void bind_sdpa(nb::module_& mod) {
 
     const auto* chunked_doc =
         R"doc(
-        Chunked causal scaled dot product attention for processing long sequences in chunks.
-        This variant allows processing of sequences longer than the maximum supported length
-        by splitting the input into chunks and maintaining KV cache state.
-        The KV cache is page-based, and the page table tensor is used to map the page indices to the corresponding KV cache indices.
+        Chunked causal scaled dot product attention for paged KV cache and long sequences.
+        Processes one Q chunk at a time; K/V are provided as paged cache. The page table
+        maps virtual block indices to physical blocks. Two calling conventions:
+
+        **Legacy (chunk_start_idx as int):**
+        Pass ``chunk_start_idx`` (integer). The offset is fixed at dispatch time. Use when
+        iterating chunks from Python and passing a new scalar each call. Program is cached
+        per (config, chunk_start_idx) for the first chunk; later chunks reuse when possible.
+
+        **Flexible (chunk_start_idx_tensor):**
+        Pass ``chunk_start_idx_tensor`` (ttnn.Tensor of shape [1], dtype int32) on device.
+        The kernel reads the start index from device memory at runtime. Use for:
+        - Trace capture/replay: capture one SDPA call, then replay with different
+          chunk_start_idx by updating the tensor on device (no recompile).
+          One pogram handles variable prefix lengths by updating
+          the tensor each step.
+        The program is compiled once (fixed max page table size); the trace key does not
+        include the runtime offset.
 
         Args:
-            input_tensor_q (ttnn.Tensor): the input tensor.          [b x nqh x s x dh]
-            input_tensor_k (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
-            input_tensor_v (ttnn.Tensor): the input tensor.          [b x nkv x s x dh]
-            page_table_tensor (ttnn.Tensor): the page table tensor.  [b x num_pages]
-            chunk_start_idx (int): Absolute position in the sequence where this chunk starts.
+            input_tensor_q (ttnn.Tensor): Q chunk.          [b x nqh x chunk_s x dh]
+            input_tensor_k (ttnn.Tensor): Paged K cache.    [max_blocks x nkv x block_s x dh]
+            input_tensor_v (ttnn.Tensor): Paged V cache.    [max_blocks x nkv x block_s x dh]
+            page_table_tensor (ttnn.Tensor): Page table.    [b x num_pages], int32.
+            chunk_start_idx (int, optional): Legacy: absolute sequence index for this chunk.
+                Must be a multiple of program_config.q_chunk_size.
+                Must be a multiple of program_config.k_chunk_size (workaround for https://github.com/tenstorrent/tt-metal/issues/35225)
+                Omit when using chunk_start_idx_tensor.
+            chunk_start_idx_tensor (ttnn.Tensor, optional): Flexible: device tensor [1] int32
+                holding the chunk start index; read at runtime. Use for trace or prefix caching.
                 Must be a multiple of program_config.q_chunk_size.
                 Must be a multiple of program_config.k_chunk_size (workaround for https://github.com/tenstorrent/tt-metal/issues/35225)
 
@@ -126,16 +145,36 @@ void bind_sdpa(nb::module_& mod) {
         ttnn::transformer::chunked_scaled_dot_product_attention,
         chunked_doc,
         ttnn::nanobind_overload_t{
+            // Dispatch: chunk_start_idx_tensor present → flexible (runtime offset); else legacy (chunk_start_idx int).
             [](const ChunkedOperationType& self,
                const ttnn::Tensor& input_tensor_q,
                const ttnn::Tensor& input_tensor_k,
                const ttnn::Tensor& input_tensor_v,
                const ttnn::Tensor& page_table_tensor,
-               int64_t chunk_start_idx,
+               nb::object chunk_start_idx_arg,
+               std::optional<ttnn::Tensor> chunk_start_idx_tensor_opt,
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,
                const std::optional<SDPAProgramConfig>& program_config,
                std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+                if (chunk_start_idx_tensor_opt.has_value()) {
+                    return self(
+                        input_tensor_q,
+                        input_tensor_k,
+                        input_tensor_v,
+                        page_table_tensor,
+                        chunk_start_idx_tensor_opt.value(),
+                        scale,
+                        memory_config,
+                        program_config,
+                        compute_kernel_config);
+                }
+                if (chunk_start_idx_arg.is_none()) {
+                    throw std::runtime_error(
+                        "chunk_start_idx (int) is required for legacy chunked SDPA. For flexible path use "
+                        "chunk_start_idx_tensor=...");
+                }
+                int64_t chunk_start_idx = nb::cast<int64_t>(chunk_start_idx_arg);
                 return self(
                     input_tensor_q,
                     input_tensor_k,
@@ -151,8 +190,9 @@ void bind_sdpa(nb::module_& mod) {
             nb::arg("input_tensor_k").noconvert(),
             nb::arg("input_tensor_v").noconvert(),
             nb::arg("page_table_tensor").noconvert(),
-            nb::arg("chunk_start_idx"),
+            nb::arg("chunk_start_idx") = nb::none(),
             nb::kw_only(),
+            nb::arg("chunk_start_idx_tensor") = nb::none(),
             nb::arg("scale").noconvert() = nb::none(),
             nb::arg("memory_config").noconvert() = nb::none(),
             nb::arg("program_config").noconvert() = nb::none(),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -107,10 +107,11 @@ void bind_sdpa(nb::module_& mod) {
         **Flexible (chunk_start_idx_tensor):**
         Pass ``chunk_start_idx_tensor`` (ttnn.Tensor of shape [1], dtype int32) on device.
         The kernel reads the start index from device memory at runtime. Use for:
+
         - Trace capture/replay: capture one SDPA call, then replay with different
           chunk_start_idx by updating the tensor on device (no recompile).
-          One program handles variable prefix lengths by updating
-          the tensor each step.
+          One program handles variable prefix lengths by updating the tensor each step.
+
         The program is compiled once (fixed max page table size); the trace key does not
         include the runtime offset.
 
@@ -151,7 +152,7 @@ void bind_sdpa(nb::module_& mod) {
                const ttnn::Tensor& input_tensor_k,
                const ttnn::Tensor& input_tensor_v,
                const ttnn::Tensor& page_table_tensor,
-               nb::object chunk_start_idx_arg,
+               const nb::object chunk_start_idx_arg,
                std::optional<ttnn::Tensor> chunk_start_idx_tensor_opt,
                std::optional<float> scale,
                const std::optional<MemoryConfig>& memory_config,


### PR DESCRIPTION
### Problem description
Current Chunked SDPA key inputs (ignoring batch size in this whole story to make things simpler):
* Q - variable length (this chunk)
* K, V - full KV cache as allocated at init, fixed length
* page table - variable length (this+previous chunks)
* chunk_start_idx - int 

When tracing, the trace key needs to be something like (seq_len, chunk_start_idx). The variable page table length is unambiguously derived from these two.
That's potentially a lot, so here's the proposal: If we pad page table to "full size" - describing full KV cache, that tensor will have fixed length. Then it is possible to have chunk_start_idx as runtime (not baked in) parameter and thus reduce the trace key space.

### What's changed
This PR adds optional chunk_start_idx_tensor input, which is only read at runtime, fully on-device. It is not compiled, and not traced (only the tensor address). That allows to use a single trace for any valid chunk start index.
Test has been updated to also run the flexible option, and the flexible traced option.

### Performance
```
Config (flexible=False,trace=False) (flexible=True,trace=False) (flexible=True,trace=True):
----------------------------------------------------------------------------------------------------
q_chunk=128 k_chunk=128 prefill_chunk=1024 page_block=128 0.0173 0.0173 0.0160
q_chunk=128 k_chunk=128 prefill_chunk=1024 page_block=64  0.0173 0.0173 0.0161
q_chunk=128 k_chunk=128 prefill_chunk=2048 page_block=128 0.0154 0.0154 0.0149
q_chunk=128 k_chunk=128 prefill_chunk=2048 page_block=64  0.0155 0.0156 0.0149
q_chunk=128 k_chunk=256 prefill_chunk=1024 page_block=128 0.0151 0.0151 0.0141
q_chunk=128 k_chunk=256 prefill_chunk=1024 page_block=64  0.0149 0.0155 0.0144
q_chunk=128 k_chunk=256 prefill_chunk=2048 page_block=128 0.0132 0.0132 0.0127
q_chunk=128 k_chunk=256 prefill_chunk=2048 page_block=64  0.0134 0.0138 0.0131
q_chunk=256 k_chunk=128 prefill_chunk=1024 page_block=128 0.0306 0.0302 0.0291
q_chunk=256 k_chunk=128 prefill_chunk=1024 page_block=64  0.0304 0.0301 0.0292
q_chunk=256 k_chunk=128 prefill_chunk=2048 page_block=128 0.0162 0.0160 0.0155
q_chunk=256 k_chunk=128 prefill_chunk=2048 page_block=64  0.0161 0.0159 0.0156
q_chunk=256 k_chunk=256 prefill_chunk=1024 page_block=128 0.0258 0.0257 0.0246
q_chunk=256 k_chunk=256 prefill_chunk=1024 page_block=64  0.0259 0.0256 0.0246
q_chunk=256 k_chunk=256 prefill_chunk=2048 page_block=128 0.0137 0.0137 0.0130
q_chunk=256 k_chunk=256 prefill_chunk=2048 page_block=64  0.0137 0.0138 0.0130
```

### CI
* Nightly tt-metal L2 tests (fast-dispatch and sdpa): https://github.com/tenstorrent/tt-metal/actions/runs/21622428653
  * Fails the same test and with the same errors as main: https://github.com/tenstorrent/tt-metal/actions/runs/21579561800
* Galaxy demo tests (Llama3 70B DP): https://github.com/tenstorrent/tt-metal/actions/runs/21622438820
  * PASS, but seems to skip some important tests, just as main: https://github.com/tenstorrent/tt-metal/actions/runs/21573167203/job/62155913816

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/flexible-chunked-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/flexible-chunked-sdpa)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
