### PR TITLE
[skip ci] BH nightly: flip default to true for multi card unit tests

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -22,7 +22,7 @@ on:
         description: 'Run Blackhole multi card nightly unit tests'
         required: false
         type: boolean
-        default: false
+        default: true
       run_bh_ttnn_stress_tests:
         description: 'Run Blackhole nightly ttnn stress tests'
         required: false


### PR DESCRIPTION
### Ticket
None

### Problem description
Change default from skipping BH multicard unit test workflow to including it