### PR TITLE
[skip ci] Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ Testing
 .auto_triage/output
 .github/actions/*/node_modules/
 models/experimental/petr/resources/*.pth
+
+.claude


### PR DESCRIPTION
### Ticket
N/A – small .gitignore improvement

### Problem description
The `.claude` directory (used by Claude/Cursor for code context) can be created in the repo during development. Without an ignore rule, it may show up in `git status` and risk being committed.

### What's changed
- Added `.claude` to `.gitignore` so this directory is ignored by git.
- No functional or build impact; .gitignore only affects which files git tracks.

### Checklist

- [ ] All post-commit tests
- [ ] Blackhole Post commit
- [ ] cpp-unit-tests
- [ ] New/Existing tests provide coverage for changes — N/A (gitignore only)

#### Model tests
N/A – no model or runtime code changed.