### PR TITLE
Encapsulate noc non blocking reads in cq into separate files

### DIFF
--- a/tt_metal/hw/inc/api/debug/noc_logging.h
+++ b/tt_metal/hw/inc/api/debug/noc_logging.h
@@ -21,8 +21,8 @@ void log_noc_xfer(uint32_t len) {
 }
 
 #define LOG_LEN(l) log_noc_xfer(l);
-#define LOG_READ_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
-#define LOG_WRITE_LEN_FROM_STATE(noc_id) LOG_LEN(NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
+#define LOG_READ_LEN_FROM_STATE(noc_id) LOG_LEN(noc_debug_read_at_len_be(noc_id, NCRISC_RD_CMD_BUF));
+#define LOG_WRITE_LEN_FROM_STATE(noc_id) LOG_LEN(noc_debug_read_at_len_be(noc_id, NCRISC_WR_CMD_BUF));
 
 #else
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -241,7 +241,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, state->targ_addr_mid);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, state->packet_tag);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
-    state->ret_addr_mid = 0;  // WH does not have ret_addr_mid register
+    state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
 }
 
 // Returns number of read transactions issued on this noc.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -247,30 +247,95 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, state->ret_addr_mid);
 }
 
-// Returns number of read transactions issued on this noc.
+/**
+ * Returns the number of read transactions issued on this NOC.
+ *
+ * Return value: Number of read transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_reads_issued(uint32_t noc) { return noc_reads_num_issued[noc]; }
-// Returns number of nonposted write transactions issued on this noc.
+
+/**
+ * Returns the number of nonposted write transactions issued on this NOC.
+ *
+ * Return value: Number of nonposted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(uint32_t noc) {
     return noc_nonposted_writes_num_issued[noc];
 }
-// Returns number of nonposted write acks received on this noc.
+
+/**
+ * Returns the number of nonposted write acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted write acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
-// Returns number of nonposted atomic acks received on this noc.
+
+/**
+ * Returns the number of nonposted atomic acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted atomic acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
     return noc_nonposted_atomics_acked[noc];
 }
-// Returns number of posted write transactions issued on this noc.
+
+/**
+ * Returns the number of posted write transactions issued on this NOC.
+ *
+ * Return value: Number of posted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
     return noc_posted_writes_num_issued[noc];
 }
 
-// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+/**
+ * Increments the nonposted write acknowledgments counter by the specified delta.
+ * Useful for multicast write accounting where multiple destinations receive the same write.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+
+/**
+ * Increments the nonposted write issued counter by the specified delta.
+ * Useful for multicast write accounting where a single transaction targets multiple destinations.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
@@ -281,26 +346,71 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(ui
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the target address coordinates for a NOC command buffer.
+ * Writes only the NOC_TARG_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full target address for a NOC command buffer.
+ * Writes both NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE registers.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                                        | Data type | Valid range | Required |
+ * |-----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc       | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf   | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | targ_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
     uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
-// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the return address coordinates for a NOC command buffer.
+ * Writes only the NOC_RET_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full return address for a NOC command buffer.
+ * Writes both NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE registers.
+ * Typically used for atomic operations where a return value is expected.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | ret_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -193,6 +193,100 @@ inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_
     *ptr = id_mask;
 }
 
+// Save/restore entire command buffer state (e.g. for profiler).
+// Same struct on all arches; ret_addr_mid only used on Blackhole and Quasar (WH keeps it for layout uniformity).
+struct NocCmdBufState {
+    uint32_t ctrl;
+    uint32_t ret_addr_coord;
+    uint32_t targ_addr_lo;
+    uint32_t ret_addr_lo;
+    uint32_t at_len_be;
+    uint32_t targ_addr_coord;
+    uint32_t targ_addr_mid;
+    uint32_t packet_tag;
+    uint32_t at_data;
+    uint32_t ret_addr_mid;
+};
+
+// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits and NOC_PACKET_TAG.
+inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
+    uint32_t noc, uint32_t cmd_buf, NocCmdBufState* state) {
+    state->ctrl = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL);
+    // Clear reserved bits in NOC_CTRL so they are not restored.
+    constexpr uint32_t noc_ctrl_reserved_bit_mask = ((1u << 27) - (1u << 18)) | (1u << 31);
+    state->ctrl &= ~noc_ctrl_reserved_bit_mask;
+    state->ret_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE);
+    state->targ_addr_lo = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_LO);
+    state->ret_addr_lo = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_LO);
+    state->at_len_be = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
+    state->targ_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE);
+    state->targ_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_MID);
+    state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
+    state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
+    // WH does not have ret_addr_mid register
+    // state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+}
+
+// Restores cmd_buf from state; waits for cmd_buf ready before writing.
+inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
+    uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, state->ctrl);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, state->ret_addr_coord);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, state->targ_addr_lo);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, state->ret_addr_lo);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, state->at_len_be);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, state->targ_addr_coord);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, state->targ_addr_mid);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, state->packet_tag);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
+    state->ret_addr_mid = 0;  // WH does not have ret_addr_mid register
+}
+
+// Returns number of read transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_reads_issued(uint32_t noc) { return noc_reads_num_issued[noc]; }
+// Returns number of nonposted write transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(uint32_t noc) {
+    return noc_nonposted_writes_num_issued[noc];
+}
+// Returns number of nonposted write acks received on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
+    return noc_nonposted_writes_acked[noc];
+}
+
+// Adds delta to nonposted-writes-acked (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
+    noc_nonposted_writes_acked[noc] += delta;
+}
+// Adds delta to nonposted-writes-issued (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
+    noc_nonposted_writes_num_issued[noc] += delta;
+}
+
+// True if hardware nonposted-writes-sent count has reached expected_count (wrap-around safe).
+inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
+    uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    return (int32_t)(sent - expected_count) >= 0;
+}
+
+// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf (target (x,y) for transactions).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
+    uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
+}
+
+// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from 64-bit ret_addr (e.g. atomic return).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));
+}
+
+// Debug only: returns NOC_AT_LEN_BE for cmd_buf (transaction length). Requires NOC_LOGGING_ENABLED.
+inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t noc, uint32_t cmd_buf) {
+    return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
+}
+
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -224,8 +224,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
     state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
-    // WH does not have ret_addr_mid register
-    // state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+    state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.
@@ -241,7 +240,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, state->targ_addr_mid);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, state->packet_tag);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
-    state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, state->ret_addr_mid);
 }
 
 // Returns number of read transactions issued on this noc.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -257,13 +257,21 @@ inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(u
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
+// Returns number of nonposted atomic acks received on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
+    return noc_nonposted_atomics_acked[noc];
+}
+// Returns number of posted write transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
+    return noc_posted_writes_num_issued[noc];
+}
 
-// Adds delta to nonposted-writes-acked (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Adds delta to nonposted-writes-issued (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
@@ -273,13 +281,26 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(ui
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf (target (x,y) for transactions).
+// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from 64-bit ret_addr (e.g. atomic return).
+// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
+    uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
+}
+
+// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
+    uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
+}
+
+// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -208,7 +208,7 @@ struct NocCmdBufState {
     uint32_t ret_addr_mid;
 };
 
-// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits and NOC_PACKET_TAG.
+// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits in the saved state.
 inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     uint32_t noc, uint32_t cmd_buf, NocCmdBufState* state) {
     state->ctrl = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL);
@@ -222,9 +222,13 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     state->targ_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE);
     state->targ_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_MID);
     state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
     state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
     state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+}
+
+// Clears NOC_PACKET_TAG register for the specified cmd_buf.
+inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t noc, uint32_t cmd_buf) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -365,7 +365,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
 
 /**
  * Sets the full target address for a NOC command buffer.
- * Writes both NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE registers.
+ * Writes NOC_TARG_ADDR_LO, NOC_TARG_ADDR_MID, and NOC_TARG_ADDR_COORDINATE registers.
  *
  * Return value: None
  *
@@ -378,6 +378,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
     uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(targ_addr >> 32) & NOC_PCIE_MASK);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
@@ -400,7 +401,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
 
 /**
  * Sets the full return address for a NOC command buffer.
- * Writes both NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE registers.
+ * Writes NOC_RET_ADDR_LO, NOC_RET_ADDR_MID, and NOC_RET_ADDR_COORDINATE registers.
  * Typically used for atomic operations where a return value is expected.
  *
  * Return value: None
@@ -413,6 +414,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
  */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(ret_addr >> 32) & NOC_PCIE_MASK);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));
 }
 

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -217,30 +217,95 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
 }
 
-// Returns number of read transactions issued on this noc.
+/**
+ * Returns the number of read transactions issued on this NOC.
+ *
+ * Return value: Number of read transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_reads_issued(uint32_t noc) { return noc_reads_num_issued[noc]; }
-// Returns number of nonposted write transactions issued on this noc.
+
+/**
+ * Returns the number of nonposted write transactions issued on this NOC.
+ *
+ * Return value: Number of nonposted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(uint32_t noc) {
     return noc_nonposted_writes_num_issued[noc];
 }
-// Returns number of nonposted write acks received on this noc.
+
+/**
+ * Returns the number of nonposted write acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted write acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
-// Returns number of nonposted atomic acks received on this noc.
+
+/**
+ * Returns the number of nonposted atomic acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted atomic acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
     return noc_nonposted_atomics_acked[noc];
 }
-// Returns number of posted write transactions issued on this noc.
+
+/**
+ * Returns the number of posted write transactions issued on this NOC.
+ *
+ * Return value: Number of posted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
     return noc_posted_writes_num_issued[noc];
 }
 
-// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+/**
+ * Increments the nonposted write acknowledgments counter by the specified delta.
+ * Useful for multicast write accounting where multiple destinations receive the same write.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+
+/**
+ * Increments the nonposted write issued counter by the specified delta.
+ * Useful for multicast write accounting where a single transaction targets multiple destinations.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
@@ -251,26 +316,71 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(ui
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the target address coordinates for a NOC command buffer.
+ * Writes only the NOC_TARG_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full target address for a NOC command buffer.
+ * Writes both NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE registers.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                                        | Data type | Valid range | Required |
+ * |-----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc       | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf   | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | targ_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
     uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
-// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the return address coordinates for a NOC command buffer.
+ * Writes only the NOC_RET_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full return address for a NOC command buffer.
+ * Writes both NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE registers.
+ * Typically used for atomic operations where a return value is expected.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | ret_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -195,9 +195,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
     state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
-#if defined(ARCH_BLACKHOLE) || defined(ARCH_QUASAR)
-    state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
-#endif
+    state->ret_addr_mid = 0;  // WH does not have ret_addr_mid register
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -211,9 +211,6 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, state->targ_addr_mid);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, state->packet_tag);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
-#if defined(ARCH_BLACKHOLE) || defined(ARCH_QUASAR)
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, state->ret_addr_mid);
-#endif
 }
 
 // Returns number of read transactions issued on this noc.

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -227,29 +227,50 @@ inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(u
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
+// Returns number of nonposted atomic acks received on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
+    return noc_nonposted_atomics_acked[noc];
+}
+// Returns number of posted write transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
+    return noc_posted_writes_num_issued[noc];
+}
 
-// Adds delta to nonposted-writes-acked (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Adds delta to nonposted-writes-issued (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
-// True if hardware nonposted-writes-sent count has reached expected_count (wrap-around safe).
+// Returns true if the hardware nonposted-write counter has reached (or passed) expected_count.
 inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
     uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf (target (x,y) for transactions).
+// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from 64-bit ret_addr (e.g. atomic return).
+// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
+    uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
+}
+
+// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
+    uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
+}
+
+// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -179,7 +179,7 @@ struct NocCmdBufState {
     uint32_t ret_addr_mid;
 };
 
-// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits and NOC_PACKET_TAG.
+// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits in the saved state.
 inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     uint32_t noc, uint32_t cmd_buf, NocCmdBufState* state) {
     state->ctrl = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL);
@@ -193,9 +193,13 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     state->targ_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE);
     state->targ_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_MID);
     state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
     state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
     state->ret_addr_mid = 0;  // WH does not have ret_addr_mid register
+}
+
+// Clears NOC_PACKET_TAG register for the specified cmd_buf.
+inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t noc, uint32_t cmd_buf) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -355,7 +355,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
 
 /**
  * Sets the full target address for a NOC command buffer.
- * Writes both NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE registers.
+ * Writes NOC_TARG_ADDR_LO, NOC_TARG_ADDR_MID, and NOC_TARG_ADDR_COORDINATE registers.
  *
  * Return value: None
  *
@@ -368,6 +368,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
     uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(targ_addr >> 32) & NOC_PCIE_MASK);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
@@ -390,7 +391,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
 
 /**
  * Sets the full return address for a NOC command buffer.
- * Writes both NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE registers.
+ * Writes NOC_RET_ADDR_LO, NOC_RET_ADDR_MID, and NOC_RET_ADDR_COORDINATE registers.
  * Typically used for atomic operations where a return value is expected.
  *
  * Return value: None
@@ -403,6 +404,7 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
  */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(ret_addr >> 32) & NOC_PCIE_MASK);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));
 }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -237,30 +237,95 @@ inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, state->ret_addr_mid);
 }
 
-// Returns number of read transactions issued on this noc.
+/**
+ * Returns the number of read transactions issued on this NOC.
+ *
+ * Return value: Number of read transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_reads_issued(uint32_t noc) { return noc_reads_num_issued[noc]; }
-// Returns number of nonposted write transactions issued on this noc.
+
+/**
+ * Returns the number of nonposted write transactions issued on this NOC.
+ *
+ * Return value: Number of nonposted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(uint32_t noc) {
     return noc_nonposted_writes_num_issued[noc];
 }
-// Returns number of nonposted write acks received on this noc.
+
+/**
+ * Returns the number of nonposted write acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted write acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
-// Returns number of nonposted atomic acks received on this noc.
+
+/**
+ * Returns the number of nonposted atomic acknowledgments received on this NOC.
+ *
+ * Return value: Number of nonposted atomic acks received
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
     return noc_nonposted_atomics_acked[noc];
 }
-// Returns number of posted write transactions issued on this noc.
+
+/**
+ * Returns the number of posted write transactions issued on this NOC.
+ *
+ * Return value: Number of posted write transactions issued
+ *
+ * | Argument | Description                | Data type | Valid range | Required |
+ * |----------|----------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                  | uint32_t  | 0 or 1      | True     |
+ */
 inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
     return noc_posted_writes_num_issued[noc];
 }
 
-// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+/**
+ * Increments the nonposted write acknowledgments counter by the specified delta.
+ * Useful for multicast write accounting where multiple destinations receive the same write.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+
+/**
+ * Increments the nonposted write issued counter by the specified delta.
+ * Useful for multicast write accounting where a single transaction targets multiple destinations.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
@@ -271,26 +336,71 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(ui
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the target address coordinates for a NOC command buffer.
+ * Writes only the NOC_TARG_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full target address for a NOC command buffer.
+ * Writes both NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE registers.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                                        | Data type | Valid range | Required |
+ * |-----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc       | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf   | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | targ_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
     uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
-// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+/**
+ * Sets the return address coordinates for a NOC command buffer.
+ * Writes only the NOC_RET_ADDR_COORDINATE register (NOC x,y coordinates).
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | coord    | Packed NOC coordinates from NOC_XY_COORD(x, y)     | uint32_t  | 0..2^32-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+/**
+ * Sets the full return address for a NOC command buffer.
+ * Writes both NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE registers.
+ * Typically used for atomic operations where a return value is expected.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                        | Data type | Valid range | Required |
+ * |----------|----------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                          | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                               | uint32_t  | 0 - 3       | True     |
+ * | ret_addr | Full NOC address from NOC_XY_ADDR(x, y, addr)      | uint64_t  | 0..2^64-1   | True     |
+ */
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -183,6 +183,99 @@ inline __attribute__((always_inline)) void noc_clear_outstanding_req_cnt(uint32_
     *ptr = id_mask;
 }
 
+// Save/restore entire command buffer state (e.g. for profiler).
+// Same struct on all arches; ret_addr_mid only used on Blackhole and Quasar (WH keeps it for layout uniformity).
+struct NocCmdBufState {
+    uint32_t ctrl;
+    uint32_t ret_addr_coord;
+    uint32_t targ_addr_lo;
+    uint32_t ret_addr_lo;
+    uint32_t at_len_be;
+    uint32_t targ_addr_coord;
+    uint32_t targ_addr_mid;
+    uint32_t packet_tag;
+    uint32_t at_data;
+    uint32_t ret_addr_mid;
+};
+
+// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits and NOC_PACKET_TAG.
+inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
+    uint32_t noc, uint32_t cmd_buf, NocCmdBufState* state) {
+    state->ctrl = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL);
+    // Clear reserved bits in NOC_CTRL so they are not restored.
+    constexpr uint32_t noc_ctrl_reserved_bit_mask = ((1u << 27) - (1u << 18)) | (1u << 31);
+    state->ctrl &= ~noc_ctrl_reserved_bit_mask;
+    state->ret_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE);
+    state->targ_addr_lo = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_LO);
+    state->ret_addr_lo = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_LO);
+    state->at_len_be = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN);
+    state->targ_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE);
+    state->targ_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_MID);
+    state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
+    state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
+    state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+}
+
+// Restores cmd_buf from state; waits for cmd_buf ready before writing.
+inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
+    uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, state->ctrl);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, state->ret_addr_coord);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, state->targ_addr_lo);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, state->ret_addr_lo);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN, state->at_len_be);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, state->targ_addr_coord);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, state->targ_addr_mid);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, state->packet_tag);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, state->at_data);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, state->ret_addr_mid);
+}
+
+// Returns number of read transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_reads_issued(uint32_t noc) { return noc_reads_num_issued[noc]; }
+// Returns number of nonposted write transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(uint32_t noc) {
+    return noc_nonposted_writes_num_issued[noc];
+}
+// Returns number of nonposted write acks received on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
+    return noc_nonposted_writes_acked[noc];
+}
+
+// Adds delta to nonposted-writes-acked (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
+    noc_nonposted_writes_acked[noc] += delta;
+}
+// Adds delta to nonposted-writes-issued (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
+    noc_nonposted_writes_num_issued[noc] += delta;
+}
+
+// True if hardware nonposted-writes-sent count has reached expected_count (wrap-around safe).
+inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
+    uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    return (int32_t)(sent - expected_count) >= 0;
+}
+
+// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf (target (x,y) for transactions).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
+    uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
+}
+
+// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from 64-bit ret_addr (e.g. atomic return).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));
+}
+
+// Debug only: returns NOC_AT_LEN for cmd_buf (transaction length). Requires NOC_LOGGING_ENABLED.
+inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t noc, uint32_t cmd_buf) {
+    return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN);
+}
+
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {
     // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
     // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -247,13 +247,21 @@ inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_issued(u
 inline __attribute__((always_inline)) uint32_t noc_get_nonposted_writes_acked(uint32_t noc) {
     return noc_nonposted_writes_acked[noc];
 }
+// Returns number of nonposted atomic acks received on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_nonposted_atomics_acked(uint32_t noc) {
+    return noc_nonposted_atomics_acked[noc];
+}
+// Returns number of posted write transactions issued on this noc.
+inline __attribute__((always_inline)) uint32_t noc_get_posted_writes_issued(uint32_t noc) {
+    return noc_posted_writes_num_issued[noc];
+}
 
-// Adds delta to nonposted-writes-acked (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-acked by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_acked(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_acked[noc] += delta;
 }
-// Adds delta to nonposted-writes-issued (e.g. for multicast write accounting).
-inline __attribute__((always_inline)) void noc_adjust_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
+// Increments nonposted-writes-issued by delta (e.g. for multicast write accounting).
+inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued(uint32_t noc, uint32_t delta) {
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
@@ -263,13 +271,26 @@ inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(ui
     return (int32_t)(sent - expected_count) >= 0;
 }
 
-// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf (target (x,y) for transactions).
+// Writes NOC_TARG_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr_coordinate(
     uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, coord);
 }
 
-// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from 64-bit ret_addr (e.g. atomic return).
+// Writes NOC_TARG_ADDR_LO and NOC_TARG_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_targ_addr(
+    uint32_t noc, uint32_t cmd_buf, uint64_t targ_addr) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(targ_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(targ_addr >> NOC_ADDR_COORD_SHIFT));
+}
+
+// Writes NOC_RET_ADDR_COORDINATE for cmd_buf. Takes NOC coordinates from NOC_XY_COORD(x, y).
+inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr_coordinate(
+    uint32_t noc, uint32_t cmd_buf, uint32_t coord) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, coord);
+}
+
+// Writes NOC_RET_ADDR_LO and NOC_RET_ADDR_COORDINATE from full NOC address from NOC_XY_ADDR(x, y, addr).
 inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc, uint32_t cmd_buf, uint64_t ret_addr) {
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)(ret_addr & 0xFFFFFFFF));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(ret_addr >> NOC_ADDR_COORD_SHIFT));

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -198,7 +198,7 @@ struct NocCmdBufState {
     uint32_t ret_addr_mid;
 };
 
-// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits and NOC_PACKET_TAG.
+// Saves all cmd_buf registers into state; clears reserved NOC_CTRL bits in the saved state.
 inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     uint32_t noc, uint32_t cmd_buf, NocCmdBufState* state) {
     state->ctrl = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL);
@@ -212,9 +212,13 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
     state->targ_addr_coord = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE);
     state->targ_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_TARG_ADDR_MID);
     state->packet_tag = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_PACKET_TAG);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
     state->at_data = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_DATA);
     state->ret_addr_mid = NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_RET_ADDR_MID);
+}
+
+// Clears NOC_PACKET_TAG register for the specified cmd_buf.
+inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t noc, uint32_t cmd_buf) {
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, 0);
 }
 
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -462,7 +462,7 @@ public:
 
     // Returns how much data is available. Will block until data is available. May release old pages before cmd_ptr to
     // writer. Updates cmd_ptr on wrap-around.
-    // noc_nonposted_writes_num_issued[noc_index] must be updated before calling this function.
+    // noc_increment_nonposted_writes_issued() must be called before calling this function.
     // If this function doesn't return sufficient data, there are two options:
     // 1. Process all the available data and then call this function again.
     // 2. Call get_cb_page_and_release_pages to attempt to get more data.
@@ -484,8 +484,8 @@ public:
     // handle the orphan data that would otherwise be lost and will then release old pages to writer.
     //
     // The argument to on_boundary is whether the next block is the first block in the circular buffer (in which case
-    // cmd_ptr is set to the base address after on_boundary is called).  noc_nonposted_writes_num_issued[noc_index] must
-    // be updated before on_boundary returns.
+    // cmd_ptr is set to the base address after on_boundary is called).
+    // noc_increment_nonposted_writes_issued() must be called before on_boundary returns.
     template <typename OnBoundaryFn>
     FORCE_INLINE uint32_t get_cb_page_and_release_pages(uint32_t& cmd_ptr, OnBoundaryFn&& on_boundary) {
         if (this->cb_fence_ == this->block_next_start_addr_[this->rd_block_idx_]) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -239,12 +239,12 @@ void process_go_signal_mcast_cmd() {
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
             (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
 
-        // Multicast write accounting: adjust counters for num_dests acks and one issued transaction.
-        noc_adjust_nonposted_writes_acked(noc_index, num_dests);
+        // Multicast write accounting: increment counters for num_dests acks and one issued transaction.
+        noc_increment_nonposted_writes_acked(noc_index, num_dests);
 
         wait_for_workers(wait_count, wait_stream);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
-        noc_adjust_nonposted_writes_issued(noc_index, 1);
+        noc_increment_nonposted_writes_issued(noc_index, 1);
     } else {
         wait_for_workers(wait_count, wait_stream);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -76,23 +76,14 @@ static uint32_t num_worker_sems = 1;
 FORCE_INLINE
 void dispatch_s_wr_reg_cmd_buf_init() {
     uint64_t xy_local_addr = get_noc_addr_helper(my_noc_xy, 0);
-    NOC_CMD_BUF_WRITE_REG(
-        my_noc_index,
-        DISPATCH_S_WR_REG_CMD_BUF,
-        NOC_TARG_ADDR_COORDINATE,
-        (uint32_t)(xy_local_addr >> NOC_ADDR_COORD_SHIFT));
+    noc_cmd_buf_set_targ_addr_coordinate(
+        my_noc_index, DISPATCH_S_WR_REG_CMD_BUF, (uint32_t)(xy_local_addr >> NOC_ADDR_COORD_SHIFT));
 }
 
 FORCE_INLINE
 void dispatch_s_atomic_cmd_buf_init() {
     uint64_t atomic_ret_addr = get_noc_addr_helper(my_noc_xy, MEM_NOC_ATOMIC_RET_VAL_ADDR);
-    NOC_CMD_BUF_WRITE_REG(
-        my_noc_index, DISPATCH_S_ATOMIC_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
-    NOC_CMD_BUF_WRITE_REG(
-        my_noc_index,
-        DISPATCH_S_ATOMIC_CMD_BUF,
-        NOC_RET_ADDR_COORDINATE,
-        (uint32_t)(atomic_ret_addr >> NOC_ADDR_COORD_SHIFT));
+    noc_cmd_buf_set_ret_addr(my_noc_index, DISPATCH_S_ATOMIC_CMD_BUF, atomic_ret_addr);
 }
 
 FORCE_INLINE
@@ -248,11 +239,12 @@ void process_go_signal_mcast_cmd() {
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
             (uint32_t)&aligned_go_signal_storage[storage_offset], dst_noc_addr_multicast, sizeof(uint32_t));
 
-        noc_nonposted_writes_acked[noc_index] += num_dests;
+        // Multicast write accounting: adjust counters for num_dests acks and one issued transaction.
+        noc_adjust_nonposted_writes_acked(noc_index, num_dests);
 
         wait_for_workers(wait_count, wait_stream);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
-        noc_nonposted_writes_num_issued[noc_index] += 1;
+        noc_adjust_nonposted_writes_issued(noc_index, 1);
     } else {
         wait_for_workers(wait_count, wait_stream);
     }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -234,6 +234,8 @@ struct NocRegisterStateSave {
 
     inline __attribute__((always_inline)) NocRegisterStateSave() {
         noc_cmd_buf_save_state(noc_index, write_cmd_buf, &state);
+        // Clear packet tag to avoid using stale transaction IDs in profiler writes
+        noc_clear_packet_tag(noc_index, write_cmd_buf);
     }
 
     inline __attribute__((always_inline)) ~NocRegisterStateSave() {

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -228,61 +228,16 @@ inline __attribute__((always_inline)) void risc_finished_profiling() {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || \
     defined(COMPILE_FOR_IDLE_ERISC) || (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0))
 
-// Saves several NoC register states restores them
-// when the NocRegisterStateSave is destroyed
+// Saves several NoC register states and restores them when the NocRegisterStateSave is destroyed.
 struct NocRegisterStateSave {
-    uint32_t noc_ctrl_state;
-    uint32_t noc_ret_addr_coord_state;
-    uint32_t noc_targ_addr_lo_state;
-    uint32_t noc_ret_addr_lo_state;
-    uint32_t noc_at_len_be_state;
-    uint32_t noc_targ_addr_coordinate_state;
-    uint32_t noc_targ_addr_mid_state;
-    uint32_t noc_packet_tag_state;
-    uint32_t noc_at_data_state;
-
-#ifdef ARCH_BLACKHOLE
-    uint32_t noc_ret_addr_mid_state;
-#endif
+    NocCmdBufState state;
 
     inline __attribute__((always_inline)) NocRegisterStateSave() {
-        noc_ctrl_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_CTRL);
-
-        // https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/NoC/MemoryMap.md#noc_ctrl
-        constexpr uint32_t reserved_bit_mask = ((1u << 27) - (1u << 18)) | (1u << 31);
-        noc_ctrl_state &= ~reserved_bit_mask;
-
-        noc_ret_addr_coord_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_COORDINATE);
-        noc_targ_addr_lo_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_LO);
-        noc_ret_addr_lo_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_LO);
-        noc_at_len_be_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_AT_LEN_BE);
-        noc_targ_addr_coordinate_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_COORDINATE);
-        noc_targ_addr_mid_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_MID);
-
-        noc_packet_tag_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_PACKET_TAG);
-        // reset the counter to zero before the push
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_PACKET_TAG, 0);
-
-        noc_at_data_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_AT_DATA);
-#ifdef ARCH_BLACKHOLE
-        noc_ret_addr_mid_state = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_MID);
-#endif
+        noc_cmd_buf_save_state(noc_index, write_cmd_buf, &state);
     }
 
     inline __attribute__((always_inline)) ~NocRegisterStateSave() {
-        while (!noc_cmd_buf_ready(noc_index, write_cmd_buf));
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_CTRL, noc_ctrl_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_COORDINATE, noc_ret_addr_coord_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_LO, noc_targ_addr_lo_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_LO, noc_ret_addr_lo_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_AT_LEN_BE, noc_at_len_be_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_COORDINATE, noc_targ_addr_coordinate_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_TARG_ADDR_MID, noc_targ_addr_mid_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_PACKET_TAG, noc_packet_tag_state);
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_AT_DATA, noc_at_data_state);
-#ifdef ARCH_BLACKHOLE
-        NOC_CMD_BUF_WRITE_REG(noc_index, write_cmd_buf, NOC_RET_ADDR_MID, noc_ret_addr_mid_state);
-#endif
+        noc_cmd_buf_restore_state(noc_index, write_cmd_buf, &state);
     }
 };
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

This change encapsulates direct NOC hardware access behind the non-blocking NOC API so that dispatch and profiler code no longer interact with low-level NOC registers or raw counter arrays.

State save/restore, counter handling, and command-buffer setup are now provided through dedicated helpers. Callers use these helpers instead of accessing `NOC_CMD_BUF_*`, `NOC_STATUS_READ_REG`, or the global counter arrays directly.

### What’s changed

#### NOC API (Wormhole / Blackhole / Quasar)

- Introduced `NocCmdBufState` along with:
  - `noc_cmd_buf_save_state()`
  - `noc_cmd_buf_restore_state()`  
  (the reserved `NOC_CTRL` mask is applied internally during save).

- Added counter accessors:
  - `noc_get_reads_issued()`
  - `noc_get_nonposted_writes_issued()`
  - `noc_get_nonposted_writes_acked()`

- Added counter adjustment helpers:
  - `noc_adjust_nonposted_writes_issued()`
  - `noc_adjust_nonposted_writes_acked()`

- Added new helpers:
  - `noc_nonposted_writes_sent_at_count()`
  - `noc_cmd_buf_set_targ_addr_coordinate()`
  - `noc_cmd_buf_set_ret_addr()`
  - `noc_debug_read_at_len_be()` (enabled when `NOC_LOGGING_ENABLED`)

- `NocCmdBufState` is architecture-independent; `ret_addr_mid` is only used on Blackhole and Quasar.

#### Profiler

- `NocRegisterStateSave` now relies exclusively on
  `noc_cmd_buf_save_state()` / `noc_cmd_buf_restore_state()`.
- All direct NOC register access and mask handling has been removed.

#### Dispatch

- **`cq_dispatch_subordinate.cpp`**
  - Command-buffer initialization now uses
    `noc_cmd_buf_set_targ_addr_coordinate()` and
    `noc_cmd_buf_set_ret_addr()`.
  - The multicast path uses
    `noc_adjust_nonposted_writes_issued()` and
    `noc_adjust_nonposted_writes_acked()`.

- **`cq_common.hpp`**
  - `CBReaderWithReleasePolicy` now uses
    `noc_nonposted_writes_sent_at_count()` and
    `noc_get_nonposted_writes_issued()` instead of
    `NOC_STATUS_READ_REG` and the counter array.

#### Debug

- In `noc_logging.h`, `LOG_READ_LEN_FROM_STATE` and
  `LOG_WRITE_LEN_FROM_STATE` now use
  `noc_debug_read_at_len_be()` instead of
  `NOC_CMD_BUF_READ_REG`.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0126-non_blocking_fd_leaks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0126-non_blocking_fd_leaks)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
