### PR TITLE
Add timeout retry in completion queue wait (SystemMemoryManager)

### DIFF
--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -626,7 +626,6 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     auto timeout_duration = tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations();
 
     // Retry once on timeout - many non-deterministic failures are transient and resolve on retry.
-    // This is cheaper than retrying the entire CI job.
     bool timeout_occurred = false;
     auto on_timeout_first_attempt = [&timeout_occurred]() {
         timeout_occurred = true;

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -618,26 +618,50 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
                cq_interface.completion_fifo_rd_toggle == write_toggle;
     };
 
-    // Handler for the timeout
-    auto on_timeout = [&exit_condition]() {
-        exit_condition.store(true);
-
-        MetalContext::instance().on_dispatch_timeout_detected();
-
-        TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");
-    };
-
     // Get dispatch progress for timeout detection
     auto get_dispatch_progress = [this, cq_id]() -> uint32_t {
         return get_cq_dispatch_progress(this->device_id, cq_id);
     };
 
+    auto timeout_duration = tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations();
+
+    // Retry once on timeout - many non-deterministic failures are transient and resolve on retry.
+    // This is cheaper than retrying the entire CI job.
+    bool timeout_occurred = false;
+    auto on_timeout_first_attempt = [&timeout_occurred]() {
+        timeout_occurred = true;
+        // Don't throw on first attempt - we'll retry
+    };
+
     loop_and_wait_with_timeout(
-        wait_operation_body,
-        wait_condition,
-        on_timeout,
-        tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations(),
-        get_dispatch_progress);
+        wait_operation_body, wait_condition, on_timeout_first_attempt, timeout_duration, get_dispatch_progress);
+
+    if (timeout_occurred) {
+        // First attempt timed out - log and retry once
+        log_warning(
+            tt::LogMetal,
+            "Completion queue wait timed out on first attempt (device_id={}, cq_id={}), retrying once...",
+            this->device_id,
+            cq_id);
+
+        // Brief delay before retry
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Handler for final timeout - this one throws
+        auto on_timeout_final = [&exit_condition]() {
+            exit_condition.store(true);
+
+            MetalContext::instance().on_dispatch_timeout_detected();
+
+            TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");
+        };
+
+        loop_and_wait_with_timeout(
+            wait_operation_body, wait_condition, on_timeout_final, timeout_duration, get_dispatch_progress);
+
+        // If we get here, retry succeeded
+        log_info(tt::LogMetal, "Completion queue wait succeeded on retry");
+    }
 
     return write_ptr_and_toggle;
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue (if applicable)

### Problem description
Non-deterministic device timeouts in completion queue wait cause CI failures that often pass on retry. These transient timeouts are expensive when they require re-running entire CI jobs.

### What's changed
- Added a **single retry** on timeout in `SystemMemoryManager::completion_queue_wait_front()`.
- On first timeout: log a warning, sleep 100ms, then retry the wait once.
- If the retry succeeds, log success and continue.
- If the retry also times out, throw as before (device unrecoverable).

This is cheaper than retrying the entire CI job and addresses many transient ND timeout failures.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/adding-timeout-retries)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/adding-timeout-retries)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/adding-timeout-retries)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/adding-timeout-retries)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/adding-timeout-retries)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/adding-timeout-retries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/adding-timeout-retries)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
