### PR TITLE
Add documentation for NOC debug dump. rename env to TT_METAL_NOC_DEBUG_DUMP

### DIFF
--- a/docs/source/tt-metalium/tools/index.rst
+++ b/docs/source/tt-metalium/tools/index.rst
@@ -61,6 +61,13 @@ The Inspector is a tool that provides insights into Metal host runtime.
 
 The tt-triage is a collection of Python scripts for analyzing and debugging Metal workload.
 
+.. toctree::
+    :maxdepth: 1
+
+    noc_debug_dump
+
+NOC debug dump collects NOC traces from the device to identify potential kernel programming issues.
+
 * `tt-smi <https://github.com/tenstorrent/tt-smi>`_
 
 TT-SMI is a command line utility to interact with all Tenstorrent devices on host.

--- a/docs/source/tt-metalium/tools/noc_debug_dump.rst
+++ b/docs/source/tt-metalium/tools/noc_debug_dump.rst
@@ -1,0 +1,74 @@
+NOC Debug Dump
+==================
+
+.. note::
+   Tools are only fully supported on source builds.
+
+.. caution::
+    This is an experimental feature.
+
+Overview
+--------
+
+The host can collect NOC traces from the device to identify potential kernel programming issues such as missing NOC barriers.
+
+Each NOC transaction is instrumented to record metadata such as type, src/dst, NOC counters, and size. These packets are collected by the host and bucketed into events per core and RISC processor. As the host collects the trace, it compares it to previous traces as well as traces on other cores on the same device.
+
+When the program finishes, the device closes, or ``tt::tt_metal::detail::ReadDeviceProfilerResults`` is manually called, the host will analyze the trace and print out any issues found grouped by core.
+
+
+Enabling
+--------
+
+This feature is enabled by setting the environment variable ``TT_METAL_NOC_DEBUG_DUMP=1`` before running your application.
+
+No kernel changes are needed to enable this feature. Trace collection is instrumented automatically.
+
+.. note::
+    Watcher, Profiler, or DPrint cannot be enabled at the same time as this feature due to kernel size constraints.
+
+Example
+-------
+
+This unit test demonstrates the feature in action by running a kernel that issues a multicast write followed by a multicast semaphore increment with a missing write barrier afterward.
+
+.. code-block:: bash
+
+    TT_METAL_NOC_DEBUG_DUMP=1 build/test/tt_metal/unit_tests_noc_debugging --gtest_filter=NOCDebuggingFixture.McastOnlyWriteFlush
+
+The output is printed to the console.
+
+.. code-block::
+
+    Running test on device 0
+    ========== NOC Debug Summary ==========
+    Unflushed async writes at kernel end (missing noc_async_write_barrier):
+        Device 0 (18,18) Processor 0 [semaphore mcast]
+    =======================================
+
+    Finished running test on device 0.
+    Running test on device 1.
+    ========== NOC Debug Summary ==========
+    Unflushed async writes at kernel end (missing noc_async_write_barrier):
+    Device 0 (18,18) Processor 0 [semaphore mcast]
+    Device 1 (18,18) Processor 0 [semaphore mcast]
+    ========================================
+
+    Finished running test on device 1.
+    ========== NOC Debug Summary ==========
+    Unflushed async writes at kernel end (missing noc_async_write_barrier):
+    Device 0 (18,18) Processor 0 [semaphore mcast]
+    Device 1 (18,18) Processor 0 [semaphore mcast]
+    ========================================
+
+    ========== NOC Debug Summary ===========
+    Unflushed async writes at kernel end (missing noc_async_write_barrier):
+    Device 0 (18,18) Processor 0 [semaphore mcast]
+    Device 1 (18,18) Processor 0 [semaphore mcast]
+    ========================================
+
+Limitations
+-----------
+
+- Not all issues can be detected due to the non-deterministic nature of the NOC. Acknowledgement of reads/writes can be returned before the trace can detect a missing barrier.
+- There is overhead on the H2D and D2H path due to host data transfers, and an additional 1-15% kernel cycle overhead.

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -327,7 +327,7 @@ def test_device_api_debugger_non_dropping():
     testCommand = f"build/{PROG_EXMP_DIR}/test_device_api_debugger"
     clear_profiler_runtime_artifacts()
 
-    envVars = "TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1 "
+    envVars = "TT_METAL_NOC_DEBUG_DUMP=1 "
 
     profilerRun = os.system(f"cd {TT_METAL_HOME} && {envVars} {testCommand}")
     assert profilerRun == 0, f"Test command failed with exit code {profilerRun}"

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -74,8 +74,8 @@ protected:
         }
 
         previous_debug_dump_enabled_ =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled();
-        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_device_debug_dump_enabled(true);
+            tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_noc_debug_dump_enabled(true);
 
         MeshDispatchFixture::SetUp();
 
@@ -91,7 +91,7 @@ protected:
             noc_debug_state->reset_state();
         }
 
-        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_device_debug_dump_enabled(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_noc_debug_dump_enabled(
             previous_debug_dump_enabled_);
     }
 };

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -73,6 +73,14 @@ protected:
             GTEST_SKIP() << "NOC debugging tests require fast dispatch mode";
         }
 
+        // This is a simple test with simple kernels
+        // Don't run this test if Watcher or DPrint is enabled
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() ||
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(
+                tt::llrt::RunTimeDebugFeatureDprint)) {
+            GTEST_SKIP() << "NOC debugging tests require Watcher and DPRINT to be disabled";
+        }
+
         previous_debug_dump_enabled_ =
             tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
         tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_noc_debug_dump_enabled(true);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -221,6 +221,14 @@ void MetalContext::initialize(
         std::make_unique<WatcherServer>();  // Watcher server always created, since we use it to register kernels
     noc_debug_state_ = std::make_unique<NOCDebugState>();
 
+    if (rtoptions_.get_experimental_noc_debug_dump_enabled()) {
+        TT_FATAL(
+            !rtoptions_.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint),
+            "Both DPRINT and NOC debug dump cannot be enabled at the same time.");
+        TT_FATAL(
+            !rtoptions_.get_watcher_enabled(), "Both Watcher and NOC debug dump cannot be enabled at the same time.");
+    }
+
     if (rtoptions_.get_profiler_enabled()) {
         profiler_state_manager_ = std::make_unique<ProfilerStateManager>();
     }

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -214,7 +214,7 @@ void DeviceManager::init_profiler() const {
     detail::ProfilerSync(ProfilerSyncState::INIT);
 
     if (tt::tt_metal::MetalContext::instance().profiler_state_manager() &&
-        tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled()) {
+        tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled()) {
         tt::tt_metal::LaunchIntervalBasedProfilerReadThread(this->get_all_active_devices());
     }
 #endif

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2208,7 +2208,7 @@ void DeviceProfiler::readResults(
 
     TT_ASSERT(doAllDispatchCoresComeAfterNonDispatchCores(device, virtual_cores));
 
-    bool force_slow_dispatch = MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled();
+    bool force_slow_dispatch = MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
 
     constexpr uint8_t default_dram_buffer_index = 0;
 
@@ -2725,7 +2725,7 @@ void DeviceProfiler::pollDebugDumpResults(
 bool getDeviceProfilerState() { return MetalContext::instance().rtoptions().get_profiler_enabled(); }
 
 bool getDeviceDebugDumpEnabled() {
-    return MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled();
+    return MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler_state_manager.cpp
+++ b/tt_metal/impl/profiler/profiler_state_manager.cpp
@@ -22,7 +22,7 @@ constexpr static uint32_t DEFAULT_PROFILER_L1_PROGRAM_MIN_OPTIONAL_MARKER_COUNT 
 uint32_t get_profiler_dram_bank_size_per_risc_bytes(llrt::RunTimeOptions& rtoptions) {
     std::optional<uint32_t> profiler_program_support_count = rtoptions.get_profiler_program_support_count();
     const bool do_profiler_sum = rtoptions.get_profiler_sum();
-    const bool debug_dump_enabled = rtoptions.get_experimental_device_debug_dump_enabled();
+    const bool debug_dump_enabled = rtoptions.get_experimental_noc_debug_dump_enabled();
 
     if (!profiler_program_support_count.has_value()) {
         profiler_program_support_count = DEFAULT_PROFILER_PROGRAM_SUPPORT_COUNT;
@@ -72,7 +72,7 @@ uint32_t get_profiler_dram_bank_size_per_risc_bytes() {
 
 uint32_t get_profiler_dram_bank_size_for_hal_allocation(llrt::RunTimeOptions& rtoptions) {
     const uint32_t per_buffer_size = get_profiler_dram_bank_size_per_risc_bytes(rtoptions);
-    const bool debug_dump_enabled = rtoptions.get_experimental_device_debug_dump_enabled();
+    const bool debug_dump_enabled = rtoptions.get_experimental_noc_debug_dump_enabled();
 
     // There are 2 DRAM buffers per risc when debug dump is enabled.
     // The size of each buffer returned by get_profiler_dram_bank_size_per_risc_bytes is half to maintain the same

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -751,7 +751,7 @@ void InitDeviceProfiler(IDevice* device) {
     std::vector<uint32_t> control_buffer(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
     control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_DEFAULT] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
 
-    if (MetalContext::instance().rtoptions().get_experimental_device_debug_dump_enabled()) {
+    if (MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled()) {
         // Split into two buffers. Assign the active DRAM buffer address to all control buffer indices.
         control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_BR_ER_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);
         control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS_NC_0] = hal.get_dev_addr(HalDramMemAddrType::PROFILER);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -196,7 +196,7 @@ void JitBuildEnv::init(
         }
         this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
     }
-    if (rtoptions.get_experimental_device_debug_dump_enabled()) {
+    if (rtoptions.get_experimental_noc_debug_dump_enabled()) {
         this->defines_ += "-DDEVICE_DEBUG_DUMP=1 ";
     }
     if (rtoptions.get_profiler_perf_counter_mode() != 0) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -123,7 +123,7 @@ enum class EnvVarID {
     TT_METAL_ARC_DEBUG_BUFFER_SIZE,                // ARC processor debug buffer size
     TT_METAL_OPERATION_TIMEOUT_SECONDS,            // Operation timeout duration
     TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE,  // Terminal command to execute on dispatch timeout.
-    TT_METAL_DEVICE_DEBUG_DUMP_ENABLED,            // Enable experimental debug dump mode for profiler
+    TT_METAL_NOC_DEBUG_DUMP,                       // Enable experimental NOC debug dump to detect missing barriers
     TT_METAL_DISPATCH_PROGRESS_UPDATE_MS,          // Dispatch kernel progress update period in milliseconds
 
     // ========================================
@@ -847,13 +847,13 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             break;
         }
 
-        // TT_METAL_DEVICE_DEBUG_DUMP_ENABLED
-        // Enable and sets the polling interval in seconds for experimental debug dump mode for profiler. In this mode,
-        // the profiler infrastructure will be used to continuously dump debug packets to a file. Default: false (debug
-        // dump mode disabled) Usage: export TT_METAL_DEVICE_DEBUG_DUMP_ENABLED=1
-        case EnvVarID::TT_METAL_DEVICE_DEBUG_DUMP_ENABLED: {
+        // TT_METAL_NOC_DEBUG_DUMP
+        // Enable experimental NOC debug dump mode. In this mode,
+        // the profiler infrastructure will be used to continuously dump NOC debug packets to a file. Default: false
+        // (debug dump mode disabled) Usage: export TT_METAL_NOC_DEBUG_DUMP=1
+        case EnvVarID::TT_METAL_NOC_DEBUG_DUMP: {
             if (is_env_enabled(value)) {
-                this->set_experimental_device_debug_dump_enabled(true);
+                this->set_experimental_noc_debug_dump_enabled(true);
             }
             break;
         }
@@ -1697,15 +1697,15 @@ tt_metal::DispatchCoreConfig RunTimeOptions::get_dispatch_core_config() const {
     return dispatch_core_config;
 }
 
-void RunTimeOptions::set_experimental_device_debug_dump_enabled(bool enabled) {
+void RunTimeOptions::set_experimental_noc_debug_dump_enabled(bool enabled) {
     if (enabled) {
         profiler_enabled = true;
         profiler_noc_events_enabled = true;
-        experimental_device_debug_dump_enabled = true;
+        experimental_noc_debug_dump_enabled = true;
     } else {
         profiler_enabled = false;
         profiler_noc_events_enabled = false;
-        experimental_device_debug_dump_enabled = false;
+        experimental_noc_debug_dump_enabled = false;
     }
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -186,7 +186,7 @@ class RunTimeOptions {
     bool profiler_disable_dump_to_files = false;
     bool profiler_disable_push_to_tracy = false;
     std::optional<uint32_t> profiler_program_support_count = std::nullopt;
-    bool experimental_device_debug_dump_enabled = false;
+    bool experimental_noc_debug_dump_enabled = false;
 
     bool null_kernels = false;
     // Kernels should return early, skipping the rest of the kernel. Kernels
@@ -531,8 +531,8 @@ public:
     std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
     bool get_profiler_disable_dump_to_files() const { return profiler_disable_dump_to_files; }
     bool get_profiler_disable_push_to_tracy() const { return profiler_disable_push_to_tracy; }
-    void set_experimental_device_debug_dump_enabled(bool enabled);
-    bool get_experimental_device_debug_dump_enabled() const { return experimental_device_debug_dump_enabled; }
+    void set_experimental_noc_debug_dump_enabled(bool enabled);
+    bool get_experimental_noc_debug_dump_enabled() const { return experimental_noc_debug_dump_enabled; }
 
     void set_kernels_nullified(bool v) { null_kernels = v; }
     bool get_kernels_nullified() const { return null_kernels; }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36769

### Problem description
No documentation for NOC debug dump tool which can detect missing barriers

### What's changed
- Add documentation under the Tools section to show how to enable it, an example, and the limitations
- Renamed the env var from `TT_METAL_DEVICE_DEBUG_DUMP_ENABLED` to `TT_METAL_NOC_DEBUG_DUMP` which better reflects what this tool does

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/noc-debug-dump-docs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/noc-debug-dump-docs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/noc-debug-dump-docs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/noc-debug-dump-docs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/noc-debug-dump-docs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/noc-debug-dump-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/noc-debug-dump-docs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
