### PR TITLE
[skip ci] Add optional-output-path with dynamic hostname-based default

### DIFF
--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -3,13 +3,13 @@
 # Script to run cluster validation commands for 50 iterations
 # Each iteration's output is logged to a separate file
 #
-# Usage: ./run_validation_4x32.sh <comma-separated-host-list>
-# Example: ./run_validation_4x32.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+# Usage: ./run_validation_4x32.sh <comma-separated-host-list> <docker-image> [optional-output-path]
+# Example: ./run_validation_4x32.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest
 
 # Check if host list is provided
 if [ $# -eq 0 ]; then
     echo "Error: No host list provided"
-    echo "Usage: $0 <comma-separated-host-list> <docker-image>"
+    echo "Usage: $0 <comma-separated-host-list> <docker-image> [optional-output-path]"
     echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
     exit 1
 fi
@@ -17,17 +17,22 @@ fi
 # Get host list from command line argument
 HOSTS="$1"
 DOCKER_IMAGE="$2"
+# Default output directory based on hosts
+DEFAULT_OUTPUT="validation_output-$(echo $HOSTS | sed 's/bh-glx-//g' | tr ',' '_')"
+# Optional output path
+OUTPUT_PATH="${3:-$DEFAULT_OUTPUT}"
 echo "Using hosts: $HOSTS"
 echo "Using docker image: $DOCKER_IMAGE"
+echo "Using output path: $OUTPUT_PATH"
 echo ""
 
 # Create output directory if it doesn't exist
-mkdir -p validation_output
+mkdir -p "$OUTPUT_PATH"
 
 for i in {1..50}; do
     echo "Starting iteration $i of 50..."
 
-    LOG_FILE="validation_output/cluster_validation_iteration_${i}.log"
+    LOG_FILE="$OUTPUT_PATH/cluster_validation_iteration_${i}.log"
 
     {
         echo "=========================================="

--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -18,7 +18,7 @@ fi
 HOSTS="$1"
 DOCKER_IMAGE="$2"
 # Default output directory based on hosts
-DEFAULT_OUTPUT="validation_output-$(echo $HOSTS | sed 's/bh-glx-//g' | tr ',' '_')"
+DEFAULT_OUTPUT="validation_output-$(echo "$HOSTS" | sed 's/bh-glx-//g' | tr ',' '_')"
 # Optional output path
 OUTPUT_PATH="${3:-$DEFAULT_OUTPUT}"
 echo "Using hosts: $HOSTS"

--- a/tools/scaleout/exabox/run_validation_4x32.sh
+++ b/tools/scaleout/exabox/run_validation_4x32.sh
@@ -56,3 +56,8 @@ for i in {1..50}; do
 done
 
 echo "All 50 iterations completed!"
+
+# Calls the analysis script on the output logs
+echo "Calling analysis script on output logs..."
+./tools/scaleout/exabox/analyze_validation_results.sh "$OUTPUT_PATH" | tee "$OUTPUT_PATH/validation_analysis.log"
+echo "Analysis complete! Summary logged to $OUTPUT_PATH/validation_analysis.log"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -57,3 +57,8 @@ for i in {1..50}; do
 done
 
 echo "All 50 iterations completed!"
+
+# Calls the analysis script on the output logs
+echo "Calling analysis script on output logs..."
+./tools/scaleout/exabox/analyze_validation_results.sh "$OUTPUT_PATH" | tee "$OUTPUT_PATH/validation_analysis.log"
+echo "Analysis complete! Summary logged to $OUTPUT_PATH/validation_analysis.log"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -18,7 +18,7 @@ fi
 HOSTS="$1"
 DOCKER_IMAGE="$2"
 # Default output directory based on hosts
-DEFAULT_OUTPUT="validation_output-$(echo $HOSTS | sed 's/bh-glx-//g' | tr ',' '_')"
+DEFAULT_OUTPUT="validation_output-$(echo "$HOSTS" | sed 's/bh-glx-//g' | tr ',' '_')"
 # Optional output path
 OUTPUT_PATH="${3:-$DEFAULT_OUTPUT}"
 echo "Using hosts: $HOSTS"

--- a/tools/scaleout/exabox/run_validation_8x16.sh
+++ b/tools/scaleout/exabox/run_validation_8x16.sh
@@ -3,13 +3,13 @@
 # Script to run cluster validation commands for 50 iterations
 # Each iteration's output is logged to a separate file
 #
-# Usage: ./run_validation_8x16.sh <comma-separated-host-list>
-# Example: ./run_validation_8x16.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
+# Usage: ./run_validation_8x16.sh <comma-separated-host-list> <docker-image> [optional-output-path]
+# Example: ./run_validation_8x16.sh bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest
 
 # Check if host list is provided
 if [ $# -eq 0 ]; then
     echo "Error: No host list provided"
-    echo "Usage: $0 <comma-separated-host-list> <docker-image>"
+    echo "Usage: $0 <comma-separated-host-list> <docker-image> [optional-output-path]"
     echo "Example: $0 bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 ghcr.io/tenstorrent/tt-metal/upstream-tests-wh-6u:latest"
     exit 1
 fi
@@ -17,17 +17,22 @@ fi
 # Get host list from command line argument
 HOSTS="$1"
 DOCKER_IMAGE="$2"
+# Default output directory based on hosts
+DEFAULT_OUTPUT="validation_output-$(echo $HOSTS | sed 's/bh-glx-//g' | tr ',' '_')"
+# Optional output path
+OUTPUT_PATH="${3:-$DEFAULT_OUTPUT}"
 echo "Using hosts: $HOSTS"
 echo "Using docker image: $DOCKER_IMAGE"
+echo "Using output path: $OUTPUT_PATH"
 echo ""
 
 # Create output directory if it doesn't exist
-mkdir -p validation_output
+mkdir -p "$OUTPUT_PATH"
 
 for i in {1..50}; do
     echo "Starting iteration $i of 50..."
 
-    LOG_FILE="validation_output/cluster_validation_iteration_${i}.log"
+    LOG_FILE="$OUTPUT_PATH/cluster_validation_iteration_${i}.log"
 
     {
         echo "=========================================="


### PR DESCRIPTION
### Ticket
[Prevent output directory naming conflicts on Exabox run_validation scripts #36984](https://github.com/tenstorrent/tt-metal/issues/36984)

### Problem description
Current scripts always write to same location, which can cause conflicts when running multiple tests.

### What's changed
- Added optional-output-path parameter so user can specify output dir
- Added dynamic default naming based on hostnames being validated
- Scripts now call analyze_validation_results.sh upon test completion and writes results summary to a log file

### Checklist

- [x] New/Existing tests provide coverage for changes