### PR TITLE
Fuse KV Cache to Main

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -227,4 +227,68 @@ void kernel_main() {
         deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> k_rope;
         k_rope(k_rope_args);
     }
+    // ========================================================================
+    // KV Cache Update: Write results to DRAM interleaved tensor
+    // BRISC handles writing from output CBs to DRAM
+    // ========================================================================
+#if defined(COMPILE_FOR_BRISC)
+    DeviceZoneScopedN("KV_CACHE_UPDATE");
+    // Get runtime args: buffer address and starting tile ID
+    uint32_t kv_cache_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t kv_cache_start_tile_id = get_arg_val<uint32_t>(1);
+
+    // Create address generator for
+    const InterleavedAddrGenFast<true> kv_cache_addr_gen = {
+        .bank_base_address = kv_cache_buffer_addr,
+        .page_size = 576 * 2,
+        .data_format = DataFormat::Float16_b,
+    };
+    // Actual calculations will differ in deepseek fused kernel, depending on the sharding scheme
+    // Write RMSNorm output (nope portion) to KV cache
+    if constexpr (Core::is_kv_rmsnorm_core) {
+        constexpr uint32_t kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb");
+        constexpr uint32_t kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles");
+
+        // Get tile size from the output CB
+        uint32_t tile_size = get_tile_size(kv_rmsnorm_output_cb);
+
+        cb_wait_front(kv_rmsnorm_output_cb, kv_rmsnorm_num_tiles);
+        uint32_t l1_read_addr = get_read_ptr(kv_rmsnorm_output_cb);
+
+        for (uint32_t tile_idx = 0; tile_idx < kv_rmsnorm_num_tiles; tile_idx++) {
+            uint32_t tile_id = kv_cache_start_tile_id + tile_idx;
+            noc_async_write_page(tile_id, kv_cache_addr_gen, l1_read_addr, /*size=*/tile_size, /*offset=*/0);
+            l1_read_addr += tile_size;
+        }
+        noc_async_write_barrier();
+        cb_pop_front(kv_rmsnorm_output_cb, kv_rmsnorm_num_tiles);
+    }
+
+    // Write Rope output to KV cache (after nope tiles)
+    if constexpr (Core::is_krope_core) {
+        constexpr uint32_t k_rope_output_cb = get_named_compile_time_arg_val("k_rope_output_cb");
+        constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
+
+        // Get tile size from the output CB
+        uint32_t tile_size = get_tile_size(k_rope_output_cb);
+
+        cb_wait_front(k_rope_output_cb, Wt);
+        uint32_t l1_read_addr = get_read_ptr(k_rope_output_cb);
+
+        uint32_t rope_offset = get_absolute_logical_y() - 8;  // yea...
+        for (uint32_t tile_idx = 0; tile_idx < Wt; tile_idx++) {
+            // Rope tiles come after nope tiles
+            uint32_t tile_id = kv_cache_start_tile_id + tile_idx;
+            noc_async_write_page(
+                tile_id,
+                kv_cache_addr_gen,
+                l1_read_addr,
+                /*size=*/tile_size,
+                /*offset=*/512 * 2 + tile_size * rope_offset);
+            l1_read_addr += tile_size;
+        }
+        noc_async_write_barrier();
+        cb_pop_front(k_rope_output_cb, Wt);
+    }
+#endif
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -133,8 +133,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
         get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
         get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
-        get_arg_val<uint32_t>(0),  // epsilon
-        get_arg_val<float>(1),     // scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(0),  // epsilon
+        get_common_arg_val<float>(1),     // scalar (1/sqrt(512))
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::
@@ -234,8 +234,8 @@ void kernel_main() {
 #if defined(COMPILE_FOR_BRISC)
     DeviceZoneScopedN("KV_CACHE_UPDATE");
     // Get runtime args: buffer address and starting tile ID
-    uint32_t kv_cache_buffer_addr = get_arg_val<uint32_t>(0);
-    uint32_t kv_cache_start_tile_id = get_arg_val<uint32_t>(1);
+    uint32_t kv_cache_buffer_addr = get_common_arg_val<uint32_t>(0);
+    uint32_t kv_cache_start_tile_id = get_common_arg_val<uint32_t>(1);
 
     // Create address generator for
     const InterleavedAddrGenFast<true> kv_cache_addr_gen = {

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -159,9 +159,7 @@ class KVCacheBranch:
             ("dkv_matmul_k_num_tiles", dkv_matmul_k_num_tiles),
             ("dkv_matmul_out_w_per_core", dkv_matmul_out_w),
         ]
-        dkv_matmul_brisc_named_compile_time_args = [
-            ("dkv_matmul_out", dkv_matmul_output_cb),
-        ]
+
         dkv_matmul_trisc_named_compile_time_args = [
             ("dkv_matmul_in0", dkv_matmul_input_cb),
             ("dkv_matmul_in1", dkv_matmul_weights_cb),
@@ -259,7 +257,8 @@ class KVCacheBranch:
         # ROPE
         krope_brisc_named_compile_time_args = [
             ("k_rope_output_cb", k_rope_output_cb),
-            ("Wt", 1),
+            ("Wt", 1),  # Needed for KV Cache update
+            ("Ht", 1),  # Needed for KV Cache update
         ]
         krope_ncrisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
@@ -285,23 +284,8 @@ class KVCacheBranch:
         # Create tile descriptor for proper tile dimensions
 
         # CB X: DKV Matmul input buffer (1x7168 with 1x32 tiles = 224 tiles)
-        # matmul_input_total_size = 14336  # 224 * 64 bytes
-        # matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        # dkv_matmul_input_total_size = matmul_input_total_size
-        # dkv_matmul_input_page_size = 64
-        # dkv_matmul_input_cb_format = ttnn.CBFormatDescriptor(
-        #    buffer_index=dkv_matmul_input_cb,
-        #    data_format=data_format,
-        #    page_size=dkv_matmul_input_page_size,
-        #    tile=matmul_input_tile_descriptor,
-        # )
-        # dkv_matmul_input_cb_core_ranges = input_core_grid
-        # dkv_matmul_input_cb_descriptor = ttnn.CBDescriptor(
-        #    total_size=dkv_matmul_input_total_size,
-        #    format_descriptors=[dkv_matmul_input_cb_format],
-        # )
         dkv_matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(dkv_matmul_input_cb, input_tensor)
-        # CB X: DKV Matmul output buffer (1x224 with 1x32 tiles = 7 tiles)
+        # CB X: DKV Matmul output buffers
         dkv_matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
         dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
         dkv_matmul_output_cb_format = ttnn.CBFormatDescriptor(
@@ -450,7 +434,6 @@ class KVCacheBranch:
             + krope_ncrisc_named_compile_time_args,
             # BRISC named compile-time args
             brisc_named_compile_time_args=dkv_gather_receiver_named_compile_time_args
-            + dkv_matmul_brisc_named_compile_time_args
             + kv_rmsnorm_brisc_named_compile_time_args
             + krope_brisc_named_compile_time_args,
             # BRISC common runtime args: KV cache buffer address and write position

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -44,6 +44,12 @@ struct Core {
     static constexpr bool is_qrope_core = get_named_compile_time_arg_val("is_qrope_core") == 1;
     // SDPA Input core: receives interleaved QNOPE/QROPE gather heads (4×2 grid = 8 cores)
     static constexpr bool is_sdpa_input_core = get_named_compile_time_arg_val("is_sdpa_input_core") == 1;
+
+    // DKV Matmul core: 9x2 grid, each core handles 1 head of 32 dim
+    static constexpr bool is_dkv_matmul_core = get_named_compile_time_arg_val("is_dkv_matmul_core") == 1;
+    static constexpr bool is_kv_rmsnorm_core = get_named_compile_time_arg_val("is_kv_rmsnorm_core") == 1;
+    static constexpr bool is_knope_core = get_named_compile_time_arg_val("is_knope_core") == 1;
+    static constexpr bool is_krope_core = get_named_compile_time_arg_val("is_krope_core") == 1;
 };
 
 void kernel_main() {
@@ -116,6 +122,48 @@ void kernel_main() {
 
     // Qrope reader args (NCRISC is no-op)
     deepseek_b1_ops::Rope::ReaderArgs qrope_args{};
+
+    // Matmul CTArgs type alias (NCRISC uses ReaderCTArgs)
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+
+    // Matmul reader args (NCRISC is no-op)
+    deepseek_b1_ops::Matmul::ReaderArgs dkv_matmul_args{};
+
+    // Gather sender args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::SenderArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_x"),
+        get_named_compile_time_arg_val("dkv_gather_dest_noc_y"),
+        get_named_compile_time_arg_val("dkv_gather_data_size_bytes"),
+        get_named_compile_time_arg_val("dkv_gather_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_src_cb"),
+        get_named_compile_time_arg_val("dkv_gather_src_num_pages"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("dkv_gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("dkv_gather_row_major"),
+        get_write_ptr(get_named_compile_time_arg_val(
+            "kv_rmsnorm_input_cb")),  // receiver_data_addr from CB write ptr (single-buffered)
+    };
+
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
+    // kv cache rmsnorm reader args
+    deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{};
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::
+        ReaderCTArgs<get_named_compile_time_arg_val("krope_Wt"), get_named_compile_time_arg_val("krope_Ht")>;
+    constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
+    constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
+    constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
+    constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
+
+    // Reader args: CB indices for sharded input signaling
+    deepseek_b1_ops::Rope::ReaderArgs krope_args{
+        .in_cb = krope_input_cb,
+        .cos_cb = krope_cos_cb,
+        .sin_cb = krope_sin_cb,
+        .trans_mat_cb = krope_trans_mat_cb,
+    };
 
 // ============================================================================
 // BRISC (Writer + Mcast Sender) - WriterConfigDescriptor compiles as BRISC
@@ -234,6 +282,27 @@ void kernel_main() {
         get_write_ptr(receive_cb),  // Write directly to output CB
     };
 
+    // Matmul writer args (BRISC is no-op)
+    using DKV_MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs dkv_matmul_args{};
+
+    // Gather receiver args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Gather::ReceiverArgs dkv_gather_args{
+        get_named_compile_time_arg_val("dkv_gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("dkv_gather_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("dkv_gather_dst_cb"),
+        get_named_compile_time_arg_val("dkv_gather_dst_num_pages"),
+    };
+
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+    deepseek_b1_ops::RMSNorm::WriterArgs kv_rmsnorm_args{};
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::WriterCTArgs;
+
+    // Writer args (empty - no-op)
+    deepseek_b1_ops::Rope::WriterArgs krope_args{};
 // ============================================================================
 // TRISC (Compute) - ComputeConfigDescriptor compiles as TRISC
 // Named compile-time args: rmsnorm compute, matmul compute
@@ -331,6 +400,61 @@ void kernel_main() {
 
     // Gather heads compute args (no-op for TRISC)
     deepseek_b1_ops::GatherHeads::ComputeArgs gather_heads_args{};
+
+    // DKV Matmul compute args
+    using DKV_MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("dkv_matmul_out_w_per_core")>;
+
+    // Matmul compute args (from compile-time args, passed to op as runtime args)
+    deepseek_b1_ops::Matmul::ComputeArgs dkv_matmul_args{
+        get_named_compile_time_arg_val("dkv_matmul_in0"),
+        get_named_compile_time_arg_val("dkv_matmul_in1"),
+        get_named_compile_time_arg_val("dkv_matmul_out"),
+        get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
+    };
+
+    // Gather compute args (no-op for TRISC)
+    deepseek_b1_ops::Gather::ComputeArgs dkv_gather_args{};
+
+    // CTArgs type aliases (required for Op templates)
+    using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+
+    // RMSNorm compute runtime args
+    deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
+        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        get_common_arg_val<uint32_t>(0),  // epsilon
+        get_common_arg_val<float>(3),     // kv_scalar (1/sqrt(512))
+    };
+
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::
+        ComputeCTArgs<get_named_compile_time_arg_val("krope_Wt"), get_named_compile_time_arg_val("krope_Ht")>;
+
+    // CB indices (passed as runtime args to ComputeArgs)
+    constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
+    constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
+    constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
+    constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
+    constexpr uint32_t krope_rotated_in_interm_cb = get_named_compile_time_arg_val("krope_rotated_in_interm_cb");
+    constexpr uint32_t krope_cos_interm_cb = get_named_compile_time_arg_val("krope_cos_interm_cb");
+    constexpr uint32_t krope_sin_interm_cb = get_named_compile_time_arg_val("krope_sin_interm_cb");
+    constexpr uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
+
+    // Compute args: all CB indices
+    deepseek_b1_ops::Rope::ComputeArgs krope_args{
+        .in_cb = krope_input_cb,
+        .cos_cb = krope_cos_cb,
+        .sin_cb = krope_sin_cb,
+        .trans_mat_cb = trans_mat_cb,
+        .rotated_in_interm_cb = krope_rotated_in_interm_cb,
+        .cos_interm_cb = krope_cos_interm_cb,
+        .sin_interm_cb = krope_sin_interm_cb,
+        .out_cb = krope_output_cb,
+    };
 #endif
 
 #if defined(COMPILE_FOR_NCRISC)
@@ -397,6 +521,31 @@ void kernel_main() {
         get_named_compile_time_arg_val("receive_cb"),  // Output CB
         get_named_compile_time_arg_val("dst_num_pages"),
     };
+
+    if constexpr (Core::is_dkv_matmul_core) {
+        // Matmul weights (in1)
+        constexpr uint32_t dkv_matmul_in1 = get_named_compile_time_arg_val("dkv_matmul_in1");
+        constexpr uint32_t dkv_matmul_out_w_per_core = get_named_compile_time_arg_val("dkv_matmul_out_w_per_core");
+        constexpr uint32_t dkv_matmul_k_num_tiles = get_named_compile_time_arg_val("dkv_matmul_k_num_tiles");
+        unified_kernels::setup_sharded_buffer(dkv_matmul_in1, dkv_matmul_k_num_tiles * dkv_matmul_out_w_per_core);
+    }
+
+    if constexpr (Core::is_kv_rmsnorm_core) {
+        // RMSNorm gamma (sharded weights)
+        constexpr uint32_t kv_rmsnorm_gamma_cb = get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb");
+        constexpr uint32_t kv_rmsnorm_num_tiles = get_named_compile_time_arg_val("kv_rmsnorm_num_tiles");
+        unified_kernels::setup_sharded_buffer(kv_rmsnorm_gamma_cb, kv_rmsnorm_num_tiles);
+    }
+
+    if constexpr (Core::is_krope_core) {
+        constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
+        constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
+        constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
+        constexpr uint32_t krope_Wt = get_named_compile_time_arg_val("krope_Wt");
+        unified_kernels::setup_sharded_buffer(krope_cos_cb, krope_Wt);
+        unified_kernels::setup_sharded_buffer(krope_sin_cb, krope_Wt);
+        unified_kernels::setup_sharded_buffer(krope_trans_mat_cb, 1);
+    }
 #endif
 
     // ========================================================================
@@ -410,7 +559,12 @@ void kernel_main() {
     }
 
     // pop_src = true (rmsnorm output is consumed after mcast)
-    deepseek_b1_ops::Mcast::Op<McastCTArgs, Core::is_input_core, Core::is_matmul2_core, Core::is_matmul_core, true>
+    deepseek_b1_ops::Mcast::Op<
+        McastCTArgs,
+        Core::is_input_core,
+        Core::is_matmul2_core,
+        Core::is_matmul_core || Core::is_dkv_matmul_core,
+        true>
         mcast;
     mcast.init(mcast_args);
     {
@@ -426,7 +580,7 @@ void kernel_main() {
     {
         DeviceZoneScopedN("MATMUL");
         // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)
-        deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_matmul_core, true, false> matmul;
+        deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_matmul_core, false, false> matmul;
         matmul(matmul_args);
     }
 
@@ -529,6 +683,44 @@ void kernel_main() {
             deepseek_b1_ops::GatherHeads::Op<is_gather_heads_sender, Core::is_sdpa_input_core, false, true, true>
                 gather_heads;
             gather_heads(gather_heads_args);
+        }
+    }
+    {
+        // ========================================================================o
+        // KV Cache Branch - Matmul
+        // DKV Matmul: 9x2 grid, each core handles 1 head of 32 dim
+        // ========================================================================
+        {
+            DeviceZoneScopedN("DKV_MATMUL");
+            // pop_in0 = true (consumed), pop_in1 = false (weights are persistent)o
+            deepseek_b1_ops::Matmul::Op<DKV_MatmulCTArgs, Core::is_dkv_matmul_core, false, false> dkv_matmul;
+            dkv_matmul(dkv_matmul_args);
+        }
+
+        // ========================================================================
+        // KV Cache Branch: Gather: dkv matmul cores (senders) -> rmsnorm core (receiver)
+        // NCRISC sends from knope grid of dkv matmul cores, BRISC receives on rmsnorm grid, TRISC no-op
+        // ========================================================================
+        {
+            DeviceZoneScopedN("DKV_GATHER");
+            deepseek_b1_ops::Gather::Op<Core::is_knope_core, Core::is_kv_rmsnorm_core, true> dkv_gather;
+            dkv_gather(dkv_gather_args);
+        }
+
+        // ========================================================================
+        // RMSNorm: Apply RMSNorm to the gathered data
+        {
+            DeviceZoneScopedN("KV_RMSNORM");
+            deepseek_b1_ops::RMSNorm::Op<KV_RMSNormCTArgs, Core::is_kv_rmsnorm_core, true> kv_rmsnorm;
+            kv_rmsnorm(kv_rmsnorm_args);
+        }
+        // ========================================================================
+        // KV Cache Branch: RoPE
+        // ========================================================================
+        {
+            DeviceZoneScopedN("K_ROPE");
+            deepseek_b1_ops::Rope::Op<K_RopeCTArgs, Core::is_krope_core> krope;
+            krope(krope_args);
         }
     }
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -255,8 +255,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("rmsnorm_input_cb"),
         get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
         get_named_compile_time_arg_val("rmsnorm_output_cb"),
-        get_arg_val<uint32_t>(0),  // epsilon
-        get_arg_val<float>(1),     // scalar (1/sqrt(7168))
+        get_common_arg_val<uint32_t>(0),  // epsilon
+        get_common_arg_val<float>(1),     // scalar (1/sqrt(7168))
     };
 
     // Mcast compute args (no-op for TRISC)
@@ -282,8 +282,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("rmsnorm2_input_cb"),   // separate input CB (3 tiles of 16x32)
         get_named_compile_time_arg_val("rmsnorm2_gamma_cb"),   // new gamma for 1536 elements
         get_named_compile_time_arg_val("rmsnorm2_output_cb"),  // separate output CB (3 tiles of 16x32)
-        get_arg_val<uint32_t>(0),                              // epsilon (same as rmsnorm1)
-        get_arg_val<float>(2),                                 // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(0),                       // epsilon (same as rmsnorm1)
+        get_common_arg_val<float>(2),                          // scalar (1/sqrt(1536))
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)

--- a/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     }
 
     // Get receiver data address from runtime arg (dst CB doesn't exist on sender cores)
-    uint32_t receiver_data_addr = get_arg_val<uint32_t>(0);
+    uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
 
     // Gather sender args (from compile-time args, passed to op as runtime args)
     Gather::SenderArgs gather_args{

--- a/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/mcast/kernels/mcast_kernel.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
     constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
 
     // Mcast receiver data address (passed from Python as runtime arg, this is the output tensor's buffer address)
-    uint32_t mcast_receiver_data_addr = get_arg_val<uint32_t>(0);
+    uint32_t mcast_receiver_data_addr = get_common_arg_val<uint32_t>(0);
 
     // Mcast sender args (from compile-time args, passed to op as runtime args)
     Mcast::SenderArgs mcast_args{

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
@@ -63,8 +63,8 @@ void kernel_main() {
         .input_cb = input_cb,
         .gamma_cb = gamma_cb,
         .output_cb = output_cb,
-        .epsilon = get_arg_val<uint32_t>(0),  // epsilon
-        .scalar = get_arg_val<float>(1),   // scalar (1/sqrt(num_elements))
+        .epsilon = get_common_arg_val<uint32_t>(0),  // epsilon
+        .scalar = get_common_arg_val<float>(1),      // scalar (1/sqrt(num_elements))
     };
 #endif
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -18,10 +18,10 @@ from models.demos.deepseek_v3_b1.fused_ops.kv_cache_branch.op import KVCacheBran
 
 @pytest.mark.parametrize("epsilon", [1e-6])
 @pytest.mark.parametrize("use_fp32", [True])
-def test_kv_cache_branch(device, epsilon, use_fp32):
+@pytest.mark.parametrize("position_id", [0, 1, 5, 7])
+def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
     """Test TTNN KV cache branch fused operation"""
 
-    position_id = 0
     max_seq_len = 8192
     batch = 1
 
@@ -34,7 +34,7 @@ def test_kv_cache_branch(device, epsilon, use_fp32):
     rope_num_heads = 1
 
     # Create input PyTorch tensors
-    torch.manual_seed(0)
+    torch.manual_seed(position_id)
     torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
     torch_W_dkv_rope = torch.randn(W_dkv_rope_shape, dtype=torch.bfloat16)
     torch_gamma = torch.randn((1, 512), dtype=torch.bfloat16)
@@ -241,21 +241,58 @@ def test_kv_cache_branch(device, epsilon, use_fp32):
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=output_mem_config,
+        tile=output_tile,
+    )
+
+    # KV Cache tensor in DRAM (interleaved)
+    # Shape: [max_seq_len, kv_dim] where kv_dim = 512 (nope) + 64 (rope) = 576
+    dram_grid_size = device.dram_grid_size()
+    kv_cache_seq_len = (
+        dram_grid_size.x * dram_grid_size.y
+    )  # For simplicity, just test up to number of DRAM banks, with one shard per bank
+    assert (
+        position_id < kv_cache_seq_len
+    ), f"Position ID {position_id} must be less than KV cache sequence length {kv_cache_seq_len}"
+    kv_cache_dim = 576  # 512 (nope) + 64 (rope)
+    kv_cache_shape = (1, 1, kv_cache_seq_len, kv_cache_dim)
+    torch_kv_cache = torch.zeros(kv_cache_shape, dtype=torch.bfloat16)
+    # Get device DRAM grid size
+    kv_cache_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [1, kv_cache_dim],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    kv_cache_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, kv_cache_shard_spec
+    )
+    # Create tensor with DRAM sharded memory config
+    ttnn_kv_cache = ttnn.from_torch(
+        torch_kv_cache,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_cache_mem_config,
         tile=tile,
     )
+
+    logger.info(f"Created KV cache tensor in DRAM with shape {kv_cache_shape}")
 
     logger.info(f"Created tensors sharded on single core with shard shape {output_shard_shape}")
     logger.info(f"Done creating TT tensors.")
     logger.info("Running KV cache branch operation...")
-    ttnn_result = KVCacheBranch.op(
-        ttnn_input, ttnn_W_dkv_rope, ttnn_gamma, tt_cos, tt_sin, tt_trans_replicated, ttnn_output, epsilon, use_fp32
+    _ = KVCacheBranch.op(
+        ttnn_input,
+        ttnn_W_dkv_rope,
+        ttnn_gamma,
+        tt_cos,
+        tt_sin,
+        tt_trans_replicated,
+        ttnn_output,
+        ttnn_kv_cache,
+        kv_cache_write_index=position_id,  # Which sequence position to write to
     )
-
-    # Convert back to torch for verification
-    output_torch = ttnn.to_torch(ttnn_result)
-
-    expected_shape = (1, 512)
-    assert output_torch.shape == expected_shape, f"Expected shape {expected_shape}, got {output_torch.shape}"
 
     logger.info("Running KV cache branch golden reference...")
     # Compute reference output using PyTorch
@@ -269,15 +306,17 @@ def test_kv_cache_branch(device, epsilon, use_fp32):
         epsilon=epsilon,
     )
 
-    torch_expected = torch_expected[:, :512]
-    max_diff = torch.max(torch.abs(output_torch - torch_expected)).item()
-    mean_diff = torch.mean(torch.abs(output_torch - torch_expected)).item()
+    # Read back from kv cache tensor in DRAM to check PCC
+    torch_kv_cache = ttnn.to_torch(ttnn_kv_cache)
+    compare_kv_cache = torch_kv_cache[:, :, position_id, :]
+    max_diff = torch.max(torch.abs(torch_expected - compare_kv_cache)).item()
+    mean_diff = torch.mean(torch.abs(torch_expected - compare_kv_cache)).item()
     logger.info(f"Max absolute difference: {max_diff}")
     logger.info(f"Mean absolute difference: {mean_diff}")
 
     from models.common.utility_functions import comp_pcc
 
-    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.98)
+    passing, pcc_message = comp_pcc(compare_kv_cache, torch_expected, 0.98)
     logger.info(pcc_message)
     assert passing, pcc_message
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -41,6 +41,8 @@ def test_pre_sdpa(device, epsilon, use_fp32):
     HEADS_PER_ROW = 8
     QNOPE_OUT_DIM = 512  # Output dimension per Qnope head after matmul3
 
+    KNOPE_DIM = 512
+    KROPE_DIM = 64
     # Device grid configuration
     device_grid_size = device.compute_with_storage_grid_size()
 
@@ -68,6 +70,39 @@ def test_pre_sdpa(device, epsilon, use_fp32):
     # Use the full device grid width for mcast core (last column)
     mcast_core_x = device_grid_size.x - 1  # Last column
     mcast_core_y = 9
+
+    # KV Cache Branch grid configuration
+    kv_cache_branch_start_offset = (0, 8)  # Offset for the operation grid
+    kv_cache_branch_grid = (9, 2)  # Grid dimensions for the operation
+
+    kv_cache_branch_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+                ttnn.CoreCoord(
+                    kv_cache_branch_grid[0] + kv_cache_branch_start_offset[0] - 1,
+                    kv_cache_branch_grid[1] + kv_cache_branch_start_offset[1] - 1,
+                ),
+            )
+        }
+    )
+    kv_cache_branch_rms_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+                ttnn.CoreCoord(kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+            )
+        }
+    )
+    kv_cache_branch_rope_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], kv_cache_branch_start_offset[1]),
+                ttnn.CoreCoord(8 + kv_cache_branch_start_offset[0], 1 + kv_cache_branch_start_offset[1]),
+            )
+        }
+    )
+    dkv_matmul_weights_shape = (7168, KNOPE_DIM + KROPE_DIM)
 
     tile = ttnn.Tile([1, 32])
 
@@ -276,6 +311,7 @@ def test_pre_sdpa(device, epsilon, use_fp32):
     # Cos/Sin sharding: HEIGHT_SHARDED on qrope grid
     # Each core gets full head_dim (since cos/sin are reused for all heads on that core)
     # Shape per core: (1, qrope_head_dim) = (1, 64)
+    # Shared with KV Cache branch, double check if modifying these tensors
     cos_selected = torch_cos[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, qrope_head_dim] = [1, 1, 1, 64]
     sin_selected = torch_sin[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, qrope_head_dim] = [1, 1, 1, 64]
 
@@ -314,11 +350,14 @@ def test_pre_sdpa(device, epsilon, use_fp32):
 
     # Trans_mat: [1, 1, 32, 32] - repeat for all qrope cores
     # Each core gets full [32, 32] transformation matrix (reused for all heads)
-    trans_mat_replicated = torch_trans_mat.repeat(1, 1, qrope_num_cores, 1)  # [1, 1, 32, 32]
+    trans_mat_replicated = torch_trans_mat.repeat(
+        1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1
+    )  # [1, 1, 32, 32]
+    trans_mat_crs = kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
     trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
     trans_shard_shape = (ttnn.TILE_SIZE, ttnn.TILE_SIZE)  # [32, 32] per core
     trans_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({qrope_grid}),
+        trans_mat_crs,
         trans_shard_shape,
         ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -331,6 +370,80 @@ def test_pre_sdpa(device, epsilon, use_fp32):
         device=device,
         memory_config=trans_mem_config,
         tile=trans_tile,
+    )
+
+    # KV Cache Branch
+    torch_dkv_matmul_weights = torch.randn(dkv_matmul_weights_shape, dtype=torch.bfloat16)
+    num_shards = kv_cache_branch_crs.num_cores()
+    shard_width = dkv_matmul_weights_shape[1] // num_shards
+    new_shard_order = [0, 1, 2, 3, 4, 5, 6, 7, 16, 8, 9, 10, 11, 12, 13, 14, 15, 17]
+    torch_dkv_matmul_weights_shards = torch_dkv_matmul_weights.reshape(
+        dkv_matmul_weights_shape[0], num_shards, shard_width
+    )
+    torch_dkv_matmul_weights_shuffled = torch_dkv_matmul_weights_shards[:, new_shard_order, :].reshape(
+        dkv_matmul_weights_shape[0], dkv_matmul_weights_shape[1]
+    )
+    dkv_matmul_weights_shard_spec = ttnn.ShardSpec(
+        kv_cache_branch_crs,
+        (dkv_matmul_weights_shape[0], shard_width),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    dkv_matmul_weights_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, dkv_matmul_weights_shard_spec
+    )
+    ttnn_dkv_matmul_weights = ttnn.from_torch(
+        torch_dkv_matmul_weights_shuffled,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dkv_matmul_weights_mem_config,
+    )
+
+    torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
+    dkv_rmsnorm_gamma_shard_spec = ttnn.ShardSpec(
+        kv_cache_branch_rms_crs,
+        (1, KNOPE_DIM),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    dkv_rmsnorm_gamma_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, dkv_rmsnorm_gamma_shard_spec
+    )
+
+    ttnn_dkv_rmsnorm_gamma = ttnn.from_torch(
+        torch_dkv_rmsnorm_gamma,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dkv_rmsnorm_gamma_mem_config,
+        tile=tile,
+    )
+
+    krope_num_heads = 1
+    krope_cos_sin_shard_spec = ttnn.ShardSpec(
+        kv_cache_branch_rope_crs,
+        (krope_num_heads, KROPE_DIM // 2),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    krope_cos_sin_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, krope_cos_sin_shard_spec
+    )
+
+    ttnn_krope_cos = ttnn.from_torch(
+        cos_selected,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=krope_cos_sin_mem_config,
+        tile=tile,
+    )
+    ttnn_krope_sin = ttnn.from_torch(
+        sin_selected,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=krope_cos_sin_mem_config,
+        tile=tile,
     )
 
     # ========================================================================
@@ -347,6 +460,10 @@ def test_pre_sdpa(device, epsilon, use_fp32):
         ttnn_sin,
         ttnn_cos,
         ttnn_trans_mat,
+        ttnn_krope_cos,
+        ttnn_krope_sin,
+        ttnn_dkv_matmul_weights,
+        ttnn_dkv_rmsnorm_gamma,
         ttnn_sdpa_input_output,
         epsilon=epsilon,
         fp32_dest_acc_en=use_fp32,
@@ -361,7 +478,7 @@ def test_pre_sdpa(device, epsilon, use_fp32):
     logger.info("Computing golden reference...")
 
     # Golden uses shuffled weights to produce same interleaved output
-    _, _, torch_sdpa_expected = PreSDPA.golden(
+    _, _, torch_sdpa_expected, torch_kv_cache_expected = PreSDPA.golden(
         torch_input,
         torch_gamma,
         torch_matmul_weights,
@@ -371,12 +488,16 @@ def test_pre_sdpa(device, epsilon, use_fp32):
         torch_sin,
         torch_cos,
         position_ids,
+        torch_dkv_matmul_weights,
+        torch_dkv_rmsnorm_gamma,
         epsilon=epsilon,
         num_qnope_heads=NUM_QNOPE_HEADS,
         num_qrope_heads=NUM_QROPE_HEADS,
         qnope_head_dim=QNOPE_HEAD_DIM,
         qrope_head_dim=QROPE_HEAD_DIM,
         heads_per_row=HEADS_PER_ROW,
+        knope_dim=KNOPE_DIM,
+        krope_dim=KROPE_DIM,
     )
 
     # ========================================================================

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -102,7 +102,6 @@ struct Matmul {
             // in1 has num_tiles * out_w tiles (K tiles for each output column)
             cb_wait_front(args.in0, args.k_num_tiles);
             cb_wait_front(args.in1, args.k_num_tiles * out_w);
-
             // Reserve output tiles
             cb_reserve_back(args.out, out_w);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35536)

### Problem description
KV Cache Op needs to be fused to main branch.

### What's changed
- Add kv cache branch update to unit test.
- Fuse kv cache branch to main branch.
- Fix bug with `get_arg_val` in fused kernels.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
